### PR TITLE
Change join type for RDP_MultipleConnectionsFromSingleSystem

### DIFF
--- a/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
+++ b/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
@@ -27,7 +27,7 @@ query: |
   | where EventID == 4624 and LogonType == 10
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ComputerCountToday = dcount(Computer), ComputerSet = makeset(Computer), ProcessSet = makeset(ProcessName)  
   by Account, IpAddress, AccountType, Activity, LogonTypeName
-  | join (
+  | join kind=inner (
   SecurityEvent
   | where TimeGenerated >= ago(starttime) and TimeGenerated < ago(endtime) 
   | where EventID == 4624 and LogonType == 10


### PR DESCRIPTION
The default innerunique will drop other rows with the same Account/IPAddress.
This could cause a row with higher count to get dropped and thus a missed detection.

Fixes #

## Proposed Changes

  -
  -
  -
