### PR TITLE
update to parse dns events for v10

### DIFF
--- a/Parsers/SysmonParser.txt
+++ b/Parsers/SysmonParser.txt
@@ -1,6 +1,6 @@
 // KQL Sysmon Event Parser
-// Last Updated Date: June 4, 2019
-// Sysmon Version : 9.1.0.0
+// Last Updated Date: Sept 4, 2019
+// Sysmon Version : 10.2.0.0
 //
 // Sysmon Instructions:
 // If you want to print configuration schema definition of sysmon. Execute below command from command shell or powershell terminal
@@ -8,12 +8,14 @@
 //
 // You can further customize config XML definition and install sysmon with it via below command. 
 // Sample Sysmon config XML from Swift on Security’s GitHub page : https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml
+// To parse DNS Events with sysmon 10, use alpha version: https://github.com/SwiftOnSecurity/sysmon-config/blob/master/z-AlphaVersion.xml
 // Sysmon.exe -i sysmonconfig-export.xml -accepteula -h md5,sha256 -n -l  
 // -n : Log all network connections and -l: log loading of modules.
 //
 // Parser Notes:
 // 1. This parser works against the above mentioned sysmon version, it may need updates if Sysmon is updated with new events or schema changes.
 // 2. technique_id and technique_name will only be parsed/available if deployed via above mentioned sample sysmon XML config.
+// 3. Make sure to use alpha version to parse DNS Events if you are using Sysmon v 10 or higher.
 //
 // Usage Instruction : 
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias (e.g. Sysmon_Normalized).
@@ -246,16 +248,26 @@ User = EventDetail.[4].["#text"],Consumer = EventDetail.[5].["#text"],Type = Eve
 ;
 processEvents;
 };
+let SysmonEvent22_DNSEvents=() {
+let processEvents = EventData
+| where EventID == 22
+| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
+QueryName = EventDetail.[4].["#text"],QueryStatus = EventDetail.[5].["#text"],QueryResults = EventDetail.[6].["#text"],Image = EventDetail.[7].["#text"]
+| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
+| project-away EventDetail, RuleName 
+;
+processEvents;
+};
 (union isfuzzy=true
 SysmonEvent1_ProcessCreate,SysmonEvent2_FileCreateTime,SysmonEvent3_NetworkConnect,SysmonEvent4_ServiceStateChange,SysmonEvent5_ProcessTerminate,
 SysmonEvent6_DriverLoad,SysmonEvent7_ImageLoad,SysmonEvent8_CreateRemoteThread,SysmonEvent9_RawAccessRead,SysmonEvent10_ProcessAccess,
 SysmonEvent11_FileCreate,SysmonEvent12_RegistryObjectAddDel,SysmonEvent13_RegistrySetValue,SysmonEvent14_RegistryObjectRename,
 SysmonEvent15_FileCreateStreamHash,SysmonEvent16_ConfigChange,SysmonEvent17_CreateNamedPipe,SysmonEvent18_ConnectNamedPipe,
-SysmonEvent19_WMIEventFilter,SysmonEvent20_WMIEventConsumer,SysmonEvent21_WMIEventConsumerToFilter)
+SysmonEvent19_WMIEventFilter,SysmonEvent20_WMIEventConsumer,SysmonEvent21_WMIEventConsumerToFilter,SysmonEvent22_DNSEvents)
 | project TimeGenerated,Source,EventID,Computer,UserName,RenderedDescription,UtcTime,ProcessGuid,ProcessId,Image,FileVersion,
 Description,Product,Company,CommandLine,CurrentDirectory,User,LogonGuid,LogonId,TerminalSessionId,IntegrityLevel,ParentProcessGuid,
 ParentProcessId,ParentImage,ParentCommandLine,TechniqueId,TechniqueName,SHA1,MD5,SHA256,IMPHASH,State,Schema,SchemaVersion,ImageLoaded,
 Hashes,Signed,Signature,SignatureStatus,SourceProcessGuid,SourceProcessId,SourceImage,TargetProcessGuid,TargetProcessId,TargetImage,
 NewThreadId,StartAddress,StartModule,StartFunction,Device,SourceProcessGUID,SourceThreadId,TargetProcessGUID,GrantedAccess,CallTrace,
 TargetFilename,CreationUtcTime,EventType,TargetObject,NewName,TargetFileName,Hash,Configuration,ConfigurationFileHash,PipeName,Operation,
-EventNamespace,Name,Query,Type,Destination,Consumer,Filter
+EventNamespace,Name,Query,Type,Destination,Consumer,Filter,QueryName,QueryStatus,QueryResults


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - update to parse dns events for sysmon v10 or higher
  - added instructions to use another xml for dns events
  - verified to check with prior versions
