### PR TITLE
Updated GitHub Integration template

### DIFF
--- a/DataConnectors/GitHub/azuredeploy.json
+++ b/DataConnectors/GitHub/azuredeploy.json
@@ -374,7 +374,7 @@
                                                             }
                                                         },
                                                         "method": "put",
-                                                        "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent('/githublogicapp/lastrun-Audit.json='))}"
+                                                        "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent('/githublogicapp/lastrun-Audit.json'))}"
                                                     }
                                                 }
 									  },

--- a/DataConnectors/GitHub/readme.md
+++ b/DataConnectors/GitHub/readme.md
@@ -7,6 +7,7 @@ There are a number of configuration steps required to deploy the Logic App playb
 
 ## Configuration Steps
 1. Generate a GitHub (Personal Access Token)[https://github.com/settings/tokens].  GitHub user settings -> Developer settings -> Personal access tokens.
+        *Necessary permissions for the token include: admin:org, admin:enterprise, read:user, repo*
 2. Get the objectId for a user that the Logic App can use.  Azure Portal -> Azure Active Directory -> Users -> User.
 This user will be used to grant access to the Key Vault secret.
 3. Deploy the ARM template and fill in the parameters.


### PR DESCRIPTION
Fixes #
Fixed an issue with the lastrun-Audit.json file name where an = seems like it was accidentally appended to the filename, causing the logic app to fail.

Provided more information around the permissions a GitHub token needs to access the APIs

## Proposed Changes 
  - Remove =
  - Updated readme with token permission info.
  -
