### PR TITLE
FixDownloadNameDuplication

### DIFF
--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -100,7 +100,7 @@ def download_omsagent():
     '''
     print("Trying to download the omsagent.")
     print_notice("wget " + oms_agent_url)
-    download_command = subprocess.Popen(["wget", oms_agent_url], stdout=subprocess.PIPE)
+    download_command = subprocess.Popen(["wget", "-O", omsagent_file_name, oms_agent_url], stdout=subprocess.PIPE)
     o, e = download_command.communicate()
     time.sleep(3)
     if e is not None:


### PR DESCRIPTION
Using the flag -O in wget we will avoid duplications in file names which cause the old file to always be run and the new files to get rotated.
