### PR TITLE
AWS S3 Buck API Logs parser fix

### DIFF
--- a/Parsers/AwsS3BucketAPILogsParser.txt
+++ b/Parsers/AwsS3BucketAPILogsParser.txt
@@ -1,5 +1,5 @@
 // KQL AWS S3 Bucket API Logs Parser
-// Last Updated Date: Nov 11 2019
+// Last Updated Date: June 22, 2020
 //
 // Enable AWS S3 Object Level Logging:
 // https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-cloudtrail-events.html

--- a/Parsers/AwsS3BucketAPILogsParser.txt
+++ b/Parsers/AwsS3BucketAPILogsParser.txt
@@ -2,7 +2,7 @@
 // Last Updated Date: Nov 11 2019
 //
 // Enable AWS S3 Object Level Logging:
-// https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-and-data-events-with-cloudtrail.html#logging-data-events
+// https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-cloudtrail-events.html
 //
 // Parser Notes:
 // 1. This parser works if logs are ingested via Logstash config under Logstash folder.


### PR DESCRIPTION
Amazon AWS changed documentation URL's

## Proposed Change

  - Change URL to https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-cloudtrail-events.html
  - Change last update date
