### PR TITLE
ExcessiveLogonFailures - change Computer/IpAddress from maklist to ma…

### DIFF
--- a/Detections/SecurityEvent/ExcessiveLogonFailures.yaml
+++ b/Detections/SecurityEvent/ExcessiveLogonFailures.yaml
@@ -53,7 +53,7 @@ query: |
   strcat('Unknown reason substatus: ', SubStatus))
   | extend WorkstationName = iff(WorkstationName == "-" or isempty(WorkstationName), Computer , WorkstationName) 
   | project StartTimeUtc, EndTimeUtc, EventID, Account, LogonTypeName, SubStatus, Reason, AccountType, Computer, WorkstationName, IpAddress, CountToday, CountPrev7day, Avg7Day = CountPrev7day/7
-  | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), Computer = makelist(Computer), IpAddressList = makelist(IpAddress), sum(CountToday), sum(CountPrev7day), avg(Avg7Day) 
+  | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), Computer = make_set(Computer,128), IpAddressList = make_set(IpAddress,128), sum(CountToday), sum(CountPrev7day), avg(Avg7Day) 
   by EventID, Account, LogonTypeName, SubStatus, Reason, AccountType, WorkstationName
   | order by sum_CountToday desc nulls last 
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Account, HostCustomEntity = WorkstationName


### PR DESCRIPTION
…ke_set, so only unique values are logged

makelist provides upto 128 values, but its not deduped.
make_set provides deduped values, and I set the limit to 128 to match makelist. If desired this number can be lowered but I kept it to match makelist. In general, make_set with a limit of 128 will provide many more unique values.

Fixes #

## Proposed Changes

  -
  -
  -
