### PR TITLE
fix wget not creating omsagent configuration file issue

### DIFF
--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -179,20 +179,29 @@ def set_omsagent_configuration(workspace_id, omsagent_incoming_port):
     :param udp:
     :return:
     '''
+    configuration_directory = "/etc/opt/microsoft/omsagent/" + workspace_id + "/conf/omsagent.d/"
     configuration_path = "/etc/opt/microsoft/omsagent/" + workspace_id + "/conf/omsagent.d/security_events.conf"
+
     print("Creating omsagent configuration to listen to syslog daemon forwarding port - " + omsagent_incoming_port)
     print("Configuration location is - " + configuration_path)
-    command_tokens = ["sudo", "wget", "-O", configuration_path, oms_agent_configuration_url]
+    command_tokens1 = ["sudo", "mkdir", "-p", configuration_directory]
+    command_tokens2 = ["sudo", "wget", "-O", configuration_path, oms_agent_configuration_url]
     print("Download configuration into the correct directory")
-    print_notice(" ".join(command_tokens))
+    print_notice(" ".join(command_tokens1))
+    print_notice(" ".join(command_tokens2))
     time.sleep(3)
-    set_omsagent_configuration_command = subprocess.Popen(command_tokens, stdout=subprocess.PIPE)
+    create_omsagent_configuration_directory = subprocess.Popen(command_tokens1, stdout=subprocess.PIPE)
+    set_omsagent_configuration_command = subprocess.Popen(command_tokens2, stdout=subprocess.PIPE)
+    o, e = create_omsagent_configuration_directory.communicate()
+    if e is not None:
+        handle_error(e, error_response_str="Error: could not create omsagent configuration directory.")
+        return False
     o, e = set_omsagent_configuration_command.communicate()
     if e is not None:
         handle_error(e, error_response_str="Error: could not download omsagent configuration.")
         return False
     print_ok("Configuration for omsagent downloaded successfully.")
-    print("Trying to changed omsagent configuration")
+    print("Trying to change omsagent configuration")
     if omsagent_incoming_port is not omsagent_default_incoming_port:
         if change_omsagent_configuration_port(omsagent_incoming_port=omsagent_incoming_port, configuration_path=configuration_path):
             print_ok("Incoming port for omsagent was changed to " + omsagent_incoming_port)

--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -184,14 +184,14 @@ def set_omsagent_configuration(workspace_id, omsagent_incoming_port):
 
     print("Creating omsagent configuration to listen to syslog daemon forwarding port - " + omsagent_incoming_port)
     print("Configuration location is - " + configuration_path)
-    command_tokens1 = ["sudo", "mkdir", "-p", configuration_directory]
-    command_tokens2 = ["sudo", "wget", "-O", configuration_path, oms_agent_configuration_url]
+    mkdir_command_tokens = ["sudo", "mkdir", "-p", configuration_directory]
+    wget_command_tokens = ["sudo", "wget", "-O", configuration_path, oms_agent_configuration_url]
     print("Download configuration into the correct directory")
-    print_notice(" ".join(command_tokens1))
-    print_notice(" ".join(command_tokens2))
+    print_notice(" ".join(mkdir_command_tokens))
+    print_notice(" ".join(wget_command_tokens))
     time.sleep(3)
-    create_omsagent_configuration_directory = subprocess.Popen(command_tokens1, stdout=subprocess.PIPE)
-    set_omsagent_configuration_command = subprocess.Popen(command_tokens2, stdout=subprocess.PIPE)
+    create_omsagent_configuration_directory = subprocess.Popen(mkdir_command_tokens, stdout=subprocess.PIPE)
+    set_omsagent_configuration_command = subprocess.Popen(wget_command_tokens, stdout=subprocess.PIPE)
     o, e = create_omsagent_configuration_directory.communicate()
     if e is not None:
         handle_error(e, error_response_str="Error: could not create omsagent configuration directory.")


### PR DESCRIPTION
wget -O didn't create the directory for the omsagent configuration it downloaded (in Debian 10).
This fixes that by adding a "mkdir" command before downloading.