### PR TITLE
Create SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts

### DIFF
--- a/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
+++ b/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
@@ -1,0 +1,48 @@
+name: Sign-ins from IPs that attempt sign-ins to disabled accounts
+description: |
+  'Identifies IPs with failed attempts to sign in to one or more disabled accounts signed in successfully to another account.
+  References: https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/reference-sign-ins-error-codes
+  50057 - User account is disabled. The account has been disabled by an administrator.' This analytic will additionally identify the successful signed in accounts as the mapped account entities for investigation in Sentinel.
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+  - Persistence
+relevantTechniques:
+  - T1078
+  - T1098
+query: |
+ let lookBack = 1d;
+  SigninLogs 
+  | where TimeGenerated >= ago(lookBack)
+  | where ResultType == "50057" 
+  | where ResultDescription == "User account is disabled. The account has been disabled by an administrator." 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), disabledAccountLoginAttempts = count(), 
+  disabledAccountsTargeted = dcount(UserPrincipalName), applicationsTargeted = dcount(AppDisplayName), disabledAccountSet = makeset(UserPrincipalName), 
+  applicationSet = makeset(AppDisplayName) by IPAddress
+  | order by disabledAccountLoginAttempts desc
+  | join kind= leftouter (
+      // Consider these IPs suspicious - and alert any related  successful sign-ins
+      SigninLogs
+      | where TimeGenerated >= ago(lookBack)
+      | where ResultType == 0
+      | summarize successfulAccountSigninCount = dcount(UserPrincipalName), successfulAccountSigninSet = makeset(UserPrincipalName, 15) by IPAddress
+      // Assume IPs associated with sign-ins from 100+ distinct user accounts are safe
+      | where successfulAccountSigninCount < 100
+  ) on IPAddress  
+  // IPs from which attempts to authenticate as disabled user accounts originated, and had a non-zero success rate for some other account
+  | where successfulAccountSigninCount != 0
+  | project StartTimeUtc, EndTimeUtc, IPAddress, disabledAccountLoginAttempts, disabledAccountsTargeted, disabledAccountSet, applicationSet, 
+  successfulAccountSigninCount, successfulAccountSigninSet
+  | order by disabledAccountLoginAttempts
+  | extend timestamp = StartTimeUtc, IPCustomEntity = IPAddress
+// Break up the string of Succesfully signed into accounts into individual events
+| mvexpand successfulAccountSigninSet
+| extend AccountCustomEntity = tostring(successfulAccountSigninSet)

--- a/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
+++ b/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
@@ -20,11 +20,12 @@ relevantTechniques:
   - T1098
 query: |
  let lookBack = 1d;
+ let threshold = 100;
   SigninLogs 
   | where TimeGenerated >= ago(lookBack)
   | where ResultType == "50057" 
   | where ResultDescription == "User account is disabled. The account has been disabled by an administrator." 
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), disabledAccountLoginAttempts = count(), 
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), disabledAccountLoginAttempts = count(), 
   disabledAccountsTargeted = dcount(UserPrincipalName), applicationsTargeted = dcount(AppDisplayName), disabledAccountSet = makeset(UserPrincipalName), 
   applicationSet = makeset(AppDisplayName) by IPAddress
   | order by disabledAccountLoginAttempts desc
@@ -35,14 +36,15 @@ query: |
       | where ResultType == 0
       | summarize successfulAccountSigninCount = dcount(UserPrincipalName), successfulAccountSigninSet = makeset(UserPrincipalName, 15) by IPAddress
       // Assume IPs associated with sign-ins from 100+ distinct user accounts are safe
-      | where successfulAccountSigninCount < 100
+      | where successfulAccountSigninCount < threshold
   ) on IPAddress  
   // IPs from which attempts to authenticate as disabled user accounts originated, and had a non-zero success rate for some other account
   | where successfulAccountSigninCount != 0
-  | project StartTimeUtc, EndTimeUtc, IPAddress, disabledAccountLoginAttempts, disabledAccountsTargeted, disabledAccountSet, applicationSet, 
+  // Successful Account Signins occur within the same lookback period as the failed 
+  | extend SuccessBeforeFailure = iff(TimeGenerated < StartTime, true, false) 
+  | project StartTime, EndTime, IPAddress, disabledAccountLoginAttempts, disabledAccountsTargeted, disabledAccountSet, applicationSet, 
   successfulAccountSigninCount, successfulAccountSigninSet
   | order by disabledAccountLoginAttempts
-  | extend timestamp = StartTimeUtc, IPCustomEntity = IPAddress
-// Break up the string of Succesfully signed into accounts into individual events
-| mvexpand successfulAccountSigninSet
-| extend AccountCustomEntity = tostring(successfulAccountSigninSet)
+  // Break up the string of Succesfully signed into accounts into individual events
+  | mvexpand successfulAccountSigninSet
+  | extend AccountCustomEntity = tostring(successfulAccountSigninSet), timestamp = StartTime, IPCustomEntity = IPAddress

--- a/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
+++ b/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
@@ -1,7 +1,7 @@
 name: Sign-ins from IPs that attempt sign-ins to disabled accounts
 description: |
   'Identifies IPs with failed attempts to sign in to one or more disabled accounts signed in successfully to another account.
-  References: https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/reference-sign-ins-error-codes
+  References: https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-sign-ins-error-codes
   50057 - User account is disabled. The account has been disabled by an administrator.' This analytic will additionally identify the successful signed in accounts as the mapped account entities for investigation in Sentinel.
 severity: Medium
 requiredDataConnectors:

--- a/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
+++ b/Detections/SigninLogs/SuccessfulAccount-SigninAttemptsByIPviaDisabledAccounts
@@ -19,8 +19,8 @@ relevantTechniques:
   - T1078
   - T1098
 query: |
- let lookBack = 1d;
- let threshold = 100;
+  let lookBack = 1d;
+  let threshold = 100;
   SigninLogs 
   | where TimeGenerated >= ago(lookBack)
   | where ResultType == "50057" 


### PR DESCRIPTION
In addition to the existing Sign ins from IPs that attempt sign ins to disabled accounts analytic; This analytic will additionally identify the successful signed in accounts as the mapped account entities for investigation in Sentinel. This analytic will additionally identify the successful signed in accounts as the mapped account entities for investigation in Sentinel.
[SignInIPsDisabled.zip](https://github.com/Azure/Azure-Sentinel/files/4507065/SignInIPsDisabled.zip)

Fixes #

## Proposed Changes

  -
  -
  -
