### PR TITLE
Update Zscaler-LowVolumeDomainRequests.yaml

### DIFF
--- a/Detections/CommonSecurityLog/Zscaler-LowVolumeDomainRequests.yaml
+++ b/Detections/CommonSecurityLog/Zscaler-LowVolumeDomainRequests.yaml
@@ -30,7 +30,7 @@ query: |
   | where SentBytes > 0 and ReceivedBytes > 0
   // Extract the Domain
   | extend Domain = iff(countof(DestinationHostName,'.') >= 2, strcat(split(DestinationHostName,'.')[-2], '.',split(DestinationHostName,'.')[-1]), DestinationHostName)
-  | extend GetData=iff(RequestURL in "?", 1, 0)
+  | extend GetData=iff(RequestURL == "?", 1, 0)
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), makelist(RequestURL), makelist(DestinationIP), makelist(SourceIP), numOfConnections = count(), make_set(RequestMethod), max(GetData), max(RequestContext) by Domain
   // Determine the number of URIs that have been visited for the domain
   | extend destinationURI = arraylength(list_RequestURL)
@@ -39,7 +39,7 @@ query: |
   //Remove matches with referer
   | where max_RequestContext == ""
   //Keep requests where data was trasferred either in a GET with parameters or a POST
-  | where set_RequestMethod in~ "POST" or max_GetData == 1
+  | where set_RequestMethod in~ ("POST") or max_GetData == 1
   //Defeat email click tracking, may increase FN's while decreasing FP's
   | where list_RequestURL !has "click" and set_RequestMethod !has "GET"
   | mvexpand list_RequestURL, list_DestinationIP

--- a/Detections/CommonSecurityLog/Zscaler-LowVolumeDomainRequests.yaml
+++ b/Detections/CommonSecurityLog/Zscaler-LowVolumeDomainRequests.yaml
@@ -19,7 +19,7 @@ relevantTechniques:
 query: |
 
   let timeRange = 1d;
-  let scriptExtensions = dynamic([".php",".aspx", ".asp", ".cfml"]);
+  let scriptExtensions = dynamic([".php", ".aspx", ".asp", ".cfml"]);
   //The number of URI's seen to be suspicious, higher = less likely to be suspicious
   let uriThreshold = 1;
   CommonSecurityLog
@@ -30,7 +30,7 @@ query: |
   | where SentBytes > 0 and ReceivedBytes > 0
   // Extract the Domain
   | extend Domain = iff(countof(DestinationHostName,'.') >= 2, strcat(split(DestinationHostName,'.')[-2], '.',split(DestinationHostName,'.')[-1]), DestinationHostName)
-  | extend GetData=iff(RequestURL contains "?", 1, 0)
+  | extend GetData=iff(RequestURL in "?", 1, 0)
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), makelist(RequestURL), makelist(DestinationIP), makelist(SourceIP), numOfConnections = count(), make_set(RequestMethod), max(GetData), max(RequestContext) by Domain
   // Determine the number of URIs that have been visited for the domain
   | extend destinationURI = arraylength(list_RequestURL)
@@ -39,7 +39,7 @@ query: |
   //Remove matches with referer
   | where max_RequestContext == ""
   //Keep requests where data was trasferred either in a GET with parameters or a POST
-  | where set_RequestMethod contains "POST" or max_GetData == 1
+  | where set_RequestMethod in~ "POST" or max_GetData == 1
   //Defeat email click tracking, may increase FN's while decreasing FP's
   | where list_RequestURL !has "click" and set_RequestMethod !has "GET"
   | mvexpand list_RequestURL, list_DestinationIP

--- a/Detections/CommonSecurityLog/Zscaler-LowVolumeDomainRequests.yaml
+++ b/Detections/CommonSecurityLog/Zscaler-LowVolumeDomainRequests.yaml
@@ -19,25 +19,31 @@ relevantTechniques:
 query: |
 
   let timeRange = 1d;
+  let scriptExtensions = dynamic([".php",".aspx", ".asp", ".cfml"]);
   //The number of URI's seen to be suspicious, higher = less likely to be suspicious
   let uriThreshold = 1;
-  let suspiciousURLs =
   CommonSecurityLog
   | where TimeGenerated >= ago(timeRange)
-  // Only look at connections that were allowed through the web proxy. Comment line out for all events including those which were blocked
+  // Only look at connections that were allowed through the web proxy
   | where DeviceVendor =~ "Zscaler" and DeviceAction =~ "Allowed"
-  // Only look where some data was exchanged. Comment out to see 0 byte connections
+  // Only look where some data was exchanged.
   | where SentBytes > 0 and ReceivedBytes > 0
   // Extract the Domain
   | extend Domain = iff(countof(DestinationHostName,'.') >= 2, strcat(split(DestinationHostName,'.')[-2], '.',split(DestinationHostName,'.')[-1]), DestinationHostName)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), makelist(RequestURL), makelist(DestinationIP), makelist(SourceIP), numOfConnections = count() by Domain
+  | extend GetData=iff(RequestURL contains "?", 1, 0)
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), makelist(RequestURL), makelist(DestinationIP), makelist(SourceIP), numOfConnections = count(), make_set(RequestMethod), max(GetData), max(RequestContext) by Domain
   // Determine the number of URIs that have been visited for the domain
   | extend destinationURI = arraylength(list_RequestURL)
   | where destinationURI <= uriThreshold
-  | where tostring(list_RequestURL) has_any (".php",".aspx")
-  ;
-  suspiciousURLs
+  | where tostring(list_RequestURL) has_any(scriptExtensions)
+  //Remove matches with referer
+  | where max_RequestContext == ""
+  //Keep requests where data was trasferred either in a GET with parameters or a POST
+  | where set_RequestMethod contains "POST" or max_GetData == 1
+  //Defeat email click tracking, may increase FN's while decreasing FP's
+  | where list_RequestURL !has "click" and set_RequestMethod !has "GET"
   | mvexpand list_RequestURL, list_DestinationIP
   | extend RequestURL = tostring(list_RequestURL), DestinationIP = tostring(list_DestinationIP), ClientIP = tostring(list_SourceIP)
+  //Extend custom entitites for incidents
   | extend timestamp = StartTimeUtc, IPCustomEntity = DestinationIP
-  | project-away list_RequestURL, list_DestinationIP, list_SourceIP, destinationURI, Domain, StartTimeUtc, EndTimeUtc, numOfConnections 
+  | project-away list_RequestURL, list_DestinationIP, list_SourceIP, destinationURI, Domain, StartTimeUtc, EndTimeUtc, max_GetData, max_RequestContext


### PR DESCRIPTION
Fixes 

- Expanded supported script extensions and made them easier to customise.
- Added additional check for POST request or GET request with parameters to remove FP's where no data was submitted to the server. Use the max summarisation function as we only care about there being one set of activity where data is transferred.
- Added additional check to ensure that no referrer was provided, this check defeats most FP's caused by wordpress's admin ajax
- Added basic defeat to remove email click tracking activity, while this may increase FN's it should significantly reduce FP's.
