### PR TITLE
Fix connectivity and graph queries

### DIFF
--- a/DataConnectors/Beyond Security beSECURE.json
+++ b/DataConnectors/Beyond Security beSECURE.json
@@ -7,8 +7,18 @@
   "graphQueries": [
     {
       "metricName": "Total data received",
-      "legend": "Beyond Security beSECURE",
-      "baseQuery": "union beSECURE_Audit_CL, beSECURE_ScanEvent_CL, beSECURE_ScanResults_CL"
+      "legend": "Beyond Security beSECURE Scan Event",
+      "baseQuery": "beSECURE_ScanEvent_CL"
+    },
+    {
+      "metricName": "Total data received",
+      "legend": "Beyond Security beSECURE Scan Results",
+      "baseQuery": "beSECURE_ScanResults_CL"
+    },
+    {
+      "metricName": "Total data received",
+      "legend": "Beyond Security beSECURE Audit",
+      "baseQuery": "beSECURE_Audit_CL"
     }
   ],
   "sampleQueries": [
@@ -62,7 +72,9 @@
     {
       "type": "IsConnectedQuery",
       "value": [
-        "beSECURE_ScanResults_CL \n | summarize LastLogReceived = max(TimeGenerated) \n | project IsConnected = LastLogReceived > ago(30d)"
+        "beSECURE_ScanEvent_CL \n | summarize LastLogReceived = max(TimeGenerated) \n | project IsConnected = LastLogReceived > ago(30d)",
+        "beSECURE_ScanResults_CL \n | summarize LastLogReceived = max(TimeGenerated) \n | project IsConnected = LastLogReceived > ago(30d)",
+        "beSECURE_Audit_CL \n | summarize LastLogReceived = max(TimeGenerated) \n | project IsConnected = LastLogReceived > ago(30d)"
       ]
     }
   ],

--- a/DataConnectors/Proofpoint TAP/ProofpointTAP_API_FunctionApp.json
+++ b/DataConnectors/Proofpoint TAP/ProofpointTAP_API_FunctionApp.json
@@ -6,8 +6,23 @@
     "graphQueries": [
         {
             "metricName": "Total data received",
-            "legend": "Proofpoint TAP Logs",
-            "baseQuery": "union ProofPointTAPMessagesBlocked_CL, ProofPointTAPMessagesDelivered_CL, ProofPointTAPClicksBlocked_CL, ProofPointTAPClicksPermitted_CL"
+            "legend": "Messages Delivered",
+            "baseQuery": "ProofPointTAPMessagesDelivered_CL"
+        },
+        {
+            "metricName": "Total data received",
+            "legend": "Messages Blocked",
+            "baseQuery": "ProofPointTAPMessagesBlocked_CL"
+        },
+        {
+            "metricName": "Total data received",
+            "legend": "Clicks Permitted",
+            "baseQuery": "ProofPointTAPClicksPermitted_CL"
+        },
+        {
+            "metricName": "Total data received",
+            "legend": "Clicks Blocked",
+            "baseQuery": "ProofPointTAPClicksBlocked_CL"
         }
     ],
     "sampleQueries": [
@@ -50,6 +65,9 @@
         {
             "type": "IsConnectedQuery",
             "value": [
+                "ProofPointTAPMessagesDelivered_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)",
+                "ProofPointTAPMessagesBlocked_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)",
+                "ProofPointTAPClicksPermitted_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)",
                 "ProofPointTAPMessagesBlocked_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)"
             ]
         }

--- a/DataConnectors/Proofpoint TAP/ProofpointTAP_API_FunctionApp.json
+++ b/DataConnectors/Proofpoint TAP/ProofpointTAP_API_FunctionApp.json
@@ -6,22 +6,22 @@
     "graphQueries": [
         {
             "metricName": "Total data received",
-            "legend": "Messages Delivered",
+            "legend": "Proofpoint TAP Messages Delivered",
             "baseQuery": "ProofPointTAPMessagesDelivered_CL"
         },
         {
             "metricName": "Total data received",
-            "legend": "Messages Blocked",
+            "legend": "Proofpoint TAP Messages Blocked",
             "baseQuery": "ProofPointTAPMessagesBlocked_CL"
         },
         {
             "metricName": "Total data received",
-            "legend": "Clicks Permitted",
+            "legend": "Proofpoint TAP Clicks Permitted",
             "baseQuery": "ProofPointTAPClicksPermitted_CL"
         },
         {
             "metricName": "Total data received",
-            "legend": "Clicks Blocked",
+            "legend": "Proofpoint TAP Clicks Blocked",
             "baseQuery": "ProofPointTAPClicksBlocked_CL"
         }
     ],

--- a/DataConnectors/VMware Carbon Black/VMwareCarbonBlack_API_FunctionApp.json
+++ b/DataConnectors/VMware Carbon Black/VMwareCarbonBlack_API_FunctionApp.json
@@ -6,8 +6,18 @@
     "graphQueries": [
         {
             "metricName": "Total data received",
-            "legend": "VMware Carbon Black Logs",
-            "baseQuery": "union CarbonBlackAuditLogs_CL, CarbonBlackNotifications_CL, CarbonBlackEvents_CL"
+            "legend": "VMware Carbon Black Events",
+            "baseQuery": "CarbonBlackEvents_CL"
+        },
+        {
+            "metricName": "Total data received",
+            "legend": "VMware Carbon Black Notifications",
+            "baseQuery": "CarbonBlackNotifications_CL"
+        },
+        {
+            "metricName": "Total data received",
+            "legend": "VMware Carbon Black Audit Logs",
+            "baseQuery": "CarbonBlackAuditLogs_CL"
         }
     ],
     "sampleQueries": [
@@ -43,7 +53,9 @@
         {
             "type": "IsConnectedQuery",
             "value": [
-                "CarbonBlackEvents_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)"
+                "CarbonBlackEvents_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)",
+                "CarbonBlackNotifications_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)",
+                "CarbonBlackAuditLogs_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)"
             ]
         }
     ],


### PR DESCRIPTION
- Use separate Graph Queries instead of `union`
- Use all tables for connectivity Criteria
- Remove empty paths from Orca logo