### PR TITLE
Update DistribPassCrackAttempt.yaml

### DIFF
--- a/Detections/SigninLogs/DistribPassCrackAttempt.yaml
+++ b/Detections/SigninLogs/DistribPassCrackAttempt.yaml
@@ -34,11 +34,11 @@ query: |
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser 
   | extend LocationString= strcat(tostring(LocationDetails["countryOrRegion"]), "/", tostring(LocationDetails["state"]), "/", tostring(LocationDetails["city"]))
   UserSignIns
-  | ssummarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),LocationCount=dcount(LocationString), Location = make_set(LocationString), IPAddress = make_set(IPAddress), IPAddressCount = dcount(IPAddress), AppDisplayName = make_set(AppDisplayName), ResultDescription = make_set(ResultDescription), Browser = make_set(Browser), OS = make_set(OS),
-SigninCount = count() by UserPrincipalName                               
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),LocationCount=dcount(LocationString), Location = make_set(LocationString), 
+  IPAddress = make_set(IPAddress), IPAddressCount = dcount(IPAddress), AppDisplayName = make_set(AppDisplayName), ResultDescription = make_set(ResultDescription), 
+  Browser = make_set(Browser), OS = make_set(OS), SigninCount = count() by UserPrincipalName                               
   // Setting a generic threshold - Can be different for different environment
-  | where SigninCount > s_threshold  
-  | summarize by UserPrincipalName | where SigninCount > s_threshold and LocationCount >= l_threshold
+  | where SigninCount > s_threshold and LocationCount >= l_threshold
   | extend tostring(Location), tostring(IPAddress), tostring(AppDisplayName), tostring(ResultDescription), tostring(Browser), tostring(OS)
   | distinct *
   | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress

--- a/Detections/SigninLogs/DistribPassCrackAttempt.yaml
+++ b/Detections/SigninLogs/DistribPassCrackAttempt.yaml
@@ -33,7 +33,6 @@ query: |
   | where ResultType in ("50126", "50053" , "50055", "50056")
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser 
   | extend LocationString= strcat(tostring(LocationDetails["countryOrRegion"]), "/", tostring(LocationDetails["state"]), "/", tostring(LocationDetails["city"]))
-  UserSignIns
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),LocationCount=dcount(LocationString), Location = make_set(LocationString), 
   IPAddress = make_set(IPAddress), IPAddressCount = dcount(IPAddress), AppDisplayName = make_set(AppDisplayName), ResultDescription = make_set(ResultDescription), 
   Browser = make_set(Browser), OS = make_set(OS), SigninCount = count() by UserPrincipalName                               

--- a/Detections/SigninLogs/DistribPassCrackAttempt.yaml
+++ b/Detections/SigninLogs/DistribPassCrackAttempt.yaml
@@ -34,13 +34,11 @@ query: |
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser 
   | extend LocationString= strcat(tostring(LocationDetails["countryOrRegion"]), "/", tostring(LocationDetails["state"]), "/", tostring(LocationDetails["city"]))
   UserSignIns
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), SigninCount=count(), LocationCount=dcount(LocationString) by UserPrincipalName
-  // Setting a generic threshold - Can be different for different environment
-  | where SigninCount > s_threshold                                     
+  | ssummarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),LocationCount=dcount(LocationString), Location = make_set(LocationString), IPAddress = make_set(IPAddress), IPAddressCount = dcount(IPAddress), AppDisplayName = make_set(AppDisplayName), ResultDescription = make_set(ResultDescription), Browser = make_set(Browser), OS = make_set(OS),
+SigninCount = count() by UserPrincipalName                               
   // Setting a generic threshold - Can be different for different environment
   | where SigninCount > s_threshold  
-  | summarize by UserPrincipalName
-  | join (UserSignIns
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), SigninCount=count(), LocationCount=dcount(LocationString) by UserPrincipalName, IPAddress, LocationString, AppDisplayName, ResultDescription, tostring(Browser), tostring(OS)
-  ) on UserPrincipalName 
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress
+  | summarize by UserPrincipalName | where SigninCount > s_threshold and LocationCount >= l_threshold
+  | extend tostring(Location), tostring(IPAddress), tostring(AppDisplayName), tostring(ResultDescription), tostring(Browser), tostring(OS)
+  | distinct *
+  | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress

--- a/Detections/SigninLogs/DistribPassCrackAttempt.yaml
+++ b/Detections/SigninLogs/DistribPassCrackAttempt.yaml
@@ -33,9 +33,14 @@ query: |
   | where ResultType in ("50126", "50053" , "50055", "50056")
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser 
   | extend LocationString= strcat(tostring(LocationDetails["countryOrRegion"]), "/", tostring(LocationDetails["state"]), "/", tostring(LocationDetails["city"]))
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), SigninCount=count(), LocationCount=dcount(LocationString) by UserPrincipalName, IPAddress, LocationString, AppDisplayName, ResultDescription, tostring(Browser), tostring(OS)
+  UserSignIns
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), SigninCount=count(), LocationCount=dcount(LocationString) by UserPrincipalName
   // Setting a generic threshold - Can be different for different environment
   | where SigninCount > s_threshold                                     
-  // Setting a generic threshold for location  - Can be different for different environment
-  | where LocationCount >= l_threshold
+  // Setting a generic threshold - Can be different for different environment
+  | where SigninCount > s_threshold  
+  | summarize by UserPrincipalName
+  | join (UserSignIns
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), SigninCount=count(), LocationCount=dcount(LocationString) by UserPrincipalName, IPAddress, LocationString, AppDisplayName, ResultDescription, tostring(Browser), tostring(OS)
+  ) on UserPrincipalName 
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress


### PR DESCRIPTION
The rule isn’t firing as expected when we tested it against the configured thresholds in the rule. After some digging in the rule logic I came to a conclusion that the rule logic is flowed and will never fire as due to the “summarize” statement highlighted below the location count will always be equal to 1.

Fixes #

## Proposed Changes
I have updated the summarize statement and then added a join statement to produce the final results
  -
  -
  -
