### PR TITLE
Add a comment about DnsAdmins and DnsUpdatePorxy

### DIFF
--- a/Hunting Queries/SecurityEvent/GroupAddedToPrivlegeGroup.yaml
+++ b/Hunting Queries/SecurityEvent/GroupAddedToPrivlegeGroup.yaml
@@ -18,6 +18,7 @@ query: |
   let timeframe = 7d;
   // For AD SID mappings - https://docs.microsoft.com/windows/security/identity-protection/access-control/active-directory-security-groups
   let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]$";
+  // The SIDs for DnsAdmins and DnsUpdateProxy can be different than *-1102 and -*1103. Check these SIDs in your domain before running the query 
   let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$";
   let GroupAddition = SecurityEvent 
   | where TimeGenerated > ago(timeframe)


### PR DESCRIPTION
Those two groups are not well-known SIDs. Although it might be those two in many deployments, their SIDs might actually depends on other factors. I suggest to just add comments. Maybe we could use variables instead but since it might very well be the right SIDs in many deployment, a comment might be enough. Another approach would be to use their names as it has the same name in all locales, suggestions?

I also updated the public documentation to reflect this: https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/active-directory-security-groups#bkmk-dnsadmins.

## Proposed Changes

  - Add a comment about DnsAdmins and DnsUpdateProxy groups as they are not well-known SIDs
