### PR TITLE
Update ExcessiveLogonFailures - detect new patterns that haven't had …

### DIFF
--- a/Detections/SecurityEvent/ExcessiveLogonFailures.yaml
+++ b/Detections/SecurityEvent/ExcessiveLogonFailures.yaml
@@ -26,14 +26,14 @@ query: |
   | where EventID == 4625 and AccountType =~ "User"
   | where IpAddress !in ("127.0.0.1", "::1")
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), CountToday = count() by EventID, Account, LogonTypeName, SubStatus, AccountType, Computer, WorkstationName, IpAddress
-  | join (
+  | join kind=leftouter (
       SecurityEvent 
       | where TimeGenerated between (ago(starttime) .. ago(endtime))
       | where EventID == 4625 and AccountType =~ "User"
       | where IpAddress !in ("127.0.0.1", "::1")
       | summarize CountPrev7day = count() by EventID, Account, LogonTypeName, SubStatus, AccountType, Computer, WorkstationName, IpAddress
   ) on EventID, Account, LogonTypeName, SubStatus, AccountType, Computer, WorkstationName, IpAddress
-  | where CountToday >= CountPrev7day*threshold and CountToday >= countlimit
+  | where CountToday >= coalesce(CountPrev7day,0)*threshold and CountToday >= countlimit
   | extend Reason = case(
   SubStatus == '0xc000005e', 'No logon servers available to service the logon request',
   SubStatus == '0xc0000062', 'Account name is not properly formatted',


### PR DESCRIPTION
…a failure in previous 7 days

The join type used (innerunique by default) will drop rows that don't show up at all in the previous 7 days. 
Switching this to leftouter so that these rows aren't dropped, and wrapping CountPrev7day in a coalesce,
because kusto evaluates x > null as 'false'

Fixes #

## Proposed Changes

  -
  -
  -
