### PR TITLE
Change the blob name to allow easier sorting

### DIFF
--- a/Playbooks/Move-LogAnalytics-to-Storage/azuredeploy.json
+++ b/Playbooks/Move-LogAnalytics-to-Storage/azuredeploy.json
@@ -225,7 +225,7 @@
                                                 "path": "/datasets/default/files",
                                                 "queries": {
                                                     "folderPath": "[concat(variables('storagecontainer'), '@{items(''For_each'')?[''DataType'']}')]",
-                                                    "name": "@{items('For_each')?['DataType']}-@{variables('StartDate')}-@{variables('HoursCount')}.json",
+                                                    "name": "@{items('For_each')?['DataType']}-@{variables('StartDate')}-@{if( less( variables('HoursCount'), 10), concat('0',variables('HoursCount')),variables('HoursCount'))}.json",
                                                     "queryParametersSingleEncoded": true
                                                 }
                                             },


### PR DESCRIPTION
I suggest to do a zero-padding of the hour part of the blob name to allow better sorting. Example of the current output generates the following blob name pattern: 
   WindowsFirewall-2020-05-21-2.json
When we order blobs by name, the WindowsFirewall-2020-05-21-10.json will be listed before the WindowsFirewall-2020-05-21-2.json. This makes automation with these blobs slightly more complex. The change will make it:
   WindowsFirewall-2020-05-21-02.json
This will allow proper lexicographic sorting.
The change consists of replacing the section with the HoursCount variable by the following expression:
if( less( variables('HoursCount'), 10), concat('0',variables('HoursCount')),variables('HoursCount'))
Note that this suggested notation will also reflect the recommendations from the ISO 8601 standard.

## Proposed Changes

  - Use: if( less( variables('HoursCount'), 10), concat('0',variables('HoursCount')),variables('HoursCount')) instead of variables('HoursCount') in the blob names.
