### PR TITLE
Pulse Connector - Add missing title property for 2nd instruction step

### DIFF
--- a/DataConnectors/Pulse Secure Connect/Connector_Syslog_PulseConnectSecure.json
+++ b/DataConnectors/Pulse Secure Connect/Connector_Syslog_PulseConnectSecure.json
@@ -105,6 +105,7 @@
 ] 
     }, 
 { 
+    "title": "2. Configure the logs to be collected",
     "description": "Configure the facilities you want to collect and their severities.\n 1. Under workspace advanced settings **Configuration**, select **Data** and then **Syslog**.\n 2. Select **Apply below configuration to my machines** and select the facilities and severities.\n 3.  Click **Save**.",
     "instructions": [
         {


### PR DESCRIPTION
Pulse Secure Connect Secure Data Connector is missing a title property for the 2nd instruction step