### PR TITLE
Fixed bug in Symantec dashboards that required both sum and sort operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,6 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 **/.ipynb_checkpoints/**
+
+#mac osx files
+.DS_Store

--- a/Dashboards/Symantec_Security_Overview_Dashboard.json
+++ b/Dashboards/Symantec_Security_Overview_Dashboard.json
@@ -1,13 +1,4 @@
 {
-    "name": "SymantecSecurityOverviewDashboard-{Workspace_Name}",
-    "type": "Microsoft.Portal/dashboards",
-    "location": "{Dashboard_Location}",
-    "tags": {
-      "dashboardKey": "SymantecSecurityOverviewDashboard",
-      "hidden-title": "Symantec Security Overview Dashboard - {Workspace_Name}",
-      "version": "1.1",
-      "workspaceName": "{Workspace_Name}"
- },
   "properties": {
     "lenses": {
       "0": {
@@ -66,6 +57,27 @@
           },
           "2": {
             "position": {
+              "x": 14,
+              "y": 0,
+              "colSpan": 2,
+              "rowSpan": 1
+            },
+            "metadata": {
+              "inputs": [],
+              "type": "Extension/HubsExtension/PartType/MarkdownPart",
+              "settings": {
+                "content": {
+                  "settings": {
+                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n\n",
+                    "title": "",
+                    "subtitle": ""
+                  }
+                }
+              }
+            }
+          },
+          "3": {
+            "position": {
               "x": 0,
               "y": 1,
               "colSpan": 8,
@@ -76,9 +88,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -112,7 +124,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -143,7 +155,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Product distribution across events",
-                  "PartSubTitle": "Symantec Integrated Cyber Defence"
+                  "PartSubTitle": "Symantec Integrated Cyber Defence",
+                  "Query": "SymantecICDx_CL \n| summarize Event_Count=count() by Product_Name=product_name_s\n| sort by Event_Count  desc \n"
                 }
               },
               "asset": {
@@ -152,7 +165,7 @@
               }
             }
           },
-          "3": {
+          "4": {
             "position": {
               "x": 8,
               "y": 1,
@@ -164,9 +177,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -183,7 +196,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -218,7 +231,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Product event statistics",
-                  "PartSubTitle": "Symantec Integrated Cyber Defence"
+                  "PartSubTitle": "Symantec Integrated Cyber Defence",
+                  "Query": "SymantecICDx_CL \n| summarize Event_Count=count() by Product_Name=product_name_s\n| sort by Event_Count  desc \n"
                 }
               },
               "asset": {
@@ -227,7 +241,7 @@
               }
             }
           },
-          "4": {
+          "5": {
             "position": {
               "x": 0,
               "y": 6,
@@ -239,9 +253,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -275,7 +289,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -306,7 +320,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Event distribution, by category",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let catMapTable = datatable(category_id_d:double, category_name:string)\n  [\n    1, \"Security\",\n    2, \"License\",\n    3, \"Application Activity\",\n    4, \"Audit\",\n    5, \"System Activity\",\n    6, \"Diagnostic\",\n    7, \"Evidence of Compromise\",\n    8, \"Information Protection\"\n  ];\nSymantecICDx_CL  \n| join kind = inner (catMapTable) on category_id_d \n| summarize Event_Count=count() by Category=category_name\n| sort by Event_Count  desc \n"
                 }
               },
               "asset": {
@@ -315,7 +330,7 @@
               }
             }
           },
-          "5": {
+          "6": {
             "position": {
               "x": 8,
               "y": 6,
@@ -327,9 +342,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -346,7 +361,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -381,7 +396,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Event statistics, by category",
-                  "PartSubTitle": "Symantec Integrated Cyber Defence"
+                  "PartSubTitle": "Symantec Integrated Cyber Defence",
+                  "Query": "let catMapTable = datatable(category_id_d:double, category_name:string)\n  [\n    1, \"Security\",\n    2, \"License\",\n    3, \"Application Activity\",\n    4, \"Audit\",\n    5, \"System Activity\",\n    6, \"Diagnostic\",\n    7, \"Evidence of Compromise\",\n    8, \"Information Protection\"\n  ];\nSymantecICDx_CL  \n| join kind = inner (catMapTable) on category_id_d \n| summarize Event_Count=count() by Category=category_name\n| sort by Event_Count  desc \n"
                 }
               },
               "asset": {
@@ -390,7 +406,7 @@
               }
             }
           },
-          "6": {
+          "7": {
             "position": {
               "x": 0,
               "y": 11,
@@ -402,9 +418,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -421,7 +437,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -465,7 +481,7 @@
               }
             }
           },
-          "7": {
+          "8": {
             "position": {
               "x": 7,
               "y": 11,
@@ -477,9 +493,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -513,7 +529,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -552,30 +568,56 @@
                 "type": "ApplicationInsights"
               }
             }
+          }
+        }
+      }
+    },
+    "metadata": {
+      "model": {
+        "timeRange": {
+          "value": {
+            "relative": {
+              "duration": 24,
+              "timeUnit": 1
+            }
           },
-          "8": {
-            "position": {
-              "x": 14,
-              "y": 0,
-              "colSpan": 2,
-              "rowSpan": 1
-            },
-            "metadata": {
-              "inputs": [],
-              "type": "Extension/HubsExtension/PartType/MarkdownPart",
-              "settings": {
-                "content": {
-                  "settings": {
-                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n\n",
-                    "title": "",
-                    "subtitle": ""
-                  }
-                }
-              }
+          "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+        },
+        "filterLocale": {
+          "value": "en-us"
+        },
+        "filters": {
+          "value": {
+            "MsPortalFx_TimeRange": {
+              "model": {
+                "format": "utc",
+                "granularity": "auto",
+                "relative": "24h"
+              },
+              "displayCache": {
+                "name": "UTC Time",
+                "value": "Past 24 hours"
+              },
+              "filteredPartIds": [
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5009",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e500b",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e500d",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e500f",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5011",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5013"
+              ]
             }
           }
         }
       }
     }
-  }
+  },
+  "id": "arm/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/ICDX_ASI/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard-ICDX-LA-workspace",
+  "name": "SymantecSecurityOverviewDashboard-ICDX-LA-workspace",
+  "type": "Microsoft.Portal/dashboards",
+  "location": "westus2",
+  "tags": {
+    "hidden-title": "Symantec Security Overview Dashboard - ICDX-LA-workspace"
+  },
+  "apiVersion": "2015-08-01-preview"
 }

--- a/Dashboards/Symantec_URL_threats_overview_dashboard.json
+++ b/Dashboards/Symantec_URL_threats_overview_dashboard.json
@@ -1,19 +1,40 @@
 {
-  "name": "SymantecURLThreatsOverviewDashboard-{Workspace_Name}",
-  "type": "Microsoft.Portal/dashboards",
-  "location": "{Dashboard_Location}",
-  "tags": {
-    "dashboardKey": "SymantecURLThreatsOverviewDashboard",
-    "hidden-title": "Symantec URL Threats Overview Dashboard - {Workspace_Name}",
-    "version": "1.1",
-    "workspaceName": "{Workspace_Name}"
-},
   "properties": {
     "lenses": {
       "0": {
         "order": 0,
         "parts": {
           "0": {
+            "position": {
+              "x": 0,
+              "y": 0,
+              "colSpan": 1,
+              "rowSpan": 1
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "subscriptionId",
+                  "value": "156f424c-febb-4286-9691-f6a24d2e7b5c"
+                },
+                {
+                  "name": "resourceGroup",
+                  "value": "ICDX_ASI"
+                },
+                {
+                  "name": "workspaceName",
+                  "value": "ICDX-LA-workspace"
+                },
+                {
+                  "name": "menuItemToOpen",
+                  "value": "Dashboards"
+                }
+              ],
+              "type": "Extension/Microsoft_Azure_Security_Insights/PartType/AsiOverviewPart",
+              "defaultMenuItemId": "0"
+            }
+          },
+          "1": {
             "position": {
               "x": 1,
               "y": 0,
@@ -34,7 +55,28 @@
               }
             }
           },
-          "1": {
+          "2": {
+            "position": {
+              "x": 16,
+              "y": 0,
+              "colSpan": 2,
+              "rowSpan": 1
+            },
+            "metadata": {
+              "inputs": [],
+              "type": "Extension/HubsExtension/PartType/MarkdownPart",
+              "settings": {
+                "content": {
+                  "settings": {
+                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n",
+                    "title": "",
+                    "subtitle": ""
+                  }
+                }
+              }
+            }
+          },
+          "3": {
             "position": {
               "x": 0,
               "y": 1,
@@ -46,9 +88,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -65,7 +107,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -100,7 +142,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Number of URL events",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name\n| sort by Event_Count desc \n"
                 }
               },
               "asset": {
@@ -109,7 +152,7 @@
               }
             }
           },
-          "2": {
+          "4": {
             "position": {
               "x": 6,
               "y": 1,
@@ -121,9 +164,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -140,7 +183,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -174,8 +217,9 @@
               "type": "Extension/AppInsightsExtension/PartType/AnalyticsPart",
               "settings": {
                 "content": {
-                  "PartTitle": "Of events with URL objects",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartTitle": "Number Of events with URL objects",
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where connection_url_path_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name\n| sort by Event_Count desc \n"
                 }
               },
               "asset": {
@@ -184,7 +228,7 @@
               }
             }
           },
-          "3": {
+          "5": {
             "position": {
               "x": 12,
               "y": 1,
@@ -196,9 +240,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -232,7 +276,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -263,7 +307,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Type distribution across events with URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where connection_url_path_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name\n| sort by Event_Count desc\n"
                 }
               },
               "asset": {
@@ -272,7 +317,7 @@
               }
             }
           },
-          "4": {
+          "6": {
             "position": {
               "x": 0,
               "y": 5,
@@ -284,9 +329,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -325,7 +370,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -356,7 +401,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "URL events trend",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name, bin(TimeGenerated, 1h)\n| render timechart \n"
                 }
               },
               "asset": {
@@ -365,7 +411,7 @@
               }
             }
           },
-          "5": {
+          "7": {
             "position": {
               "x": 12,
               "y": 5,
@@ -377,9 +423,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -413,7 +459,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -444,7 +490,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Disposition distribution across events with URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let disptypeMap = datatable(disposition_type:string, Action:string)\n[\n\"1,20\", \"LOGON\",\n\"2,20\", \"LOGOFF\",\n\"1,21\", \"Create\",\n\"2,21\", \"Update\",\n\"3,21\", \"Delete\",\n\"10,22\", \"User rule override\",\n\"20,22\", \"Admin request\",\n\"30,22\", \"User policy override\",\n\"31,22\", \"User policy override extend time\",\n\"32,22\", \"User policy restore manual\",\n\"33,22\", \"User policy restore automatic\",\n\"40,22\", \"Execution block override\",\n\"41,22\", \"User policy override removed\",\n\"1,1000\", \"Log\",\n\"1,1005\", \"Normal\",\n\"2,1005\", \"Overload\",\n\"1,1006\", \"Normal\",\n\"2,1006\", \"Overload\",\n\"1,1007\", \"Normal\",\n\"2,1007\", \"Overload\",\n\"1,8025\", \"Blocked\",\n\"2,8025\", \"Allowed\",\n\"3,8025\", \"No Action\",\n\"4,8025\", \"Log\",\n\"5,8025\", \"Command Script\",\n\"6,8025\", \"Corrected\",\n\"7,8025\", \"Partially Corrected\",\n\"8,8025\", \"Uncorrected\",\n\"14,8025\", \"Detected\",\n\"1,8031\", \"Blocked\",\n\"2,8031\", \"Allowed\",\n\"3,8031\", \"No Action\",\n\"4,8031\", \"Log\",\n\"5,8031\", \"Command Script\",\n\"6,8031\", \"Corrected\",\n\"7,8031\", \"Partially Corrected\",\n\"8,8031\", \"Uncorrected\",\n\"10,8031\", \"Delayed (required reboot)\",\n\"11,8031\", \"Deleted\",\n\"12,8031\", \"Quarantined\",\n\"13,8031\", \"Restored\",\n\"14,8031\", \"Detected\",\n\"1,8030\", \"Blocked\",\n\"2,8030\", \"Allowed\",\n\"3,8030\", \"No Action\",\n\"4,8030\", \"Log\",\n\"5,8030\", \"Command Script\",\n\"8,8030\", \"Uncorrected\",\n\"10,8030\", \"Delayed (required reboot)\",\n\"11,8030\", \"Deleted\",\n\"14,8030\", \"Detected\",\n\"1,8029\", \"Blocked\",\n\"2,8029\", \"Allowed\",\n\"3,8029\", \"No Action\",\n\"4,8029\", \"Log\",\n\"5,8029\", \"Command Script\",\n\"6,8029\", \"Corrected\",\n\"7,8029\", \"Partially Corrected\",\n\"8,8029\", \"Uncorrected\",\n\"10,8029\", \"Delayed (required reboot)\",\n\"11,8029\", \"Deleted\",\n\"12,8029\", \"Quarantined\",\n\"13,8029\", \"Restored\",\n\"14,8029\", \"Detected\",\n\"1,8028\", \"Blocked\",\n\"2,8028\", \"Allowed\",\n\"3,8028\", \"No Action\",\n\"4,8028\", \"Log\",\n\"5,8028\", \"Command Script\",\n\"6,8028\", \"Corrected\",\n\"7,8028\", \"Partially Corrected\",\n\"8,8028\", \"Uncorrected\",\n\"10,8028\", \"Delayed (required reboot)\",\n\"11,8028\", \"Deleted\",\n\"12,8028\", \"Quarantined\",\n\"13,8028\", \"Restored\",\n\"14,8028\", \"Detected\",\n\"1,8027\", \"Blocked\",\n\"2,8027\", \"Allowed\",\n\"3,8027\", \"No Action\",\n\"4,8027\", \"Log\",\n\"5,8027\", \"Command Script\",\n\"6,8027\", \"Corrected\",\n\"7,8027\", \"Partially Corrected\",\n\"8,8027\", \"Uncorrected\",\n\"10,8027\", \"Delayed (required reboot)\",\n\"11,8027\", \"Deleted\",\n\"12,8027\", \"Quarantined\",\n\"13,8027\", \"Restored\",\n\"14,8027\", \"Detected\",\n\"15,8027\", \"Terminated\",\n\"1,8032\", \"Blocked\",\n\"2,8032\", \"Allowed\",\n\"3,8032\", \"No Action\",\n\"4,8032\", \"Log\",\n\"5,8032\", \"Command Script\",\n\"6,8032\", \"Corrected\",\n\"7,8032\", \"Partially Corrected\",\n\"8,8032\", \"Uncorrected\",\n\"10,8032\", \"Delayed (required reboot)\",\n\"11,8032\", \"Deleted\",\n\"13,8032\", \"Restored\",\n\"14,8032\", \"Detected\",\n\"1,8033\", \"Blocked\",\n\"2,8033\", \"Allowed\",\n\"3,8033\", \"No Action\",\n\"4,8033\", \"Log\",\n\"5,8033\", \"Command Script\",\n\"6,8033\", \"Corrected\",\n\"7,8033\", \"Partially Corrected\",\n\"8,8033\", \"Uncorrected\",\n\"10,8033\", \"Delayed (required reboot)\",\n\"11,8033\", \"Deleted\",\n\"13,8033\", \"Restored\",\n\"14,8033\", \"Detected\",\n\"1,8026\", \"Blocked\",\n\"2,8026\", \"Allowed\",\n\"3,8026\", \"No Action\",\n\"4,8026\", \"Log\",\n\"5,8026\", \"Command Script\",\n\"14,8026\", \"Detected\",\n\"15,8026\", \"Terminated\",\n\"4,8060\", \"Log\",\n\"1,8040\", \"Blocked\",\n\"2,8040\", \"Allowed\",\n\"3,8040\", \"No Action\",\n\"4,8040\", \"Log\",\n\"4,8045\", \"Log\",\n\"10,8045\", \"Delayed\",\n\"15,8045\", \"Terminated\",\n\"1,8047\", \"Blocked\",\n\"2,8047\", \"Allowed\",\n\"3,8047\", \"No Action\",\n\"4,8047\", \"Log\",\n\"5,8047\", \"Command Script\",\n\"6,8047\", \"Corrected\",\n\"7,8047\", \"Partially Corrected\",\n\"8,8047\", \"Uncorrected\",\n\"10,8047\", \"Delayed (required reboot)\",\n\"11,8047\", \"Deleted\",\n\"12,8047\", \"Quarantined\",\n\"13,8047\", \"Restored\",\n\"14,8047\", \"Detected\",\n\"1,8048\", \"Blocked\",\n\"2,8048\", \"Allowed\",\n\"3,8048\", \"No Action\",\n\"4,8048\", \"Log\",\n\"5,8048\", \"Command Script\",\n\"6,8048\", \"Corrected\",\n\"7,8048\", \"Partially Corrected\",\n\"8,8048\", \"Uncorrected\",\n\"10,8048\", \"Delayed (required reboot)\",\n\"11,8048\", \"Deleted\",\n\"12,8048\", \"Quarantined\",\n\"13,8048\", \"Restored\",\n\"14,8048\", \"Detected\",\n\"1,8020\", \"Started\",\n\"2,8020\", \"Completed\",\n\"3,8020\", \"Cancelled\",\n\"4,8020\", \"Duration Violation\",\n\"5,8020\", \"Pause Violation\",\n\"6,8020\", \"Error\",\n\"1,8021\", \"Permission\",\n\"2,8021\", \"Encrypted\",\n\"3,8021\", \"Size\",\n\"4,8021\", \"Error\",\n\"5,8021\", \"Malformed\",\n\"1,8034\", \"Blocked\",\n\"2,8034\", \"Allowed\",\n\"12,8034\", \"Quarantined\",\n\"1,8036\", \"Blocked\",\n\"2,8036\", \"Allowed\",\n\"1,8037\", \"Blocked\",\n\"2,8037\", \"Allowed\",\n\"3,8037\", \"No Action\",\n\"4,8037\", \"Log\",\n\"5,8037\", \"Command Script\",\n\"6,8037\", \"Corrected\",\n\"7,8037\", \"Partially Corrected\",\n\"8,8037\", \"Uncorrected\",\n\"10,8037\", \"Delayed (required reboot)\",\n\"11,8037\", \"Deleted\",\n\"12,8037\", \"Quarantined\",\n\"13,8037\", \"Restored\",\n\"14,8037\", \"Detected\",\n\"1,8038\", \"Blocked\",\n\"2,8038\", \"Allowed\",\n\"4,8045\", \"Log\",\n\"10,8045\", \"Delayed\",\n\"15,8045\", \"Terminated\",\n\"1,8\", \"Install\",\n\"2,8\", \"Remove\",\n\"3,8\", \"Update\",\n\"4,8\", \"Expire\",\n\"5,8\", \"Exceed\",\n\"6,8\", \"Report\",\n\"7,8\", \"Low Count\",\n\"8,8\", \"Expiring\",\n\"4,1\", \"Application Log\",\n\"1,2\", \"Install\",\n\"2,2\", \"Remove\",\n\"3,2\", \"Start\",\n\"4,2\", \"Stop\",\n\"5,2\", \"Heartbeat\",\n\"1,3\", \"Code\",\n\"2,3\", \"Content\",\n\"3,3\", \"Configuration\",\n\"4,3\", \"Policy\",\n\"1,6\", \"Code\",\n\"2,6\", \"Content\",\n\"3,6\", \"Configuration\",\n\"4,6\", \"Policy\",\n\"1,7\", \"E-mail\",\n\"2,7\", \"SMS\",\n\"1,9\", \"Register\",\n\"2,9\", \"Unregister\",\n\"1,11\", \"Submitted\",\n\"2,11\", \"Queued\",\n\"3,11\", \"Started\",\n\"4,11\", \"Cancel Requested\",\n\"5,11\", \"Completed\",\n\"6,11\", \"Canceled\",\n\"7,11\", \"Error\",\n\"8,11\", \"Rejected\",\n\"1,15\", \"Failure\",\n\"2,15\", \"Encryption Started\",\n\"3,15\", \"Encryption Finished\",\n\"10,15\", \"Recovery Key Recycled\",\n\"1,40\", \"Install\",\n\"2,40\", \"Remove\",\n\"3,40\", \"Update\",\n\"1,41\", \"Expiring\",\n\"2,41\", \"Expired\",\n\"1,8080\", \"Exists\",\n\"2,8080\", \"Partial\",\n\"1,8081\", \"Exists\",\n\"2,8081\", \"Partial\",\n\"1,8082\", \"Exists\",\n\"2,8082\", \"Partial\",\n\"1,8085\", \"Exists\",\n\"2,8085\", \"Partial\",\n\"1,8086\", \"Exists\",\n\"2,8086\", \"Partial\",\n\"1,8087\", \"Exists\",\n\"2,8087\", \"Partial\",\n\"1,8089\", \"Exists\",\n\"2,8089\", \"Partial\",\n\"1,8090\", \"Exists\",\n\"2,8090\", \"Partial\",\n\"1,8100\", \"Remediation Completed\",\n\"2,8100\", \"Partial Remediation\",\n\"1,8101\", \"Remediation Completed\",\n\"2,8101\", \"Partial Remediation\",\n\"1,8105\", \"Remediation Completed\",\n\"2,8105\", \"Partial Remediation\",\n\"1,8106\", \"Remediation Completed\",\n\"2,8106\", \"Partial Remediation\",\n\"1,8109\", \"Remediation Completed\",\n\"2,8109\", \"Partial Remediation\",\n\"1,8110\", \"Remediation Completed\",\n\"2,8110\", \"Partial Remediation\",\n\"3,8119\", \"Does Not Exists\",\n\"4,8119\", \"Error\",\n\"5,8119\", \"Unsupported\",\n\"1,8107\", \"Remediation Completed\",\n\"2,8107\", \"Partial Remediation\",\n\"1,8084\", \"Exists\",\n\"2,8084\", \"Partial\",\n\"1,8083\", \"Exists\",\n\"2,8083\", \"Partial\",\n\"1,8104\", \"Remediation Completed\",\n\"2,8104\", \"Partial Remediation\",\n\"1,8103\", \"Remediation Completed\",\n\"2,8103\", \"Partial Remediation\",\n\"1,8102\", \"Remediation Completed\",\n\"2,8102\", \"Partial Remediation\",\n\"1,8000\", \"Logon\",\n\"2,8000\", \"Logoff\",\n\"1,8004\", \"Create\",\n\"2,8004\", \"Delete\",\n\"4,8004\", \"Rename\",\n\"5,8004\", \"Modify\",\n\"6,8004\", \"Set Attributes\",\n\"7,8004\", \"Set Security\",\n\"8,8004\", \"Get Attributes\",\n\"9,8004\", \"Get Security\",\n\"10,8004\", \"Encrypt\",\n\"11,8004\", \"Decrypt\",\n\"12,8004\", \"Mount\",\n\"13,8004\", \"Unmount\",\n\"1,8005\", \"Create Key\",\n\"2,8005\", \"Delete Key\",\n\"3,8005\", \"Open Key\",\n\"4,8005\", \"Rename Key\",\n\"5,8005\", \"Set Key Security Descriptor\",\n\"6,8005\", \"Restore Key\",\n\"1,8006\", \"Get Value\",\n\"2,8006\", \"Set Value\",\n\"3,8006\", \"Delete Value\",\n\"1,8008\", \"Page Allocate\",\n\"2,8008\", \"Page Modify\",\n\"3,8008\", \"Page Delete\",\n\"4,8008\", \"Buffer Overflow\",\n\"1,8009\", \"Create\",\n\"2,8009\", \"Read\",\n\"3,8009\", \"Delete\",\n\"5,8010\", \"System Activity\",\n\"5,8011\", \"System Activity\",\n\"5,8012\", \"System Activity\",\n\"5,8013\", \"System Activity\",\n\"1,8003\", \"Create\",\n\"2,8003\", \"Delete\",\n\"3,8003\", \"Open\",\n\"4,8003\", \"Rename\",\n\"5,8003\", \"Modify\",\n\"6,8003\", \"Set Attributes\",\n\"7,8003\", \"Set Security\",\n\"8,8003\", \"Get Attributes\",\n\"9,8003\", \"Get Security\",\n\"10,8003\", \"Encrypt\",\n\"11,8003\", \"Decrypt\",\n\"1,8002\", \"Load\",\n\"2,8002\", \"Unload\",\n\"1,8035\", \"Blocked\",\n\"2,8035\", \"Allowed\",\n\"3,8035\", \"No Action\",\n\"4,8035\", \"Log\",\n\"5,8035\", \"Command Script\",\n\"6,8035\", \"Corrected\",\n\"7,8035\", \"Partially Corrected\",\n\"8,8035\", \"Uncorrected\",\n\"10,8035\", \"Delayed (required reboot)\",\n\"11,8035\", \"Deleted\",\n\"12,8035\", \"Quarantined\",\n\"13,8035\", \"Restored\",\n\"14,8035\", \"Detected\",\n\"1,8050\", \"Blocked\",\n\"2,8050\", \"Allowed\",\n\"3,8050\", \"Dropped\",\n\"4,8050\", \"Deleted\",\n\"5,8050\", \"Isolated\",\n\"1,8070\", \"Passed\",\n\"2,8070\", \"Failed\",\n\"3,8070\", \"Soft Fail\",\n\"4,8070\", \"Log\",\n\"1,8071\", \"Compliance Check\",\n\"2,8071\", \"Remediation Check\",\n\"1,8001\", \"Launch\",\n\"2,8001\", \"Terminate\",\n\"3,8001\", \"Open\",\n\"4,8001\", \"Inject\",\n\"1,8007\", \"Connect\",\n\"2,8007\", \"Disconnect\",\n\"1,30\", \"Install\",\n\"2,30\", \"Remove\",\n\"3,30\", \"Update\",\n\"1,31\", \"Expiring\",\n\"2,31\", \"Expired\",\n\"1,32\", \"Low Count\",\n\"2,32\", \"Exceeded\",\n\"1,9000\", \"Blocked\",\n\"2,9000\", \"Allowed\",\n\"1,9001\", \"Blocked\",\n\"2,9001\", \"Allowed\",\n\"12,9001\", \"Quarantined\",\n\"1,9002\", \"Blocked\",\n\"2,9002\", \"Allowed\",\n\"12,9002\", \"Quarantined\",\n\"20,9002\", \"Approved\",\n\"21,9002\", \"Custom Action\",\n\"22,9002\", \"Expunged\",\n\"1,9003\", \"Blocked\",\n\"2,9003\", \"Allowed\"\n];\nSymantecICDx_CL\n| where connection_url_path_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| extend disposition_type = strcat(toint(id_d), \",\", toint(type_id_d))  \n| join kind = inner (disptypeMap) on disposition_type\n| summarize Action_Count=count() by Action\n"
                 }
               },
               "asset": {
@@ -453,7 +500,7 @@
               }
             }
           },
-          "6": {
+          "8": {
             "position": {
               "x": 0,
               "y": 9,
@@ -465,9 +512,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -501,7 +548,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -532,7 +579,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Product distribution across events with URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Exchange"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where connection_url_path_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| summarize Count=count() by Product_Name=product_name_s\n| sort by Count desc\n"
                 }
               },
               "asset": {
@@ -541,7 +589,7 @@
               }
             }
           },
-          "7": {
+          "9": {
             "position": {
               "x": 6,
               "y": 9,
@@ -553,9 +601,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -589,7 +637,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -620,7 +668,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 25 hosts across URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where connection_url_host_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n| summarize Count=count() by Host=connection_url_host_s\n| sort by Count desc\n| top 25 by Count desc\n"
                 }
               },
               "asset": {
@@ -629,7 +678,7 @@
               }
             }
           },
-          "8": {
+          "10": {
             "position": {
               "x": 12,
               "y": 9,
@@ -641,9 +690,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -677,7 +726,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -707,8 +756,9 @@
               "type": "Extension/AppInsightsExtension/PartType/AnalyticsPart",
               "settings": {
                 "content": {
-                  "PartTitle": "AnalytSeverity distribution across events with URL objectics",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartTitle": "Analytics Severity distribution across events with URL objects",
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let severityMapTable = datatable(severity_id_d:double, severity_name:string)\n  [\n    0, \"Unknown\",\n    1, \"Informational\",\n    2, \"Warning\",\n    3, \"Minor\",\n    4, \"Major\",\n    5, \"Critical\",\n    6, \"Fatal\"\n];\nSymantecICDx_CL  \n| join kind = inner (severityMapTable) on severity_id_d \n| summarize Count=count() by Severity_Type=severity_name\n| sort by Count desc\n"
                 }
               },
               "asset": {
@@ -717,7 +767,7 @@
               }
             }
           },
-          "9": {
+          "11": {
             "position": {
               "x": 0,
               "y": 13,
@@ -729,9 +779,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -765,7 +815,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -796,7 +846,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 25 users across events with URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where connection_url_path_s <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107))\n | extend username = iff(user_name_s <> \"\", user_name_s , \"Unknown\")\n | summarize Count=count() by User_Name=username \n | sort by Count desc\n | top 25 by Count desc\n"
                 }
               },
               "asset": {
@@ -805,7 +856,7 @@
               }
             }
           },
-          "10": {
+          "12": {
             "position": {
               "x": 6,
               "y": 13,
@@ -817,9 +868,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -853,7 +904,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -884,7 +935,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Threat categories across events with URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let threatTypeMap = datatable(threat_type_id_d:double, threat_category:string)\n  [\n    1, \"Malware\",\n    2, \"Behavioural\",\n    3, \"Potentially Unwanted Applications\",\n    4, \"Exploit (pep)\",\n    5, \"Heuristic\",\n    6, \"Security Risk\"\n  ];\nSymantecICDx_CL\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107)) \n| join kind = inner (threatTypeMap) on threat_type_id_d \n| summarize Count=count() by Threat_Category=threat_category\n| sort by Count desc\n"
                 }
               },
               "asset": {
@@ -893,7 +945,7 @@
               }
             }
           },
-          "11": {
+          "13": {
             "position": {
               "x": 12,
               "y": 13,
@@ -905,9 +957,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -941,7 +993,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -972,7 +1024,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 25 threats across events with URL object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where threat_name_s  <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107)) \n| summarize Count=count() by  Threat_Name=threat_name_s\n| sort by Count desc\n| top 25 by Count desc\n"
                 }
               },
               "asset": {
@@ -981,7 +1034,7 @@
               }
             }
           },
-          "12": {
+          "14": {
             "position": {
               "x": 0,
               "y": 17,
@@ -993,9 +1046,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -1012,7 +1065,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecURLTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -1047,7 +1100,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 25 URL objects with threat",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where connection_url_path_s  <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021  or type_id_d==8040 or type_id_d==8050)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002 or type_id_d==8007 or type_id_d==8010)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102 or type_id_d==8087 or type_id_d==8107)) \n| extend threatname = iff(threat_name_s <> \"\", threat_name_s , \"Unknown\")\n| extend domainname = iff(connection_url_host_s <> \"\", connection_url_host_s , \"-\")\n| summarize Event_Count=count() by Domain=domainname, URL_Path=connection_url_path_s, Threat_Name=threatname, Product_Name=product_name_s\n| sort by Event_Count desc\n| top 25 by Event_Count desc\n"
                 }
               },
               "asset": {
@@ -1055,60 +1109,86 @@
                 "type": "ApplicationInsights"
               }
             }
-          },
-          "13": {
-            "position": {
-              "x": 16,
-              "y": 0,
-              "colSpan": 2,
-              "rowSpan": 1
-            },
-            "metadata": {
-              "inputs": [],
-              "type": "Extension/HubsExtension/PartType/MarkdownPart",
-              "settings": {
-                "content": {
-                  "settings": {
-                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n",
-                    "title": "",
-                    "subtitle": ""
-                  }
-                }
-              }
+          }
+        }
+      }
+    },
+    "metadata": {
+      "model": {
+        "timeRange": {
+          "value": {
+            "relative": {
+              "duration": 24,
+              "timeUnit": 1
             }
           },
-          "14": {
-            "position": {
-              "x": 0,
-              "y": 0,
-              "colSpan": 1,
-              "rowSpan": 1
-            },
-            "metadata": {
-              "inputs": [
-                {
-                  "name": "subscriptionId",
-                  "value": "{Subscription_Id}"
-                },
-                {
-                  "name": "resourceGroup",
-                  "value": "{Resource_Group}"
-                },
-                {
-                  "name": "workspaceName",
-                  "value": "{Workspace_Name}"
-                },
-                {
-                  "name": "menuItemToOpen",
-                  "value": "Dashboards"
-                }
-              ],
-              "type": "Extension/Microsoft_Azure_Security_Insights/PartType/AsiOverviewPart",
-              "defaultMenuItemId": "0"
+          "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+        },
+        "filterLocale": {
+          "value": "en-us"
+        },
+        "filters": {
+          "value": {
+            "MsPortalFx_TimeRange": {
+              "model": {
+                "format": "utc",
+                "granularity": "auto",
+                "relative": "24h"
+              },
+              "displayCache": {
+                "name": "UTC Time",
+                "value": "Past 24 hours"
+              },
+              "filteredPartIds": [
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b5710e",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57110",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57112",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57114",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57116",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57118",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b5711a",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b5711c",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b5711e",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57120",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57122",
+                "StartboardPart-AnalyticsPart-6136d6f5-8a5a-4c02-af45-4a4b56b57124",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad077",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad079",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad07b",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad07d",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad07f",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad081",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad083",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad085",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad087",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad089",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad08b",
+                "StartboardPart-AnalyticsPart-4e674033-38bc-411e-9c1d-29b4875ad08d",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0c7",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0c9",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0cb",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0cd",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0cf",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0d1",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0d3",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0d5",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0d7",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0d9",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0db",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d0dd"
+              ]
             }
           }
         }
       }
     }
-  }
+  },
+  "id": "arm/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/ICDX_ASI/providers/Microsoft.Portal/dashboards/SymantecURLThreatsOverviewDashboard-ICDX-LA-workspace",
+  "name": "SymantecURLThreatsOverviewDashboard-ICDX-LA-workspace",
+  "type": "Microsoft.Portal/dashboards",
+  "location": "westus2",
+  "tags": {
+    "hidden-title": "Symantec URL Threats Overview Dashboard - ICDX-LA-workspace"
+  },
+  "apiVersion": "2015-08-01-preview"
 }

--- a/Dashboards/Symantec_file_threats_overview_dashboard.json
+++ b/Dashboards/Symantec_file_threats_overview_dashboard.json
@@ -1,19 +1,40 @@
 {
-  "name": "SymantecFileThreatsOverviewDashboard-{Workspace_Name}",
-  "type": "Microsoft.Portal/dashboards",
-  "location": "{Dashboard_Location}",
-  "tags": {
-    "dashboardKey": "SymantecFileThreatsOverviewDashboard",
-    "hidden-title": "Symantec File Threats Overview Dashboard - {Workspace_Name}",
-    "version": "1.1",
-    "workspaceName": "{Workspace_Name}"
-},
   "properties": {
     "lenses": {
       "0": {
         "order": 0,
         "parts": {
           "0": {
+            "position": {
+              "x": 0,
+              "y": 0,
+              "colSpan": 1,
+              "rowSpan": 1
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "subscriptionId",
+                  "value": "156f424c-febb-4286-9691-f6a24d2e7b5c"
+                },
+                {
+                  "name": "resourceGroup",
+                  "value": "ICDX_ASI"
+                },
+                {
+                  "name": "workspaceName",
+                  "value": "ICDX-LA-workspace"
+                },
+                {
+                  "name": "menuItemToOpen",
+                  "value": "Dashboards"
+                }
+              ],
+              "type": "Extension/Microsoft_Azure_Security_Insights/PartType/AsiOverviewPart",
+              "defaultMenuItemId": "0"
+            }
+          },
+          "1": {
             "position": {
               "x": 1,
               "y": 0,
@@ -34,7 +55,28 @@
               }
             }
           },
-          "1": {
+          "2": {
+            "position": {
+              "x": 16,
+              "y": 0,
+              "colSpan": 2,
+              "rowSpan": 1
+            },
+            "metadata": {
+              "inputs": [],
+              "type": "Extension/HubsExtension/PartType/MarkdownPart",
+              "settings": {
+                "content": {
+                  "settings": {
+                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n",
+                    "title": "",
+                    "subtitle": ""
+                  }
+                }
+              }
+            }
+          },
+          "3": {
             "position": {
               "x": 0,
               "y": 1,
@@ -46,9 +88,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -65,7 +107,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -100,7 +142,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Number of file events",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n | where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name\n"
                 }
               },
               "asset": {
@@ -109,7 +152,7 @@
               }
             }
           },
-          "2": {
+          "4": {
             "position": {
               "x": 6,
               "y": 1,
@@ -121,18 +164,19 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "44e4eff8-1fcb-4a22-a7d6-992ac7286382",
-                    "ResourceGroup": "SOC",
-                    "Name": "CyberSecurityDemo"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace",
+                    "ResourceId": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/ICDX_ASI/providers/Microsoft.OperationalInsights/workspaces/ICDX-LA-workspace"
                   }
                 },
                 {
                   "name": "Query",
-                  "value": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDX_CL\n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name\n| sort by Event_Count desc\n"
+                  "value": "let typeMapTable = datatable(type_id_d:double, type_name:string)   \n  [     \n     1,  \"Application Log\", \n     2,  \"Application Lifecycle\", \n     3,  \"Update\",     \n     6,  \"Update Available\",     \n     7,  \"User Message\",     \n     9,  \"Registration\",     \n     11, \"Commmand Activity\",     \n     15, \"BitLocker\",     \n     20, \"User Session Audit\",     \n     21, \"Entity Audit\",     \n     22, \"Policy Override Audit\",     \n     40, \"Certificate Lifecycle\",     \n     41, \"Certificate Expiry\",     \n     30, \"License Lifecycle\",     \n     31, \"License Expiry\",     \n     32, \"License Count\",     \n     1000, \"Status\",     \n     1005, \"CPU Usage\",     \n     1006, \"Memory Usage\",     \n     1007, \"Throughput\",     \n     8000, \"User Session Activity\",     \n     8001, \"Process Activity\",     \n     8002, \"Module Activity\",     \n     8003, \"File Activity\",     \n     8004, \"Directory Activity\",     \n     8005, \"Registry Key Activity\",     \n     8006, \"Registry Value Activity\",     \n     8007, \"Host Network Activity\",     \n     8008, \"Memory Activity\",     \n     8009, \"Kernel Activity\",     \n     8010, \"Network Activity\",     \n     8011, \"Email Activity\",     \n     8012, \"Email File Activity\",     \n     8013, \"Email URL Activity\",     \n     8014, \"Host Network Traffice Activity\",     \n     8020, \"Scan\",     \n     8021, \"Unscannable File\",     \n     8025, \"Boot Record Detection\",     \n     8026, \"User Session Detection\",     \n     8027, \"Process Detection\",     \n     8028, \"Module Detection\",     \n     8029, \"Memory Detection\",     \n     8030, \"Kernel Detection\",     \n     8031, \"File Detection\",     \n     8032, \"Registry Key Detection\",     \n     8033, \"Registry Value Detection\",     \n     8034, \"Email File Detection\",     \n     8035, \"Email Detection\",     \n     8036, \"Email URL Detection\",     \n     8037, \"Host Network Traffic Detection\",     \n     8038, \"Peripheral Device Detection\",     \n     8040, \"Host Network Detection\",     \n     8045, \"Process Response\",     \n     8046, \"File Response\",     \n     8047, \"Registry Key Response\",     \n     8048, \"Registry Value Response\",     \n     8050, \"Network Detection\",     \n     8060, \"Monitored Source\",     \n     8070, \"Compliance Scan\",     \n     8071, \"Compliance\",     \n     8080, \"User Session Query Result\",     \n     8081, \"Process Query Result\",     \n     8082, \"Module Query Result\",     \n     8083, \"File Query Result\",     \n     8084, \"Directory Query Result\",     \n     8085, \"Registry Key Query Result\",     \n     8086, \"Registry Value Query Result\",     \n     8087, \"Network Query Result\",     \n     8089, \"Kernel Object Query Result\",     \n     8090, \"Service Query Result\",     \n     8100, \"User Session Remediation\",     \n     8101, \"Process Remediation\",     \n     8102, \"Module Remediation\",     \n     8103, \"File Remediation\",     \n     8104, \"Directory Remediation\",     \n     8105, \"Registry Key Remediation\",     \n     8106, \"Registry Value Remediation\",     \n     8107, \"Network Remediation\",     \n     8109, \"Kernel Remediation\",     \n     8110, \"Service Remediation\",     \n     8119, \"Unsuccessful Remediation Result\",     \n     9000, \"Content Detection\",     \n     9001, \"File Content Detection\",     \n     9002, \"Email Content Detection\",     \n     9003, \"Instant Message Content Detection\"   \n  ];\nSymantecICDx_CL\n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or  (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or  (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name\n| sort by Event_Count desc\n"
                 },
                 {
                   "name": "TimeRange",
-                  "value": "P1D"
+                  "value": "PT4H"
                 },
                 {
                   "name": "Version",
@@ -140,11 +184,11 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/ICDX_ASI/providers/Microsoft.Portal/dashboards/SymantecFileThreatsOverviewDashboard-ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
-                  "value": "bc57fdcb-908b-4c51-a082-4039ef098e2b"
+                  "value": "8bb4248a-bac1-4c2b-a00e-9eb17c492935"
                 },
                 {
                   "name": "PartTitle",
@@ -152,7 +196,7 @@
                 },
                 {
                   "name": "PartSubTitle",
-                  "value": "my-analytics-workspace"
+                  "value": "ICDX-LA-workspace"
                 },
                 {
                   "name": "resourceTypeMode",
@@ -174,7 +218,7 @@
               "type": "Extension/AppInsightsExtension/PartType/AnalyticsPart",
               "settings": {
                 "content": {
-                  "PartTitle": "Number of file events with file objects",
+                  "PartTitle": "Number of File Events with File Objects",
                   "PartSubTitle": "Symantec Integrated Cyber Defense"
                 }
               },
@@ -184,7 +228,7 @@
               }
             }
           },
-          "3": {
+          "5": {
             "position": {
               "x": 12,
               "y": 1,
@@ -196,9 +240,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -232,7 +276,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -263,7 +307,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Type distribution across events with file object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize count() by type_name\n"
                 }
               },
               "asset": {
@@ -272,7 +317,7 @@
               }
             }
           },
-          "4": {
+          "6": {
             "position": {
               "x": 0,
               "y": 5,
@@ -284,9 +329,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -325,7 +370,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -356,7 +401,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "File events trend",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| join kind = inner (typeMapTable) on type_id_d \n| summarize Event_Count=count() by Event_Type=type_name, bin(TimeGenerated, 1h)\n| render timechart \n"
                 }
               },
               "asset": {
@@ -365,7 +411,7 @@
               }
             }
           },
-          "5": {
+          "7": {
             "position": {
               "x": 12,
               "y": 5,
@@ -377,9 +423,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -413,7 +459,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -444,7 +490,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Disposition distribution across events with file object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let disptypeMap = datatable(disposition_type:string, Action:string)\n[\n\"1,20\", \"LOGON\",\n\"2,20\", \"LOGOFF\",\n\"1,21\", \"Create\",\n\"2,21\", \"Update\",\n\"3,21\", \"Delete\",\n\"10,22\", \"User rule override\",\n\"20,22\", \"Admin request\",\n\"30,22\", \"User policy override\",\n\"31,22\", \"User policy override extend time\",\n\"32,22\", \"User policy restore manual\",\n\"33,22\", \"User policy restore automatic\",\n\"40,22\", \"Execution block override\",\n\"41,22\", \"User policy override removed\",\n\"1,1000\", \"Log\",\n\"1,1005\", \"Normal\",\n\"2,1005\", \"Overload\",\n\"1,1006\", \"Normal\",\n\"2,1006\", \"Overload\",\n\"1,1007\", \"Normal\",\n\"2,1007\", \"Overload\",\n\"1,8025\", \"Blocked\",\n\"2,8025\", \"Allowed\",\n\"3,8025\", \"No Action\",\n\"4,8025\", \"Log\",\n\"5,8025\", \"Command Script\",\n\"6,8025\", \"Corrected\",\n\"7,8025\", \"Partially Corrected\",\n\"8,8025\", \"Uncorrected\",\n\"14,8025\", \"Detected\",\n\"1,8031\", \"Blocked\",\n\"2,8031\", \"Allowed\",\n\"3,8031\", \"No Action\",\n\"4,8031\", \"Log\",\n\"5,8031\", \"Command Script\",\n\"6,8031\", \"Corrected\",\n\"7,8031\", \"Partially Corrected\",\n\"8,8031\", \"Uncorrected\",\n\"10,8031\", \"Delayed (required reboot)\",\n\"11,8031\", \"Deleted\",\n\"12,8031\", \"Quarantined\",\n\"13,8031\", \"Restored\",\n\"14,8031\", \"Detected\",\n\"1,8030\", \"Blocked\",\n\"2,8030\", \"Allowed\",\n\"3,8030\", \"No Action\",\n\"4,8030\", \"Log\",\n\"5,8030\", \"Command Script\",\n\"8,8030\", \"Uncorrected\",\n\"10,8030\", \"Delayed (required reboot)\",\n\"11,8030\", \"Deleted\",\n\"14,8030\", \"Detected\",\n\"1,8029\", \"Blocked\",\n\"2,8029\", \"Allowed\",\n\"3,8029\", \"No Action\",\n\"4,8029\", \"Log\",\n\"5,8029\", \"Command Script\",\n\"6,8029\", \"Corrected\",\n\"7,8029\", \"Partially Corrected\",\n\"8,8029\", \"Uncorrected\",\n\"10,8029\", \"Delayed (required reboot)\",\n\"11,8029\", \"Deleted\",\n\"12,8029\", \"Quarantined\",\n\"13,8029\", \"Restored\",\n\"14,8029\", \"Detected\",\n\"1,8028\", \"Blocked\",\n\"2,8028\", \"Allowed\",\n\"3,8028\", \"No Action\",\n\"4,8028\", \"Log\",\n\"5,8028\", \"Command Script\",\n\"6,8028\", \"Corrected\",\n\"7,8028\", \"Partially Corrected\",\n\"8,8028\", \"Uncorrected\",\n\"10,8028\", \"Delayed (required reboot)\",\n\"11,8028\", \"Deleted\",\n\"12,8028\", \"Quarantined\",\n\"13,8028\", \"Restored\",\n\"14,8028\", \"Detected\",\n\"1,8027\", \"Blocked\",\n\"2,8027\", \"Allowed\",\n\"3,8027\", \"No Action\",\n\"4,8027\", \"Log\",\n\"5,8027\", \"Command Script\",\n\"6,8027\", \"Corrected\",\n\"7,8027\", \"Partially Corrected\",\n\"8,8027\", \"Uncorrected\",\n\"10,8027\", \"Delayed (required reboot)\",\n\"11,8027\", \"Deleted\",\n\"12,8027\", \"Quarantined\",\n\"13,8027\", \"Restored\",\n\"14,8027\", \"Detected\",\n\"15,8027\", \"Terminated\",\n\"1,8032\", \"Blocked\",\n\"2,8032\", \"Allowed\",\n\"3,8032\", \"No Action\",\n\"4,8032\", \"Log\",\n\"5,8032\", \"Command Script\",\n\"6,8032\", \"Corrected\",\n\"7,8032\", \"Partially Corrected\",\n\"8,8032\", \"Uncorrected\",\n\"10,8032\", \"Delayed (required reboot)\",\n\"11,8032\", \"Deleted\",\n\"13,8032\", \"Restored\",\n\"14,8032\", \"Detected\",\n\"1,8033\", \"Blocked\",\n\"2,8033\", \"Allowed\",\n\"3,8033\", \"No Action\",\n\"4,8033\", \"Log\",\n\"5,8033\", \"Command Script\",\n\"6,8033\", \"Corrected\",\n\"7,8033\", \"Partially Corrected\",\n\"8,8033\", \"Uncorrected\",\n\"10,8033\", \"Delayed (required reboot)\",\n\"11,8033\", \"Deleted\",\n\"13,8033\", \"Restored\",\n\"14,8033\", \"Detected\",\n\"1,8026\", \"Blocked\",\n\"2,8026\", \"Allowed\",\n\"3,8026\", \"No Action\",\n\"4,8026\", \"Log\",\n\"5,8026\", \"Command Script\",\n\"14,8026\", \"Detected\",\n\"15,8026\", \"Terminated\",\n\"4,8060\", \"Log\",\n\"1,8040\", \"Blocked\",\n\"2,8040\", \"Allowed\",\n\"3,8040\", \"No Action\",\n\"4,8040\", \"Log\",\n\"4,8045\", \"Log\",\n\"10,8045\", \"Delayed\",\n\"15,8045\", \"Terminated\",\n\"1,8047\", \"Blocked\",\n\"2,8047\", \"Allowed\",\n\"3,8047\", \"No Action\",\n\"4,8047\", \"Log\",\n\"5,8047\", \"Command Script\",\n\"6,8047\", \"Corrected\",\n\"7,8047\", \"Partially Corrected\",\n\"8,8047\", \"Uncorrected\",\n\"10,8047\", \"Delayed (required reboot)\",\n\"11,8047\", \"Deleted\",\n\"12,8047\", \"Quarantined\",\n\"13,8047\", \"Restored\",\n\"14,8047\", \"Detected\",\n\"1,8048\", \"Blocked\",\n\"2,8048\", \"Allowed\",\n\"3,8048\", \"No Action\",\n\"4,8048\", \"Log\",\n\"5,8048\", \"Command Script\",\n\"6,8048\", \"Corrected\",\n\"7,8048\", \"Partially Corrected\",\n\"8,8048\", \"Uncorrected\",\n\"10,8048\", \"Delayed (required reboot)\",\n\"11,8048\", \"Deleted\",\n\"12,8048\", \"Quarantined\",\n\"13,8048\", \"Restored\",\n\"14,8048\", \"Detected\",\n\"1,8020\", \"Started\",\n\"2,8020\", \"Completed\",\n\"3,8020\", \"Cancelled\",\n\"4,8020\", \"Duration Violation\",\n\"5,8020\", \"Pause Violation\",\n\"6,8020\", \"Error\",\n\"1,8021\", \"Permission\",\n\"2,8021\", \"Encrypted\",\n\"3,8021\", \"Size\",\n\"4,8021\", \"Error\",\n\"5,8021\", \"Malformed\",\n\"1,8034\", \"Blocked\",\n\"2,8034\", \"Allowed\",\n\"12,8034\", \"Quarantined\",\n\"1,8036\", \"Blocked\",\n\"2,8036\", \"Allowed\",\n\"1,8037\", \"Blocked\",\n\"2,8037\", \"Allowed\",\n\"3,8037\", \"No Action\",\n\"4,8037\", \"Log\",\n\"5,8037\", \"Command Script\",\n\"6,8037\", \"Corrected\",\n\"7,8037\", \"Partially Corrected\",\n\"8,8037\", \"Uncorrected\",\n\"10,8037\", \"Delayed (required reboot)\",\n\"11,8037\", \"Deleted\",\n\"12,8037\", \"Quarantined\",\n\"13,8037\", \"Restored\",\n\"14,8037\", \"Detected\",\n\"1,8038\", \"Blocked\",\n\"2,8038\", \"Allowed\",\n\"4,8045\", \"Log\",\n\"10,8045\", \"Delayed\",\n\"15,8045\", \"Terminated\",\n\"1,8\", \"Install\",\n\"2,8\", \"Remove\",\n\"3,8\", \"Update\",\n\"4,8\", \"Expire\",\n\"5,8\", \"Exceed\",\n\"6,8\", \"Report\",\n\"7,8\", \"Low Count\",\n\"8,8\", \"Expiring\",\n\"4,1\", \"Application Log\",\n\"1,2\", \"Install\",\n\"2,2\", \"Remove\",\n\"3,2\", \"Start\",\n\"4,2\", \"Stop\",\n\"5,2\", \"Heartbeat\",\n\"1,3\", \"Code\",\n\"2,3\", \"Content\",\n\"3,3\", \"Configuration\",\n\"4,3\", \"Policy\",\n\"1,6\", \"Code\",\n\"2,6\", \"Content\",\n\"3,6\", \"Configuration\",\n\"4,6\", \"Policy\",\n\"1,7\", \"E-mail\",\n\"2,7\", \"SMS\",\n\"1,9\", \"Register\",\n\"2,9\", \"Unregister\",\n\"1,11\", \"Submitted\",\n\"2,11\", \"Queued\",\n\"3,11\", \"Started\",\n\"4,11\", \"Cancel Requested\",\n\"5,11\", \"Completed\",\n\"6,11\", \"Canceled\",\n\"7,11\", \"Error\",\n\"8,11\", \"Rejected\",\n\"1,15\", \"Failure\",\n\"2,15\", \"Encryption Started\",\n\"3,15\", \"Encryption Finished\",\n\"10,15\", \"Recovery Key Recycled\",\n\"1,40\", \"Install\",\n\"2,40\", \"Remove\",\n\"3,40\", \"Update\",\n\"1,41\", \"Expiring\",\n\"2,41\", \"Expired\",\n\"1,8080\", \"Exists\",\n\"2,8080\", \"Partial\",\n\"1,8081\", \"Exists\",\n\"2,8081\", \"Partial\",\n\"1,8082\", \"Exists\",\n\"2,8082\", \"Partial\",\n\"1,8085\", \"Exists\",\n\"2,8085\", \"Partial\",\n\"1,8086\", \"Exists\",\n\"2,8086\", \"Partial\",\n\"1,8087\", \"Exists\",\n\"2,8087\", \"Partial\",\n\"1,8089\", \"Exists\",\n\"2,8089\", \"Partial\",\n\"1,8090\", \"Exists\",\n\"2,8090\", \"Partial\",\n\"1,8100\", \"Remediation Completed\",\n\"2,8100\", \"Partial Remediation\",\n\"1,8101\", \"Remediation Completed\",\n\"2,8101\", \"Partial Remediation\",\n\"1,8105\", \"Remediation Completed\",\n\"2,8105\", \"Partial Remediation\",\n\"1,8106\", \"Remediation Completed\",\n\"2,8106\", \"Partial Remediation\",\n\"1,8109\", \"Remediation Completed\",\n\"2,8109\", \"Partial Remediation\",\n\"1,8110\", \"Remediation Completed\",\n\"2,8110\", \"Partial Remediation\",\n\"3,8119\", \"Does Not Exists\",\n\"4,8119\", \"Error\",\n\"5,8119\", \"Unsupported\",\n\"1,8107\", \"Remediation Completed\",\n\"2,8107\", \"Partial Remediation\",\n\"1,8084\", \"Exists\",\n\"2,8084\", \"Partial\",\n\"1,8083\", \"Exists\",\n\"2,8083\", \"Partial\",\n\"1,8104\", \"Remediation Completed\",\n\"2,8104\", \"Partial Remediation\",\n\"1,8103\", \"Remediation Completed\",\n\"2,8103\", \"Partial Remediation\",\n\"1,8102\", \"Remediation Completed\",\n\"2,8102\", \"Partial Remediation\",\n\"1,8000\", \"Logon\",\n\"2,8000\", \"Logoff\",\n\"1,8004\", \"Create\",\n\"2,8004\", \"Delete\",\n\"4,8004\", \"Rename\",\n\"5,8004\", \"Modify\",\n\"6,8004\", \"Set Attributes\",\n\"7,8004\", \"Set Security\",\n\"8,8004\", \"Get Attributes\",\n\"9,8004\", \"Get Security\",\n\"10,8004\", \"Encrypt\",\n\"11,8004\", \"Decrypt\",\n\"12,8004\", \"Mount\",\n\"13,8004\", \"Unmount\",\n\"1,8005\", \"Create Key\",\n\"2,8005\", \"Delete Key\",\n\"3,8005\", \"Open Key\",\n\"4,8005\", \"Rename Key\",\n\"5,8005\", \"Set Key Security Descriptor\",\n\"6,8005\", \"Restore Key\",\n\"1,8006\", \"Get Value\",\n\"2,8006\", \"Set Value\",\n\"3,8006\", \"Delete Value\",\n\"1,8008\", \"Page Allocate\",\n\"2,8008\", \"Page Modify\",\n\"3,8008\", \"Page Delete\",\n\"4,8008\", \"Buffer Overflow\",\n\"1,8009\", \"Create\",\n\"2,8009\", \"Read\",\n\"3,8009\", \"Delete\",\n\"5,8010\", \"System Activity\",\n\"5,8011\", \"System Activity\",\n\"5,8012\", \"System Activity\",\n\"5,8013\", \"System Activity\",\n\"1,8003\", \"Create\",\n\"2,8003\", \"Delete\",\n\"3,8003\", \"Open\",\n\"4,8003\", \"Rename\",\n\"5,8003\", \"Modify\",\n\"6,8003\", \"Set Attributes\",\n\"7,8003\", \"Set Security\",\n\"8,8003\", \"Get Attributes\",\n\"9,8003\", \"Get Security\",\n\"10,8003\", \"Encrypt\",\n\"11,8003\", \"Decrypt\",\n\"1,8002\", \"Load\",\n\"2,8002\", \"Unload\",\n\"1,8035\", \"Blocked\",\n\"2,8035\", \"Allowed\",\n\"3,8035\", \"No Action\",\n\"4,8035\", \"Log\",\n\"5,8035\", \"Command Script\",\n\"6,8035\", \"Corrected\",\n\"7,8035\", \"Partially Corrected\",\n\"8,8035\", \"Uncorrected\",\n\"10,8035\", \"Delayed (required reboot)\",\n\"11,8035\", \"Deleted\",\n\"12,8035\", \"Quarantined\",\n\"13,8035\", \"Restored\",\n\"14,8035\", \"Detected\",\n\"1,8050\", \"Blocked\",\n\"2,8050\", \"Allowed\",\n\"3,8050\", \"Dropped\",\n\"4,8050\", \"Deleted\",\n\"5,8050\", \"Isolated\",\n\"1,8070\", \"Passed\",\n\"2,8070\", \"Failed\",\n\"3,8070\", \"Soft Fail\",\n\"4,8070\", \"Log\",\n\"1,8071\", \"Compliance Check\",\n\"2,8071\", \"Remediation Check\",\n\"1,8001\", \"Launch\",\n\"2,8001\", \"Terminate\",\n\"3,8001\", \"Open\",\n\"4,8001\", \"Inject\",\n\"1,8007\", \"Connect\",\n\"2,8007\", \"Disconnect\",\n\"1,30\", \"Install\",\n\"2,30\", \"Remove\",\n\"3,30\", \"Update\",\n\"1,31\", \"Expiring\",\n\"2,31\", \"Expired\",\n\"1,32\", \"Low Count\",\n\"2,32\", \"Exceeded\",\n\"1,9000\", \"Blocked\",\n\"2,9000\", \"Allowed\",\n\"1,9001\", \"Blocked\",\n\"2,9001\", \"Allowed\",\n\"12,9001\", \"Quarantined\",\n\"1,9002\", \"Blocked\",\n\"2,9002\", \"Allowed\",\n\"12,9002\", \"Quarantined\",\n\"20,9002\", \"Approved\",\n\"21,9002\", \"Custom Action\",\n\"22,9002\", \"Expunged\",\n\"1,9003\", \"Blocked\",\n\"2,9003\", \"Allowed\"\n];\nSymantecICDx_CL\n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| extend disposition_type = strcat(toint(id_d), \",\", toint(type_id_d))  \n| join kind = inner (disptypeMap) on disposition_type\n| summarize Action_Count=count() by Action\n"
                 }
               },
               "asset": {
@@ -453,7 +500,7 @@
               }
             }
           },
-          "6": {
+          "8": {
             "position": {
               "x": 0,
               "y": 9,
@@ -465,9 +512,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -501,7 +548,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -532,7 +579,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Product distribution across events with file objects",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL \n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n | summarize Count=count() by product_name_s\n | sort by Count desc \n"
                 }
               },
               "asset": {
@@ -541,7 +589,7 @@
               }
             }
           },
-          "7": {
+          "9": {
             "position": {
               "x": 6,
               "y": 9,
@@ -553,9 +601,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -589,7 +637,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -620,7 +668,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Severity distribution across events with file object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let severityMapTable = datatable(severity_id_d:double, severity_name:string)\n  [\n    0, \"Unknown\",\n    1, \"Informational\",\n    2, \"Warning\",\n    3, \"Minor\",\n    4, \"Major\",\n    5, \"Critical\",\n    6, \"Fatal\"\n];\nSymantecICDx_CL \n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| join kind = inner (severityMapTable) on severity_id_d \n| summarize Count=count() by Severity_Type=severity_name\n| sort by Count desc\n"
                 }
               },
               "asset": {
@@ -629,7 +678,7 @@
               }
             }
           },
-          "8": {
+          "10": {
             "position": {
               "x": 12,
               "y": 9,
@@ -641,9 +690,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -677,7 +726,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -708,7 +757,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 25 users Across events with file object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n | extend username = iff(user_name_s <> \"\", user_name_s , \"Unknown\")\n | summarize Count=count() by User_Name=username \n | sort by Count desc\n | top 25 by Count desc\n"
                 }
               },
               "asset": {
@@ -717,7 +767,7 @@
               }
             }
           },
-          "9": {
+          "11": {
             "position": {
               "x": 0,
               "y": 13,
@@ -729,9 +779,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -765,7 +815,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -796,7 +846,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Threat categories across events with file object",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let threatTypeMap = datatable(threat_type_id_d:double, threat_category:string)\n  [\n    1, \"Malware\",\n    2, \"Behavioural\",\n    3, \"Potentially Unwanted Applications\",\n    4, \"Exploit (pep)\",\n    5, \"Heuristic\",\n    6, \"Security Risk\"\n  ];\nSymantecICDx_CL\n| where file_name_s <> \"\"\n| join kind = inner (threatTypeMap) on threat_type_id_d \n| extend threat_category_fnl = iff(threat_category <> \"\", threat_category, \"Unknown\")\n| summarize Count=count() by Threat_Category=threat_category_fnl\n| sort by Count desc\n| top 25 by Count desc\n"
                 }
               },
               "asset": {
@@ -805,7 +856,7 @@
               }
             }
           },
-          "10": {
+          "12": {
             "position": {
               "x": 6,
               "y": 13,
@@ -817,9 +868,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -836,7 +887,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecSecurityOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -871,7 +922,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 25 Files with threat",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where file_name_s <> \"\"\n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n (category_id_d == 5 and (type_id_d==8004 or type_id_d==8003 or type_id_d==8002)) or\n (category_id_d == 7 and (type_id_d==8084 or type_id_d==8083 or type_id_d==8082 or type_id_d==8104 or type_id_d==8103 or type_id_d==8102))\n| extend threatname = iff(threat_name_s <> \"\", threat_name_s , \"Unknown\")\n| summarize Event_Count=count() by File_Name=file_name_s, Threat_Name=threatname, Product_Name=product_name_s\n| sort by Event_Count desc\n| top 25 by Event_Count desc\n"
                 }
               },
               "asset": {
@@ -879,60 +931,69 @@
                 "type": "ApplicationInsights"
               }
             }
-          },
-          "11": {
-            "position": {
-              "x": 16,
-              "y": 0,
-              "colSpan": 2,
-              "rowSpan": 1
-            },
-            "metadata": {
-              "inputs": [],
-              "type": "Extension/HubsExtension/PartType/MarkdownPart",
-              "settings": {
-                "content": {
-                  "settings": {
-                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n",
-                    "title": "",
-                    "subtitle": ""
-                  }
-                }
-              }
+          }
+        }
+      }
+    },
+    "metadata": {
+      "model": {
+        "timeRange": {
+          "value": {
+            "relative": {
+              "duration": 24,
+              "timeUnit": 1
             }
           },
-          "12": {
-            "position": {
-              "x": 0,
-              "y": 0,
-              "colSpan": 1,
-              "rowSpan": 1
-            },
-            "metadata": {
-              "inputs": [
-                {
-                  "name": "subscriptionId",
-                  "value": "{Subscription_Id}"
-                },
-                {
-                  "name": "resourceGroup",
-                  "value": "{Resource_Group}"
-                },
-                {
-                  "name": "workspaceName",
-                  "value": "{Workspace_Name}"
-                },
-                {
-                  "name": "menuItemToOpen",
-                  "value": "Dashboards"
-                }
-              ],
-              "type": "Extension/Microsoft_Azure_Security_Insights/PartType/AsiOverviewPart",
-              "defaultMenuItemId": "0"
+          "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+        },
+        "filterLocale": {
+          "value": "en-us"
+        },
+        "filters": {
+          "value": {
+            "MsPortalFx_TimeRange": {
+              "model": {
+                "format": "utc",
+                "granularity": "auto",
+                "relative": "24h"
+              },
+              "displayCache": {
+                "name": "UTC Time",
+                "value": "Past 24 hours"
+              },
+              "filteredPartIds": [
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5154",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5158",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e515a",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e515c",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e515e",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5160",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5162",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5164",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5166",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d00b",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d00d",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d00f",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d011",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d013",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d015",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d017",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d019",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d01b",
+                "StartboardPart-AnalyticsPart-4f1dac7c-c84c-47ac-9e88-66667bb9d01d"
+              ]
             }
           }
         }
       }
     }
-  }
+  },
+  "id": "arm/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/ICDX_ASI/providers/Microsoft.Portal/dashboards/SymantecFileThreatsOverviewDashboard-ICDX-LA-workspace",
+  "name": "SymantecFileThreatsOverviewDashboard-ICDX-LA-workspace",
+  "type": "Microsoft.Portal/dashboards",
+  "location": "westus2",
+  "tags": {
+    "hidden-title": "Symantec File Threats Overview Dashboard - ICDX-LA-workspace"
+  },
+  "apiVersion": "2015-08-01-preview"
 }

--- a/Dashboards/Symantec_threats_overview_dashboard.json
+++ b/Dashboards/Symantec_threats_overview_dashboard.json
@@ -1,13 +1,4 @@
 {
-    "name": "SymantecThreatsOverviewDashboard-{Workspace_Name}",
-    "type": "Microsoft.Portal/dashboards",
-    "location": "{Dashboard_Location}",
-    "tags": {
-      "dashboardKey": "SymantecThreatsOverviewDashboard",
-      "hidden-title": "Symantec Threats Overview Dashboard - {Workspace_Name}",
-      "version": "1.2",
-      "workspaceName": "{Workspace_Name}"
-  },
   "properties": {
     "lenses": {
       "0": {
@@ -66,6 +57,27 @@
           },
           "2": {
             "position": {
+              "x": 19,
+              "y": 0,
+              "colSpan": 2,
+              "rowSpan": 1
+            },
+            "metadata": {
+              "inputs": [],
+              "type": "Extension/HubsExtension/PartType/MarkdownPart",
+              "settings": {
+                "content": {
+                  "settings": {
+                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n\n\n",
+                    "title": "",
+                    "subtitle": ""
+                  }
+                }
+              }
+            }
+          },
+          "3": {
+            "position": {
               "x": 0,
               "y": 1,
               "colSpan": 7,
@@ -76,9 +88,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -95,7 +107,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -130,7 +142,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 20 malicious URLs",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where connection_url_path_s <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021)) or\n  (category_id_d == 1 and (type_id_d==8040 or type_id_d==8050))\n| summarize Count=count() by URL=connection_url_path_s\n| sort by Count desc \n| top 20 by Count desc\n"
                 }
               },
               "asset": {
@@ -139,7 +152,7 @@
               }
             }
           },
-          "3": {
+          "4": {
             "position": {
               "x": 7,
               "y": 1,
@@ -151,9 +164,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -170,7 +183,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -206,6 +219,7 @@
                 "content": {
                   "PartTitle": "Top 20 malicious files",
                   "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "SymantecICDx_CL\n| where file_name_s  <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| summarize Count=count() by File_Name=file_name_s\n| sort by Count desc \n| top 20 by Count desc\n",
                   "GridColumnsWidth": {
                     "File_Name": "521px",
                     "Count": "343px"
@@ -218,7 +232,7 @@
               }
             }
           },
-          "4": {
+          "5": {
             "position": {
               "x": 14,
               "y": 1,
@@ -230,9 +244,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -271,7 +285,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -302,7 +316,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 10 malicious sources",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let TopMaliciousSource = SymantecICDx_CL\n| where connection_src_ip_s <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| summarize Count =  sum(count_d) by Source_IP=connection_src_ip_s\n| sort by Count desc\n| limit 10 \n| project Source_IP;\nSymantecICDx_CL\n| where connection_src_ip_s <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| where connection_src_ip_s in (TopMaliciousSource)\n| summarize Count= sum(count_d)  by Source_IP=connection_src_ip_s, bin(TimeGenerated, 1h)\n| render timechart"
                 }
               },
               "asset": {
@@ -311,7 +326,7 @@
               }
             }
           },
-          "5": {
+          "6": {
             "position": {
               "x": 0,
               "y": 5,
@@ -323,9 +338,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -364,7 +379,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -395,7 +410,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 10 risky Endpoints",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let TopDevices = SymantecICDx_CL\n| where device_ip_s <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| summarize Count = sum(count_d) by Device_Ip=device_ip_s\n| sort by Count desc\n| limit 10 \n| project Device_Ip;\nSymantecICDx_CL\n| where device_ip_s <> \"\" \n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| where device_ip_s in (TopDevices)\n| summarize Count = sum(count_d) by Device_Ip=device_ip_s, bin(TimeGenerated, 1h)\n| render timechart"
                 }
               },
               "asset": {
@@ -404,7 +420,7 @@
               }
             }
           },
-          "6": {
+          "7": {
             "position": {
               "x": 7,
               "y": 5,
@@ -416,9 +432,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -488,7 +504,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Top 10 risky users",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let TopUsers = SymantecICDx_CL\n| where user_name_s <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| summarize Count =  sum(count_d)  by User_Name=user_name_s\n| sort by Count desc\n| limit 10 \n| project User_Name;\nSymantecICDx_CL\n| where user_name_s <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| where user_name_s in (TopUsers)\n| summarize Count= sum(count_d)  by User_Name=user_name_s, bin(TimeGenerated, 1h)\n| render timechart"
                 }
               },
               "asset": {
@@ -497,7 +514,7 @@
               }
             }
           },
-          "7": {
+          "8": {
             "position": {
               "x": 0,
               "y": 9,
@@ -509,9 +526,9 @@
                 {
                   "name": "ComponentId",
                   "value": {
-                    "SubscriptionId": "{Subscription_Id}",
-                    "ResourceGroup": "{Resource_Group}",
-                    "Name": "{Workspace_Name}"
+                    "SubscriptionId": "156f424c-febb-4286-9691-f6a24d2e7b5c",
+                    "ResourceGroup": "ICDX_ASI",
+                    "Name": "ICDX-LA-workspace"
                   }
                 },
                 {
@@ -528,7 +545,7 @@
                 },
                 {
                   "name": "DashboardId",
-                  "value": "/subscriptions/{Subscription_Id}/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_{Workspace_Name}"
+                  "value": "/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/SymantecTreatsOverviewDashboard_ICDX-LA-workspace"
                 },
                 {
                   "name": "PartId",
@@ -563,7 +580,8 @@
               "settings": {
                 "content": {
                   "PartTitle": "Threat details",
-                  "PartSubTitle": "Symantec Integrated Cyber Defense"
+                  "PartSubTitle": "Symantec Integrated Cyber Defense",
+                  "Query": "let disptypeMap = datatable(disposition_type:string, Action:string)\n[\n\"1,20\", \"LOGON\",\n\"2,20\", \"LOGOFF\",\n\"1,21\", \"Create\",\n\"2,21\", \"Update\",\n\"3,21\", \"Delete\",\n\"10,22\", \"User rule override\",\n\"20,22\", \"Admin request\",\n\"30,22\", \"User policy override\",\n\"31,22\", \"User policy override extend time\",\n\"32,22\", \"User policy restore manual\",\n\"33,22\", \"User policy restore automatic\",\n\"40,22\", \"Execution block override\",\n\"41,22\", \"User policy override removed\",\n\"1,1000\", \"Log\",\n\"1,1005\", \"Normal\",\n\"2,1005\", \"Overload\",\n\"1,1006\", \"Normal\",\n\"2,1006\", \"Overload\",\n\"1,1007\", \"Normal\",\n\"2,1007\", \"Overload\",\n\"1,8025\", \"Blocked\",\n\"2,8025\", \"Allowed\",\n\"3,8025\", \"No Action\",\n\"4,8025\", \"Log\",\n\"5,8025\", \"Command Script\",\n\"6,8025\", \"Corrected\",\n\"7,8025\", \"Partially Corrected\",\n\"8,8025\", \"Uncorrected\",\n\"14,8025\", \"Detected\",\n\"1,8031\", \"Blocked\",\n\"2,8031\", \"Allowed\",\n\"3,8031\", \"No Action\",\n\"4,8031\", \"Log\",\n\"5,8031\", \"Command Script\",\n\"6,8031\", \"Corrected\",\n\"7,8031\", \"Partially Corrected\",\n\"8,8031\", \"Uncorrected\",\n\"10,8031\", \"Delayed (required reboot)\",\n\"11,8031\", \"Deleted\",\n\"12,8031\", \"Quarantined\",\n\"13,8031\", \"Restored\",\n\"14,8031\", \"Detected\",\n\"1,8030\", \"Blocked\",\n\"2,8030\", \"Allowed\",\n\"3,8030\", \"No Action\",\n\"4,8030\", \"Log\",\n\"5,8030\", \"Command Script\",\n\"8,8030\", \"Uncorrected\",\n\"10,8030\", \"Delayed (required reboot)\",\n\"11,8030\", \"Deleted\",\n\"14,8030\", \"Detected\",\n\"1,8029\", \"Blocked\",\n\"2,8029\", \"Allowed\",\n\"3,8029\", \"No Action\",\n\"4,8029\", \"Log\",\n\"5,8029\", \"Command Script\",\n\"6,8029\", \"Corrected\",\n\"7,8029\", \"Partially Corrected\",\n\"8,8029\", \"Uncorrected\",\n\"10,8029\", \"Delayed (required reboot)\",\n\"11,8029\", \"Deleted\",\n\"12,8029\", \"Quarantined\",\n\"13,8029\", \"Restored\",\n\"14,8029\", \"Detected\",\n\"1,8028\", \"Blocked\",\n\"2,8028\", \"Allowed\",\n\"3,8028\", \"No Action\",\n\"4,8028\", \"Log\",\n\"5,8028\", \"Command Script\",\n\"6,8028\", \"Corrected\",\n\"7,8028\", \"Partially Corrected\",\n\"8,8028\", \"Uncorrected\",\n\"10,8028\", \"Delayed (required reboot)\",\n\"11,8028\", \"Deleted\",\n\"12,8028\", \"Quarantined\",\n\"13,8028\", \"Restored\",\n\"14,8028\", \"Detected\",\n\"1,8027\", \"Blocked\",\n\"2,8027\", \"Allowed\",\n\"3,8027\", \"No Action\",\n\"4,8027\", \"Log\",\n\"5,8027\", \"Command Script\",\n\"6,8027\", \"Corrected\",\n\"7,8027\", \"Partially Corrected\",\n\"8,8027\", \"Uncorrected\",\n\"10,8027\", \"Delayed (required reboot)\",\n\"11,8027\", \"Deleted\",\n\"12,8027\", \"Quarantined\",\n\"13,8027\", \"Restored\",\n\"14,8027\", \"Detected\",\n\"15,8027\", \"Terminated\",\n\"1,8032\", \"Blocked\",\n\"2,8032\", \"Allowed\",\n\"3,8032\", \"No Action\",\n\"4,8032\", \"Log\",\n\"5,8032\", \"Command Script\",\n\"6,8032\", \"Corrected\",\n\"7,8032\", \"Partially Corrected\",\n\"8,8032\", \"Uncorrected\",\n\"10,8032\", \"Delayed (required reboot)\",\n\"11,8032\", \"Deleted\",\n\"13,8032\", \"Restored\",\n\"14,8032\", \"Detected\",\n\"1,8033\", \"Blocked\",\n\"2,8033\", \"Allowed\",\n\"3,8033\", \"No Action\",\n\"4,8033\", \"Log\",\n\"5,8033\", \"Command Script\",\n\"6,8033\", \"Corrected\",\n\"7,8033\", \"Partially Corrected\",\n\"8,8033\", \"Uncorrected\",\n\"10,8033\", \"Delayed (required reboot)\",\n\"11,8033\", \"Deleted\",\n\"13,8033\", \"Restored\",\n\"14,8033\", \"Detected\",\n\"1,8026\", \"Blocked\",\n\"2,8026\", \"Allowed\",\n\"3,8026\", \"No Action\",\n\"4,8026\", \"Log\",\n\"5,8026\", \"Command Script\",\n\"14,8026\", \"Detected\",\n\"15,8026\", \"Terminated\",\n\"4,8060\", \"Log\",\n\"1,8040\", \"Blocked\",\n\"2,8040\", \"Allowed\",\n\"3,8040\", \"No Action\",\n\"4,8040\", \"Log\",\n\"4,8045\", \"Log\",\n\"10,8045\", \"Delayed\",\n\"15,8045\", \"Terminated\",\n\"1,8047\", \"Blocked\",\n\"2,8047\", \"Allowed\",\n\"3,8047\", \"No Action\",\n\"4,8047\", \"Log\",\n\"5,8047\", \"Command Script\",\n\"6,8047\", \"Corrected\",\n\"7,8047\", \"Partially Corrected\",\n\"8,8047\", \"Uncorrected\",\n\"10,8047\", \"Delayed (required reboot)\",\n\"11,8047\", \"Deleted\",\n\"12,8047\", \"Quarantined\",\n\"13,8047\", \"Restored\",\n\"14,8047\", \"Detected\",\n\"1,8048\", \"Blocked\",\n\"2,8048\", \"Allowed\",\n\"3,8048\", \"No Action\",\n\"4,8048\", \"Log\",\n\"5,8048\", \"Command Script\",\n\"6,8048\", \"Corrected\",\n\"7,8048\", \"Partially Corrected\",\n\"8,8048\", \"Uncorrected\",\n\"10,8048\", \"Delayed (required reboot)\",\n\"11,8048\", \"Deleted\",\n\"12,8048\", \"Quarantined\",\n\"13,8048\", \"Restored\",\n\"14,8048\", \"Detected\",\n\"1,8020\", \"Started\",\n\"2,8020\", \"Completed\",\n\"3,8020\", \"Cancelled\",\n\"4,8020\", \"Duration Violation\",\n\"5,8020\", \"Pause Violation\",\n\"6,8020\", \"Error\",\n\"1,8021\", \"Permission\",\n\"2,8021\", \"Encrypted\",\n\"3,8021\", \"Size\",\n\"4,8021\", \"Error\",\n\"5,8021\", \"Malformed\",\n\"1,8034\", \"Blocked\",\n\"2,8034\", \"Allowed\",\n\"12,8034\", \"Quarantined\",\n\"1,8036\", \"Blocked\",\n\"2,8036\", \"Allowed\",\n\"1,8037\", \"Blocked\",\n\"2,8037\", \"Allowed\",\n\"3,8037\", \"No Action\",\n\"4,8037\", \"Log\",\n\"5,8037\", \"Command Script\",\n\"6,8037\", \"Corrected\",\n\"7,8037\", \"Partially Corrected\",\n\"8,8037\", \"Uncorrected\",\n\"10,8037\", \"Delayed (required reboot)\",\n\"11,8037\", \"Deleted\",\n\"12,8037\", \"Quarantined\",\n\"13,8037\", \"Restored\",\n\"14,8037\", \"Detected\",\n\"1,8038\", \"Blocked\",\n\"2,8038\", \"Allowed\",\n\"4,8045\", \"Log\",\n\"10,8045\", \"Delayed\",\n\"15,8045\", \"Terminated\",\n\"1,8\", \"Install\",\n\"2,8\", \"Remove\",\n\"3,8\", \"Update\",\n\"4,8\", \"Expire\",\n\"5,8\", \"Exceed\",\n\"6,8\", \"Report\",\n\"7,8\", \"Low Count\",\n\"8,8\", \"Expiring\",\n\"4,1\", \"Application Log\",\n\"1,2\", \"Install\",\n\"2,2\", \"Remove\",\n\"3,2\", \"Start\",\n\"4,2\", \"Stop\",\n\"5,2\", \"Heartbeat\",\n\"1,3\", \"Code\",\n\"2,3\", \"Content\",\n\"3,3\", \"Configuration\",\n\"4,3\", \"Policy\",\n\"1,6\", \"Code\",\n\"2,6\", \"Content\",\n\"3,6\", \"Configuration\",\n\"4,6\", \"Policy\",\n\"1,7\", \"E-mail\",\n\"2,7\", \"SMS\",\n\"1,9\", \"Register\",\n\"2,9\", \"Unregister\",\n\"1,11\", \"Submitted\",\n\"2,11\", \"Queued\",\n\"3,11\", \"Started\",\n\"4,11\", \"Cancel Requested\",\n\"5,11\", \"Completed\",\n\"6,11\", \"Canceled\",\n\"7,11\", \"Error\",\n\"8,11\", \"Rejected\",\n\"1,15\", \"Failure\",\n\"2,15\", \"Encryption Started\",\n\"3,15\", \"Encryption Finished\",\n\"10,15\", \"Recovery Key Recycled\",\n\"1,40\", \"Install\",\n\"2,40\", \"Remove\",\n\"3,40\", \"Update\",\n\"1,41\", \"Expiring\",\n\"2,41\", \"Expired\",\n\"1,8080\", \"Exists\",\n\"2,8080\", \"Partial\",\n\"1,8081\", \"Exists\",\n\"2,8081\", \"Partial\",\n\"1,8082\", \"Exists\",\n\"2,8082\", \"Partial\",\n\"1,8085\", \"Exists\",\n\"2,8085\", \"Partial\",\n\"1,8086\", \"Exists\",\n\"2,8086\", \"Partial\",\n\"1,8087\", \"Exists\",\n\"2,8087\", \"Partial\",\n\"1,8089\", \"Exists\",\n\"2,8089\", \"Partial\",\n\"1,8090\", \"Exists\",\n\"2,8090\", \"Partial\",\n\"1,8100\", \"Remediation Completed\",\n\"2,8100\", \"Partial Remediation\",\n\"1,8101\", \"Remediation Completed\",\n\"2,8101\", \"Partial Remediation\",\n\"1,8105\", \"Remediation Completed\",\n\"2,8105\", \"Partial Remediation\",\n\"1,8106\", \"Remediation Completed\",\n\"2,8106\", \"Partial Remediation\",\n\"1,8109\", \"Remediation Completed\",\n\"2,8109\", \"Partial Remediation\",\n\"1,8110\", \"Remediation Completed\",\n\"2,8110\", \"Partial Remediation\",\n\"3,8119\", \"Does Not Exists\",\n\"4,8119\", \"Error\",\n\"5,8119\", \"Unsupported\",\n\"1,8107\", \"Remediation Completed\",\n\"2,8107\", \"Partial Remediation\",\n\"1,8084\", \"Exists\",\n\"2,8084\", \"Partial\",\n\"1,8083\", \"Exists\",\n\"2,8083\", \"Partial\",\n\"1,8104\", \"Remediation Completed\",\n\"2,8104\", \"Partial Remediation\",\n\"1,8103\", \"Remediation Completed\",\n\"2,8103\", \"Partial Remediation\",\n\"1,8102\", \"Remediation Completed\",\n\"2,8102\", \"Partial Remediation\",\n\"1,8000\", \"Logon\",\n\"2,8000\", \"Logoff\",\n\"1,8004\", \"Create\",\n\"2,8004\", \"Delete\",\n\"4,8004\", \"Rename\",\n\"5,8004\", \"Modify\",\n\"6,8004\", \"Set Attributes\",\n\"7,8004\", \"Set Security\",\n\"8,8004\", \"Get Attributes\",\n\"9,8004\", \"Get Security\",\n\"10,8004\", \"Encrypt\",\n\"11,8004\", \"Decrypt\",\n\"12,8004\", \"Mount\",\n\"13,8004\", \"Unmount\",\n\"1,8005\", \"Create Key\",\n\"2,8005\", \"Delete Key\",\n\"3,8005\", \"Open Key\",\n\"4,8005\", \"Rename Key\",\n\"5,8005\", \"Set Key Security Descriptor\",\n\"6,8005\", \"Restore Key\",\n\"1,8006\", \"Get Value\",\n\"2,8006\", \"Set Value\",\n\"3,8006\", \"Delete Value\",\n\"1,8008\", \"Page Allocate\",\n\"2,8008\", \"Page Modify\",\n\"3,8008\", \"Page Delete\",\n\"4,8008\", \"Buffer Overflow\",\n\"1,8009\", \"Create\",\n\"2,8009\", \"Read\",\n\"3,8009\", \"Delete\",\n\"5,8010\", \"System Activity\",\n\"5,8011\", \"System Activity\",\n\"5,8012\", \"System Activity\",\n\"5,8013\", \"System Activity\",\n\"1,8003\", \"Create\",\n\"2,8003\", \"Delete\",\n\"3,8003\", \"Open\",\n\"4,8003\", \"Rename\",\n\"5,8003\", \"Modify\",\n\"6,8003\", \"Set Attributes\",\n\"7,8003\", \"Set Security\",\n\"8,8003\", \"Get Attributes\",\n\"9,8003\", \"Get Security\",\n\"10,8003\", \"Encrypt\",\n\"11,8003\", \"Decrypt\",\n\"1,8002\", \"Load\",\n\"2,8002\", \"Unload\",\n\"1,8035\", \"Blocked\",\n\"2,8035\", \"Allowed\",\n\"3,8035\", \"No Action\",\n\"4,8035\", \"Log\",\n\"5,8035\", \"Command Script\",\n\"6,8035\", \"Corrected\",\n\"7,8035\", \"Partially Corrected\",\n\"8,8035\", \"Uncorrected\",\n\"10,8035\", \"Delayed (required reboot)\",\n\"11,8035\", \"Deleted\",\n\"12,8035\", \"Quarantined\",\n\"13,8035\", \"Restored\",\n\"14,8035\", \"Detected\",\n\"1,8050\", \"Blocked\",\n\"2,8050\", \"Allowed\",\n\"3,8050\", \"Dropped\",\n\"4,8050\", \"Deleted\",\n\"5,8050\", \"Isolated\",\n\"1,8070\", \"Passed\",\n\"2,8070\", \"Failed\",\n\"3,8070\", \"Soft Fail\",\n\"4,8070\", \"Log\",\n\"1,8071\", \"Compliance Check\",\n\"2,8071\", \"Remediation Check\",\n\"1,8001\", \"Launch\",\n\"2,8001\", \"Terminate\",\n\"3,8001\", \"Open\",\n\"4,8001\", \"Inject\",\n\"1,8007\", \"Connect\",\n\"2,8007\", \"Disconnect\",\n\"1,30\", \"Install\",\n\"2,30\", \"Remove\",\n\"3,30\", \"Update\",\n\"1,31\", \"Expiring\",\n\"2,31\", \"Expired\",\n\"1,32\", \"Low Count\",\n\"2,32\", \"Exceeded\",\n\"1,9000\", \"Blocked\",\n\"2,9000\", \"Allowed\",\n\"1,9001\", \"Blocked\",\n\"2,9001\", \"Allowed\",\n\"12,9001\", \"Quarantined\",\n\"1,9002\", \"Blocked\",\n\"2,9002\", \"Allowed\",\n\"12,9002\", \"Quarantined\",\n\"20,9002\", \"Approved\",\n\"21,9002\", \"Custom Action\",\n\"22,9002\", \"Expunged\",\n\"1,9003\", \"Blocked\",\n\"2,9003\", \"Allowed\"\n];\nlet typeMapTable = datatable(type_id_d:double, type_name:string)\n  [\n    1,  \"Application Log\",\n    2,  \"Application Lifecycle\",\n    3,  \"Update\",\n    6,  \"Update Available\",\n    7,  \"User Message\",\n    9,  \"Registration\",\n    11, \"Commmand Activity\",\n    15, \"BitLocker\",\n    20, \"User Session Audit\",\n    21, \"Entity Audit\",\n    22, \"Policy Override Audit\",\n    40, \"Certificate Lifecycle\",\n    41, \"Certificate Expiry\",\n    30, \"License Lifecycle\",\n    31, \"License Expiry\",\n    32, \"License Count\",\n    1000, \"Status\",\n    1005, \"CPU Usage\",\n    1006, \"Memory Usage\",\n    1007, \"Throughput\",\n    8000, \"User Session Activity\",\n    8001, \"Process Activity\",\n    8002, \"Module Activity\",\n    8003, \"File Activity\",\n    8004, \"Directory Activity\",\n    8005, \"Registry Key Activity\",\n    8006, \"Registry Value Activity\",\n    8007, \"Host Network Activity\",\n    8008, \"Memory Activity\",\n    8009, \"Kernel Activity\",\n    8010, \"Network Activity\",\n    8011, \"Email Activity\",\n    8012, \"Email File Activity\",\n    8013, \"Email URL Activity\",\n    8014, \"Host Network Traffice Activity\",\n    8020, \"Scan\",\n    8021, \"Unscannable File\",\n    8025, \"Boot Record Detection\",\n    8026, \"User Session Detection\",\n    8027, \"Process Detection\",\n    8028, \"Module Detection\",\n    8029, \"Memory Detection\",\n    8030, \"Kernel Detection\",\n    8031, \"File Detection\",\n    8032, \"Registry Key Detection\",\n    8033, \"Registry Value Detection\",\n    8034, \"Email File Detection\",\n    8035, \"Email Detection\",\n    8036, \"Email URL Detection\",\n    8037, \"Host Network Traffic Detection\",\n    8038, \"Peripheral Device Detection\",\n    8040, \"Host Network Detection\",\n    8045, \"Process Response\",\n    8046, \"File Response\",\n    8047, \"Registry Key Response\",\n    8048, \"Registry Value Response\",\n    8050, \"Network Detection\",\n    8060, \"Monitored Source\",\n    8070, \"Compliance Scan\",\n    8071, \"Compliance\",\n    8080, \"User Session Query Result\",\n    8081, \"Process Query Result\",\n    8082, \"Module Query Result\",\n    8083, \"File Query Result\",\n    8084, \"Directory Query Result\",\n    8085, \"Registry Key Query Result\",\n    8086, \"Registry Value Query Result\",\n    8087, \"Network Query Result\",\n    8089, \"Kernel Object Query Result\",\n    8090, \"Service Query Result\",\n    8100, \"User Session Remediation\",\n    8101, \"Process Remediation\",\n    8102, \"Module Remediation\",\n    8103, \"File Remediation\",\n    8104, \"Directory Remediation\",\n    8105, \"Registry Key Remediation\",\n    8106, \"Registry Value Remediation\",\n    8107, \"Network Remediation\",\n    8109, \"Kernel Remediation\",\n    8110, \"Service Remediation\",\n    8119, \"Unsuccessful Remediation Result\",\n    9000, \"Content Detection\",\n    9001, \"File Content Detection\",\n    9002, \"Email Content Detection\",\n    9003, \"Instant Message Content Detection\"\n  ];\nSymantecICDx_CL\n| where file_name_s  <> \"\"\n| where threat_id_d <> \"\" and threat_name_s <> \"\" and threat_type_id_d <> \"\" \n| where (category_id_d == 1 and (type_id_d==8031 or type_id_d==8046 or type_id_d==8028 or type_id_d==8021))\n| extend disposition_type = strcat(toint(id_d), \",\", toint(type_id_d))  \n| join kind = inner (disptypeMap) on disposition_type\n| join kind = inner (typeMapTable) on type_id_d\n| extend threat_type_category = strcat(toint(threat_type_id_d),\",\",type_name)\n| extend Event_Time = datetime('1970-01-01T00:00:00Z') + (log_time_d/1000)*1s\n| summarize Event_Count= sum(count_d)  by Event_Time, Type_Id=type_id_d, Threat_Type_Id=threat_type_id_d, Threat_Type=threat_name_s, Disposition_Id=id_d, Product_Name=product_name_s, Threat_Type_Category=threat_type_category, Username=user_name_s, Action, Type_Name=type_name \n| sort by Event_Time, Event_Count desc \n"
                 }
               },
               "asset": {
@@ -571,30 +589,62 @@
                 "type": "ApplicationInsights"
               }
             }
+          }
+        }
+      }
+    },
+    "metadata": {
+      "model": {
+        "timeRange": {
+          "value": {
+            "relative": {
+              "duration": 24,
+              "timeUnit": 1
+            }
           },
-          "8": {
-            "position": {
-              "x": 19,
-              "y": 0,
-              "colSpan": 2,
-              "rowSpan": 1
-            },
-            "metadata": {
-              "inputs": [],
-              "type": "Extension/HubsExtension/PartType/MarkdownPart",
-              "settings": {
-                "content": {
-                  "settings": {
-                    "content": "<img width='65' height='55' src='https://www.symantec.com/content/dam/symantec/images/about/logo-symantec-vertical.png '/> \n\n\n",
-                    "title": "",
-                    "subtitle": ""
-                  }
-                }
-              }
+          "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+        },
+        "filterLocale": {
+          "value": "en-us"
+        },
+        "filters": {
+          "value": {
+            "MsPortalFx_TimeRange": {
+              "model": {
+                "format": "utc",
+                "granularity": "auto",
+                "relative": "24h"
+              },
+              "displayCache": {
+                "name": "UTC Time",
+                "value": "Past 24 hours"
+              },
+              "filteredPartIds": [
+                "StartboardPart-AnalyticsPart-49476c54-5e9d-43d3-a35f-9953c1e190d1",
+                "StartboardPart-AnalyticsPart-49476c54-5e9d-43d3-a35f-9953c1e190d3",
+                "StartboardPart-AnalyticsPart-49476c54-5e9d-43d3-a35f-9953c1e190d5",
+                "StartboardPart-AnalyticsPart-49476c54-5e9d-43d3-a35f-9953c1e190d7",
+                "StartboardPart-AnalyticsPart-49476c54-5e9d-43d3-a35f-9953c1e190d9",
+                "StartboardPart-AnalyticsPart-49476c54-5e9d-43d3-a35f-9953c1e190db",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5094",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5096",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e5098",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e509a",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e509c",
+                "StartboardPart-AnalyticsPart-9772a232-a5ba-42e3-b0d5-18747b3e509e"
+              ]
             }
           }
         }
       }
     }
-  }
+  },
+  "id": "arm/subscriptions/156f424c-febb-4286-9691-f6a24d2e7b5c/resourceGroups/ICDX_ASI/providers/Microsoft.Portal/dashboards/SymantecThreatsOverviewDashboard-ICDX-LA-workspace",
+  "name": "SymantecThreatsOverviewDashboard-ICDX-LA-workspace",
+  "type": "Microsoft.Portal/dashboards",
+  "location": "westus2",
+  "tags": {
+    "hidden-title": "Symantec Threats Overview Dashboard - ICDX-LA-workspace"
+  },
+  "apiVersion": "2015-08-01-preview"
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Updates multiple dashboards that required summarize and sort by properly using joins.
  - Fixes a file thread dashboard that was failing due to improper syntax
  - NOTE: I was told that MS would update make sure the workspace-id and subscription id's were made generic, ie, that a tool exists to perform this operation before merging dashboards back to master.
