### PR TITLE
query to detect account lockouts

### DIFF
--- a/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
+++ b/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
@@ -7,8 +7,7 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
 tactics:
-  - InitialAccess
-  - CredentialAccess
+  - Impact
 relevantTechniques:
   - T1531
 query: |

--- a/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
+++ b/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
@@ -1,0 +1,20 @@
+id: e7642e6e-cf27-46ec-a4b9-e4475228fead
+name: AD Account Lockout
+description: |
+  'Detects Active Directory account lockouts'
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvent
+tactics:
+  - InitialAccess
+  - CredentialAccess
+relevantTechniques:
+  - T1531
+query: |
+  let timeframe = 7d;
+  SecurityEvent
+  | where TimeGenerated >= ago(timeframe)
+  | where EventID == 4740
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count() by Account
+  | extend Timestamp = StartTimeUtc

--- a/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
+++ b/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
@@ -12,9 +12,10 @@ tactics:
 relevantTechniques:
   - T1531
 query: |
-  let timeframe = 7d;
-  SecurityEvent
-  | where TimeGenerated >= ago(timeframe)
-  | where EventID == 4740
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count() by Account
-  | extend Timestamp = StartTimeUtc
+let timeframe = 7d;
+SecurityEvent
+| where TimeGenerated >= ago(timeframe)
+| where EventID == 4740
+| extend AccountCustomEntity = tostring(split(Account, '\\', 1)), SourceDomainController = Computer, HostCustomEntity = TargetDomainName
+| summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), LockoutsCount = count() by AccountCustomEntity, HostCustomEntity, SourceDomainController
+| extend timestamp = StartTime

--- a/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
+++ b/Hunting Queries/SecurityEvent/ADAccountLockouts.yaml
@@ -12,10 +12,9 @@ tactics:
 relevantTechniques:
   - T1531
 query: |
-let timeframe = 7d;
-SecurityEvent
-| where TimeGenerated >= ago(timeframe)
-| where EventID == 4740
-| extend AccountCustomEntity = tostring(split(Account, '\\', 1)), SourceDomainController = Computer, HostCustomEntity = TargetDomainName
-| summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), LockoutsCount = count() by AccountCustomEntity, HostCustomEntity, SourceDomainController
-| extend timestamp = StartTime
+  let timeframe = 7d;
+  SecurityEvent
+  | where TimeGenerated >= ago(timeframe)
+  | where EventID == 4740
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), LockoutsCount = count() by Activity, Account, TargetSid, TargetDomainName, SourceComputerId, SourceDomainController = Computer
+  | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = TargetDomainName


### PR DESCRIPTION
this is a hunting query for account lockouts in active directory environments.

## Proposed Changes
- new hunting query
