### PR TITLE
Signin event correlation rules

### DIFF
--- a/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
@@ -1,5 +1,5 @@
 id: 643c2025-9604-47c5-833f-7b4b9378a1f5
-name: IP with multiple failed AAD logins successfully logs in to the AWS Console.
+name: IP with multiple failed Azure AD logins successfully logs in to the AWS Console.
 description: |
 	This query creates a list of IP addresses with a number failed login attempts to AAD 
 	above a set threshold.  It then looks for any successful AWS Console logins from any

--- a/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
@@ -1,0 +1,40 @@
+id: 643c2025-9604-47c5-833f-7b4b9378a1f5
+name: IP with multiple failed AAD logins successfully logs in to the AWS Console.
+description: |
+	This query looks for IP addresses with multiple failed login attempts to AAD 
+	with a successful AWS Console login within the same timeframe.
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+     - SigninLogs
+  - connectorId: AWS
+    dataTypes:
+      - AWSCloudTrail
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+  
+query: |
+
+	let signin_threshold = 5; 
+	let suspicious_signins = 
+	SigninLogs
+	| where TimeGenerated >= ago(1d)
+	| where ResultType !in ("0", "50125", "50140")
+	| summarize count() by IPAddress
+	| where count_ >  signin_threshold
+	| summarize makelist(IPAddress);
+	AWSCloudTrail
+	| where TimeGenerated > ago(1d)
+	| where EventName == "ConsoleLogin"
+	| extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin) 
+	| where LoginResult == "Success"
+	| where SourceIpAddress in (suspicious_signins)
+	| extend Reason = "Multiple failed AAD logins from IP address"
+	| extend MFAUsed = tostring(parse_json(AdditionalEventData).MFAUsed)
+	| extend User = iif(UserIdentityUserName == "", UserIdentityType, UserIdentityUserName) 
+	| project TimeGenerated, Reason, LoginResult, EventTypeName, UserIdentityType, User, AWSRegion, SourceIpAddress, UserAgent, MFAUsed

--- a/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
@@ -1,8 +1,9 @@
 id: 643c2025-9604-47c5-833f-7b4b9378a1f5
 name: IP with multiple failed AAD logins successfully logs in to the AWS Console.
 description: |
-	This query looks for IP addresses with multiple failed login attempts to AAD 
-	with a successful AWS Console login within the same timeframe.
+	This query creates a list of IP addresses with a number failed login attempts to AAD 
+	above a set threshold.  It then looks for any successful AWS Console logins from any
+	of these IPs within the same timeframe.
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -17,17 +18,22 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - InitialAccess
-  
-query: |
+releventTechniques:
+  - T1078
 
+query: |
+	//Adjust this threshold to fit your environment
 	let signin_threshold = 5; 
+	//Make a list of IPs with AAD signin failures above our threshold
 	let suspicious_signins = 
 	SigninLogs
 	| where TimeGenerated >= ago(1d)
 	| where ResultType !in ("0", "50125", "50140")
+	| where IPAddress != "127.0.0.1"
 	| summarize count() by IPAddress
 	| where count_ >  signin_threshold
 	| summarize makelist(IPAddress);
+	//See if any of those IPs have sucessfully logged into the AWS console
 	AWSCloudTrail
 	| where TimeGenerated > ago(1d)
 	| where EventName == "ConsoleLogin"
@@ -37,4 +43,6 @@ query: |
 	| extend Reason = "Multiple failed AAD logins from IP address"
 	| extend MFAUsed = tostring(parse_json(AdditionalEventData).MFAUsed)
 	| extend User = iif(UserIdentityUserName == "", UserIdentityType, UserIdentityUserName) 
-	| project TimeGenerated, Reason, LoginResult, EventTypeName, UserIdentityType, User, AWSRegion, SourceIpAddress, UserAgent, MFAUsed
+	| extend AccountCustomEntity = User
+	| extend IPCustomEntity = SourceIpAddress
+	| project TimeGenerated, Reason, LoginResult, EventTypeName, UserIdentityType, User, AWSRegion, SourceIpAddress, UserAgent, MFAUsed, AccountCustomEntity, IPCustomEntity 

--- a/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
@@ -18,8 +18,10 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - InitialAccess
+  - CredentialAccess
 relevantTechniques:
   - T1078
+  - T1110
 
 query: |
 	//Adjust this threshold to fit your environment

--- a/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
@@ -18,7 +18,7 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - InitialAccess
-releventTechniques:
+relevantTechniques:
   - T1078
 
 query: |

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -34,6 +34,7 @@ query: |
 	SigninLogs
 	| where TimeGenerated >= ago(1d)
 	| where ResultType !in ("0", "50125", "50140")
+	| where IPAddress != "127.0.0.1"
 	| summarize count() by IPAddress
 	| where count_ > signin_threshold
 	| summarize makelist(IPAddress);
@@ -53,7 +54,7 @@ query: |
 	| where TimeGenerated >= ago(1d)
 	| where EventID == 4624
 	| where LogonType == 10 or LogonType == 7 or LogonType == 3
-	| where IpAddress != "-" and IpAddress != "127.0.0.1"
+	| where IpAddress != "-" and IpAddress
 	| where IpAddress in (suspicious_signins)
 	| extend Reason = "Multiple failed AAD logins from IP address"
 	| extend AccountCustomEntity = Account

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -26,7 +26,7 @@ query: |
 	let suspicious_signins =
 	SigninLogs
 	| where TimeGenerated >= ago(1d)
-	| where ResultType != "0"
+	| where ResultType !in ("0", "50125", "50140")
 	| summarize count() by IPAddress
 	| where count_ > signin_threshold
 	| summarize makelist(IPAddress);

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -1,8 +1,9 @@
 id:  8ee967a2-a645-4832-85f4-72b635bcb3a6
-name: IP with multiple failed AAD login attempts and successful remote login to host.
+name: IP with multiple failed Azure AD login attempts and successful remote login to host.
 description: |
-	This query looks for IP addresses with multiple failed logins to Azure AD and
-	within the same timeframe a successful login to a host via a remote protocol such as RDP or SSH.
+	This query creates a list of IP addresses with multiple failed logins to Azure
+	AD above our set threshold. It then looks for successful remote logins to hosts 
+	in environment from these IP addresses within the same timeframe.
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -20,10 +21,15 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - InitialAccess
-  
-query: |
+  - CredentialAccess
+relevantTechniques:
+  - T1078
+  - T1110
 
-	let signin_threshold = 5; 
+query: |
+	//Adjust this threshold to fit the environment
+	let signin_threshold = 5;
+	//Make a list of all IPs with failed signins to AAD above our threshold
 	let suspicious_signins =
 	SigninLogs
 	| where TimeGenerated >= ago(1d)
@@ -31,6 +37,7 @@ query: |
 	| summarize count() by IPAddress
 	| where count_ > signin_threshold
 	| summarize makelist(IPAddress);
+	//See if any of these IPs have sucessfull logged into *nix hosts
 	let linux_logons =
 	Syslog
 	| where TimeGenerated >= ago(1d)
@@ -39,13 +46,17 @@ query: |
 	| where SyslogMessage has_any (suspicious_signins)
 	| extend Reason = "Multiple failed AAD logins from IP address"
 	| project TimeGenerated, Computer, HostIP, SyslogMessage, Facility, ProcessName, Reason;
+	//See if any of these IPs have sucessfull logged into Windows hosts
 	let win_logons =
 	SecurityEvent
 	| where TimeGenerated >= ago(1d)
 	| where EventID == 4624
 	| where LogonType == 10 or LogonType == 7 or LogonType == 3
-	| where IpAddress != "-"
+	| where IpAddress != "-" and IpAddress != "127.0.0.1"
 	| where IpAddress in (suspicious_signins)
 	| extend Reason = "Multiple failed AAD logins from IP address"
+	| extend AccountCustomEntity = Account
 	| project TimeGenerated, Account, AccountType, Computer, Activity, EventID, LogonProcessName, IpAddress,  LogonTypeName, TargetUserSid, Reason;
 	union isfuzzy=true linux_logons,win_logons
+	| extend AccountCustomEntity = Account
+	| extend IPCustomEntity = iif(IpAddress != "", IpAddress, 

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -36,7 +36,7 @@ query: |
 	| where TimeGenerated >= ago(1d)
 	| where Facility contains "auth" and ProcessName != "sudo"
 	| where SyslogMessage has "Accepted"
-	| where SyslogMessage in (suspicious_signins)
+	| where SyslogMessage has_any (suspicious_signins)
 	| extend Reason = "Multiple failed AAD logins from IP address"
 	| project TimeGenerated, Computer, HostIP, SyslogMessage, Facility, ProcessName, Reason;
 	let win_logons =

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -1,7 +1,8 @@
 id:  8ee967a2-a645-4832-85f4-72b635bcb3a6
 name: IP with multiple failed AAD login attempts and successful remote login to host.
 description: |
-	This query looks for IP addresses with multiple failed logins to Azure AD and within the same timeframe a successful login to a host via a remote protocol such as RDP or SSH.
+	This query looks for IP addresses with multiple failed logins to Azure AD and
+	within the same timeframe a successful login to a host via a remote protocol such as RDP or SSH.
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -43,9 +43,10 @@ query: |
 	| where TimeGenerated >= ago(1d)
 	| where Facility contains "auth" and ProcessName != "sudo"
 	| where SyslogMessage has "Accepted"
-	| where SyslogMessage has_any (suspicious_signins)
+	| extend SourceIP = extract("(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3})))",1,SyslogMessage)
+	| where SourceIP in (suspicious_signins)
 	| extend Reason = "Multiple failed AAD logins from IP address"
-	| project TimeGenerated, Computer, HostIP, SyslogMessage, Facility, ProcessName, Reason;
+	| project TimeGenerated, Computer, HostIP, SourceIP, SyslogMessage, Facility, ProcessName, Reason;
 	//See if any of these IPs have sucessfull logged into Windows hosts
 	let win_logons =
 	SecurityEvent
@@ -59,4 +60,4 @@ query: |
 	| project TimeGenerated, Account, AccountType, Computer, Activity, EventID, LogonProcessName, IpAddress,  LogonTypeName, TargetUserSid, Reason;
 	union isfuzzy=true linux_logons,win_logons
 	| extend AccountCustomEntity = Account
-	| extend IPCustomEntity = iif(IpAddress != "", IpAddress, 
+	| extend IPCustomEntity = iif(IpAddress != "", IpAddress, SourceIP)

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -62,3 +62,4 @@ query: |
 	union isfuzzy=true linux_logons,win_logons
 	| extend AccountCustomEntity = Account
 	| extend IPCustomEntity = iif(IpAddress != "", IpAddress, SourceIP)
+	| extend HostCustomEntity = iif(Computer != "", Computer, Computer1)

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -1,0 +1,50 @@
+id:  8ee967a2-a645-4832-85f4-72b635bcb3a6
+name: IP with multiple failed AAD login attempts and successful remote login to host.
+description: |
+	This query looks for IP addresses with multiple failed logins to Azure AD and within the same timeframe a successful login to a host via a remote protocol such as RDP or SSH.
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+     - SigninLogs
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+  - connectorId: Syslog
+    dataTypes:
+      - Syslog 
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+  
+query: |
+
+	let signin_threshold = 5; 
+	let suspicious_signins =
+	SigninLogs
+	| where TimeGenerated >= ago(1d)
+	| where ResultType != "0"
+	| summarize count() by IPAddress
+	| where count_ > signin_threshold
+	| summarize makelist(IPAddress);
+	let linux_logons =
+	Syslog
+	| where TimeGenerated >= ago(1d)
+	| where Facility contains "auth" and ProcessName != "sudo"
+	| where SyslogMessage has "Accepted"
+	| where SyslogMessage in (suspicious_signins)
+	| extend Reason = "Multiple failed AAD logins from IP address"
+	| project TimeGenerated, Computer, HostIP, SyslogMessage, Facility, ProcessName, Reason;
+	let win_logons =
+	SecurityEvent
+	| where TimeGenerated >= ago(1d)
+	| where EventID == 4624
+	| where LogonType == 10 or LogonType == 7 or LogonType == 3
+	| where IpAddress != "-"
+	| where IpAddress in (suspicious_signins)
+	| extend Reason = "Multiple failed AAD logins from IP address"
+	| project TimeGenerated, Account, AccountType, Computer, Activity, EventID, LogonProcessName, IpAddress,  LogonTypeName, TargetUserSid, Reason;
+	union isfuzzy=true linux_logons,win_logons

--- a/Detections/MultipleDataSources/AWSConsoleAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/AWSConsoleAADCorrelation.yaml
@@ -1,0 +1,35 @@
+id: 910124df-913c-47e3-a7cd-29e1643fa55e
+name: IP with multiple failed AWS console logins successfully logs in to AAD.
+description: |
+	This query looks for IP addresses with multiple failed login attempts to the AWS console with a successful Azure AD login within the same timeframe.
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+     - SigninLogs
+  - connectorId: AWS
+    dataTypes:
+      - AWSCloudTrail
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+  
+query: |
+
+	let  signin_threshold = 5; 
+	let aws_fails = AWSCloudTrail
+	| where TimeGenerated >= ago(1d)
+	| where EventName == "ConsoleLogin"
+	| extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin) 
+	| where LoginResult == "Success"
+	| summarize count() by SourceIpAddress
+	| where count_ >  signin_threshold
+	| summarize makelist(SourceIpAddress);
+	SigninLogs
+	| where TimeGenerated >= ago(1d)
+	| where ResultType !in ("0", "50125", "50140")
+	| where IPAddress in (aws_fails) 
+	| extend Reason=  "Multiple failed AWS Console logins from IP address"

--- a/Detections/MultipleDataSources/AWSConsoleAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/AWSConsoleAADCorrelation.yaml
@@ -1,7 +1,9 @@
 id: 910124df-913c-47e3-a7cd-29e1643fa55e
-name: IP with multiple failed AWS console logins successfully logs in to AAD.
+name: IP with multiple failed AWS console logins successfully logs in to Azure AD.
 description: |
-	This query looks for IP addresses with multiple failed login attempts to the AWS console with a successful Azure AD login within the same timeframe.
+	This query creates a list of IP addresses with multiple failed login attempts 
+	to the AWS console above a set threshold. It then looks for any successful Azure
+	AD logins from these IPs within the same timeframe.
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -16,20 +18,29 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - InitialAccess
+  - CredentialAccess
+ relevantTechniques:
+   - T1078
+   - T1110
   
 query: |
-
+	//Adjust this threshold to fit environment
 	let  signin_threshold = 5; 
+	//Make a list of IPs with failed AWS console logins
 	let aws_fails = AWSCloudTrail
 	| where TimeGenerated >= ago(1d)
 	| where EventName == "ConsoleLogin"
 	| extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin) 
 	| where LoginResult == "Success"
+	| where SourceIPAddress != "127.0.0.1"
 	| summarize count() by SourceIpAddress
 	| where count_ >  signin_threshold
 	| summarize makelist(SourceIpAddress);
+	//See if any of those IPs have sucessfully logged into Azure AD.
 	SigninLogs
 	| where TimeGenerated >= ago(1d)
 	| where ResultType !in ("0", "50125", "50140")
 	| where IPAddress in (aws_fails) 
 	| extend Reason=  "Multiple failed AWS Console logins from IP address"
+	| extend AccountCustomEntity = UserPrincipalName
+	| extend IPCustomEntity = IPAddress

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -1,0 +1,48 @@
+id:  1ce5e766-26ab-4616-b7c8-3b33ae321e80
+name: IP with multiple failed host login attempts and successful AAD login.
+description: |
+	This query looks for IP addresses with multiple failed host logins via remote protocols, and within the same timeframe a successful login Azure AD.
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+     - SigninLogs
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+  - connectorId: Syslog
+    dataTypes:
+      - Syslog 
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+  
+query: |
+
+	let signin_threshold = 5; 
+	let win_fails = 
+	SecurityEvent
+	| where TimeGenerated >= ago(1d)
+	| where EventID == 4625
+	| where LogonType == 10 or LogonType == 7 or LogonType == 3
+	| where IpAddress != "-"
+	| summarize count() by IpAddress
+	| where count_ > signin_threshold
+	| summarize makelist(IpAddress);
+	let linux_fails = 
+	Syslog
+	| where TimeGenerated > ago(1d)
+	| where Facility contains 'auth' and ProcessName != 'sudo'
+	| extend SourceIP = extract("(([0-9]|[0-9][0-9]|[0-9][0-9][0-9])\\.([0-9]|[0-9][0-9]|[0-9][0-9][0-9])\\.([0-9]|[0-9][0-9]|[0-9][0-9][0-9])\\.([0-9]|[0-9][0-9]|[0-9][0-9][0-9]))",1,SyslogMessage)
+	| where SourceIP != ""
+	| summarize count() by SourceIP
+	| where count_ > signin_threshold
+	| summarize makelist(SourceIP);
+	SigninLogs
+	| where TimeGenerated > ago(1d)
+	| where ResultType != "0"
+	| where IPAddress in (win_fails) or IPAddress in (linux_fails)
+	| extend Reason=  "Multiple failed host logins from IP address"

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -1,8 +1,9 @@
 id:  1ce5e766-26ab-4616-b7c8-3b33ae321e80
-name: IP with multiple failed host login attempts and successful AAD login.
+name: IP with multiple failed host login attempts successfully logs into Azure AD.
 description: |
-	This query looks for IP addresses with multiple failed host logins 
-	via remote protocols, and within the same timeframe a successful login Azure AD.
+	This query makes a list of IP addresses with multiple failed host logins
+	above our defined threshold. It then looks for a sucessful Azure AD login
+	from any of those IPs within the same timeframe.
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -20,10 +21,15 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - InitialAccess
+  - CredentialAccess
+relevantTechniques:
+  - T1078
+  - T1110
   
 query: |
-
+	//Adjust this threshold to fit environment
 	let signin_threshold = 5; 
+	//Make a list of IPs with failed Windows host logins above threshold
 	let win_fails = 
 	SecurityEvent
 	| where TimeGenerated >= ago(1d)
@@ -33,17 +39,21 @@ query: |
 	| summarize count() by IpAddress
 	| where count_ > signin_threshold
 	| summarize makelist(IpAddress);
-	let linux_fails = 
+	//Make a list of IPs with failed *nix host logins above threshold
+	let nix_fails = 
 	Syslog
 	| where TimeGenerated > ago(1d)
 	| where Facility contains 'auth' and ProcessName != 'sudo'
-	| extend SourceIP = extract("(([0-9]|[0-9][0-9]|[0-9][0-9][0-9])\\.([0-9]|[0-9][0-9]|[0-9][0-9][0-9])\\.([0-9]|[0-9][0-9]|[0-9][0-9][0-9])\\.([0-9]|[0-9][0-9]|[0-9][0-9][0-9]))",1,SyslogMessage)
-	| where SourceIP != ""
+	| extend SourceIP = extract("(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3})))",1,SyslogMessage)
+	| where SourceIP != "" and SourceIP != "127.0.0.1"
 	| summarize count() by SourceIP
 	| where count_ > signin_threshold
 	| summarize makelist(SourceIP);
+	//See if any of the IPs with failed host logins hve had a sucessful Azure AD login
 	SigninLogs
 	| where TimeGenerated > ago(1d)
 	| where ResultType !in ("0", "50125", "50140")
-	| where IPAddress in (win_fails) or IPAddress in (linux_fails)
+	| where IPAddress in (win_fails) or IPAddress in (nix_fails)
 	| extend Reason=  "Multiple failed host logins from IP address"
+	| extend AccountCustomEntity = UserPrincipalName
+	| extend IPCustomEntity = IPAddress

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -1,7 +1,8 @@
 id:  1ce5e766-26ab-4616-b7c8-3b33ae321e80
 name: IP with multiple failed host login attempts and successful AAD login.
 description: |
-	This query looks for IP addresses with multiple failed host logins via remote protocols, and within the same timeframe a successful login Azure AD.
+	This query looks for IP addresses with multiple failed host logins 
+	via remote protocols, and within the same timeframe a successful login Azure AD.
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -43,6 +44,6 @@ query: |
 	| summarize makelist(SourceIP);
 	SigninLogs
 	| where TimeGenerated > ago(1d)
-	| where ResultType != "0"
+	| where ResultType !in ("0", "50125", "50140")
 	| where IPAddress in (win_fails) or IPAddress in (linux_fails)
 	| extend Reason=  "Multiple failed host logins from IP address"


### PR DESCRIPTION
Correlation rules between AAD <> hosts as well as AAD  <> AWS.
Set signin threshold at 5 as appears to be best balance across available data sets. Customers using proxy services will need to change this or explicitly exclude certain IPs before using these detections.