### PR TITLE
Bugfix/fix agent error identification

### DIFF
--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -28,6 +28,7 @@ import subprocess
 import time
 import sys
 import os
+import re
 
 rsyslog_daemon_name = "rsyslog"
 syslog_ng_daemon_name = "syslog-ng"
@@ -135,9 +136,13 @@ def install_omsagent(workspace_id, primary_key, oms_agent_install_url):
     install_omsagent_command = subprocess.Popen(command_tokens, stdout=subprocess.PIPE)
     o, e = install_omsagent_command.communicate()
     time.sleep(3)
+    return_code = re.search(".*Shell bundle exiting with code (\d+)", o, re.IGNORECASE)
     if e is not None:
         handle_error(e, error_response_str="Error: could not install omsagent.")
-        return False
+        sys.exit()
+    elif return_code.group(1) != '0':
+        handle_error(o, error_response_str="Error: could not install omsagent.")
+        sys.exit()
     print_ok("Installed omsagent successfully.")
     return True
 

--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -141,7 +141,7 @@ def install_omsagent(workspace_id, primary_key, oms_agent_install_url):
     if e is not None:
         handle_error(e, error_response_str="Error: could not install omsagent.")
         sys.exit()
-    elif return_code.group(1) != '0':
+    elif return_code is not None and return_code.group(1) != '0':
         handle_error(o, error_response_str="Error: could not install omsagent.")
         sys.exit()
     print_ok("Installed omsagent successfully.")

--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -136,6 +136,7 @@ def install_omsagent(workspace_id, primary_key, oms_agent_install_url):
     install_omsagent_command = subprocess.Popen(command_tokens, stdout=subprocess.PIPE)
     o, e = install_omsagent_command.communicate()
     time.sleep(3)
+    # Parsing the agent's installation return code
     return_code = re.search(".*Shell bundle exiting with code (\d+)", o, re.IGNORECASE)
     if e is not None:
         handle_error(e, error_response_str="Error: could not install omsagent.")


### PR DESCRIPTION
Forwards installation errors from agent instead of ignoring it.
In addition- stops the program if the agent installation is not successful. 
