### PR TITLE
Add TAXII connector dependency to Threat Intelligence workbook

### DIFF
--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -186,7 +186,7 @@
     "logoFileName": "",
     "description": "Gain insights into threat indicators, including type and severity of threats, threat activity over time, and correlation with other data sources, including Office 365 and firewalls.",
     "dataTypesDependencies": [ "ThreatIntelligenceIndicator" ],
-    "dataConnectorsDependencies": [ "ThreatIntelligence" ],
+    "dataConnectorsDependencies": [ "ThreatIntelligence", "ThreatIntelligenceTaxii" ],
     "previewImagesFileNames": [ "ThreatIntelligenceWhite.png", "ThreatIntelligenceBlack.png" ],
     "version": "1.0",
     "title": "Threat Intelligence",


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Threat Intelligence TAXII connector uses the same workbook as Threat Intelligence Platforms connector.
  -
  -
