### PR TITLE
Update FluentD-VMSS-UB-Templatev2.json

### DIFF
--- a/DataConnectors/Fluentd-VMSS/FluentD-VMSS-UB-Templatev2.json
+++ b/DataConnectors/Fluentd-VMSS/FluentD-VMSS-UB-Templatev2.json
@@ -41,7 +41,7 @@
         "autoscale_Name": "[concat(parameters('Base_Name'),'-autoscale')]",
         "loadbalancer_Name": "[concat(parameters('Base_Name'),'-lb')]",
         "maxPortRange": "[if(lessOrEquals(parameters('Autoscale_Max'), 9), '5000', '500')]",
-        "cloudinit": "[concat('#cloud-config\nruncmd:\n  - sudo apt-get update\n  - sudo apt-get install build-essential\n  - sudo apt-get install libgeoip-dev\n  - sudo echo \"root         soft    nofile         65536\" >> /etc/security/limits.conf\n  - sudo echo \"root         hard    nofile         65536\" >> /etc/security/limits.conf\n  - sudo echo \"*         soft    nofile         65536\" >> /etc/security/limits.conf\n  - sudo echo \"*         hard    nofile         65536\" >> /etc/security/limits.conf\n  - sudo curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-bionic-td-agent3.sh | sh\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/FluentD-VMSS/td-agent.conf -O /etc/td-agent/td-agent.conf\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/FluentD-VMSS/cef_version_0_keys.yaml -O /etc/td-agent/plugin/cef_version_0_keys.yaml\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/FluentD-VMSS/formatter_cef-as.rb -O /etc/td-agent/plugin/formatter_cef-as.rb\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/FluentD-VMSS/out_remote_syslog-as.rb -O /etc/td-agent/plugin/out_remote_syslog-as.rb\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/FluentD-VMSS/parser_cef-as.rb -O /etc/td-agent/plugin/parser_cef-as.rb\n  - wget -q ', parameters('GeoLiteDBURL'), ' -O /etc/td-agent/plugin/GeoLite2-City.mmdb\n  - sudo td-agent-gem install fluent-plugin-geoip\n  - sudo systemctl start td-agent.service\n  - sudo systemctl enable td-agent.service\n  - sudo wget https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/CEF/cef_installer.py&&sudo python cef_installer.py ', parameters('WorkspaceID'), ' ', parameters('WorkspaceKey'))]"
+        "cloudinit": "[concat('#cloud-config\nruncmd:\n  - sudo apt-get update\n  - sudo apt-get install build-essential\n  - sudo apt-get install libgeoip-dev\n  - sudo echo \"root         soft    nofile         65536\" >> /etc/security/limits.conf\n  - sudo echo \"root         hard    nofile         65536\" >> /etc/security/limits.conf\n  - sudo echo \"*         soft    nofile         65536\" >> /etc/security/limits.conf\n  - sudo echo \"*         hard    nofile         65536\" >> /etc/security/limits.conf\n  - sudo curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-bionic-td-agent3.sh | sh\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Fluentd-VMSS/td-agent.conf -O /etc/td-agent/td-agent.conf\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Fluentd-VMSS/plugin/cef_version_0_keys.yaml -O /etc/td-agent/plugin/cef_version_0_keys.yaml\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Fluentd-VMSS/plugin/formatter_cef-as.rb -O /etc/td-agent/plugin/formatter_cef-as.rb\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Fluentd-VMSS/plugin/out_remote_syslog-as.rb -O /etc/td-agent/plugin/out_remote_syslog-as.rb\n  - wget -q https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Fluentd-VMSS/plugin/parser_cef-as.rb -O /etc/td-agent/plugin/parser_cef-as.rb\n  - curl ', parameters('GeoLiteDBURL'), ' -o /etc/td-agent/plugin/GeoLite2-City.mmdb\n  - sudo td-agent-gem install fluent-plugin-geoip\n  - sudo systemctl start td-agent.service\n  - sudo systemctl enable td-agent.service\n  - sudo wget https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/CEF/cef_installer.py&&sudo python cef_installer.py ', parameters('WorkspaceID'), ' ', parameters('WorkspaceKey'))]"
     },
     "resources": [
         {
@@ -113,7 +113,7 @@
         {
             "type": "Microsoft.Network/networkSecurityGroups/securityRules",
             "apiVersion": "2019-09-01",
-            "name": "[concat(variables('nsg_Name'), '/Allow-Syslog')]",
+            "name": "[concat(variables('nsg_Name'), '/Allow-Syslog-TCP')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg_Name'))]"
             ],
@@ -139,6 +139,32 @@
         {
             "type": "Microsoft.Network/networkSecurityGroups/securityRules",
             "apiVersion": "2019-09-01",
+            "name": "[concat(variables('nsg_Name'), '/Allow-Syslog-UDP')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg_Name'))]"
+            ],
+            "properties": {
+                "protocol": "UDP",
+                "sourcePortRange": "*",
+                "destinationPortRange": "5514",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 1001,
+                "direction": "Inbound",
+                "sourcePortRanges": [
+                ],
+                "destinationPortRanges": [
+                ],
+                "sourceAddressPrefixes": [
+                ],
+                "destinationAddressPrefixes": [
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+            "apiVersion": "2019-09-01",
             "name": "[concat(variables('nsg_Name'), '/Allow-SSH')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg_Name'))]"
@@ -150,7 +176,7 @@
                 "sourceAddressPrefix": "*",
                 "destinationAddressPrefix": "*",
                 "access": "Allow",
-                "priority": 1001,
+                "priority": 1002,
                 "direction": "Inbound",
                 "sourcePortRanges": [
                 ],
@@ -441,37 +467,7 @@
                         }
                     },
                     "extensionProfile": {
-                        "extensions": [
-                            {
-                                "type": "extensions",
-                                "name": "OMSExtension",
-                                "location": "[resourceGroup().location]",
-                                "properties": {
-                                    "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-                                    "type": "OmsAgentForLinux",
-                                    "typeHandlerVersion": "1.4",
-                                    "autoUpgradeMinorVersion": true,
-                                    "settings": {
-                                        "workspaceId": "[parameters('workspaceId')]",
-                                        "stopOnMultipleConnections": "true"
-                                    },
-                                    "protectedSettings": {
-                                        "workspaceKey": "[parameters('workspaceKey')]"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "extensions",
-                                "name": "DependencyAgentLinux",
-                                "location": "[resourceGroup().location]",
-                                "properties": {
-                                    "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
-                                    "type": "DependencyAgentLinux",
-                                    "typeHandlerVersion": "9.5",
-                                    "autoUpgradeMinorVersion": true
-                                }
-                            }
-                        ]
+                        "extensions": []
                     },
                     "priority": "Regular"
                 },


### PR DESCRIPTION
## Proposed Changes

- Removed the extensionProfiles as they are replaced by the code executed in the cloud-init. (not sure if the agent dependencies need to be written into the cloud-init.)
- Added The Syslog 5514 UDP rule to the NSG.
- Adding TCP to the Syslog 5514 TCP rule name.
- Changed the Allow SSH NSG priority.
- URL errors were found in the Github links where FluentD-VMSS should be Fluend-vmss and the yaml link was missing a /plugins/ folder.
- Change the wget command to that downloads the GeoIP MMDB to curl. For some reason, the mmdb was not being downloaded on install.
