### PR TITLE
Unique Function Name using ResourceGroup id

### DIFF
--- a/DataConnectors/Templates/Connector_REST_API_AzureFunctionApp_template/azuredeploy_DataConnector_API_AzureFunctionApp_template.json
+++ b/DataConnectors/Templates/Connector_REST_API_AzureFunctionApp_template/azuredeploy_DataConnector_API_AzureFunctionApp_template.json
@@ -32,6 +32,7 @@
         }
       },
       "variables": {
+          "FunctionName": "[concat(toLower(parameters('FunctionName')), uniqueString(resourceGroup().id))]"
       },
       "resources": [
           {


### PR DESCRIPTION
To use resourceGroup().id to get unique function name for each installation to avoid conflicts.

