### PR TITLE
Update links to point to 7.2 documentation

### DIFF
--- a/DataConnectors/esetSmc.json
+++ b/DataConnectors/esetSmc.json
@@ -140,7 +140,7 @@
       },
       {
           "title": "6. Configure Eset SMC to send logs to connector",
-          "description": "Configure Eset Logs using BSD style and JSON format.\r\n- Go to Syslog server configuration as described in [Eset documentation](https://help.eset.com/esmc_admin/72/en-US/admin_server_settings.html?admin_server_settings_syslog.html) and configure Host (your connector), Format BSD, Transport TCP\r\n- Go to Logging section as described in [Eset documentation](https://help.eset.com/esmc_admin/70/en-US/admin_server_settings.html?admin_server_settings_export_to_syslog.html) and enable JSON"
+          "description": "Configure Eset Logs using BSD style and JSON format.\r\n- Go to Syslog server configuration as described in [Eset documentation](https://help.eset.com/esmc_admin/72/en-US/admin_server_settings.html?admin_server_settings_syslog.html) and configure Host (your connector), Format BSD, Transport TCP\r\n- Go to Logging section as described in [Eset documentation](https://help.eset.com/esmc_admin/72/en-US/admin_server_settings.html?admin_server_settings_export_to_syslog.html) and enable JSON"
       }
   ]
 }

--- a/DataConnectors/esetSmc.json
+++ b/DataConnectors/esetSmc.json
@@ -2,7 +2,7 @@
     "id": "EsetSMC",
     "title": "Eset Security Management Center (Preview)",
     "publisher": "Eset",
-    "descriptionMarkdown": "Connector for [Eset SMC](https://help.eset.com/esmc_admin/70/en-US/) threat events, audit logs, firewall events and web sites filter.",
+    "descriptionMarkdown": "Connector for [Eset SMC](https://help.eset.com/esmc_admin/72/en-US/) threat events, audit logs, firewall events and web sites filter.",
     "graphQueries": [
         {
             "metricName": "Total data received",
@@ -140,7 +140,7 @@
       },
       {
           "title": "6. Configure Eset SMC to send logs to connector",
-          "description": "Configure Eset Logs using BSD style and JSON format.\r\n- Go to Syslog server configuration as described in [Eset documentation](https://help.eset.com/esmc_admin/70/en-US/admin_server_settings.html?admin_server_settings_syslog.html) and configure Host (your connector), Format BSD, Transport TCP\r\n- Go to Logging section as described in [Eset documentation](https://help.eset.com/esmc_admin/70/en-US/admin_server_settings.html?admin_server_settings_export_to_syslog.html) and enable JSON"
+          "description": "Configure Eset Logs using BSD style and JSON format.\r\n- Go to Syslog server configuration as described in [Eset documentation](https://help.eset.com/esmc_admin/72/en-US/admin_server_settings.html?admin_server_settings_syslog.html) and configure Host (your connector), Format BSD, Transport TCP\r\n- Go to Logging section as described in [Eset documentation](https://help.eset.com/esmc_admin/70/en-US/admin_server_settings.html?admin_server_settings_export_to_syslog.html) and enable JSON"
       }
   ]
 }


### PR DESCRIPTION
Hello,

This is my first time contributing to Sentinel, so this is a rather small PR. Still, I think it is an important one. The documentation for version 7.2 versus version 7.0 is a lot more detailed. For example, the 7.0 only lists 5 types of exported events:

https://help.eset.com/esmc_admin/70/en-US/events-exported-to-json-format.html

While 7.2 lists 7:

https://help.eset.com/esmc_admin/72/en-US/events-exported-to-json-format.html

If all goes well I also plan to add support for the extra event types into the connector itself, but I'll first have to take a look at how the integration actually works. I'm a bit of a sentinel newbie at this point :).