### PR TITLE
Create MDATP web shell hunting enrichments

### DIFF
--- a/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
@@ -21,21 +21,22 @@ query: |
   let lookupBin = lookupWindow / 2.0;
   let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);
   //Extract all MDATP security alert data for alerts associated with command execution by a web shell
-  let alldata = SecurityAlert  
+  let alldata = materialize(SecurityAlert
+  | where TimeGenerated >= ago(timeRange)
   | where ProviderName =~ "MDATP"  
   | where DisplayName has_any("Possible IIS web shell", "Possible IIS compromise", "Suspicious processes indicative of a web shell", "A suspicious web script was created")
   | extend alertData = parse_json(Entities)  
   | extend recordGuid = new_guid()  
-  | mvexpand alertData  
+  | mvexpand alertData)  
   ;  
   //Extract process data from alert JSON
   let filedata = alldata  
   | extend id = tostring(alertData.$id)  
   | extend type = alertData.Type  
   | extend imagename = alertData.Name  
-  | where type =~ "file"  
-  | where imagename != ""  
-  | extend imagefileref = id  
+  | where type =~ "file"
+  | where imagename != ""
+  | extend imagefileref = id
   ;
   //Extract commandline data from alert JSON
   let commanddata = alldata  
@@ -55,7 +56,8 @@ query: |
   | extend Start = TimeGenerated 
   //Join to W3CIISLog using a time windows and key to find files accessed during the time that the commandline was executed
   | join kind=inner ( 
-  W3CIISLog  
+  W3CIISLog
+  | where TimeGenerated >= ago(timeRange)
   | where csUriStem has_any(scriptExtensions)
   | extend splitUriStem = split(csUriStem, "/")  
   | extend FileName = splitUriStem[-1] | extend firstDir = splitUriStem[-2]  
@@ -65,5 +67,6 @@ query: |
   ) on TimeKey 
   | where (Start - EndTime) between (0min .. lookupWindow) 
   | extend attackerP = pack(AttackerIP, AttackerUserAgent)  
-  | summarize Site=makeset(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(imagename), tostring(commandline) 
-  | project Site, ShellLocation=csUriStem, ShellName=filename, ParentProcess=imagename, CommandLine=commandline, Attacker
+  | extend timestamp = StartTime, IPCustomEntity = AttackerIP
+  | summarize Site=make_set(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(imagename), tostring(commandline), timestamp, IPCustomEntity
+  | project Site, ShellLocation=csUriStem, ShellName=filename, ParentProcess=imagename, CommandLine=commandline, Attacker, timestamp, IPCustomEntity

--- a/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
@@ -16,57 +16,63 @@ tactics:
   - Privilege Escalation
   - Persistence
 query: |
-  let timeRange = 3d;  
-  let lookupWindow = 5min;  
-  let lookupBin = lookupWindow / 2.0;
   let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);
-  //Extract all MDATP security alert data for alerts associated with command execution by a web shell
-  let alldata = materialize(SecurityAlert
-  | where TimeGenerated >= ago(timeRange)
+  let timeRange = 3d; 
+  let lookupWindow = 1m;  
+  let lookupBin = lookupWindow / 2.0; 
+  let distinctIpThreshold = 3; 
+  let alerts = SecurityAlert  
+  | where TimeGenerated > ago(timeRange) 
+  | extend alertData = parse_json(Entities), recordGuid = new_guid(); 
+  let shellAlerts = alerts 
   | where ProviderName =~ "MDATP"  
-  | where DisplayName has_any("Possible IIS web shell", "Possible IIS compromise", "Suspicious processes indicative of a web shell", "A suspicious web script was created")
-  | extend alertData = parse_json(Entities)  
-  | extend recordGuid = new_guid()  
-  | mvexpand alertData)  
-  ;  
-  //Extract process data from alert JSON
+  | mvexpand alertData 
+  | where alertData.Type =~ "file" and alertData.Name =~ "w3wp.exe" 
+  | distinct SystemAlertId 
+  | join kind=inner (alerts) on SystemAlertId; 
+  let alldata = shellAlerts  
+  | mvexpand alertData 
+  | extend Type = alertData.Type; 
   let filedata = alldata  
   | extend id = tostring(alertData.$id)  
-  | extend type = alertData.Type  
-  | extend imagename = alertData.Name  
-  | where type =~ "file"
-  | where imagename != ""
-  | extend imagefileref = id
-  ;
-  //Extract commandline data from alert JSON
+  | extend ImageName = alertData.Name  
+  | where Type =~ "file" and ImageName != "w3wp.exe" 
+  | extend imagefileref = id;  
   let commanddata = alldata  
-  | extend type = alertData.Type  
-  | extend commandline = tostring(alertData.CommandLine)  
+  | extend CommandLine = tostring(alertData.CommandLine)  
   | extend creationtime = tostring(alertData.CreationTimeUtc)  
-  | where type =~ "process"  
-  | extend imagefileref = tostring(alertData.ImageFile.$ref);
-  //Join file and command data together, we have no parsed the JSON object into a table we can work with
-  filedata  
-  | join kind=leftouter (  
+  | where Type =~ "process"  
+  | where isnotempty(CommandLine)  
+  | extend imagefileref = tostring(alertData.ImageFile.$ref); 
+  let hostdata = alldata 
+  | where Type =~ "host" 
+  | project HostName = tostring(alertData.HostName), DnsDomain = tostring(alertData.DnsDomain), SystemAlertId 
+  | distinct HostName, DnsDomain, SystemAlertId; 
+  let commandKeyedData = filedata 
+  | join kind=inner (  
   commanddata  
-  | extend id = imagefileref  
-  ) on imagefileref  
-  | project recordGuid, TimeGenerated, creationtime, imagename, commandline, TimeKey = bin(TimeGenerated, lookupBin) 
-  | where commandline != "" 
-  | extend Start = TimeGenerated 
-  //Join to W3CIISLog using a time windows and key to find files accessed during the time that the commandline was executed
+  ) on imagefileref 
+  | join kind=inner (hostdata) on SystemAlertId 
+  | project recordGuid, TimeGenerated, ImageName, CommandLine, TimeKey = bin(TimeGenerated, lookupBin), HostName, DnsDomain 
+  | extend Start = TimeGenerated; 
+  let baseline = W3CIISLog  
+  | where TimeGenerated > ago(timeRange) 
+  | project-rename SourceIP=cIP, PageAccessed=csUriStem 
+  | summarize dcount(SourceIP) by PageAccessed 
+  | where dcount_SourceIP <= distinctIpThreshold; 
+  commandKeyedData 
   | join kind=inner ( 
-  W3CIISLog
-  | where TimeGenerated >= ago(timeRange)
-  | where csUriStem has_any(scriptExtensions)
+  W3CIISLog  
+  | where TimeGenerated > ago(timeRange) 
+  | where csUriStem has_any(scriptExtensions)  
   | extend splitUriStem = split(csUriStem, "/")  
-  | extend FileName = splitUriStem[-1] | extend firstDir = splitUriStem[-2]  
-  | extend TimeKey = range(bin(TimeGenerated-lookupWindow, lookupBin), bin(TimeGenerated, lookupBin),lookupBin)  
+  | extend FileName = splitUriStem[-1] | extend firstDir = splitUriStem[-2] | extend TimeKey = range(bin(TimeGenerated-lookupWindow, lookupBin), bin(TimeGenerated, lookupBin),lookupBin)  
   | mv-expand TimeKey to typeof(datetime)  
-  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated) by Site=sSiteName, AttackerIP=cIP, AttackerUserAgent=csUserAgent, csUriStem, filename=tostring(FileName), tostring(firstDir), TimeKey 
-  ) on TimeKey 
-  | where (Start - EndTime) between (0min .. lookupWindow) 
+  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated) by Site=sSiteName, HostName=sComputerName, AttackerIP=cIP, AttackerUserAgent=csUserAgent, csUriStem, filename=tostring(FileName), tostring(firstDir), TimeKey 
+  ) on TimeKey, HostName 
+  | where (StartTime - EndTime) between (0min .. lookupWindow) 
+  | extend IPCustomEntity = AttackerIP, timestamp = StartTime
   | extend attackerP = pack(AttackerIP, AttackerUserAgent)  
-  | extend timestamp = StartTime, IPCustomEntity = AttackerIP
-  | summarize Site=make_set(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(imagename), tostring(commandline), timestamp, IPCustomEntity
-  | project Site, ShellLocation=csUriStem, ShellName=filename, ParentProcess=imagename, CommandLine=commandline, Attacker, timestamp, IPCustomEntity
+  | summarize Site=makeset(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(ImageName), CommandLine, HostName, IPCustomEntity, timestamp
+  | project Site, ShellLocation=csUriStem, ShellName=filename, ParentProcess=ImageName, CommandLine, Attacker, HostName, IPCustomEntity, timestamp
+  | join kind=inner (baseline) on $left.ShellLocation == $right.PageAccessed

--- a/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
@@ -70,6 +70,6 @@ query: |
   | where (StartTime - EndTime) between (0min .. lookupWindow) 
   | extend IPCustomEntity = AttackerIP, timestamp = StartTime
   | extend attackerP = pack(AttackerIP, AttackerUserAgent)  
-  | summarize Site=makeset(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(ImageName), CommandLine, HostName, IPCustomEntity, timestamp
+  | summarize Site=make_set(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(ImageName), CommandLine, HostName, IPCustomEntity, timestamp
   | project Site, ShellLocation=csUriStem, ShellName=filename, ParentProcess=ImageName, CommandLine, Attacker, HostName, IPCustomEntity, timestamp
   | join kind=inner (baseline) on $left.ShellLocation == $right.PageAccessed

--- a/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
@@ -1,0 +1,68 @@
+id: d2e6f31b-add1-4f44-b54d-1975a5605c1d
+name: Web shell command alert enrichment
+description: |
+  'Extracts MDATP Alerts that indicate a command was executed by a web shell. Uses time window based querying to idneitfy the potential web shell location on the server, then enriches with Attacker IP and User Agent'
+requiredDataConnectors:
+  - connectorId: AzureSecurityCenter
+    dataTypes:
+      - SecurityAlert
+  - connectorId: MicrosoftCloudAppSecurity
+    dataTypes:
+      - SecurityAlert
+  - connectorId: AzureMonitor(IIS)
+    dataTypes:
+      - W3CIISLog
+tactics:
+  - Privilege Escalation
+  - Persistence
+query: |
+  let timeRange = 3d;  
+  let lookupWindow = 5min;  
+  let lookupBin = lookupWindow / 2.0;
+  //Extract all MDATP security alert data for alerts associated with command execution by a web shell
+  let alldata = SecurityAlert  
+  | where ProviderName =~ "MDATP"  
+  | where AlertType =~ "c6a690b5-d9ee-447f-9ef5-f4a81aaf204d" or AlertType =~ "209703f8-7096-426a-bb95-2fc5f40970b9" or AlertType =~ "57c6571e-f37c-4c7f-8482-5f8dbd11b022" or AlertType =~ "1acde8eb-1c0b-45de-98b6-da1817cec9a3" 
+  | extend alertData = parse_json(Entities)  
+  | extend recordGuid = new_guid()  
+  | mvexpand alertData  
+  ;  
+  //Extract process data from alert JSON
+  let filedata = alldata  
+  | extend id = tostring(alertData.$id)  
+  | extend type = alertData.Type  
+  | extend imagename = alertData.Name  
+  | where type =~ "file"  
+  | where imagename != ""  
+  | extend imagefileref = id  
+  ;
+  //Extract commandline data from alert JSON
+  let commanddata = alldata  
+  | extend type = alertData.Type  
+  | extend commandline = tostring(alertData.CommandLine)  
+  | extend creationtime = tostring(alertData.CreationTimeUtc)  
+  | where type =~ "process"  
+  | extend imagefileref = tostring(alertData.ImageFile.$ref);
+  //Join file and command data together, we have no parsed the JSON object into a table we can work with
+  filedata  
+  | join kind=leftouter (  
+  commanddata  
+  | extend id = imagefileref  
+  ) on imagefileref  
+  | project recordGuid, TimeGenerated, creationtime, imagename, commandline, TimeKey = bin(TimeGenerated, lookupBin) 
+  | where commandline != "" 
+  | extend Start = TimeGenerated 
+  //Join to W3CIISLog using a time windows and key to find files accessed during the time that the commandline was executed
+  | join kind=inner ( 
+  W3CIISLog  
+  | where csUriStem endswith ".aspx" or csUriStem endswith ".asmx"  
+  | extend splitUriStem = split(csUriStem, "/")  
+  | extend FileName = splitUriStem[-1] | extend firstDir = splitUriStem[-2]  
+  | extend TimeKey = range(bin(TimeGenerated-lookupWindow, lookupBin), bin(TimeGenerated, lookupBin),lookupBin)  
+  | mv-expand TimeKey to typeof(datetime)  
+  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated) by Site=sSiteName, AttackerIP=cIP, AttackerUserAgent=csUserAgent, csUriStem, filename=tostring(FileName), tostring(firstDir), TimeKey 
+  ) on TimeKey 
+  | where (Start - EndTime) between (0min .. lookupWindow) 
+  | extend attackerP = pack(AttackerIP, AttackerUserAgent)  
+  | summarize Site=makeset(Site), Attacker=make_bag(attackerP) by csUriStem, filename, tostring(imagename), tostring(commandline) 
+  | project Site, ShellLocation=csUriStem, ShellName=filename, ParentProcess=imagename, CommandLine=commandline, Attacker

--- a/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
@@ -3,10 +3,7 @@ name: Web shell command alert enrichment
 description: |
   'Extracts MDATP Alerts that indicate a command was executed by a web shell. Uses time window based querying to idneitfy the potential web shell location on the server, then enriches with Attacker IP and User Agent'
 requiredDataConnectors:
-  - connectorId: AzureSecurityCenter
-    dataTypes:
-      - SecurityAlert
-  - connectorId: MicrosoftCloudAppSecurity
+  - connectorId: MicrosoftDefenderAdvancedThreatProtection
     dataTypes:
       - SecurityAlert
   - connectorId: AzureMonitor(IIS)

--- a/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellCommandAlertEnrich.yaml
@@ -19,10 +19,11 @@ query: |
   let timeRange = 3d;  
   let lookupWindow = 5min;  
   let lookupBin = lookupWindow / 2.0;
+  let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);
   //Extract all MDATP security alert data for alerts associated with command execution by a web shell
   let alldata = SecurityAlert  
   | where ProviderName =~ "MDATP"  
-  | where AlertType =~ "c6a690b5-d9ee-447f-9ef5-f4a81aaf204d" or AlertType =~ "209703f8-7096-426a-bb95-2fc5f40970b9" or AlertType =~ "57c6571e-f37c-4c7f-8482-5f8dbd11b022" or AlertType =~ "1acde8eb-1c0b-45de-98b6-da1817cec9a3" 
+  | where DisplayName has_any("Possible IIS web shell", "Possible IIS compromise", "Suspicious processes indicative of a web shell", "A suspicious web script was created")
   | extend alertData = parse_json(Entities)  
   | extend recordGuid = new_guid()  
   | mvexpand alertData  
@@ -55,7 +56,7 @@ query: |
   //Join to W3CIISLog using a time windows and key to find files accessed during the time that the commandline was executed
   | join kind=inner ( 
   W3CIISLog  
-  | where csUriStem endswith ".aspx" or csUriStem endswith ".asmx"  
+  | where csUriStem has_any(scriptExtensions)
   | extend splitUriStem = split(csUriStem, "/")  
   | extend FileName = splitUriStem[-1] | extend firstDir = splitUriStem[-2]  
   | extend TimeKey = range(bin(TimeGenerated-lookupWindow, lookupBin), bin(TimeGenerated, lookupBin),lookupBin)  

--- a/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
@@ -3,10 +3,7 @@ name: Web shell file alert enrichment
 description: |
   'Extracts MDATP Alert for a web shell being placed on the server and then enriches this event with information from W3CIISLog to idnetigy the Attacker that placed the shell'
 requiredDataConnectors:
-  - connectorId: AzureSecurityCenter
-    dataTypes:
-      - SecurityAlert
-  - connectorId: MicrosoftCloudAppSecurity
+  - connectorId: MicrosoftDefenderAdvancedThreatProtection
     dataTypes:
       - SecurityAlert
   - connectorId: AzureMonitor(IIS)

--- a/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
@@ -16,17 +16,17 @@ tactics:
   - Privilege Escalation
   - Persistence
 query: |
-  let timeWindow = 3d; 
+  let timeWindow = 3d;
+  let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);  
   SecurityAlert  
   | where TimeGenerated > ago(timeWindow)  
-  //This alert type in MDATP indicates a web shell file was dropped to the server
-  | where AlertType =~ "faf95e46-c089-4b6a-b0ce-0286a007b379"  
+  | where DisplayName =~ "Possible web shell installation"  
   | extend alertData = parse_json(Entities)  
   | mvexpand alertData  
   // Get only the file type from the JSON, this gives us the file name
   | where alertData.Type == "file"  
   // This can be expanded to include other script extensions 
-  | where alertData.Name endswith ".aspx" or alertData.Name endswith ".asmx" 
+  | where alertData.Name has_any(scriptExtensions)
   | extend FileName = alertData.Name 
   | project TimeGenerated, tostring(FileName), alertData.Directory 
   | join (  

--- a/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
@@ -24,7 +24,7 @@ query: |
   | extend alertData = parse_json(Entities)  
   | mvexpand alertData  
   // Get only the file type from the JSON, this gives us the file name
-  | where alertData.Type == "file"  
+  | where alertData.Type =~ "file"  
   // This can be expanded to include other script extensions 
   | where alertData.Name has_any(scriptExtensions)
   | extend FileName = alertData.Name 
@@ -37,4 +37,5 @@ query: |
   | extend FileName = splitUriStem[-1] 
   | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated) by AttackerIP=cIP, AttackerUserAgent=csUserAgent, SiteName=sSiteName, ShellLocation=csUriStem, tostring(FileName)  
   ) on FileName 
-  | project StartTime, EndTime, AttackerIP, AttackerUserAgent, SiteName, ShellLocation 
+  | project StartTime, EndTime, AttackerIP, AttackerUserAgent, SiteName, ShellLocation
+  | extend timestamp = StartTime, IPCustomEntity = AttackerIP  

--- a/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
@@ -17,7 +17,7 @@ query: |
   let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);  
   SecurityAlert  
   | where TimeGenerated > ago(timeWindow)  
-  | where DisplayName =~ "Possible web shell installation"  
+  | where ProviderName =~ "MDATP" 
   | extend alertData = parse_json(Entities)  
   | mvexpand alertData  
   // Get only the file type from the JSON, this gives us the file name

--- a/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
@@ -29,7 +29,7 @@ query: |
   | join (  
   W3CIISLog  
   | where TimeGenerated > ago(timeWindow)  
-  | where csUriStem endswith ".aspx" or csUriStem endswith ".asmx"  
+  | where csUriStem has_any(scriptExtensions) 
   | extend splitUriStem = split(csUriStem, "/")  
   | extend FileName = splitUriStem[-1] 
   | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated) by AttackerIP=cIP, AttackerUserAgent=csUserAgent, SiteName=sSiteName, ShellLocation=csUriStem, tostring(FileName)  

--- a/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
+++ b/Hunting Queries/SecurityAlert/WebShellFileAlertEnrich.yaml
@@ -1,0 +1,40 @@
+id: d0a3cb7b-375e-402d-9827-adafe0ce386d
+name: Web shell file alert enrichment
+description: |
+  'Extracts MDATP Alert for a web shell being placed on the server and then enriches this event with information from W3CIISLog to idnetigy the Attacker that placed the shell'
+requiredDataConnectors:
+  - connectorId: AzureSecurityCenter
+    dataTypes:
+      - SecurityAlert
+  - connectorId: MicrosoftCloudAppSecurity
+    dataTypes:
+      - SecurityAlert
+  - connectorId: AzureMonitor(IIS)
+    dataTypes:
+      - W3CIISLog
+tactics:
+  - Privilege Escalation
+  - Persistence
+query: |
+  let timeWindow = 3d; 
+  SecurityAlert  
+  | where TimeGenerated > ago(timeWindow)  
+  //This alert type in MDATP indicates a web shell file was dropped to the server
+  | where AlertType =~ "faf95e46-c089-4b6a-b0ce-0286a007b379"  
+  | extend alertData = parse_json(Entities)  
+  | mvexpand alertData  
+  // Get only the file type from the JSON, this gives us the file name
+  | where alertData.Type == "file"  
+  // This can be expanded to include other script extensions 
+  | where alertData.Name endswith ".aspx" or alertData.Name endswith ".asmx" 
+  | extend FileName = alertData.Name 
+  | project TimeGenerated, tostring(FileName), alertData.Directory 
+  | join (  
+  W3CIISLog  
+  | where TimeGenerated > ago(timeWindow)  
+  | where csUriStem endswith ".aspx" or csUriStem endswith ".asmx"  
+  | extend splitUriStem = split(csUriStem, "/")  
+  | extend FileName = splitUriStem[-1] 
+  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated) by AttackerIP=cIP, AttackerUserAgent=csUserAgent, SiteName=sSiteName, ShellLocation=csUriStem, tostring(FileName)  
+  ) on FileName 
+  | project StartTime, EndTime, AttackerIP, AttackerUserAgent, SiteName, ShellLocation 


### PR DESCRIPTION
Two queries that enrich MDATP web shell alerts. Covering MDATP alerts for a suspicious file on disk and MDATP alerts for a suspicious command line execution.

**WebShellCommandAlertEnrich.yaml**
Collects MDATP alert events where a command was likely executed by a web shell. Parses the MDATP JSON object and then queries W3CIISLog using a time window to highlight possible shells. Enriching from W3CIIS also means that possible attacker IP's and User Agents are collected.

**WebShellFileAlertEnrich.yaml**
Collects MDATP alert for a web shell file being deployed to the server, does a direct enrich on W3CIISLog to collect attacker information.

## Proposed Changes
  - Create WebShellCommandAlertEnrich.yaml
  - Create WebShellFileAlertEnrich.yaml