### PR TITLE
Create Wazuh-Large Number of Web errors from an IP

### DIFF
--- a/Detections/CommonSecurityLog/Wazuh-Large Number of Web errors from an IP
+++ b/Detections/CommonSecurityLog/Wazuh-Large Number of Web errors from an IP
@@ -1,7 +1,7 @@
 id:
 name: Wazuh - Large Number of Web errors from an IP
 description: |
-  'Identifies instances where Wazuh logged over 400 '403' Web Errors from one IP Address.'
+  'Identifies instances where Wazuh logged over 400 '403' Web Errors from one IP Address. To onboard Wazuh data into Sentinel please view: https://github.com/wazuh/wazuh-documentation/blob/master/source/azure/monitoring%20activity.rst'
 severity: Low
 requiredDataConnectors:
   - connectorId: Wazuh
@@ -13,16 +13,18 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - Persistance
+relevantTechniques:
+  - T1110
 query: | 
 
-let incidentTime = ago(1d);
-CommonSecurityLog
-| where DeviceProduct == "Wazuh"
-| where Activity contains "Web server 400 error code."
-| where Message contains "403"
-| where TimeGenerated > incidentTime
-| extend CustomHostName=substring(split(DeviceCustomString1,")")[0],1)
-| extend CustomIP = SourceIP 
-| summarize NumberOfErrors = count(SourceIP) by CustomHostName, CustomIP
-| where NumberOfErrors > 400
-| sort by NumberOfErrors desc
+  let incidentTime = ago(1d);
+  CommonSecurityLog
+  | where TimeGenerated > incidentTime
+  | where DeviceProduct =~ "Wazuh"
+  | where Activity has "Web server 400 error code."
+  | where Message has "403"
+  | extend HostName=substring(split(DeviceCustomString1,")")[0],1)
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), NumberOfErrors = count(SourceIP) by HostName, SourceIP
+  | where NumberOfErrors > 400
+  | sort by NumberOfErrors desc
+  | extend timestamp = StartTime, HostCustomEntity = HostName, IPCustomEntity = SourceIP

--- a/Detections/CommonSecurityLog/Wazuh-Large Number of Web errors from an IP
+++ b/Detections/CommonSecurityLog/Wazuh-Large Number of Web errors from an IP
@@ -1,0 +1,28 @@
+id:
+name: Wazuh - Large Number of Web errors from an IP
+description: |
+  'Identifies instances where Wazuh logged over 400 '403' Web Errors from one IP Address.'
+severity: Low
+requiredDataConnectors:
+  - connectorId: Wazuh
+    dataTypes:
+      - CommonSecurityLog
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Persistance
+query: | 
+
+let incidentTime = ago(1d);
+CommonSecurityLog
+| where DeviceProduct == "Wazuh"
+| where Activity contains "Web server 400 error code."
+| where Message contains "403"
+| where TimeGenerated > incidentTime
+| extend CustomHostName=substring(split(DeviceCustomString1,")")[0],1)
+| extend CustomIP = SourceIP 
+| summarize NumberOfErrors = count(SourceIP) by CustomHostName, CustomIP
+| where NumberOfErrors > 400
+| sort by NumberOfErrors desc


### PR DESCRIPTION

[Wazuh-LargeNumberOf403Errors.zip](https://github.com/Azure/Azure-Sentinel/files/4507034/Wazuh-LargeNumberOf403Errors.zip)


The following detection uses the ComonSecurityLog for users that have Wazuh as a Data Connection source. The analytic Identifies instances where Wazuh logged over 400 '403' Web Errors from one IP Address.

Fixes #

## Proposed Changes

  -
  -
  -
