### PR TITLE
Updated AzureActivity.json

### DIFF
--- a/Workbooks/AzureActivity.json
+++ b/Workbooks/AzureActivity.json
@@ -87,7 +87,7 @@
               "selectAllValue": "All"
             },
             "queryType": 0,
-            "resourceType": "microsoft.resources/resourcegroups"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "46375a76-7ae1-4d7e-9082-4191531198a9",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -6,7 +6,7 @@
     "dataTypesDependencies": [ "AzureActivity" ],
     "dataConnectorsDependencies": [ "AzureActivity" ],
     "previewImagesFileNames": [ "AzureActivityWhite1.png", "AzureActivityBlack1.png" ],
-    "version": "1.2",
+    "version": "1.3",
     "title": "Azure Activity",
     "templateRelativePath": "AzureActivity.json",
     "subtitle": "",


### PR DESCRIPTION
Reason : Making Caller pill similar to ResourceGroup to get data from Log Analytics workspace instead of resource group.This will be enable users with limited permission only to workspace to deploy the workbook, instead the resource group.

![image](https://user-images.githubusercontent.com/20562985/86025760-36ecf080-ba4c-11ea-8e71-5dd9d4b2b39e.png)

