### PR TITLE
change  supported query ids to informative names.

### DIFF
--- a/Exploration Queries/DnsEvents/LeastPrevClientIP-DNSNameQueryToIP.txt
+++ b/Exploration Queries/DnsEvents/LeastPrevClientIP-DNSNameQueryToIP.txt
@@ -1,4 +1,4 @@
-// Id: 801bacb0-612a-4195-a84f-7939cca63b92
+// Id: LeastPrevClientIPDNSNameQueryToIP
 // DisplayName: DNS Name Lookup Query from least prevalent ClientIP to remote IP Address
 // Description: Summary of Bottom 10 Client IP and Domain Names for a given remote IPAddress from DnsEvent Lookup Query data (set time range to +-3h when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/DnsEvents/MostPrevClientIP-DNSNameQueryToIP.txt
+++ b/Exploration Queries/DnsEvents/MostPrevClientIP-DNSNameQueryToIP.txt
@@ -1,4 +1,4 @@
-// Id: 0cb64e03-8534-47b6-9094-7de2d018fd7a
+// Id: MostPrevClientIPDNSNameQueryToIP
 // DisplayName: DNS Name Lookup Query from most prevalent ClientIP to remote IP Address
 // Description: Summary of Top 10 Client IP and Domain Names for a given remote IPAddress from DnsEvent Lookup Query data (set time range to +-3h when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/InputEntity_Account/Acc2Host_HostWithMostFails.txt
+++ b/Exploration Queries/InputEntity_Account/Acc2Host_HostWithMostFails.txt
@@ -1,4 +1,4 @@
-// Id: 4c541df8-a680-4da5-96c9-74456927213f
+// Id: HostsWithMostFailedLogins
 // DisplayName: Hosts The Account Failed to Log-in to Most
 // Description: Hosts The Account Failed to Log-in to Most during the range of -1d and +1d
 // InputEntityType: Account

--- a/Exploration Queries/InputEntity_Account/Acc2IP_rareIPLocation.txt
+++ b/Exploration Queries/InputEntity_Account/Acc2IP_rareIPLocation.txt
@@ -1,4 +1,4 @@
-// Id: 2db8cac9-d2ce-4494-93bf-4678cd872ce4
+// Id: IPsFromRareLocations
 // Name: IPs From Rare Locations Used By Account
 // Description: IPs with rare location (less than 10 per cent of user's activity) during the range of +1w and -1w
 // InputEntityType: Account

--- a/Exploration Queries/InputEntity_Host/Host2Acc_PossibleSuccessfulBruteForce.txt
+++ b/Exploration Queries/InputEntity_Host/Host2Acc_PossibleSuccessfulBruteForce.txt
@@ -1,4 +1,4 @@
-// Id: 98b2ce21-167d-43bd-a496-9f2c85c5f95b
+// Id: AccountsWithPossibleSuccessfulBruteForce
 // DisplayName: Accounts With Several Failed Logins Immediately Followed By A Successful Login
 // Description: Accounts With Several Failed Logins immediately Followed By A Successful Login during the range of -1w and +1w
 // InputEntityType: Host

--- a/Exploration Queries/InputEntity_IP/IP2Account_byAccountAzureActivityLeast.txt
+++ b/Exploration Queries/InputEntity_IP/IP2Account_byAccountAzureActivityLeast.txt
@@ -1,4 +1,4 @@
-// Id: 37ca3555-c135-4a73-a65e-9c1d00323f5d
+// Id: AccountActivityByIPLeastActive
 // DisplayName: Least Active Accounts On Azure From IP
 // Description: Least active accounts on azure from IP during the range of -12h and +12h
 // InputEntityType: IP

--- a/Exploration Queries/InputEntity_IP/IP2Account_byAccountAzureActivityMost.txt
+++ b/Exploration Queries/InputEntity_IP/IP2Account_byAccountAzureActivityMost.txt
@@ -1,4 +1,4 @@
-// Id: 97a1d515-abf2-4231-9a35-985f9de0bb91
+// Id: AccountActivityByIPMostActive
 // DisplayName: Most Active Accounts On Azure From IP
 // Description: Most active accounts on azure from IP during the range of -12h and +12h
 // InputEntityType: IP

--- a/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficFromIPLeast.txt
+++ b/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficFromIPLeast.txt
@@ -1,4 +1,4 @@
-// Id: aa497951-c779-4ea2-be2a-127ea66c5fba
+// Id: HostsByTrafficFromIPLeast
 // DisplayName: Hosts Receiving Least Amount of Data from IP
 // Description: Hosts receiving least Amount of data from IP during the range of -1d and +1d
 // DataConnector: ; DataTypes: #WireData

--- a/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficFromIPMost.txt
+++ b/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficFromIPMost.txt
@@ -1,4 +1,4 @@
-// Id: 73fb9b8d-fd13-4c43-8136-6d693cafaa23
+// Id: HostsByTrafficFromIPMost
 // DisplayName: Hosts Receiving Most Amount of Data from IP
 // Description: Hosts Receiving Most Amount of Data from IP during the range of -1d and +1d
 // DataConnector: ; DataTypes: #WireData

--- a/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficToIPLeast.txt
+++ b/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficToIPLeast.txt
@@ -1,4 +1,4 @@
-// Id: ab597a67-352e-4914-b2e6-d64919a910a8
+// Id: HostsByTrafficToIPLeast
 // DisplayName: Hosts Sending Least Amount of Data to IP
 // Description: Hosts sending least amount of data to IP during the range of -1d and +1d
 // InputEntityType: IP

--- a/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficToIPMost.txt
+++ b/Exploration Queries/InputEntity_IP/IP2Host_HostByTrafficToIPMost.txt
@@ -1,4 +1,4 @@
-// Id: 5b57680b-d60a-42a5-9cd5-17e499834f8e
+// Id: HostsByTrafficToIPMost
 // DisplayName: Hosts Sending Most Amount of Data to IP
 // Description: Hosts Sending Most Amount of Data to IP
 // InputEntityType: IP

--- a/Exploration Queries/InputEntity_IP/IP2IP_IPsWithMostDROPs.txt
+++ b/Exploration Queries/InputEntity_IP/IP2IP_IPsWithMostDROPs.txt
@@ -1,4 +1,4 @@
-// Id: 980762f8-014e-4439-8840-5f0a90285dce
+// Id: IPsWithMostDrops
 // DisplayName: Destination IPs with Most Dropped Sessions
 // Description: Destination IPs with most dropped sessions, sorted by number of ports and number of drops
 // DataConnector: #WindowsFirewall; DataTypes: #WindowsFirewall

--- a/Exploration Queries/InputEntity_IP/IP2IP_SrcIPsWithMostDROP.txt
+++ b/Exploration Queries/InputEntity_IP/IP2IP_SrcIPsWithMostDROP.txt
@@ -1,4 +1,4 @@
-// Id: 935ab312-cb52-42a5-b296-548f21786102
+// Id: SrcIPsWithMostDrops
 // DisplayName: Source IPs with Most Dropped Sessions
 // Description: Source IPs with most dropped sessions
 // DataConnector: #WindowsFirewall; DataTypes: #WindowsFirewall

--- a/Exploration Queries/OfficeActivity/IpAddress_AccountLogons.txt
+++ b/Exploration Queries/OfficeActivity/IpAddress_AccountLogons.txt
@@ -1,4 +1,4 @@
-// Id: 588f5d9f-3380-4eff-9983-e61d62fdd172
+// Id: IPAddressAccountLogons
 // DisplayName: Office Activity IP Address by Account
 // Description: Summary of Accounts for a given ClientIP on Office Activity data (set time range to +-12h when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/OfficeActivity/UserAccount_LogonsFromIPAddress.txt
+++ b/Exploration Queries/OfficeActivity/UserAccount_LogonsFromIPAddress.txt
@@ -1,4 +1,4 @@
-// Id: 7f3989bf-1558-4d3c-bb5e-e17ac2a67a87
+// Id: UserAccountLogonsFromIPAddress
 // DisplayName: Office Activity Account logons from IP
 // Description: Summary of IP addresses for logins based on Office Activity data (set time range to +-12h when running the query)
 // InputEntityType: Account

--- a/Exploration Queries/SecurityEvent/FilesOnHost.txt
+++ b/Exploration Queries/SecurityEvent/FilesOnHost.txt
@@ -1,4 +1,4 @@
-// Id: 62527635-bc5a-4233-bb93-e4eb4e60bb70
+// Id: FilesOnHost
 // DisplayName: Files identified on Host
 // Description: Any file referenced on a given host during the time of or recently after compromise (set time range to +-30m when running the query)
 // InputEntityType: File

--- a/Exploration Queries/SecurityEvent/ParentProcessesOnHost.txt
+++ b/Exploration Queries/SecurityEvent/ParentProcessesOnHost.txt
@@ -1,4 +1,4 @@
-// Id: 07da3cc8-c8ad-4710-a44e-334cdcb7882b
+// Id: ParentProcessesOnHost
 // DisplayName: Parent Processes running on Host
 // Description: Any 4688 event that contains Parent Process running on a given host during the time of or recently after compromise (set time range to +-10m when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/SecurityEvent/ProcessesOnHost.txt
+++ b/Exploration Queries/SecurityEvent/ProcessesOnHost.txt
@@ -1,4 +1,4 @@
-// Id: d3393571-0533-4127-bfe1-6b1de4ab126e
+// Id: ProcessesOnHost
 // DisplayName: Processes running on Host
 // Description: Any processes running on a given host during the time of or recently after compromise (set time range to +-10m when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/SecurityEvent/ServiceCreatedByAccount.txt
+++ b/Exploration Queries/SecurityEvent/ServiceCreatedByAccount.txt
@@ -1,4 +1,4 @@
-// Id: dd8f30e4-8171-452e-84a0-99bcd570bd08
+// Id: ServicesCreatedByAccount
 // DisplayName: Service Created by Account
 // Description: Any Service Created on any system by the given account during the time of or recently after compromise (set time range to +-6h when running the query)
 // InputEntityType: Account

--- a/Exploration Queries/SecurityEvent/ServiceCreatedOnHost.txt
+++ b/Exploration Queries/SecurityEvent/ServiceCreatedOnHost.txt
@@ -1,4 +1,4 @@
-// Id: 6537a8c3-a269-4b2f-8c70-3824c23fef7b
+// Id: ServiceCreatedOnHost
 // DisplayName: Service Created on Host
 // Description: Any Service Created on a given host during the time of or recently after compromise (set time range to +-6h when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/SecurityEvent/UserAccount_CreatedDeleted.txt
+++ b/Exploration Queries/SecurityEvent/UserAccount_CreatedDeleted.txt
@@ -1,4 +1,4 @@
-// Id: 3aed43db-e358-4952-a5cd-a10f00d90af4
+// Id: UserAccountsCreatedOrDeleted
 // DisplayName: User Account Created or Deleted
 // Description: User account creations and deletions on a given host during the time of or recently after compromise (set time range to +-12h when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/SecurityEvent/UserAccount_FailedLogons.txt
+++ b/Exploration Queries/SecurityEvent/UserAccount_FailedLogons.txt
@@ -1,4 +1,4 @@
-// Id: 84375346-c3f0-4926-ae48-a156010c67e3
+// Id: UserAccountFailedLogons
 // DisplayName: User Account Failed logons
 // Description: Failed logons by a given user during the time of or recently after compromise (set time range to +-1h when running the query)
 // InputEntityType: Account

--- a/Exploration Queries/SecurityEvent/UserAccount_SuccessLogons.txt
+++ b/Exploration Queries/SecurityEvent/UserAccount_SuccessLogons.txt
@@ -1,4 +1,4 @@
-// Id: 8a697f4c-04af-4198-a6d3-ce5dc3acc8dd
+// Id: UserAccountSuccessLogons
 // DisplayName: User Account Success logons
 // Description: Successful logons by a given user during the time of or recently after compromise (set time range to +-1h when running the query)
 // InputEntityType: Account

--- a/Exploration Queries/SecurityEvent/WinHosts_WithThisProcess.txt
+++ b/Exploration Queries/SecurityEvent/WinHosts_WithThisProcess.txt
@@ -1,4 +1,4 @@
-// Id: 0880a6d7-d914-40f6-91bc-150de4810e4e
+// Id: WinHostsWithThisProcess
 // DisplayName: Windows Hosts With This Process
 // Description: Any host with this same process (set time range to +-1h when running the query)
 // InputEntityType: Process

--- a/Exploration Queries/SigninLogs/LeastPrevUsersByIPAddress.txt
+++ b/Exploration Queries/SigninLogs/LeastPrevUsersByIPAddress.txt
@@ -1,4 +1,4 @@
-// Id: fdb3e714-c036-4708-a0eb-6ae10a1912a1
+// Id: LeastPrevUsersByIPAddress
 // DisplayName: IPAddress associated with bottom 10 Accounts
 // Description: The bottom 10 count of user account logon attempts from a given IPAddress during a given time period based on SigninLogs (set time range to +-1d when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/SigninLogs/MostPrevUsersByIPAddress.txt
+++ b/Exploration Queries/SigninLogs/MostPrevUsersByIPAddress.txt
@@ -1,4 +1,4 @@
-// Id: bc6c7cc9-da18-4afd-8fda-d201f13b54a4
+// Id: MostPrevUsersByIPAddress
 // DisplayName: IPAddress associated with Top 10 Accounts
 // Description: The top 10 count of user account logon attempts from a given IPAddress during a given time period based on SigninLogs (set time range to +-1d when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/SigninLogs/UserAccount_ResourceLogon.txt
+++ b/Exploration Queries/SigninLogs/UserAccount_ResourceLogon.txt
@@ -1,4 +1,4 @@
-// Id: c34bf507-cedf-4120-bf41-f835dd68b0d9
+// Id: UserAccountResourceLogon
 // DisplayName: Resources on which an Account logged onto 
 // Description: Resources on which an Account was logged on during a given time period based on SigninLogs (set time range to +-1d when running the query)
 // InputEntityType: Account

--- a/Exploration Queries/SigninLogs/UsersConnectedByHost.txt
+++ b/Exploration Queries/SigninLogs/UsersConnectedByHost.txt
@@ -1,4 +1,4 @@
-// Id: 37fdc179-d35c-4dcd-b6ff-6cf02248d8f9
+// Id: UsersConnectedByHost
 // DisplayName: HostName with accociated Accounts
 // Description: The hostname usage by a given Account (set time range to +-1d when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/Syslog/LeastPrevLxHosts_ByProcess.txt
+++ b/Exploration Queries/Syslog/LeastPrevLxHosts_ByProcess.txt
@@ -1,4 +1,4 @@
-// Id: def383f2-dff3-4f5b-9416-aca8dca39812
+// Id: LeastPrevLxHostsByProcess
 // DisplayName: Least Prevalent Linux Hosts With This Process
 // Description: Bottom 10 Hosts, IP with this process and syslog message (set time range to +-1h when running the query)
 // InputEntityType: Process

--- a/Exploration Queries/Syslog/LeastPrevProcess_ByAccount.txt
+++ b/Exploration Queries/Syslog/LeastPrevProcess_ByAccount.txt
@@ -1,4 +1,4 @@
-// Id: f89061dd-e6d6-4553-9c88-301a7360fc14
+// Id: LeastPrevProcessesByAccount
 // DisplayName: Least Prevalent Process by Account
 // Description: Bottom 10 process by Account (set time range to +-1h when running the query)
 // InputEntityType: Account

--- a/Exploration Queries/Syslog/LeastPrevProcess_ByHost.txt
+++ b/Exploration Queries/Syslog/LeastPrevProcess_ByHost.txt
@@ -1,4 +1,4 @@
-// Id: ea747f91-23f9-425a-baa8-628f30193888
+// Id: LeastPrevProcessesByHost
 // DisplayName: Least Prevalent Process on Host
 // Description: Bottom 10 process on host (set time range to +-1h when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/Syslog/MostPrevLxHosts_ByIP.txt
+++ b/Exploration Queries/Syslog/MostPrevLxHosts_ByIP.txt
@@ -1,4 +1,4 @@
-// Id: 41146c58-ffc6-47ff-975e-f85013629dfd
+// Id: MostPrevLxHostsByIP
 // DisplayName: Most Prevalent Linux Hosts With This IPAddress
 // Description: Top 10 Hosts and ProcessName with this IPAddress (set time range to +-6h when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/WireData/LeastPrevIn_ByHost.txt
+++ b/Exploration Queries/WireData/LeastPrevIn_ByHost.txt
@@ -1,4 +1,4 @@
-// Id: bb6100ee-ae38-41b5-8457-88d503a3bf8f
+// Id: LeastPrevInByHost
 // DisplayName: WireData Least Prevalent Inbound Connections by Host
 // Description: Bottom 10 (least prevalent) for WireData Inbound event by a given Host (set time range to +-30m when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/WireData/LeastPrevIn_ByIPAddress.txt
+++ b/Exploration Queries/WireData/LeastPrevIn_ByIPAddress.txt
@@ -1,4 +1,4 @@
-// Id: 188ff904-e3c3-4253-9326-e0190b4b7a01
+// Id: LeastPrevInByIPAddress
 // DisplayName: WireData Least Prevalent Inbound Connections by IPAddress
 // Description: Bottom 10 (least prevalent) for WireData Inbound event by a given IPAddress (set time range to +-30m when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/WireData/LeastPrevIn_ByProcess.txt
+++ b/Exploration Queries/WireData/LeastPrevIn_ByProcess.txt
@@ -1,4 +1,4 @@
-// Id: 77f9839a-1c03-49e2-803e-72b97042fc05
+// Id: LeastPrevInByProcess
 // DisplayName: WireData Least Prevalent Inbound Connections by Process
 // Description: Bottom 10 (least prevalent) for WireData Inbound event by a given process (set time range to +-30m when running the query)
 // InputEntityType: Process

--- a/Exploration Queries/WireData/LeastPrevOut_ByHost.txt
+++ b/Exploration Queries/WireData/LeastPrevOut_ByHost.txt
@@ -1,4 +1,4 @@
-// Id: 8c00a2a0-43d3-45a9-aa2e-f73deb0abfbb
+// Id: LeastPrevOutByHost
 // DisplayName: WireData Least Prevalent Outbound Connections by Host
 // Description: Bottom 10 (least prevalent) for WireData Outbound event by a given Host (set time range to +-30m when running the query)
 // InputEntityType: Host

--- a/Exploration Queries/WireData/LeastPrevOut_ByIPAddress.txt
+++ b/Exploration Queries/WireData/LeastPrevOut_ByIPAddress.txt
@@ -1,4 +1,4 @@
-// Id: 897267e4-68e1-4827-b318-7fb055b52fc0
+// Id: LeastPrevOutByIPAddress
 // DisplayName: WireData Least Prevalent Outbound Connections by IPAddress
 // Description: Bottom 10 (least prevalent) for WireData Outbound event by a given IPAddress (set time range to +-30m when running the query)
 // InputEntityType: Ip

--- a/Exploration Queries/WireData/LeastPrevOut_ByProcess.txt
+++ b/Exploration Queries/WireData/LeastPrevOut_ByProcess.txt
@@ -1,4 +1,4 @@
-// Id: 39df618a-684d-402d-b096-6f505a8e741e
+// Id: LeastPrevOutByProcess
 // DisplayName: WireData Least Prevalent Outbound Connections by Process
 // Description: Bottom 10 (least prevalent) for WireData Outbound event by a given process (set time range to +-1h when running the query)
 // InputEntityType: Process


### PR DESCRIPTION
Changed the ids of our supported queries to informative names, rather than guids.