### PR TITLE
Added timestamp mapping

### DIFF
--- a/Hunting Queries/AuditLogs/RareAuditActivityByApp.txt
+++ b/Hunting Queries/AuditLogs/RareAuditActivityByApp.txt
@@ -37,3 +37,4 @@ RareAudits
 | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc),Activity = make_set(Activity) by InitiatedByApp, OperationName, UserPrincipalName
 | order by UserPrincipalName asc, StartTimeUtc asc
 | extend AccountCustomEntity = UserPrincipalName
+| extend timestamp = StartTimeUtc


### PR DESCRIPTION
Added timestamp mapping (| extend timestamp = StartTimeUtc) so that bookmarks will track the event time in the bookmarked row by default vs. the time the bookmark was created.

Fixes #

## Proposed Changes

  -
  -
  -
