### PR TITLE
Adding space to the datatype name

### DIFF
--- a/DataConnectors/Templates/Connector_Syslog_template.json
+++ b/DataConnectors/Templates/Connector_Syslog_template.json
@@ -19,7 +19,7 @@
     ],
     "dataTypes": [
         {
-            "name": "Syslog(DATATYPE_NAME)",
+            "name": "Syslog (DATATYPE_NAME)",
             "lastDataReceivedQuery": "DATATYPE_NAME\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
         }
     ],


### PR DESCRIPTION
Adding space to the datatype name

Fixes #

## Proposed Changes

  -
  -
  -
