### PR TITLE
Typos in the LDAP and AAD Legacy Auth sections

### DIFF
--- a/Workbooks/InsecureProtocols.json
+++ b/Workbooks/InsecureProtocols.json
@@ -745,7 +745,7 @@
               "version": "KqlItem/1.0",
               "query": "Event \r\n | where EventID == 2889 \r\n | parse ParameterXml with * '><Param>' Account '</' *\r\n | parse ParameterXml with * '<Param>' IPAddress ':' * \r\n | parse kind = regex ParameterXml with * '</Param><Param>' * '</Param><Param>' BindingType '</Param>'\r\n | extend TimeFromNow = now() - TimeGenerated\r\n | extend TimeAgo = strcat(case(TimeFromNow < 2m, strcat(toint(TimeFromNow / 1m), ' seconds'), TimeFromNow < 2h, strcat(toint(TimeFromNow / 1m), ' minutes'), TimeFromNow < 2d, strcat(toint(TimeFromNow / 1h), ' hours'), strcat(toint(TimeFromNow / 1d), ' days')), ' ago')\r\n | where Account == '{Account:escape}' or  '{Account:escape}' == \"All\"\r\n | summarize count() by Account, bin(TimeGenerated, {TimeRange:grain})",
               "size": 0,
-              "title": "Acount events over time - select timebrush",
+              "title": "Account events over time - select timebrush",
               "timeContext": {
                 "durationMs": 604800000
               },
@@ -772,7 +772,7 @@
               "version": "KqlItem/1.0",
               "query": "Event \r\n | where EventID == 2889 \r\n | parse ParameterXml with * '><Param>' Account '</' *\r\n | parse ParameterXml with * '<Param>' IPAddress ':' * \r\n | parse kind = regex ParameterXml with * '</Param><Param>' * '</Param><Param>' BindingType '</Param>'\r\n | extend TimeFromNow = now() - TimeGenerated\r\n | extend TimeAgo = strcat(case(TimeFromNow < 2m, strcat(toint(TimeFromNow / 1m), ' seconds'), TimeFromNow < 2h, strcat(toint(TimeFromNow / 1m), ' minutes'), TimeFromNow < 2d, strcat(toint(TimeFromNow / 1h), ' hours'), strcat(toint(TimeFromNow / 1d), ' days')), ' ago')\r\n | where Account == '{Account:escape}' or  '{Account:escape}' == \"All\"\r\n | extend BindingType = case(BindingType==0,\"Unsigned\",BindingType==1,\"Simple\",\"Unknown\")\r\n | summarize Count=count() by Account, bin(TimeGenerated, {TimeRange:grain}), BindingType\r\n| order by Count",
               "size": 0,
-              "title": "Acount events over time ({LDAPTimebrushAccount:label})",
+              "title": "Account events over time ({LDAPTimebrushAccount:label})",
               "timeContext": {
                 "durationMs": 0
               },
@@ -2321,7 +2321,7 @@
               "version": "KqlItem/1.0",
               "query": "SigninLogs\r\n| where ClientAppUsed !contains \"Browser\" and ClientAppUsed !contains \"Mobile Apps and Desktop clients\" and ClientAppUsed !contains \"Exchange ActiveSync\"\r\n| summarize Count=count() by UserPrincipalName, bin(TimeGenerated, {TimeRange:grain})\r\n| order by Count\r\n",
               "size": 1,
-              "title": "Acount events over time ({AADTimebrushAccount:label})",
+              "title": "Account events over time ({AADTimebrushAccount:label})",
               "timeContext": {
                 "durationMs": 0
               },


### PR DESCRIPTION
I guess it is either "Count of events over time" or "Account events over time" I suggest "Accounts" as the charts and tables underneath are listing accounts.

## Proposed Changes

  - Correct the word "Acounts"