### PR TITLE
Spelling error in AIP workbook title

### DIFF
--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -398,7 +398,7 @@
     "dataConnectorsDependencies": [ "AzureInformationProtection" ],
     "previewImagesFileNames": [ "AzureInformationProtectionWhite.png", "AzureInformationProtectionBlack.png" ],
     "version": "1.1",
-    "title": "Azure Information Protecton - Usage Report",
+    "title": "Azure Information Protection - Usage Report",
     "templateRelativePath": "AzureInformationProtection.json",
     "subtitle": "",
     "provider": "Microsoft"


### PR DESCRIPTION
Customer noticed a spelling error, added the 'i' into the name:

 
"title": "Azure Information Protection - Usage Report",

Fixes #

## Proposed Changes

  -
  -
  -
