### PR TITLE
Set Security Event Log cleared Severity to High

### DIFF
--- a/Detections/SecurityEvent/SecurityEventLogCleared.yaml
+++ b/Detections/SecurityEvent/SecurityEventLogCleared.yaml
@@ -3,7 +3,7 @@ name: Security Event log cleared
 description: |
   'Checks for event id 1102 which indicates the security event log was cleared. 
   It uses Event Source Name "Microsoft-Windows-Eventlog" to avoid generating false positives from other sources, like AD FS servers for instance.'
-severity: Low
+severity: High
 requiredDataConnectors:
   - connectorId: SecurityEvents
     dataTypes:


### PR DESCRIPTION
Event ID 1102 is extremely rare in normal operations, but is a known marker of severe malicious activity. Most guidance recommends treating 1102 generating events as critical alerts. Alert severity in Sentinel should be increased to High to reflect this.

Fixes #

## Proposed Changes

  -
  -
  -
