### PR TITLE
fixed typo from mas.util to mas.utils

### DIFF
--- a/Notebooks/Guided Hunting - Windows-Host-Explorer.ipynb
+++ b/Notebooks/Guided Hunting - Windows-Host-Explorer.ipynb
@@ -156,7 +156,7 @@
     "from matplotlib import MatplotlibDeprecationWarning\n",
     "warnings.simplefilter(\"ignore\", category=MatplotlibDeprecationWarning)\n",
     "\n",
-    "display(HTML(mas.util._TOGGLE_CODE_PREPARE_STR))\n",
+    "display(HTML(mas.utils._TOGGLE_CODE_PREPARE_STR))\n",
     "HTML('''\n",
     "    <script type=\"text/javascript\">\n",
     "        IPython.notebook.kernel.execute(\"nb_query_string='\".concat(window.location.search).concat(\"'\"));\n",


### PR DESCRIPTION
Fixes #

fixed typo from mas.util to mas.utils

  -
  -
  -
