### PR TITLE
Fix requiredDataType in KnownPHOSPHORUSDomainsIP-October2020.yaml template

### DIFF
--- a/Detections/MultipleDataSources/KnownPHOSPHORUSDomainsIP-October2020.yaml
+++ b/Detections/MultipleDataSources/KnownPHOSPHORUSDomainsIP-October2020.yaml
@@ -25,7 +25,7 @@ requiredDataConnectors:
       - CommonSecurityLog (Fortinet)
   - connectorId: OfficeATP
     dataTypes:
-      - SecurityAlert (Office 365 Security & Compliance)
+      - SecurityAlert (OATP)
   - connectorId: AzureFirewall
     dataTypes:
       - AzureDiagnostics (Azure Firewall)


### PR DESCRIPTION
The current requieredDataType(SecurityAlert (Office 365 Security & Compliance)) is incorrect. 
According to OfficeATP it should be SecurityAlert (OATP).

Fixes #

## Proposed Changes

  -
  -
  -
