### PR TITLE
Update azuredeploy.json GitHubVulnAlerts App

### DIFF
--- a/DataConnectors/GitHub/azuredeploy.json
+++ b/DataConnectors/GitHub/azuredeploy.json
@@ -2264,7 +2264,7 @@
                                                             "type": "string"
                                                           },
                                                           "permalink": {
-                                                            "type": "string"
+                                                            "type": ["string", "null"]
                                                           },
                                                           "publishedAt": {
                                                             "type": "string"


### PR DESCRIPTION
Updated azuredeply.json Get-GitHubVulnerabilityAlerts Logic App to allow permalinks for each advisory to be null.

Fixes #
In the Get-GitHubVulnerabilityAlerts logic app, permalinks needed to allow null values or data ingestion would fail on advisories without permalinks.

## Proposed Changes

  - Allow permalinks to be string or null values
  -
  -
