### PR TITLE
new playbook bulk close incidents

### DIFF
--- a/Playbooks/Close-SelectiveBulkIncidents/azuredeploy.json
+++ b/Playbooks/Close-SelectiveBulkIncidents/azuredeploy.json
@@ -1,0 +1,384 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata":{
+        "comments": "This Logic App will use a KQL query to discover Azure Sentinel Security Incidents through the SecurityIncident table you wish to bulk change on. It also includes a path for using the API to bulk change all",
+        "author": "Priscila Viana, Nathan Swift"
+    },
+    "parameters": {
+        "PlaybookName": {
+            "defaultValue": "Close-SelectiveBulkIncidents",
+            "type": "String"
+        },
+        "UserName": {
+            "defaultValue": "<username>@<domain>",
+            "type": "string"
+        },
+        "AzureSentinelSubscriptionID": {
+            "defaultValue": "<AZURE SENTINEL - SUBSCRIPTION ID>",
+            "type": "string"
+        },
+        "AzureSentinelResourceGroup": {
+            "defaultValue": "<AZURE SENTINEL - RESOURCEGROUP>",
+            "type": "string"
+        },
+        "AzureSentinelWorkspaceName": {
+            "defaultValue": "<AZURE SENTINEL - WORKSPACE NAME>",
+            "type": "string"
+        }
+    },
+    "variables": {
+        "azuremonitorlogsConnectionName": "[concat('azuremonitorlogs-', parameters('PlaybookName'))]",
+        "azuresentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]"
+    },
+    "resources": [
+            {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('azuremonitorlogsConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[parameters('UserName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuremonitorlogs')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[parameters('UserName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('PlaybookName')]",
+            "location": "[resourceGroup().location]",
+            "tags": {
+                "LogicAppsCategory": "security"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/connections', variables('azuremonitorlogsConnectionName'))]"
+            ],
+            "properties": {
+                "state": "Enabled",
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        },
+                        "WorkspaceId": {
+                            "defaultValue": "[parameters('AzureSentinelWorkspaceName')]",
+                            "type": "String"
+                        }
+                    },
+                    "triggers": {
+                        "When_a_response_to_an_Azure_Sentinel_alert_is_triggered": {
+                            "type": "ApiConnectionWebhook",
+                            "inputs": {
+                                "body": {
+                                    "callback_url": "@{listCallbackUrl()}"
+                                },
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                    }
+                                },
+                                "path": "/subscribe"
+                            }
+                        }
+                    },
+                    "actions": {
+                        "Initialize_UseSecurityIncident": {
+                            "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "UseSecurityIncident",
+                                        "type": "boolean",
+                                        "value": "@true"
+                                    }
+                                ]
+                            }
+                        },
+                        "UseSecurityIncident": {
+                            "actions": {
+                                "For_each_2": {
+                                    "foreach": "@body('SearchSecurityIncident')?['value']",
+                                    "actions": {
+                                        "Change_incident_status_2": {
+                                            "runAfter": {},
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": {
+                                                    "CloseReasonText": "Selective Bulk Close - via Playbook"
+                                                },
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "put",
+                                                "path": "/Case/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}/@{encodeURIComponent('Incident')}/@{encodeURIComponent(items('For_each_2')?['IncidentNumber'])}/Status/@{encodeURIComponent('Closed')}"
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "SearchSecurityIncident": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Foreach"
+                                },
+                                "SearchSecurityIncident": {
+                                    "runAfter": {},
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "body": "SecurityIncident\n| where TimeGenerated >= ago(720d)\n// | where TimeGenerated between (datetime(2019-06-01) .. datetime(2020-06-10))\n// | where parse_json(tostring(AdditionalData.alertProductNames))[0] == \"Azure Security Center\"\n| where Status == \"New\"",
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['azuremonitorlogs']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/queryData",
+                                        "queries": {
+                                            "resourcegroups": "[parameters('AzureSentinelResourceGroup')]",
+                                            "resourcename": "[parameters('AzureSentinelWorkspaceName')]",
+                                            "resourcetype": "Log Analytics Workspace",
+                                            "subscriptions": "[parameters('AzureSentinelSubscriptionID')]",
+                                            "timerange": "Set in query"
+                                        }
+                                    },
+                                    "description": "Selectively run a KQL query to close certain incidents"
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_UseSecurityIncident": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "else": {
+                                "actions": {
+                                    "BulkAllIncidents": {
+                                        "runAfter": {},
+                                        "type": "Http",
+                                        "inputs": {
+                                            "authentication": {
+                                                "audience": "https://management.azure.com/",
+                                                "type": "ManagedServiceIdentity"
+                                            },
+                                            "method": "GET",
+                                            "uri": "https://management.azure.com/subscriptions/@{triggerBody()?['WorkspaceSubscriptionId']}/resourceGroups/@{triggerBody()?['WorkspaceResourceGroup']}/providers/Microsoft.OperationalInsights/workspaces/@{parameters('WorkspaceName')}/providers/Microsoft.SecurityInsights/incidents/?api-version=2020-01-01"
+                                        },
+                                        "description": "Use the API and Bulk Close all incidents - must use MSI and assign reader rights"
+                                    },
+                                    "For_each": {
+                                        "foreach": "@body('Parse_JSON')?['value']",
+                                        "actions": {
+                                            "Change_incident_status": {
+                                                "runAfter": {},
+                                                "type": "ApiConnection",
+                                                "inputs": {
+                                                    "body": {
+                                                        "CloseReasonText": "Bulk Close All - via Playbook"
+                                                    },
+                                                    "host": {
+                                                        "connection": {
+                                                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                        }
+                                                    },
+                                                    "method": "put",
+                                                    "path": "/Case/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}/@{encodeURIComponent('Incident')}/@{encodeURIComponent(items('For_each')?['properties']?['incidentNumber'])}/Status/@{encodeURIComponent('Closed')}"
+                                                }
+                                            }
+                                        },
+                                        "runAfter": {
+                                            "Parse_JSON": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "Foreach"
+                                    },
+                                    "Parse_JSON": {
+                                        "runAfter": {
+                                            "BulkAllIncidents": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "ParseJson",
+                                        "inputs": {
+                                            "content": "@body('BulkAllIncidents')",
+                                            "schema": {
+                                                "properties": {
+                                                    "nextLink": {
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "etag": {
+                                                                    "type": "string"
+                                                                },
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "properties": {
+                                                                    "properties": {
+                                                                        "additionalData": {
+                                                                            "properties": {
+                                                                                "alertProductNames": {
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "alertsCount": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "bookmarksCount": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "commentsCount": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "tactics": {
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "createdTimeUtc": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "firstActivityTimeGenerated": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "firstActivityTimeUtc": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "incidentNumber": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "incidentUrl": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "labels": {
+                                                                            "type": "array"
+                                                                        },
+                                                                        "lastActivityTimeGenerated": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "lastActivityTimeUtc": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "lastModifiedTimeUtc": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "owner": {
+                                                                            "properties": {
+                                                                                "assignedTo": {},
+                                                                                "email": {},
+                                                                                "objectId": {},
+                                                                                "userPrincipalName": {}
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "relatedAnalyticRuleIds": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        "severity": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "status": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "title": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id",
+                                                                "name",
+                                                                "etag",
+                                                                "type",
+                                                                "properties"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "equals": [
+                                            "@variables('UseSecurityIncident')",
+                                            "@true"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "If",
+                            "description": "Use SecurityIncident Table and be selective via KQL which incidents to close"
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "$connections": {
+                        "value": {
+                            "azuremonitorlogs": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('azuremonitorlogsConnectionName'))]",
+                                "connectionName": "[variables('azuremonitorlogsConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuremonitorlogs')]"
+                            },
+                            "azuresentinel": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('azuresentinelConnectionName'))]",
+                                "connectionName": "[variables('azuresentinelConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/Playbooks/Close-SelectiveBulkIncidents/readme.md
+++ b/Playbooks/Close-SelectiveBulkIncidents/readme.md
@@ -1,0 +1,15 @@
+# Close-SelectiveBulkIncidents
+authors: Priscila Viana, Nathan Swift
+
+This Logic App will use a KQL query to discover Azure Sentinel Security Incidents through the SecurityIncident table you wish to bulk change on. It also includes a path for using the API to bulk change all
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FClose-SelectiveBulkIncidents%2Fazuredeploy.json" target="_blank">
+    <img src="https://aka.ms/deploytoazurebutton"/>
+</a>
+<a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FClose-SelectiveBulkIncidents%2Fazuredeploy.json" target="_blank">
+<img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.png"/>
+</a>
+
+**Additional Post Install Notes:**
+
+The Logic App requires the SecurityIncident Table preview | You need to change the KQL Query within the action to close selective Security incidents else it will bulk close all Incidents creates. There is a seprate path as well so if you want to bulk close all security incidents via API you can, need to turn on MSI and assign RBAC 'Reader' role to the Logic App at the RG of the Azure Sentinel Workspace.


### PR DESCRIPTION
The following new playbook can use a KQL query to selective bulk close or change Azure Sentinel incidents.

Fixes #

## Proposed Changes

  -
  -
  -
