### PR TITLE
Feature/logstash mergefix

### DIFF
--- a/DataConnectors/microsoft-logstash-output-azure-loganalytics/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb
+++ b/DataConnectors/microsoft-logstash-output-azure-loganalytics/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb
@@ -72,19 +72,19 @@ class LogStashAutoResizeBuffer
     # We would like to do it until we reached to the duration 
     def resend_message(documents_json, amount_of_documents, remaining_duration)
         if remaining_duration > 0
-            @logger.info("Resending #{amount_of_documents} documents as log type #{@logstashLoganalyticsConfiguration.custom_log_table_name} to DataCollector API in #{@logstashLoganalyticsConfiguration.RETRANSMITION_DELAY} seconds.")
+            @logger.info("Resending #{amount_of_documents} documents as log type #{@logstashLoganalyticsConfiguration.custom_log_table_name} to DataCollector API in #{@logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY} seconds.")
             sleep @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY
             begin
                 response = @client.post_data(documents_json)
                 if is_successfully_posted(response)
                     @logger.info("Successfully sent #{amount_of_documents} logs into custom log analytics table[#{@logstashLoganalyticsConfiguration.custom_log_table_name}] after resending.")
                 else
-                    @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY)}")
-                    resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY))
+                    @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY)}")
+                    resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY))
                 end
             rescue Exception => ex
-                @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY)}")
-                resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMITION_DELAY))
+                @logger.debug("Resending #{amount_of_documents} documents failed, will try to resend for #{(remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY)}")
+                resend_message(documents_json, amount_of_documents, (remaining_duration - @logstashLoganalyticsConfiguration.RETRANSMISSION_DELAY))
             end
         else 
             @logger.error("Could not resend #{amount_of_documents} documents, message is dropped.")

--- a/DataConnectors/microsoft-logstash-output-azure-loganalytics/lib/logstash/logAnalyticsClient/logstashLoganalyticsConfiguration.rb
+++ b/DataConnectors/microsoft-logstash-output-azure-loganalytics/lib/logstash/logAnalyticsClient/logstashLoganalyticsConfiguration.rb
@@ -28,8 +28,11 @@ class LogstashLoganalyticsOutputConfiguration
         elsif @workspace_id.empty? or @workspace_key.empty? or @custom_log_table_name.empty? 
             raise ArgumentError, "Malformed configuration , the following arguments can not be null or empty.[workspace_id=#{@workspace_id} , workspace_key=#{@workspace_key} , custom_log_table_name=#{@custom_log_table_name}]"
 
-        elsif not @custom_log_table_name.match(/^[[:alpha:]]+$/)
-            raise ArgumentError, 'custom_log_table_name must be only alpha characters.' 
+        elsif not @custom_log_table_name.match(/^[[:alpha:][:digit:]_]+$/)
+            raise ArgumentError, 'custom_log_table_name must be only alpha characters, numbers and underscore.'
+
+        elsif @custom_log_table_name.length > 100
+            raise ArgumentError, 'custom_log_table_name must not exceed 100 characters.'
 
         elsif custom_log_table_name.empty?
             raise ArgumentError, 'custom_log_table_name should not be empty.' 

--- a/DataConnectors/microsoft-logstash-output-azure-loganalytics/lib/logstash/outputs/microsoft-logstash-output-azure-loganalytics.rb
+++ b/DataConnectors/microsoft-logstash-output-azure-loganalytics/lib/logstash/outputs/microsoft-logstash-output-azure-loganalytics.rb
@@ -19,7 +19,8 @@ class LogStash::Outputs::AzureLogAnalytics < LogStash::Outputs::Base
   config :workspace_key, :validate => :string, :required => true
 
   # The name of the event type that is being submitted to Log Analytics. 
-  # This must be only alpha characters.
+  # This must be only alpha characters, numbers and underscore.
+  # This must not exceed 100 characters.
   # Table name under custom logs in which the data will be inserted
   config :custom_log_table_name, :validate => :string, :required => true
 


### PR DESCRIPTION
Hi, let me make this PR to merge original repository 2 fixes.
Please let me know If I should separate these into each PR.

Fixes #
https://github.com/Ronmarsiano/logstashALAOutputPlugin/pull/1

We found some typo.
"RETRANS**MITION**_DELAY" should be "RETRANS**MISSION**_DELAY".

Due to this, we are facing NoMethod error when resend occurs. like below.
```
> [2020-06-11T00:36:18,563][WARN ][logstash.outputs.azureloganalytics][main] Failed to flush outgoing items {:outgoing_count=>516, :exception=>"NoMethodError", :backtrace=>[
"/usr/share/logstash/vendor/local_gems/2698bf9b/microsoft-logstash-output-azure-loganalytics-0.1.0/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb:75:in `resend_message'", 
"/usr/share/logstash/vendor/local_gems/2698bf9b/microsoft-logstash-output-azure-loganalytics-0.1.0/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb:67:in `send_message_to_loganalytics'", "/usr/share/logstash/vendor/local_gems/2698bf9b/microsoft-logstash-output-azure-loganalytics-0.1.0/lib/logstash/logAnalyticsClient/logStashAutoResizeBuffer.rb:47:in `flush'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:219:in `block in buffer_flush'", "org/jruby/RubyHash.java:1428:in `each'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:216:in `buffer_flush'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:112:in `block in buffer_initialize'", "org/jruby/RubyKernel.java:1446:in `loop'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/stud-0.0.23/lib/stud/buffer.rb:110:in `block in buffer_initialize'"]}
```



https://github.com/Ronmarsiano/logstashALAOutputPlugin/pull/2
https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api

Log-Type | Specify the record type of the data that is being submitted. Can only contain letters, numbers, and underscore (_), and may not exceed 100 characters.
-- | --

According to document, numbers and underscore are also acceptable in tablename.
and should not exceed 100 characters.

so let me suggest you to add and follow this rule.

## Proposed Changes

  - Fix "RETRANS**MITION**_DELAY"  to "RETRANS**MISSION**_DELAY".
  - Change Character setting rule for LogType name 
  - Add 100 char length limitation.
