### PR TITLE
Update PulseConnectSecure.txt

### DIFF
--- a/Parsers/PulseConnectSecure/PulseConnectSecure.txt
+++ b/Parsers/PulseConnectSecure/PulseConnectSecure.txt
@@ -29,7 +29,7 @@
 //
 Syslog
 | where Computer in ("datasource") and Facility == "local7"
-//Version 8.0R7 and below
+//Version 8.0R7 and below using the Standard format
 | extend Parser = extract_all(@'^(\d{4}\-\d{2}-\d{2})\s(\d{2}\:\d{2}:\d{2})\s(\S+)\s(\S+)\s(\S+)\s\[(\S+)\]\s(\S+)\((.*)?\)\[(.*)\]\s\-\s(.*)',dynamic([1,2,3,4,5,6,7,8,9,10]),SyslogMessage)
 | mv-expand Parser
 | extend LogTime = todatetime(strcat(tostring(Parser[0]),'T',tostring(Parser[1]))), 
@@ -40,7 +40,9 @@ Syslog
     EventID = tostring(Parser[8]), 
     Messages = tostring(Parser[9])
 | project-away Parser
-//Version 8.0R7 and above
+
+// The section below is for parsing WebTrends Enhanced Log Format (WELF) logs.  If you are NOT using WELF, then keep this section separated or remove it
+//Version 8.0R7 and above using the WELF format
 | extend User = extract(@'user=(\S+)',1,SyslogMessage),
     EventID = extract(@'id=(\S+)',1,SyslogMessage),
     Pri = extract(@'pri=(\S+)',1,SyslogMessage),
@@ -49,5 +51,5 @@ Syslog
     Roles = extract(@'roles=\"([\w\s\:\.]+)\"',1,SyslogMessage),
     Type = extract(@'type=(\S+)',1,SyslogMessage),
     Messages = extract(@'msg=\"([\w\s\:\.]+)\"',1,SyslogMessage),
-    Source_IP = extract(@'fw=([\d\.]+)',1,SyslogMessage),
+    Source_IP = extract(@'fw=([\d\.]+)',1,SyslogMessage)
 


### PR DESCRIPTION
Removed extra "," from end of query.  Separated the two versions of the parser namely that the first parser section works with the default PulseSecure format and the second is expecting WebTrends Enhanced Log Format (WELF)

Fixes #
Removed stray comment
## Proposed Changes
Clarify format of logs and parser sections
  -
  -
  -
