### PR TITLE
Exes with double file extension in SharePoint

### DIFF
--- a/Hunting Queries/OfficeActivity/double_file_ext_exes.yaml
+++ b/Hunting Queries/OfficeActivity/double_file_ext_exes.yaml
@@ -14,23 +14,22 @@ relevantTechniques:
 query: |
 
   let timeframe = 14d;
-  let known_ext=dynamic(["lnk","log","option","config", "manifest", "partial"]);
+  let known_ext = dynamic(["lnk","log","option","config", "manifest", "partial"]);
+  let excluded_users = dynamic(["app@sharepoint"]);
   OfficeActivity
   | where TimeGenerated > ago(timeframe)
-  | where RecordType =~ "SharePointFileOperation"
-  | where SourceFileExtension !in~ (known_ext)
-  | where OfficeObjectId contains ".exe."
+  | where RecordType =~ "SharePointFileOperation" and isnotempty(SourceFileName)
+  | where OfficeObjectId has ".exe." and SourceFileExtension !in~ (known_ext)
   | extend Extension = extract("[^.]*.[^.]*$",0, OfficeObjectId)
   | join kind= leftouter ( 
     OfficeActivity
       | where TimeGenerated > ago(timeframe)
-      | where RecordType =~ "SharePointFileOperation"
-      | where Operation =~ "FileDownloaded" or Operation =~ "FileAccessed" 
+      | where RecordType =~ "SharePointFileOperation" and (Operation =~ "FileDownloaded" or Operation =~ "FileAccessed") 
       | where SourceFileExtension !in~ (known_ext)
   ) on OfficeObjectId 
-  | where UserId1 !~ "app@sharepoint"
+  | where UserId1 !in~ (excluded_users)
   | extend userBag = pack(UserId1, ClientIP1) 
-  | summarize makeset(UserId1), make_bag(userBag) by TimeGenerated, UserId, OfficeObjectId, SourceFileName, Extension
-  | extend NumberUsers = array_length(bag_keys(bag_userBag))
-  | project UploadTime=TimeGenerated, Uploader=UserId, FileLocation=OfficeObjectId, FileName=SourceFileName, AccessedBy=bag_userBag, Extension, NumberUsers
-  | extend timestamp = UploadTime, AccountCustomEntity = UserId
+  | summarize makeset(UserId1), make_bag(userBag), Start=max(TimeGenerated), End=min(TimeGenerated) by UserId, OfficeObjectId, SourceFileName, Extension 
+  | extend NumberOfUsers = array_length(bag_keys(bag_userBag))
+  | project UploadTime=Start, Uploader=UserId, FileLocation=OfficeObjectId, FileName=SourceFileName, AccessedBy=bag_userBag, Extension, NumberOfUsers
+  | extend timestamp = UploadTime, AccountCustomEntity = Uploader

--- a/Hunting Queries/OfficeActivity/double_file_ext_exes.yaml
+++ b/Hunting Queries/OfficeActivity/double_file_ext_exes.yaml
@@ -1,0 +1,36 @@
+id: d12580c2-1474-4125-a8a3-553f50d91215
+name: Exes with double file extentsion and access summary
+description: |
+  'Provides a summary of executable files with double file extensions in SharePoint 
+   and the users and IP addresses that have accessed them.'
+requiredDataConnectors:
+  - connectorId: Office365
+    dataTypes:
+      - OfficeActivity
+tactics:
+  - Defense Evasion
+relevantTechniques:
+  - T1036
+query: |
+
+  let timeframe = 14d;
+  let known_ext=dynamic(["lnk","log","option","config", "manifest", "partial"]);
+  OfficeActivity
+  | where TimeGenerated > ago(timeframe)
+  | where RecordType =~ "SharePointFileOperation"
+  | where SourceFileExtension !in~ (known_ext)
+  | where OfficeObjectId contains ".exe."
+  | extend Extension = extract("[^.]*.[^.]*$",0, OfficeObjectId)
+  | join kind= leftouter ( 
+    OfficeActivity
+      | where TimeGenerated > ago(timeframe)
+      | where RecordType =~ "SharePointFileOperation"
+      | where Operation =~ "FileDownloaded" or Operation =~ "FileAccessed" 
+      | where SourceFileExtension !in~ (known_ext)
+  ) on OfficeObjectId 
+  | where UserId1 !~ "app@sharepoint"
+  | extend userBag = pack(UserId1, ClientIP1) 
+  | summarize makeset(UserId1), make_bag(userBag) by TimeGenerated, UserId, OfficeObjectId, SourceFileName, Extension
+  | extend NumberUsers = array_length(bag_keys(bag_userBag))
+  | project UploadTime=TimeGenerated, Uploader=UserId, FileLocation=OfficeObjectId, FileName=SourceFileName, AccessedBy=bag_userBag, Extension, NumberUsers
+  | extend timestamp = UploadTime, AccountCustomEntity = UserId


### PR DESCRIPTION
New hunting query to look for executable files with suspicious double extensions. 
Query returns file, along with details of who uploaded them and who accessed them (if this information is available in time frame of query)
