### PR TITLE
Functions to check if daylight savings in US/EU

### DIFF
--- a/Functions/CheckifDayLightSavings-US-EU.txt
+++ b/Functions/CheckifDayLightSavings-US-EU.txt
@@ -1,0 +1,50 @@
+// Usage Instruction : 
+// Either run this query as a stand alone query within Azure Sentinel or save it as a KQL function for later use. Further details on
+// functions can be found here: https://techcommunity.microsoft.com/t5/Azure-Sentinel/Using-KQL-functions-to-speed-up-analysis-in-Azure-Sentinel/ba-p/712381
+// For US Daylight Savings
+//Below function will take timestamp as input and provides status if the timestamp is in US DaylightSavings window or not. 
+// Check sample usage on test data at the end
+let CheckifDaylightSavingUS = (UtcDateTime:datetime) {
+// Reference formula: http://www.webexhibits.org/daylightsaving/i.html
+// US daylight savings time begins (clocks go forward) on the second Sunday in March, 
+// and ends (clocks go back) on the first Sunday in November:
+let Year = getyear(UtcDateTime);
+// Calculate day portion of last sunday in March and in November
+let SecondSundayMarch = 14 - ((1+(5 * Year)/4)%7);
+let FirstSundayNovember = 7 - ((1+(5 * Year)/4)%7);
+// Make full datetime object to compare with Current datetime - Add UTC offset to convert local Pacific Time
+let DaylightStart = datetime_add("Hour",-7,make_datetime(Year,03,SecondSundayMarch));
+let DaylightEnd = datetime_add("Hour",-8,make_datetime(Year,11,FirstSundayNovember));
+// Compare the input datetime to the DaylightSavings window
+iff(UtcDateTime between (DaylightStart .. DaylightEnd), "True", "False")
+};
+// For EU Daylight Savings
+let CheckifDaylightSavingEU = (UtcDateTime:datetime) {
+// Reference formula: http://www.webexhibits.org/daylightsaving/i.html
+// European Summer Time begins (clocks go forward) at 01:00 UTC on the last Sunday in March, 
+// and ends (clocks go back) at 01:00 UTC on the last Sunday in October:
+let Year = getyear(UtcDateTime);
+// Calculate day portion of last sunday in March and in October
+let LastSundayMarch = (31 - (((5 * Year)/4)+4)%7);
+let LastSundayOctober = (31 - (((5 * Year)/4)+1)%7);
+// Make full datetime object to compare with Current datetime
+let DaylightStart = make_datetime(Year,03,LastSundayMarch,01,00);
+let DaylightEnd = make_datetime(Year,10,LastSundayOctober,01,00);
+// Compare the input datetime to the DaylightSavings window
+iff(UtcDateTime between (DaylightStart .. DaylightEnd), "True", "False")
+};
+// Sample Usage in the Query - Generate Status based on InputDatetime in UTC
+// let T = materialize(datatable(InputDateTime:datetime)
+// [
+//          datetime(2020-03-07 16:59),
+//          datetime(2020-03-07 17:01),
+//          datetime(2020-10-31 15:59),
+//          datetime(2020-10-31 16:01),
+//          datetime(2020-03-29 00:59),
+//          datetime(2020-03-29 01:00),
+//          datetime(2020-10-25 00:59),
+//          datetime(2020-10-25 01:01),
+// ])
+// ;
+// T
+// | extend DstinUSStatus = CheckifDaylightSavingUS(InputDateTime), DstinEUStatus = CheckifDaylightSavingEU(InputDateTime)


### PR DESCRIPTION
## Proposed Changes

  - Based on customer request - custom KQL function to check if any timestamp is in Daylight savings window or not which can affect certain detections criteria such as Afterhours login.
  - Currently has 2 separate functions for US and  EU
  - Expects input datetime in UTC format. Returns True or False if given time is in Day light savings.
  - Have sample usage commented to check status on input timestamp.
