### PR TITLE
Avoid false positives on AD FS

### DIFF
--- a/Detections/SecurityEvent/SecurityEventLogCleared.yaml
+++ b/Detections/SecurityEvent/SecurityEventLogCleared.yaml
@@ -1,7 +1,8 @@
 ﻿id: 80da0a8f-cfe1-4cd0-a895-8bc1771a720e
 name: Security Event log cleared
 description: |
-  'Checks for event id 1102 which indicates the security event log was cleared.'
+  'Checks for event id 1102 which indicates the security event log was cleared. 
+  Exclude events from "AD FS Auditing" as Event Source Name to avoid generating false positives when detecting this on AD FS servers.'
 severity: Low
 requiredDataConnectors:
   - connectorId: SecurityEvents
@@ -17,9 +18,10 @@ relevantTechniques:
   - T1107
 query: |
 
-  let timeframe = 1d;
+let timeframe = 1d;
   SecurityEvent
   | where TimeGenerated >= ago(timeframe)
   | where EventID == 1102
+  | where EventSourceName <> "AD FS Auditing" 
   | summarize count() by StartTimeUtc = TimeGenerated, Computer, Account, EventID, Activity
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Account, HostCustomEntity = Computer

--- a/Detections/SecurityEvent/SecurityEventLogCleared.yaml
+++ b/Detections/SecurityEvent/SecurityEventLogCleared.yaml
@@ -2,7 +2,7 @@
 name: Security Event log cleared
 description: |
   'Checks for event id 1102 which indicates the security event log was cleared. 
-It uses Event Source Name "Microsoft-Windows-Eventlog" to avoid generating false positives from other sources, like AD FS servers for instance.'
+  It uses Event Source Name "Microsoft-Windows-Eventlog" to avoid generating false positives from other sources, like AD FS servers for instance.'
 severity: Low
 requiredDataConnectors:
   - connectorId: SecurityEvents
@@ -18,7 +18,7 @@ relevantTechniques:
   - T1107
 query: |
 
- let timeframe = 1d;
+  let timeframe = 1d;
   SecurityEvent
   | where TimeGenerated >= ago(timeframe)
   | where EventID == 1102 and EventSourceName == "Microsoft-Windows-Eventlog" 

--- a/Detections/SecurityEvent/SecurityEventLogCleared.yaml
+++ b/Detections/SecurityEvent/SecurityEventLogCleared.yaml
@@ -2,7 +2,7 @@
 name: Security Event log cleared
 description: |
   'Checks for event id 1102 which indicates the security event log was cleared. 
-  Exclude events from "AD FS Auditing" as Event Source Name to avoid generating false positives when detecting this on AD FS servers.'
+It uses Event Source Name "Microsoft-Windows-Eventlog" to avoid generating false positives from other sources, like AD FS servers for instance.'
 severity: Low
 requiredDataConnectors:
   - connectorId: SecurityEvents
@@ -18,10 +18,9 @@ relevantTechniques:
   - T1107
 query: |
 
-let timeframe = 1d;
+ let timeframe = 1d;
   SecurityEvent
   | where TimeGenerated >= ago(timeframe)
-  | where EventID == 1102
-  | where EventSourceName <> "AD FS Auditing" 
+  | where EventID == 1102 and EventSourceName == "Microsoft-Windows-Eventlog" 
   | summarize count() by StartTimeUtc = TimeGenerated, Computer, Account, EventID, Activity
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Account, HostCustomEntity = Computer


### PR DESCRIPTION
Added one line to exclude events from "AD FS Auditing" as Event Source Name to avoid generating false positives when detecting this on AD FS servers.

Fixes #

## Proposed Changes

  -
  -
  -
