### PR TITLE
AWS IAM policy update for timestamp mapping

### DIFF
--- a/Hunting Queries/AWSCloudTrail/AWS_IAM_PolicyChange.txt
+++ b/Hunting Queries/AWSCloudTrail/AWS_IAM_PolicyChange.txt
@@ -29,4 +29,5 @@ AWSCloudTrail
 | project TimeGenerated , EventName , EventTypeName  , UserIdentityAccountId ,  UserIdentityPrincipalid , UserAgent , UserIdentityUserName , SessionMfaAuthenticated , SourceIpAddress , AWSRegion , EventSource , AdditionalEventData , ResponseElements
 | extend IPCustomEntity = SourceIpAddress
 | extend AccountCustomEntity = UserIdentityAccountId
+| extend timestamp = TimeGenerated
 


### PR DESCRIPTION
Added timestamp mapping "| extend timestamp = TimeGenerated" so create bookmark will know which column to use for the timestamp.

Fixes #

## Proposed Changes

  -
  -
  -
