### PR TITLE
Fixing typo in description of "Suspicious number of resource creation or deployment activities"

### DIFF
--- a/Detections/AzureActivity/Creating_Anomalous_Number_Of_Resources_detection.yaml
+++ b/Detections/AzureActivity/Creating_Anomalous_Number_Of_Resources_detection.yaml
@@ -2,7 +2,7 @@
 name: Suspicious number of resource creation or deployment activities
 description: |
   'Indicates when an anomalous number of VM creations or deployment activities occur in Azure via the AzureActivity log.
-  The anomaly detection identifies activities that have occured both since the start of the day 1 day ago and the start of the day 7 days ago.
+  The anomaly detection identifies activities that have occurred both since the start of the day 1 day ago and the start of the day 7 days ago.
   The start of the day is considered 12am UTC time.'
 severity: Medium
 requiredDataConnectors:


### PR DESCRIPTION
There was a small typo in the description for rule 361dd1e3-1c11-491e-82a3-bb2e44ac36ba: "occured" as opposed to "occurred".  This is a PR to fix that.
