### PR TITLE
Added timestamp mapping

### DIFF
--- a/Hunting Queries/AuditLogs/ConsentToApplicationDiscovery.txt
+++ b/Hunting Queries/AuditLogs/ConsentToApplicationDiscovery.txt
@@ -52,3 +52,4 @@ Results
 | extend PropertyUpdate = pack(PropertyName, newValue, "Id", Id)
 | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), PropertyUpdateSet = make_bag(PropertyUpdate) by InitiatedBy, TargetAppName, OperationName, CorrelationId
 | extend AccountCustomEntity = InitiatedBy
+| extend timestamp = StartTimeUtc


### PR DESCRIPTION
Added timestamp mapping (| extend timestamp = StartTimeUtc) so that bookmarks will track the event time in the bookmarked row by default vs. the time the bookmark was created.
