### PR TITLE
Add TAXII data source to analytics and hunting queries

### DIFF
--- a/Detections/GitHub/Threat Intel Matches to GitHub Audit Logs.yaml
+++ b/Detections/GitHub/Threat Intel Matches to GitHub Audit Logs.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -30,10 +30,9 @@ query: |
     | summarize make_list(tld);
     ThreatIntelligenceIndicator
     | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
-    | where isnotempty(DomainName)
     | where Active == true
     // Picking up only IOC's that contain the entities we want
-    | where ExternalIndicatorId startswith 'domain'
+    | where isnotempty(DomainName)
     | join (
          DnsEvents
         | where TimeGenerated > ago(dt_lookBack)

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: MicrosoftCloudAppSecurity
     dataTypes:
       - SecurityAlert

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -26,7 +29,7 @@ query: |
   | where Active == true
   //Filtering the table for Email related IOCs
   | where isnotempty(EmailRecipient)
-  | join (  
+  | join (
       AzureActivity | where TimeGenerated >= ago(dt_lookBack) and isnotempty(Caller)
       | extend Caller = tolower(Caller)
       | where Caller matches regex emailregex
@@ -34,7 +37,7 @@ query: |
   )
   on $left.EmailRecipient == $right.Caller
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Url, AzureActivity_TimeGenerated, 
-  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Caller, Level, CallerIpAddress, Category, OperationName, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Url, AzureActivity_TimeGenerated,
+  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Caller, Level, CallerIpAddress, Category, OperationName,
   OperationNameValue, ActivityStatus, ResourceGroup, SubscriptionId
   | extend timestamp = AzureActivity_TimeGenerated, AccountCustomEntity = Caller, IPCustomEntity = CallerIpAddress, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -26,13 +29,13 @@ query: |
   | where Active == true
   //Filtering the table for Email related IOCs
   | where isnotempty(EmailRecipient)
-  | join (   
+  | join (
       OfficeActivity | where TimeGenerated >= ago(dt_lookBack) and isnotempty(UserId)
       | where UserId matches regex emailregex
       | extend OfficeActivity_TimeGenerated = TimeGenerated
   )
   on $left.EmailRecipient == $right.UserId
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, OfficeActivity_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, OfficeActivity_TimeGenerated,
   EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, UserId, ClientIP, Operation, UserType, RecordType, OfficeWorkload, Parameters
   | extend timestamp = OfficeActivity_TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -26,7 +29,7 @@ query: |
   | where Active == true
   //Filtering the table for Email related IOCs
   | where isnotempty(EmailRecipient)
-  | join (   
+  | join (
       CommonSecurityLog | where TimeGenerated >= ago(dt_lookBack) and isnotempty(DestinationUserID)
       // Filtering PAN Logs for specific event type to match relevant email entities
       | where DeviceVendor == "Palo Alto Networks" and  DeviceEventClassID == "wildfire" and ApplicationProtocol in ("smtp","pop3")
@@ -36,7 +39,7 @@ query: |
   )
   on $left.EmailRecipient == $right.DestinationUserID
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, CommonSecurityLog_TimeGenerated, 
-  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, DestinationUserID, DeviceEventClassID, LogSeverity, DeviceAction, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, CommonSecurityLog_TimeGenerated,
+  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, DestinationUserID, DeviceEventClassID, LogSeverity, DeviceAction,
   SourceIP, SourcePort, DestinationIP, DestinationPort, Protocol, ApplicationProtocol
   | extend timestamp = CommonSecurityLog_TimeGenerated, AccountCustomEntity = DestinationUserID, IPCustomEntity = SourceIP, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -26,21 +29,21 @@ query: |
   | where Active == true
   //Filtering the table for Email related IOCs
   | where isnotempty(EmailRecipient)
-  | join (   
+  | join (
       SecurityAlert | where TimeGenerated >= ago(dt_lookBack)
       // Converting Entities into dynamic data type and use mv-expand to unpack the array
       | extend EntitiesDynamicArray = parse_json(Entities) | mv-expand EntitiesDynamicArray
       // Parsing relevant entity column to filter type account and creating new column by combining account and UPNSuffix
-      | extend Entitytype = tostring(parse_json(EntitiesDynamicArray).Type), EntityName = tostring(parse_json(EntitiesDynamicArray).Name), 
+      | extend Entitytype = tostring(parse_json(EntitiesDynamicArray).Type), EntityName = tostring(parse_json(EntitiesDynamicArray).Name),
       EntityUPNSuffix = tostring(parse_json(EntitiesDynamicArray).UPNSuffix)
-      | where Entitytype =~ "account" 
+      | where Entitytype =~ "account"
       | extend EntityEmail = tolower(strcat(EntityName, "@", EntityUPNSuffix))
       | where EntityEmail matches regex emailregex
       | extend SecurityAlert_TimeGenerated = TimeGenerated
   )
   on $left.EmailRecipient == $right.EntityEmail
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SecurityAlert_TimeGenerated, 
-  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, EntityEmail, AlertName, AlertType, 
-  AlertSeverity, Entities, ProviderName, VendorName 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SecurityAlert_TimeGenerated,
+  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, EntityEmail, AlertName, AlertType,
+  AlertSeverity, Entities, ProviderName, VendorName
   | extend timestamp = SecurityAlert_TimeGenerated, AccountCustomEntity = EntityEmail, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: SecurityEvents
     dataTypes:
       - SecurityEvent
@@ -35,7 +38,7 @@ query: |
   )
   on $left.EmailRecipient == $right.TargetUserName
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SecurityEvent_TimeGenerated, 
-  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Computer, EventID, TargetUserName, Activity, IpAddress, AccountType, 
-  LogonTypeName, LogonProcessName, Status, SubStatus 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SecurityEvent_TimeGenerated,
+  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Computer, EventID, TargetUserName, Activity, IpAddress, AccountType,
+  LogonTypeName, LogonProcessName, Status, SubStatus
   | extend timestamp = SecurityEvent_TimeGenerated, AccountCustomEntity = TargetUserName, IPCustomEntity = IpAddress, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AzureActiveDirectory
     dataTypes:
       - SigninLogs
@@ -38,7 +41,7 @@ query: |
   )
   on $left.EmailRecipient == $right.UserPrincipalName
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SigninLogs_TimeGenerated, 
-  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, IPAddress, UserPrincipalName, AppDisplayName, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SigninLogs_TimeGenerated,
+  EmailSenderName, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, IPAddress, UserPrincipalName, AppDisplayName,
   StatusCode, StatusDetails, NetworkIP, NetworkDestinationIP, NetworkSourceIP
   | extend timestamp = SigninLogs_TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -34,7 +37,7 @@ query: |
   )
   on $left.FileHashValue == $right.FileHash
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
-  CommonSecurityLog_TimeGenerated, SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
+  CommonSecurityLog_TimeGenerated, SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction,
   RequestURL, DestinationUserName, DestinationUserID, ApplicationProtocol, Activity
   | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, AccountCustomEntity = SourceUserName, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -32,6 +35,6 @@ query: |
   )
   on $left.FileHashValue == $right.FileHash
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   SecurityEvent_TimeGenerated, Process, FileHash, Computer, Account, Event
   | extend timestamp = SecurityEvent_TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AWS
     dataTypes:
       - AWSCloudTrail
@@ -17,7 +20,7 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-  
+
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -37,7 +40,7 @@ query: |
   )
   on $left.TI_ipEntity == $right.SourceIpAddress
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AWSCloudTrail_TimeGenerated, 
-  TI_ipEntity, EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserIdentityUserName, SourceIpAddress, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AWSCloudTrail_TimeGenerated,
+  TI_ipEntity, EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserIdentityUserName, SourceIpAddress,
   NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AWSCloudTrail_TimeGenerated, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AzureActivity
     dataTypes:
       - AzureActivity
@@ -37,6 +40,6 @@ query: |
   )
   on $left.TI_ipEntity == $right.CallerIpAddress
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AzureActivity_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AzureActivity_TimeGenerated,
   TI_ipEntity, CallerIpAddress, Caller, OperationName, ActivityStatus, Category, ResourceId, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureActivity_TimeGenerated, IPCustomEntity = CallerIpAddress, AccountCustomEntity = Caller, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: DNS
     dataTypes:
       - DnsEvents
@@ -33,7 +36,7 @@ query: |
   | join (
       DnsEvents | where TimeGenerated >= ago(dt_lookBack)
       | where SubType =~ "LookupQuery" and isnotempty(IPAddresses)
-      | extend SingleIP = split(IPAddresses, ",")  
+      | extend SingleIP = split(IPAddresses, ",")
       | mvexpand SingleIP
       | extend SingleIP = tostring(SingleIP)
       // renaming time column so it is clear the log this came from
@@ -41,6 +44,6 @@ query: |
   )
   on $left.TI_ipEntity == $right.SingleIP
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, DNS_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, DNS_TimeGenerated,
   TI_ipEntity, Computer, EventId, SubType, ClientIP, Name, IPAddresses, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = DNS_TimeGenerated, IPCustomEntity = ClientIP, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: Office365
     dataTypes:
       - OfficeActivity
@@ -37,6 +40,6 @@ query: |
   )
   on $left.TI_ipEntity == $right.ClientIP
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, OfficeActivity_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, OfficeActivity_TimeGenerated,
   TI_ipEntity, ClientIP, UserId, Operation, ResultStatus, RecordType, OfficeObjectId, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = OfficeActivity_TimeGenerated, IPCustomEntity = ClientIP, AccountCustomEntity = UserId, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AzureMonitor(VMInsights)
     dataTypes:
       - VMConnection
@@ -31,13 +34,13 @@ query: |
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
   | join (
-      VMConnection 
+      VMConnection
       | where TimeGenerated >= ago(dt_lookBack)
       // renaming time column so it is clear the log this came from
       | extend VMConnection_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIp
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, VMConnection_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, VMConnection_TimeGenerated,
   TI_ipEntity, Computer, Direction, ProcessName, SourceIp, DestinationIp, RemoteIp, Protocol, DestinationPort, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = VMConnection_TimeGenerated, IPCustomEntity = RemoteIp, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AzureMonitor(IIS)
     dataTypes:
       - W3CIISLog
@@ -31,7 +34,7 @@ query: |
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
   | join (
-      W3CIISLog 
+      W3CIISLog
       | where TimeGenerated >= ago(dt_lookBack)
       | where isnotempty(cIP)
       // renaming time column so it is clear the log this came from
@@ -39,7 +42,7 @@ query: |
   )
   on $left.TI_ipEntity == $right.cIP
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
-  W3CIISLog_TimeGenerated, TI_ipEntity, Computer, sSiteName, cIP, sIP, sPort, csMethod, csUserName, scStatus, scSubStatus, scWin32Status, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
+  W3CIISLog_TimeGenerated, TI_ipEntity, Computer, sSiteName, cIP, sIP, sPort, csMethod, csUserName, scStatus, scSubStatus, scWin32Status,
   NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = W3CIISLog_TimeGenerated, IPCustomEntity = cIP, HostCustomEntity = Computer, AccountCustomEntity = csUserName, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AzureMonitor(WireData)
     dataTypes:
       - WireData
@@ -38,6 +41,6 @@ query: |
   )
   on $left.TI_ipEntity == $right.RemoteIP
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, WireData_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, WireData_TimeGenerated,
   TI_ipEntity, Computer, LocalIP, RemoteIP, ProcessName, ApplicationProtocol, LocalPortNumber, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = WireData_TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
@@ -7,6 +7,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: AzureActiveDirectory
     dataTypes:
       - SigninLogs
@@ -39,6 +42,6 @@ query: |
   )
   on $left.TI_ipEntity == $right.IPAddress
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SigninLogs_TimeGenerated, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SigninLogs_TimeGenerated,
   TI_ipEntity, IPAddress, UserPrincipalName, AppDisplayName, StatusCode, StatusDetails, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = SigninLogs_TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -25,17 +28,17 @@ query: |
   | where Active == true
   // Picking up only IOC's that contain the entities we want
   | where isnotempty(Url)
-  | join (   
-    AuditLogs 
+  | join (
+    AuditLogs
     | where TimeGenerated >= ago(dt_lookBack)
     // Extract the URL that is contained within the JSON data
-    | extend Url = extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+);", 1,tostring(TargetResources)) 
+    | extend Url = extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+);", 1,tostring(TargetResources))
     | where isnotempty(Url)
     | extend userPrincipalName = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-    | extend TargetResourceDisplayName = tostring(TargetResources[0].displayName) 
+    | extend TargetResourceDisplayName = tostring(TargetResources[0].displayName)
     | extend Audit_TimeGenerated = TimeGenerated
   ) on Url
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
   Audit_TimeGenerated, OperationName, Identity, userPrincipalName, TargetResourceDisplayName, Url
   | extend timestamp = Audit_TimeGenerated, AccountCustomEntity = userPrincipalName, HostCustomEntity = TargetResourceDisplayName, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
@@ -13,6 +13,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -28,8 +31,8 @@ query: |
   | where Active == true
   // Picking up only IOC's that contain the entities we want
   | where isnotempty(Url)
-  | join (   
-    SecurityAlert 
+  | join (
+    SecurityAlert
     | where TimeGenerated >= ago(dt_lookBack)
     // Extract URL from JSON data
     | extend Url = extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)", 1,Entities)
@@ -40,6 +43,6 @@ query: |
     | extend Alert_TimeGenerated = TimeGenerated
   ) on Url
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated, 
+  | project LatestIndicatorTime, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated,
   AlertName, AlertSeverity, Description, Url, Compromised_Host
   | extend timestamp = Alert_TimeGenerated, HostCustomEntity = Compromised_Host, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
@@ -10,6 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt

--- a/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_OfficeActivity.yaml
+++ b/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_OfficeActivity.yaml
@@ -1,4 +1,4 @@
-id: 410da56d-4a63-4d22-b68c-9fb1a303be6d 
+id: 410da56d-4a63-4d22-b68c-9fb1a303be6d
 name: Preview - TI map File entity to OfficeActivity Event
 description: |
   'Identifies a match in OfficeActivity Event data from any FileName IOC from TI.
@@ -10,10 +10,13 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 tactics:
   - Impact
 query: |
-  
+
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -27,6 +30,6 @@ query: |
   )
   on $left.FileName == $right.SourceFileName
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   OfficeActivity_TimeGenerated, FileName, UserId, ClientIP, OfficeObjectId
   | extend timestamp = OfficeActivity_TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Url

--- a/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_SecurityEvent.yaml
+++ b/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_SecurityEvent.yaml
@@ -10,10 +10,13 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 tactics:
   - Impact
 query: |
-  
+
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -28,6 +31,6 @@ query: |
   )
   on $left.FileName == $right.Process
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
-  SecurityEvent_TimeGenerated, FileName, Computer, IpAddress, Account, Event, Activity  
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
+  SecurityEvent_TimeGenerated, FileName, Computer, IpAddress, Account, Event, Activity
   | extend timestamp = SecurityEvent_TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IpAddress, URLCustomEntity = Url

--- a/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_Syslog.yaml
+++ b/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_Syslog.yaml
@@ -1,4 +1,4 @@
-id: 18f7de84-de55-4983-aca3-a18bc846b4e0 
+id: 18f7de84-de55-4983-aca3-a18bc846b4e0
 name: Preview - TI map File entity to Syslog Event
 description: |
   'Identifies a match in Syslog Event data from any FileName IOC from TI.
@@ -8,6 +8,9 @@ requiredDataConnectors:
     dataTypes:
       - Syslog
   - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
     dataTypes:
       - ThreatIntelligenceIndicator
 tactics:
@@ -28,6 +31,6 @@ query: |
   )
   on $left.TI_ProcessEntity == $right.ProcessName
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
-  Syslog_TimeGenerated, FileName, Computer, HostIP, SyslogMessage  
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
+  Syslog_TimeGenerated, FileName, Computer, HostIP, SyslogMessage
   | extend timestamp = Syslog_TimeGenerated, HostCustomEntity = Computer, IPCustomEntity = HostIP, URLCustomEntity = Url

--- a/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_VMConnection.yaml
+++ b/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_VMConnection.yaml
@@ -10,10 +10,13 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 tactics:
   - Impact
 query: |
-  
+
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -28,6 +31,6 @@ query: |
   )
   on $left.TI_ProcessEntity == $right.ProcessName
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
-  VMConnection_TimeGenerated, FileName, Computer, Direction, SourceIp, DestinationIp, RemoteIp, DestinationPort, Protocol 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
+  VMConnection_TimeGenerated, FileName, Computer, Direction, SourceIp, DestinationIp, RemoteIp, DestinationPort, Protocol
   | extend timestamp = VMConnection_TimeGenerated, IPCustomEntity = RemoteIp, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_WireData.yaml
+++ b/Hunting Queries/ThreatIntelligenceIndicator/FileEntity_WireData.yaml
@@ -1,4 +1,4 @@
-id: 689a9475-440b-4e69-8ab1-a5e241685f39 
+id: 689a9475-440b-4e69-8ab1-a5e241685f39
 name: Preview - TI map File entity to WireData Event
 description: |
   'Identifies a match in WireData Event data from any FileName IOC from TI.
@@ -10,10 +10,13 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 tactics:
   - Impact
 query: |
-  
+
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -28,6 +31,6 @@ query: |
   )
   on $left.FileName == $right.Process
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   WireData_TimeGenerated, FileName, Computer, Direction, LocalIP, RemoteIP, LocalPortNumber, RemotePortNumber
   | extend timestamp = WireData_TimeGenerated, HostCustomEntity = Computer, IPCustomEntity = RemoteIP, URLCustomEntity = Url

--- a/Hunting Queries/ThreatIntelligenceIndicator/Sample-DNSEventsMatchToThreatIntel.yaml
+++ b/Hunting Queries/ThreatIntelligenceIndicator/Sample-DNSEventsMatchToThreatIntel.yaml
@@ -10,16 +10,19 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 tactics:
   - Impact
 query: |
 
   let timeframe = 1d;
   DnsEvents
-  | where TimeGenerated >= ago(timeframe) 
-  | join (ThreatIntelligenceIndicator 
+  | where TimeGenerated >= ago(timeframe)
+  | join (ThreatIntelligenceIndicator
     | summarize arg_max(TimeGenerated, *) by IndicatorId
     | summarize by Url) on $left.Name == $right.Url
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count() 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count()
   by Computer, ClientIP, ThreatIntel_Related_Domain = Name, Url
   | extend timestamp = StartTimeUtc, HostCustomEntity = Computer, IPCustomEntity = ClientIP, URLCustomEntity = Url


### PR DESCRIPTION
## Proposed Changes

- Currently analytic templates will look as if they don't have the required source ThreatIntelligenceIndicator data if nothing is coming specifically from the Graph Security API. However these analytics are still valid and work if TI data is coming from the TAXII connector.

<img width="458" alt="Screen Shot 2020-08-25 at 10 20 31" src="https://user-images.githubusercontent.com/939704/91157151-e0530a00-e6bc-11ea-8280-9b60ca9265ae.png">

- Minor change to the "(Preview) TI map Domain entity to DnsEvent" to bring it inline with the other Domain entity analytics so the filter doesn't rely on an arbitrary ID but rather the presence of a domain entity.