### PR TITLE
Filter FW TI detections to filter out blocked connections

### DIFF
--- a/Detections/CommonSecurityLog/HighConfTIDetection.txt
+++ b/Detections/CommonSecurityLog/HighConfTIDetection.txt
@@ -12,7 +12,7 @@
 //
 // AlertTriggerThreshold: 0
 //
-// DataSource: #CommonSecurityLog
+// DataConnector: #CommonSecurityLog; DataTypes: #Firewall
 //
 // Tactics: #CommandAndControl
 //

--- a/Detections/CommonSecurityLog/HighConfTIDetection.txt
+++ b/Detections/CommonSecurityLog/HighConfTIDetection.txt
@@ -20,4 +20,4 @@ let timeframe = 1h;
 CommonSecurityLog
 | where TimeGenerated >= ago(timeframe) 
 | where toint(ThreatConfidence) >= 76
-
+| where tolower(SimplifiedDeviceAction) !in ('deny', 'drop', 'block', 'reset-server', 'reset-both', 'reset-server', '')

--- a/Detections/CommonSecurityLog/NewTIDetectionOnIP.txt
+++ b/Detections/CommonSecurityLog/NewTIDetectionOnIP.txt
@@ -13,7 +13,7 @@
 //
 // AlertTriggerThreshold: 0
 //
-// DataSource: #CommonSecurityLog
+// DataConnector: #CommonSecurityLog; DataTypes: #Firewall
 //
 // Tactics: #CommandAndControl, #InitialAccess
 //


### PR DESCRIPTION
Fixes #
Responding to - https://github.com/Azure/Azure-Sentinel/issues/213
Adding in filters for events where the threat is blocked, we don't want this level of detail in a detection rule.

## Proposed Changes

  -
  -
  -
