### PR TITLE
Update Sysmon-v10.42-Parser.txt

### DIFF
--- a/Parsers/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon-v10.42-Parser.txt
@@ -271,4 +271,4 @@ ParentProcessId, ParentImage, ParentCommandLine, TechniqueId, TechniqueName, SHA
 Hashes, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, 
 NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace, 
 TargetFilename, CreationUtcTime, EventType, TargetObject, NewName, TargetFileName, Hash, Configuration, ConfigurationFileHash, PipeName, Operation, 
-EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName
+EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName, RuleName, PreviousCreationUtcTime, Details

--- a/Parsers/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon-v10.42-Parser.txt
@@ -1,5 +1,5 @@
 // KQL Sysmon Event Parser
-// Last Updated Date: Dec 17,  2019
+// Last Updated Date: Jan 7,  2020
 // Sysmon Version: 10.42, Binary Version : 9.20 , Schema Version: 4.22
 //
 // Sysmon Instructions:

--- a/Parsers/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon-v10.42-Parser.txt
@@ -271,4 +271,4 @@ ParentProcessId, ParentImage, ParentCommandLine, TechniqueId, TechniqueName, SHA
 Hashes, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, 
 NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace, 
 TargetFilename, CreationUtcTime, EventType, TargetObject, NewName, TargetFileName, Hash, Configuration, ConfigurationFileHash, PipeName, Operation, 
-EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults
+EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName


### PR DESCRIPTION
Added field for network event parsing in the project declaration

Fixes #
When normalizing SysMon EventID 3 you could use the column data like SourceIp and Port

## Proposed Changes

  -
  -
  -
