### PR TITLE
Qualys Host Detection Template Package URL broken

### DIFF
--- a/DataConnectors/Qualys VM/azuredeploy_QualysVM_API_FunctionApp.json
+++ b/DataConnectors/Qualys VM/azuredeploy_QualysVM_API_FunctionApp.json
@@ -180,7 +180,7 @@
                           "apiPassword": "[parameters('APIPassword')]",
                           "uri": "[parameters('Uri')]",
                           "timeInterval": "[parameters('TimeInterval')]",
-                          "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinelqualysvmazurefunctionzip"
+                          "WEBSITE_RUN_FROM_PACKAGE": "https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/Qualys%20VM/AzureFunctionQualysVM.zip?raw=true"
                                    } 
                   }
               ]


### PR DESCRIPTION
The Microsoft shortened URL is pointing to a broken link to the author person folk of the repo. I changed the package link to point to the Azure-Sentinel repo package link.

Fixes #

## Proposed Changes

  -
  -
  -
