### PR TITLE
Change SID regex

### DIFF
--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -23,7 +23,7 @@ query: |
   let timeframe = 1h;
   // For AD SID mappings - https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/active-directory-security-groups
   let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]";
-  let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103";
+  let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-498|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1000";
   SecurityEvent 
   | where TimeGenerated > ago(timeframe)
   // When MemberName contains '-' this indicates addition of a group to a group


### PR DESCRIPTION
Changed the variable "WellKnownGroupSID" to include two more SID/RID (-498 and -1000) and a $ sign on the first SID/RID regex, since it was generating false positives when last number has more than two number after 5. Example: S-1-5-21-1111111111-2222222222-333333333-550390.

Fixes #

## Proposed Changes

  -
  -
  -
