### PR TITLE
Added timestamp mapping

### DIFF
--- a/Hunting Queries/AuditLogs/RareAuditActivityByUser.txt
+++ b/Hunting Queries/AuditLogs/RareAuditActivityByUser.txt
@@ -38,3 +38,4 @@ RareAudits
 | order by UserPrincipalName asc, StartTimeUtc asc
 | extend AccountCustomEntity = InitiatedByUser
 | extend IPCustomEntity = InitiatedByIPAddress
+| extend timestamp = StartTimeUtc


### PR DESCRIPTION
Added timestamp mapping (| extend timestamp = StartTimeUtc) so that bookmarks will track the event time in the bookmarked row by default vs. the time the bookmark was created.