### PR TITLE
Changing the DataSources field in IOT query to a list type

### DIFF
--- a/Exploration Queries/IoT/Process_byIoTDevice.yaml
+++ b/Exploration Queries/IoT/Process_byIoTDevice.yaml
@@ -9,7 +9,8 @@ OutputEntityTypes:
   - Process
 QueryPeriodBefore: 30m
 QueryPeriodAfter: 30m
-DataSources: SecurityIoTRawEvent
+DataSources: 
+  - SecurityIoTRawEvent
 query: |
 
   let Process_byIoTDevice = (v_IotDevice_DeviceId:string, v_IoTDevice_IoTHub:string){


### PR DESCRIPTION
Changing the DataSources field in IOT query to a list type, according to the query template format.