### PR TITLE
Updating Product Parsers

### DIFF
--- a/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/CheckPoint.kql
+++ b/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/CheckPoint.kql
@@ -5,7 +5,7 @@
 // Reference: Sentinel normalization documentation: https://aka.ms/sentinelnormalizationdocs
 //
 // Note: This parser only populates and shows relevant fields within the networking schema. Please use the meta parser to see all relevant fields, or union this parser with the empty network schema. 
-// Parser Version: 1.0.0
+// Parser Version: 1.0.1
 // Schema version: 1.0.0
 // Alias name: CheckPoint-Network-NormalizedParser (please change hypens(-) to underscores(_) when creating the alias)
 let NetworkParserCheckPoint=(){
@@ -30,7 +30,7 @@ CommonSecurityLog
 	, DvcAction=DeviceAction
 | extend
     EventSchemaVersion="1.0.0"
-	, EventCount=tolong(1)
+	, EventCount=toint(1)
 	, EventUid=_ItemId
     , EventOriginalUid=extract(@'loguid=(\{[^\}]+\})',1,AdditionalExtensions, typeof(string))
     , EventTimeIngested =ingestion_time()

--- a/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/PaloAlto9.kql
+++ b/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/PaloAlto9.kql
@@ -5,7 +5,7 @@
 // Reference: Sentinel normalization documentation: https://aka.ms/sentinelnormalizationdocs
 //
 // Note: This parser only populates and shows relevant fields within the networking schema. Please use the meta parser to see all relevant fields, or union this parser with the empty network schema. 
-// Parser Version: 1.0.0
+// Parser Version: 1.0.1
 // Schema version: 1.0.0
 // Alias name: PAN-9-Network-NormalizedParser (please change hypens(-) to underscores(_) when creating the alias)
 let IP_TYPE=(ip:string){case(ip has ".", "IPv4", ip contains ":", "IPv6", "unknown")};
@@ -47,7 +47,7 @@ CommonSecurityLog
     , TimeGenerated  
     , EventTimeIngested =ingestion_time()
     , EventType="Traffic"
-    , EventCount=tolong(1)
+    , EventCount=toint(1)
     , EventResult=case(DeviceAction=="allow","Success","Failure")
     , NetworkSessionId=tostring(DeviceCustomNumber1)
     , NetworkDuration=DeviceCustomNumber3

--- a/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/WindowsFirewall.kql
+++ b/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/WindowsFirewall.kql
@@ -5,13 +5,13 @@
 // Reference: Sentinel normalization documentation: https://aka.ms/sentinelnormalizationdocs
 //
 // Note: This parser only populates and shows relevant fields within the networking schema. Please use the meta parser to see all relevant fields, or union this parser with the empty network schema. 
-// Parser Version: 1.0.1
+// Parser Version: 1.0.2
 // Schema version: 1.0.0
 // Alias name: WindowsFW-Network-NormalizedParser (please change hypens(-) to underscores(_) when using the alias)
 let NetworkParserWindowsFirewall=(){ WindowsFirewall
 | extend EventType = "Traffic"
   , EventSchemaVersion="1.0.0"
-  , EventCount=tolong(1) 
+  , EventCount=toint(1) 
   , EventVendor = "Microsoft"
   , EventProduct = "WindowsFirewall"
   , EventResult="Success"

--- a/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/Wiredata.kql
+++ b/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/Wiredata.kql
@@ -11,7 +11,7 @@
 let ParserWireData=(){ WireData
 | extend EventType = "Traffic"
   , EventSchemaVersion="1.0.0"
-  , EventCount=tolong(1) 
+  , EventCount=toint(1) 
   , EventVendor = "Microsoft"
   , EventProduct = "WireData"
   , EventResult = "Success"

--- a/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/Wiredata.kql
+++ b/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/Wiredata.kql
@@ -5,7 +5,7 @@
 // Reference: Sentinel normalization documentation: https://aka.ms/sentinelnormalizationdocs
 //
 // Note: This parser only populates and shows relevant fields within the networking schema. Please use the meta parser to see all relevant fields, or union this parser with the empty network schema. 
-// Parser Version: 1.0.0
+// Parser Version: 1.0.1
 // Schema version: 1.0.0
 // Alias name: WireData-Network-NormalizedParser (please change hypens(-) to underscores(_) when using the alias)
 let ParserWireData=(){ WireData

--- a/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/Zscaler.kql
+++ b/Parsers/Normalized Schema - Networking (v1.0.0)/Product parsers/Zscaler.kql
@@ -5,7 +5,7 @@
 // Reference: Sentinel normalization documentation: https://aka.ms/sentinelnormalizationdocs
 //
 // Note: This parser only populates and shows relevant fields within the networking schema. Please use the meta parser to see all relevant fields, or union this parser with the empty network schema. 
-// Parser Version: 1.0.0
+// Parser Version: 1.0.1
 // Schema version: 1.0.0
 // Alias name: ZScaler-Network-NormalizedParser (please change hypens(-) to underscores(_) when using the alias)
 let NetworkParserZscaler=(){
@@ -34,7 +34,7 @@ let NetworkParserZscaler=(){
 		, SrcMacAddr=SourceMACAddress
     | extend
         EventTimeIngested =ingestion_time()
-        , EventCount=tolong(EventCount)
+        , EventCount=toint(EventCount)
         , EventType="Traffic"
         , EventResult=case(DeviceAction has "Allow","Success","Failure") 
         , EventSchemaVersion="1.0.0"


### PR DESCRIPTION
Product parsers used long datatype for EventCount, changed to int to comply with schema