### PR TITLE
Keyvault detection tuning

### DIFF
--- a/Detections/AzureDiagnostics/KeyVaultSensitiveOperations.yaml
+++ b/Detections/AzureDiagnostics/KeyVaultSensitiveOperations.yaml
@@ -20,7 +20,7 @@ query: |
 
   let timeframe = 1d;
   let SensitiveOperationList = dynamic(
-  ["VaultDelete", "KeyDelete", "KeyDecrypt", "SecretDelete", "SecretPurge", "KeyPurge", "SecretBackup", "KeyBackup"]);
+  ["VaultDelete", "KeyDelete", "SecretDelete", "SecretPurge", "KeyPurge", "SecretBackup", "KeyBackup"]);
   AzureDiagnostics
   | where TimeGenerated > ago(timeframe)
   | extend ResultType = columnifexists("ResultType", "NoResultType")

--- a/Detections/AzureDiagnostics/KeyvaultMassSecretRetrieval.yaml
+++ b/Detections/AzureDiagnostics/KeyvaultMassSecretRetrieval.yaml
@@ -2,7 +2,9 @@
 name: Mass secret retrieval from Azure Key Vault
 description: |
   'Identifies mass secret retrieval from Azure Key Vault observed by a single user. 
-  Mass secret retrival crossing a certain threshold is an indication of credential dump operations or mis-configured applications. You can tweak the EventCountThreshold based on average count seen in your environment'
+  Mass secret retrival crossing a certain threshold is an indication of credential dump operations or mis-configured applications. 
+  You can tweak the EventCountThreshold based on average count seen in your environment 
+  and also filter any known sources (IP/Account) and useragent combinations based on historical analysis to further reduce noise'
 severity: Low
 requiredDataConnectors:
   - connectorId: WAF

--- a/Detections/AzureDiagnostics/TimeSeriesKeyvaultAccessAnomaly.yaml
+++ b/Detections/AzureDiagnostics/TimeSeriesKeyvaultAccessAnomaly.yaml
@@ -3,7 +3,8 @@ name: Azure Key Vault access TimeSeries anomaly
 description: |
   'Indentifies a sudden increase in count of Azure Key Vault secret or vault access operations by CallerIPAddress. The query leverages a built-in KQL anomaly detection algorithm 
   to find large deviations from baseline Azure Key Vault access patterns. Any sudden increase in the count of Azure Key Vault accesses can be an 
-  indication of adversary dumping credentials via automated methods.'
+  indication of adversary dumping credentials via automated methods. If you are seeing any noise, try filtering known source(IP/Account) and user-agent combinations.
+  TimeSeries Reference Blog: https://techcommunity.microsoft.com/t5/azure-sentinel/looking-for-unknown-anomalies-what-is-normal-time-series/ba-p/555052'
 severity: Low
 requiredDataConnectors:
   - connectorId: WAF
@@ -20,8 +21,9 @@ relevantTechniques:
 query: |
 
   let starttime = 14d;
-  let timeframe = 1h;
+  let timeframe = 1d;
   let scorethreshold = 3;
+  let baselinethreshold = 5;
   let OperationList = dynamic(
   ["SecretGet", "KeyGet", "VaultGet"]);
   let TimeSeriesData = AzureDiagnostics
@@ -38,12 +40,15 @@ query: |
   | extend (anomalies, score, baseline) = series_decompose_anomalies(HourlyCount, scorethreshold, -1, 'linefit')
   | mv-expand HourlyCount to typeof(double), TimeGenerated to typeof(datetime), anomalies to typeof(double),score to typeof(double), baseline to typeof(long)
   | where anomalies > 0 | extend AnomalyHour = TimeGenerated
+  | where baseline > baselinethreshold // Filtering low count events per baselinethreshold
   | project Resource, AnomalyHour, TimeGenerated, HourlyCount, baseline, anomalies, score;
-  // Join against base logs to retrive records associated with the hour of anomoly
+  // Filter the alerts since specified timeframe
   TimeSeriesAlerts
+  | where TimeGenerated > ago(timeframe)
+  // Join against base logs since specified timeframe to retrive records associated with the hour of anomoly
   | join (
   AzureDiagnostics
-  | where TimeGenerated between (startofday(ago(starttime))..startofday(now()))
+  | where TimeGenerated > ago(timeframe)
   | extend ResultType = columnifexists("ResultType", "NoResultType")
   | extend requestUri_s = columnifexists("requestUri_s", "None"), identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g = columnifexists("identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g", "None")
   | extend id_s = columnifexists("id_s", "None"), CallerIPAddress = columnifexists("CallerIPAddress", "None"), clientInfo_s = columnifexists("clientInfo_s", "None")


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Sensitive Operation: Remove Keydecrypt from sensitive operations
    + Operation too noisy from benign Azure/MSFT IPs. 
    + May need separate detection with alternate logic to monitor KeyDecrypt operation.
* Time Series : Correcting timeframe and baseline threshold to reduce noise
* Mass Secret Retrieval: Updated description on tuning notes to reduce noise
