### PR TITLE
Main change is to the uncommon processes query.

### DIFF
--- a/Hunting Queries/Deployed/base64_decodedpayload.txt
+++ b/Hunting Queries/Deployed/base64_decodedpayload.txt
@@ -2,7 +2,7 @@ let ProcessCreationEvents=() {
 let processEvents=SecurityEvent
 | where EventID==4688
 | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName, AccountDomain=SubjectDomainName,
-FileName=reverse(substring(reverse(NewProcessName), 0, indexof(reverse(NewProcessName), "\\\\"))), 
+FileName=tostring(split(NewProcessName, '\\')[-1]),
 ProcessCommandLine = CommandLine, 
 FolderPath = "",
 InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine="",InitiatingProcessParentFileName="";

--- a/Hunting Queries/Deployed/base_encoded_pefile.txt
+++ b/Hunting Queries/Deployed/base_encoded_pefile.txt
@@ -2,7 +2,7 @@ let ProcessCreationEvents=() {
 let processEvents=SecurityEvent
 | where EventID==4688
 | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName, AccountDomain=SubjectDomainName,
-FileName=reverse(substring(reverse(NewProcessName), 0, indexof(reverse(NewProcessName), "\\\\"))), 
+FileName=tostring(split(NewProcessName, '\\')[-1]),
 ProcessCommandLine = CommandLine, 
 FolderPath = "",
 InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine="",InitiatingProcessParentFileName="";

--- a/Hunting Queries/Deployed/enumeration_user_and_group.txt
+++ b/Hunting Queries/Deployed/enumeration_user_and_group.txt
@@ -2,7 +2,7 @@ let ProcessCreationEvents=() {
 let processEvents=SecurityEvent
 | where EventID==4688
 | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName,        AccountDomain=SubjectDomainName,
-FileName=reverse(substring(reverse(NewProcessName), 0, indexof(reverse(NewProcessName), "\\\\"))),
+FileName=tostring(split(NewProcessName, '\\')[-1]),
 ProcessCommandLine = CommandLine, 
 FolderPath = "",
 InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine="",InitiatingProcessParentFileName="";

--- a/Hunting Queries/Deployed/malware_in_recyclebin.txt
+++ b/Hunting Queries/Deployed/malware_in_recyclebin.txt
@@ -2,7 +2,7 @@ let ProcessCreationEvents=() {
 let processEvents=SecurityEvent
 | where EventID==4688
 | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName,        AccountDomain=SubjectDomainName,
-FileName=reverse(substring(reverse(NewProcessName), 0, indexof(reverse(NewProcessName), "\\\\"))),
+FileName=tostring(split(NewProcessName, '\\')[-1]),
 ProcessCommandLine = CommandLine, 
 InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine="",InitiatingProcessParentFileName="";
 processEvents};

--- a/Hunting Queries/Deployed/persistance_create_account.txt
+++ b/Hunting Queries/Deployed/persistance_create_account.txt
@@ -1,8 +1,8 @@
 SecurityEvent
 | where EventID==4688
 | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName, 
-    AccountDomain=SubjectDomainName, FileName=reverse(substring(reverse(NewProcessName), 0, 
-    indexof(reverse(NewProcessName), "\\\\"))), ProcessCommandLine = CommandLine, 
+    AccountDomain=SubjectDomainName, FileName=tostring(split(NewProcessName, '\\')[-1]), 
+    ProcessCommandLine = CommandLine, 
     FolderPath = "", InitiatingProcessFileName=ParentProcessName,
     InitiatingProcessCommandLine="",InitiatingProcessParentFileName=""
 | where FileName in~ ("net.exe", "net1.exe")

--- a/Hunting Queries/Deployed/powershell_downloads.txt
+++ b/Hunting Queries/Deployed/powershell_downloads.txt
@@ -2,7 +2,7 @@ let ProcessCreationEvents=() {
 let processEvents=SecurityEvent
 | where EventID==4688
 | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName,        AccountDomain=SubjectDomainName,
-FileName=reverse(substring(reverse(NewProcessName), 0, indexof(reverse(NewProcessName), "\\\\"))),
+  FileName=tostring(split(NewProcessName, '\\')[-1]),
 ProcessCommandLine = CommandLine, 
 InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine="",InitiatingProcessParentFileName="";
 processEvents};

--- a/Hunting Queries/Deployed/uncommon_processes.txt
+++ b/Hunting Queries/Deployed/uncommon_processes.txt
@@ -1,23 +1,40 @@
-let processEvents = SecurityEvent
-| where EventID==4688
-| project TimeGenerated,
-ComputerName=Computer,
-AccountName=SubjectUserName,
-FileName=NewProcessName,
-AccountDomain=SubjectDomainName,
-ProcessCommandLine=CommandLine,
-InitiatingProcessFileName=ParentProcessName,
-InitiatingProcessCommandLine='',
-InitiatingProcessParentFileName='' ;
-let freqs = processEvents
-| project FileName
-| where FileName !startswith "C:\\\\Program Files\\\\" and FileName !startswith "C:\\\\Program Files (x86)" and FileName !contains "DismHost.exe" and FileName !startswith "C:\\\\Windows"
-| summarize frequency=count() by tostring(FileName)
-| join kind= leftouter (
-   processEvents
-| summarize Since=min(TimeGenerated) by tostring(FileName)
-) on FileName;
-freqs
-| where frequency < toscalar(freqs | serialize | extend r=row_number() | project r, frequency | summarize percentilesw (r, frequency, 95))
-| order by frequency asc
-| project FileName, frequency, Since
+// Shows the rarest processes seen running for the first time. 
+// These new processes could be benign new programs installed on hosts; 
+// However, especially in normally stable environments, these new processes could provide an indication of an unauthorized/malicious binary that has been installed and run. 
+// Reviewing the wider context of the logon sessions in which these binaries ran can provide a good starting point for identifying possible attacks.
+// Uncommon processes/files - bottom 5%
+// Tags: #Initial Access, #Execution, #Persistence, #Privilege Escalation, #Credential Access, #Discovery, #Lateral Movement, #Collection, #Exfiltration, #Command and Control
+let ProcessCreationEvents=() {
+    let processEvents=SecurityEvent
+    | where EventID==4688
+    // filter out common randomly named files related to MSI installers and browsers
+    | where not(NewProcessName matches regex @"Temp\\[0-9]{1}\\TRA[0-9A-Fa-f]{3}.tmp")
+    | where not(NewProcessName matches regex @"Temp\\[0-9]{1}\\TRA[0-9A-Fa-f]{4}.tmp")
+    | where not(NewProcessName matches regex @"Installer\\MSI[0-9A-Fa-f]{3}\.tmp")
+    | where not(NewProcessName matches regex @"Installer\\MSI[0-9A-Fa-f]{4}\.tmp")
+    | project TimeGenerated, 
+      ComputerName=Computer,
+      AccountName=SubjectUserName, 
+      AccountDomain=SubjectDomainName,
+      FileName=tostring(split(NewProcessName, '\\')[-1]),
+      ProcessCommandLine = CommandLine, 
+      InitiatingProcessFileName=ParentProcessName,
+      InitiatingProcessCommandLine="",
+      InitiatingProcessParentFileName="";
+    processEvents;
+    };
+    let normalizedProcesses = ProcessCreationEvents 
+       | project TimeGenerated, FileName = replace("[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}", "<guid>", FileName) // normalize guids
+       | project TimeGenerated, FileName=replace(@'\d', 'n', FileName); // normalize digits away
+    let freqs = normalizedProcesses
+    | summarize frequency=count() by FileName
+    | join kind= leftouter (
+       normalizedProcesses
+       | summarize Since=min(TimeGenerated), LastSeen=max(TimeGenerated) by FileName
+    ) on FileName;
+    freqs 
+    | where frequency <= toscalar( freqs | serialize | project frequency | summarize percentiles(frequency, 5))
+    | order by frequency asc
+    | project FileName, frequency, Since, LastSeen 
+    // restrict results to unusual processes seen in last day 
+    | where LastSeen >= ago(1d)


### PR DESCRIPTION
Multiple queries update to use split instead of the convoluted reverse() to extract filename.
Copied all queries to Deployed - on the basis that the PR for this in ASI-portal repo has been completed already.