### PR TITLE
Add keys permissions for connectors

### DIFF
--- a/DataConnectors/AIVectraDetect.json
+++ b/DataConnectors/AIVectraDetect.json
@@ -58,7 +58,16 @@
                     "write": true,
                     "delete": true
                 }
-            }
+            },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
         ]
     },
     "instructionSteps": [

--- a/DataConnectors/Beyond Security beSECURE.json
+++ b/DataConnectors/Beyond Security beSECURE.json
@@ -93,7 +93,16 @@
                        "write": true, 
                        "delete": true 
 					}
-      }
+      },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
     ],
     "customs": [
     ]

--- a/DataConnectors/FORCEPOINT_NGFW.json
+++ b/DataConnectors/FORCEPOINT_NGFW.json
@@ -54,7 +54,16 @@
           "write": true,
           "delete": true
         }
-      }
+      },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
     ]
   },
   "instructionSteps": [

--- a/DataConnectors/Forcepoint DLP.json
+++ b/DataConnectors/Forcepoint DLP.json
@@ -54,6 +54,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ]
     },

--- a/DataConnectors/Okta Single Sign-On/Connector_REST_API_FunctionApp_Okta.json
+++ b/DataConnectors/Okta Single Sign-On/Connector_REST_API_FunctionApp_Okta.json
@@ -50,6 +50,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ],
         "customs": [

--- a/DataConnectors/OrcaSecurityAlerts.json
+++ b/DataConnectors/OrcaSecurityAlerts.json
@@ -50,6 +50,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ]
     },

--- a/DataConnectors/Perimeter81ActivityLogs.json
+++ b/DataConnectors/Perimeter81ActivityLogs.json
@@ -62,7 +62,16 @@
           "read": true,
           "delete": true
         }
-      }
+      },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
     ]
   },
   "instructionSteps": [

--- a/DataConnectors/Proofpoint TAP/ProofpointTAP_API_FunctionApp.json
+++ b/DataConnectors/Proofpoint TAP/ProofpointTAP_API_FunctionApp.json
@@ -88,6 +88,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ],
         "customs": [

--- a/DataConnectors/Qualys VM/QualysVM_API_FunctionApp.json
+++ b/DataConnectors/Qualys VM/QualysVM_API_FunctionApp.json
@@ -46,6 +46,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ],
         "customs": [

--- a/DataConnectors/SquadraTechnologies.SecRMM.json
+++ b/DataConnectors/SquadraTechnologies.SecRMM.json
@@ -86,7 +86,16 @@
           "read": true,
           "delete": true
         }
-      }
+      },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
     ],
     "customs": [
     ]

--- a/DataConnectors/Templates/Connector_REST_API_AzureFunctionApp_template/DataConnector_API_AzureFunctionApp_template.json
+++ b/DataConnectors/Templates/Connector_REST_API_AzureFunctionApp_template/DataConnector_API_AzureFunctionApp_template.json
@@ -45,7 +45,16 @@
                     "read": true,
                     "delete": true
                 }
-            }
+            },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
         ],
         "customs": [
             {

--- a/DataConnectors/Templates/Connector_REST_API_template.json
+++ b/DataConnectors/Templates/Connector_REST_API_template.json
@@ -45,6 +45,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ],
         "customs": [

--- a/DataConnectors/VMware Carbon Black/VMwareCarbonBlack_API_FunctionApp.json
+++ b/DataConnectors/VMware Carbon Black/VMwareCarbonBlack_API_FunctionApp.json
@@ -75,6 +75,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ],
         "customs": [

--- a/DataConnectors/Zimperium MTD Alerts.json
+++ b/DataConnectors/Zimperium MTD Alerts.json
@@ -58,6 +58,15 @@
                     "read": true,
                     "delete": true
                 }
+            },
+            {
+                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "providerDisplayName": "Keys",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                    "action": true
+                }
             }
         ],
         "customs":""

--- a/DataConnectors/alcide_kaudit.json
+++ b/DataConnectors/alcide_kaudit.json
@@ -66,6 +66,15 @@
                   "read": true,
                   "delete": true
               }
+          },
+          {
+              "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+              "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+              "providerDisplayName": "Keys",
+              "scope": "Workspace",
+              "requiredPermissions": {
+                  "action": true
+              }
           }
       ]
   },

--- a/DataConnectors/illusive Attack Management System.json
+++ b/DataConnectors/illusive Attack Management System.json
@@ -49,7 +49,16 @@
                     "write": true,
                     "delete": true
                 }
-            }
+            },
+			{
+				"provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+				"permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
+				"providerDisplayName": "Keys",
+				"scope": "Workspace",
+				"requiredPermissions": {
+					"action": true
+				}
+			}
         ]
     },
     "instructionSteps": [


### PR DESCRIPTION
Connectors that have a reference to the `PrimaryKey` parameter need to have `sharedKeys` permissions.