### PR TITLE
Fixes due to connector bug

### DIFF
--- a/Playbooks/Open-JIRA-Ticket/azuredeploy.json
+++ b/Playbooks/Open-JIRA-Ticket/azuredeploy.json
@@ -100,7 +100,7 @@
                                     }
                                 },
                                 "method": "get",
-                                "path": "/cases/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}"
+                                "path": "/Cases/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}"
                             }
                         },
                         "For_each": {

--- a/Playbooks/Open-SNOW-Ticket/azuredeploy.json
+++ b/Playbooks/Open-SNOW-Ticket/azuredeploy.json
@@ -96,7 +96,7 @@
                                     }
                                 },
                                 "method": "get",
-                                "path": "/cases/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}"
+                                "path": "/Cases/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}"
                             }
                         },
                         "For_each": {


### PR DESCRIPTION
Fixes #
#638 - cases in the Path needs to be Cases.
"Alert_-_Get_incident": {
                            "runAfter": {
                            },
                            "type": "ApiConnection",
                            "inputs": {
                                "host": {
                                    "connection": {
                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
                                    }
                                },
                                "method": "get",
                                "path": "/**Cases**/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}"
                            }
                        },