### PR TITLE
Removed BIN as this can miss bruteforces spread across BIN windows

### DIFF
--- a/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
+++ b/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
@@ -1,4 +1,4 @@
-id: 28b42356-45af-40a6-a0b4-a554cdfd5d8a
+﻿id: 28b42356-45af-40a6-a0b4-a554cdfd5d8a
 name: Brute force attack against Azure Portal
 description: |
   'Identifies evidence of brute force activity against Azure Portal by highlighting multiple authentication failures 

--- a/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
+++ b/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
@@ -21,25 +21,26 @@ relevantTechniques:
   - T1110
 query: |
 
-  let failureCountThreshold = 5;
-  let successCountThreshold = 1;
-  let timeRange = 1d;
-  let authenticationWindow = 20m;
-  SigninLogs
-  | where TimeGenerated >= ago(timeRange)
-  | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
-  | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
-  | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city)
-  | where AppDisplayName contains "Azure Portal"
-  // Split out failure versus non-failure types
-  | extend FailureOrSuccess = iff(ResultType in ("0", "50125", "50140", "70043", "70044"), "Success", "Failure")
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), IPAddress = makeset(IPAddress), makeset(OS), makeset(Browser), makeset(City), 
-  makeset(ResultType), FailureCount = countif(FailureOrSuccess=="Failure"), SuccessCount = countif(FailureOrSuccess=="Success") 
-  by bin(TimeGenerated, authenticationWindow), UserDisplayName, UserPrincipalName, AppDisplayName
-  | where FailureCount >= failureCountThreshold and SuccessCount >= successCountThreshold
-  | mvexpand IPAddress
-  | extend IPAddress = tostring(IPAddress)
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress 
+let failureCountThreshold = 5;
+let successCountThreshold = 1;
+let timeRange = 1d;
+let authenticationWindow = 20;
+SigninLogs
+| where TimeGenerated >= ago(timeRange) 
+| extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
+| extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
+| extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city)
+//| where AppDisplayName contains "Azure Portal"
+// Split out failure versus non-failure types
+| extend FailureOrSuccess = iff(ResultType in ("0", "50125", "50140", "70043", "70044"), "Success", "Failure")
+| summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), IPAddress = makeset(IPAddress), makeset(OS), makeset(Browser), makeset(City), 
+makeset(ResultType), FailureCount = countif(FailureOrSuccess=="Failure"), SuccessCount = countif(FailureOrSuccess=="Success") 
+by UserDisplayName, UserPrincipalName, AppDisplayName
+| extend time_between_events = (EndTimeUtc - StartTimeUtc) / 1m
+| where FailureCount >= failureCountThreshold and SuccessCount >= successCountThreshold and time_between_events < authenticationWindow
+| mvexpand IPAddress
+| extend IPAddress = tostring(IPAddress)
+| extend timestamp = StartTimeUtc, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress 
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
+++ b/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
@@ -1,4 +1,4 @@
-﻿id: 28b42356-45af-40a6-a0b4-a554cdfd5d8a
+id: 28b42356-45af-40a6-a0b4-a554cdfd5d8a
 name: Brute force attack against Azure Portal
 description: |
   'Identifies evidence of brute force activity against Azure Portal by highlighting multiple authentication failures 
@@ -20,7 +20,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
 let failureCountThreshold = 5;
 let successCountThreshold = 1;
 let timeRange = 1d;


### PR DESCRIPTION
Fixes #
Removed the BIN, and replaced this with a check to see if the bruteforce occurred during a 20 min window.  This is now performed using datetime math instead.  
## Proposed Changes
In some instance, a bruteforce activity can occur that is of a short duration (< 20 mins) but it spans two BIN windows.  Because it spans two BIN windows, the detection rule will not fire.

For Example:
User A attempt 5 failed logins from 1:19 to 1:20.  This is across a duration of 1 minute but because of the BIN function, the 5 events will be split across two windows.  1:00 and 1:20.  Because of this, the threshold is not met.  
  -
  -
  -
