### PR TITLE
Update azuredeploy.json

### DIFF
--- a/Playbooks/Block-AADUser/azuredeploy.json
+++ b/Playbooks/Block-AADUser/azuredeploy.json
@@ -86,12 +86,8 @@
                         }
                     },
                     "actions": {
-                        "Alert_-_Get_accounts": {
-                            "runAfter": {
-                                "Alert_-_Get_incident": [
-                                    "Succeeded"
-                                ]
-                            },
+                        "Entities_-_Get_Accounts": {
+                            "runAfter": {},
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": "@triggerBody()?['Entities']",
@@ -104,39 +100,9 @@
                                 "path": "/entities/account"
                             }
                         },
-                        "Alert_-_Get_incident": {
-                            "runAfter": {},
-                            "type": "ApiConnection",
-                            "inputs": {
-                                "host": {
-                                    "connection": {
-                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                    }
-                                },
-                                "method": "get",
-                                "path": "/Cases/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}"
-                            }
-                        },
                         "For_each": {
-                            "foreach": "@body('Alert_-_Get_accounts')?['Accounts']",
+                            "foreach": "@body('Entities_-_Get_Accounts')?['Accounts']",
                             "actions": {
-                                "Add_comment_to_incident": {
-                                    "runAfter": {
-                                        "Update_user": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "put",
-                                        "path": "/Comment/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}/@{encodeURIComponent('Incident')}/@{encodeURIComponent(body('Alert_-_Get_incident')?['properties']?['CaseNumber'])}/@{encodeURIComponent('User was disabled in AAD via playbook')}"
-                                    }
-                                },
                                 "Update_user": {
                                     "runAfter": {},
                                     "type": "ApiConnection",
@@ -155,7 +121,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Alert_-_Get_accounts": [
+                                "Entities_-_Get_Accounts": [
                                     "Succeeded"
                                 ]
                             },
@@ -168,14 +134,14 @@
                     "$connections": {
                         "value": {
                             "azuread": {
-                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureADConnectionName'))]",
-                                "connectionName": "[variables('AzureADConnectionName')]",
-                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuread')]"
+                                "connectionId": "/subscriptions/93567498-7c73-4b1e-a94b-84093d439d23/resourceGroups/WHCDC/providers/Microsoft.Web/connections/azuread",
+                                "connectionName": "azuread",
+                                "id": "/subscriptions/93567498-7c73-4b1e-a94b-84093d439d23/providers/Microsoft.Web/locations/eastus2/managedApis/azuread"
                             },
                             "azuresentinel": {
-                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                                "connectionName": "[variables('AzureSentinelConnectionName')]",
-                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                                "connectionId": "/subscriptions/93567498-7c73-4b1e-a94b-84093d439d23/resourceGroups/WHCDC/providers/Microsoft.Web/connections/azuresentinel-2",
+                                "connectionName": "azuresentinel-2",
+                                "id": "/subscriptions/93567498-7c73-4b1e-a94b-84093d439d23/providers/Microsoft.Web/locations/eastus2/managedApis/azuresentinel"
                             }
                         }
                     }


### PR DESCRIPTION
The template was using the old get-incident action which was causing a JSON format error, using the new Get-Account action removes this challenge

{
  "error": {
    "code": 400,
    "source": "logic-apis-eastus2.azure-apim.net",
    "clientRequestId": "43813499-8616-42ae-bc05-877ba2b0fbc1",
    "message": "The response is not in a JSON format.",
    "innerError": "Invalid subscription id or resource group"
  }
}

Fixes #

## Proposed Changes

  -
  -
  -
