### PR TITLE
Increased threshold

### DIFF
--- a/Detections/Syslog/FailedLogonAttempts_UnknownUser.yaml
+++ b/Detections/Syslog/FailedLogonAttempts_UnknownUser.yaml
@@ -21,7 +21,7 @@ relevantTechniques:
 query: |
 
   let startdate = 1d;
-  let threshold = 6;
+  let threshold = 15;
   // Below pulls messages from syslog-authpriv logs where there was an authentication failure with an unknown user.
   // IP address of system attempting logon is also extracted from the SyslogMessage field. Some of these messages
   // are aggregated.


### PR DESCRIPTION
Fixes # High hit rate from FailedLogonAttempts analytic

## Proposed Changes

  -Adjust hit threshold up to 15 to focus more solidly on brute force logon attempts.
  -
  -
