### PR TITLE
Adding Azure-Sentinel-Notebooks as submodule of Azure-Sentinel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Notebooks"]
+	path = Notebooks
+	url = https://github.com/Azure/Azure-Sentinel-Notebooks.git


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Add Azure-Sentinel-Notebooks as a submodule
  -
  -
