### PR TITLE
Update UserAccountAddedToPrivlegeGroup.yaml

### DIFF
--- a/Hunting Queries/SecurityEvent/UserAccountAddedToPrivlegeGroup.yaml
+++ b/Hunting Queries/SecurityEvent/UserAccountAddedToPrivlegeGroup.yaml
@@ -17,8 +17,8 @@ query: |
 
   let timeframe = 10d;
   // For AD SID mappings - https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/active-directory-security-groups
-  let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]";
-  let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103";
+  let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]$";
+  let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$";
   SecurityEvent 
   | where TimeGenerated > ago(timeframe) 
   | where AccountType == "User"


### PR DESCRIPTION
Add '$' to regex expressions. The query returns invalid extra results without it.

For example:
```
let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103";
print "S-1-5-21-1017671301-3769557286-3873332140-5560" matches regex WellKnownGroupSID
```

should return 'false' but it returns 'true'