### PR TITLE
Replaced 'Domain' with 'Computer' in the join because domain will be …

### DIFF
--- a/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.txt
+++ b/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.txt
@@ -31,9 +31,8 @@ SecurityEvent
 | where EventID == 4732
 //TargetSid is the builin Admins group: S-1-5-32-544
 | where TargetSid == "S-1-5-32-544"
-| project GroupAddTime = TimeGenerated, GroupAddEventID = EventID, GroupAddActivity = Activity, Computer = toupper(Computer), GroupName = TargetUserName, Domain = toupper(TargetDomainName), GroupSid = TargetSid, UserAdded = SubjectUserName, UserAddedSid = SubjectUserSid, CreatedUser = tolower(SubjectUserName)
+| project GroupAddTime = TimeGenerated, GroupAddEventID = EventID, GroupAddActivity = Activity, Computer = toupper(Computer), GroupName = TargetUserName, Domain = toupper(TargetDomainName), GroupSid = TargetSid, UserAdded = SubjectUserName, UserAddedSid = SubjectUserSid, CreatedUser = tolower(SubjectUserName), CreatedUserSid = MemberSid
 )
-on CreatedUser, Domain
+on CreatedUserSid, Computer
 //Create User first, then the add to the group.
-| where CreatedUserTime < GroupAddTime
 | project Computer, CreatedUserTime, CreatedUserEventID, CreatedUserActivity, CreatedUser, CreatedUserSid, Domain, GroupAddTime, GroupAddEventID, GroupAddActivity, AccountUsedToCreateUser, GroupName, GroupSid, UserAdded, UserAddedSid 

--- a/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.txt
+++ b/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.txt
@@ -33,6 +33,6 @@ SecurityEvent
 | where TargetSid == "S-1-5-32-544"
 | project GroupAddTime = TimeGenerated, GroupAddEventID = EventID, GroupAddActivity = Activity, Computer = toupper(Computer), GroupName = TargetUserName, Domain = toupper(TargetDomainName), GroupSid = TargetSid, UserAdded = SubjectUserName, UserAddedSid = SubjectUserSid, CreatedUser = tolower(SubjectUserName), CreatedUserSid = MemberSid
 )
-on CreatedUserSid, Computer
+on CreatedUserSid
 //Create User first, then the add to the group.
 | project Computer, CreatedUserTime, CreatedUserEventID, CreatedUserActivity, CreatedUser, CreatedUserSid, Domain, GroupAddTime, GroupAddEventID, GroupAddActivity, AccountUsedToCreateUser, GroupName, GroupSid, UserAdded, UserAddedSid 


### PR DESCRIPTION
…'Builtin' for the group and host/domain for the user, preventing a match. Also replaced 'CreatedUser' with 'CreatedUserSid' because the group add entry may not reliably include the name of the user added to the group (SID is also a more reliable identifier in general). Lasltly, removed 'where CreatedUserTime < GroupAddTime' because I'm not sure any other case is possible without manually rigging the logs.

Fixes #

## Proposed Changes

  -
  -
  -
