### PR TITLE
New low severity daily detection for AAD StsRefresh modification

### DIFF
--- a/Detections/AuditLogs/StsRefreshTokenModification.yaml
+++ b/Detections/AuditLogs/StsRefreshTokenModification.yaml
@@ -31,8 +31,10 @@ query: |
   | extend InitiatingUserOrApp = iff(isnotempty(InitiatedBy.user.userPrincipalName),tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName))
   | extend targetUserOrApp = TargetResources[0].userPrincipalName
   | extend eventName = tostring(TargetResourcesModProps.displayName)
-  | extend LastDirSyncTimeOld = todatetime(parse_json(tostring(TargetResourcesModProps.oldValue))[0])
-  | extend LastDirSyncTimeNew = todatetime(parse_json(tostring(TargetResourcesModProps.newValue))[0])
+  | extend oldStsRefreshValidFrom = todatetime(parse_json(tostring(TargetResourcesModProps.oldValue))[0])
+  | extend newStsRefreshValidFrom = todatetime(parse_json(tostring(TargetResourcesModProps.newValue))[0])
+  | extend tokenMinutesAdded = datetime_diff('minute',newStsRefreshValidFrom,oldStsRefreshValidFrom)
+  | extend tokenMinutesRemaining = datetime_diff('minute',TimeGenerated,newStsRefreshValidFrom)
   | project-reorder Result, AADOperationType
   | extend InitiatingIpAddress = iff(isnotempty(InitiatedBy.user.ipAddress), tostring(InitiatedBy.user.ipAddress), tostring(InitiatedBy.app.ipAddress))
   | extend timestamp = TimeGenerated, AccountCustomEntity = InitiatingUserOrApp, IPCustomEntity = InitiatingIpAddress

--- a/Detections/AuditLogs/StsRefreshTokenModification.yaml
+++ b/Detections/AuditLogs/StsRefreshTokenModification.yaml
@@ -1,0 +1,46 @@
+id: 4696e072-aca8-4a4f-bf05-89fddc5ac3c9
+name: Interactive STS refresh token modifications
+description: |
+  'This will show Active Directory Security Token Service (STS) refresh token modifications by Service Principals and Applications other than DirectorySync. Refresh tokens are used to validate identification and obtain access tokens.
+  This event is most often generated when legitimate administrators troubleshoot frequent AAD user sign-ins but may also be generated as a result of malicious token extensions. Confirm that the activity is related to an administrator legitimately modifying STS refresh tokens and check the new token validation time period for high values.
+  For in-depth documentation of AAD Security Tokens, see https://docs.microsoft.com/azure/active-directory/develop/security-tokens.
+  For further information on AuditLogs please see https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities.'
+severity: Low
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1550.001
+query: |
+  let auditLookback = 1d;
+  AuditLogs
+  | where TimeGenerated > ago(auditLookback)
+  | where OperationName has 'StsRefreshTokenValidFrom'
+  | where TargetResources[0].modifiedProperties != '[]'
+  | where TargetResources[0].modifiedProperties !has 'DirectorySync'
+  | extend InitiatingUserOrApp = iff(isnotempty(InitiatedBy.user.userPrincipalName),tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName))
+  | extend targetUserOrApp = TargetResources[0].userPrincipalName
+  | mv-expand TargetResources[0].modifiedProperties
+  | extend eventName = TargetResources_0_modifiedProperties.displayName
+  | where TargetResources_0_modifiedProperties.displayName == 'StsRefreshTokensValidFrom'
+  | extend LastDirSyncTimeOld = TargetResources_0_modifiedProperties.oldValue
+  | extend LastDirSyncTimeNew = TargetResources_0_modifiedProperties.newValue
+  | project-reorder Result, AADOperationType
+  | extend InitiatingIpAddress = iff(isnotempty(InitiatedBy.user.ipAddress), tostring(InitiatedBy.user.ipAddress), tostring(InitiatedBy.app.ipAddress))
+  | extend timestamp = TimeGenerated, AccountCustomEntity = InitiatingUserOrApp, IPCustomEntity = InitiatingIpAddress
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPCustomEntity

--- a/Detections/AuditLogs/StsRefreshTokenModification.yaml
+++ b/Detections/AuditLogs/StsRefreshTokenModification.yaml
@@ -29,6 +29,7 @@ query: |
   | mv-expand TargetResourcesModProps
   | where tostring(TargetResourcesModProps.displayName) =~ 'StsRefreshTokensValidFrom'
   | extend InitiatingUserOrApp = iff(isnotempty(InitiatedBy.user.userPrincipalName),tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName))
+  | where InitiatingUserOrApp !in ('Microsoft Cloud App Security')
   | extend targetUserOrApp = TargetResources[0].userPrincipalName
   | extend eventName = tostring(TargetResourcesModProps.displayName)
   | extend oldStsRefreshValidFrom = todatetime(parse_json(tostring(TargetResourcesModProps.oldValue))[0])

--- a/Detections/AuditLogs/StsRefreshTokenModification.yaml
+++ b/Detections/AuditLogs/StsRefreshTokenModification.yaml
@@ -25,13 +25,14 @@ query: |
   | where OperationName has 'StsRefreshTokenValidFrom'
   | where TargetResources[0].modifiedProperties != '[]'
   | where TargetResources[0].modifiedProperties !has 'DirectorySync'
+  | extend TargetResourcesModProps = TargetResources[0].modifiedProperties
+  | mv-expand TargetResourcesModProps
+  | where tostring(TargetResourcesModProps.displayName) =~ 'StsRefreshTokensValidFrom'
   | extend InitiatingUserOrApp = iff(isnotempty(InitiatedBy.user.userPrincipalName),tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName))
   | extend targetUserOrApp = TargetResources[0].userPrincipalName
-  | mv-expand TargetResources[0].modifiedProperties
-  | extend eventName = TargetResources_0_modifiedProperties.displayName
-  | where TargetResources_0_modifiedProperties.displayName == 'StsRefreshTokensValidFrom'
-  | extend LastDirSyncTimeOld = TargetResources_0_modifiedProperties.oldValue
-  | extend LastDirSyncTimeNew = TargetResources_0_modifiedProperties.newValue
+  | extend eventName = tostring(TargetResourcesModProps.displayName)
+  | extend LastDirSyncTimeOld = todatetime(parse_json(tostring(TargetResourcesModProps.oldValue))[0])
+  | extend LastDirSyncTimeNew = todatetime(parse_json(tostring(TargetResourcesModProps.newValue))[0])
   | project-reorder Result, AADOperationType
   | extend InitiatingIpAddress = iff(isnotempty(InitiatedBy.user.ipAddress), tostring(InitiatedBy.user.ipAddress), tostring(InitiatedBy.app.ipAddress))
   | extend timestamp = TimeGenerated, AccountCustomEntity = InitiatingUserOrApp, IPCustomEntity = InitiatingIpAddress


### PR DESCRIPTION
Adding this initial anomalous StsRefreshToken modification rule that may accompany and aid in triaging other suspicious AAD & OAuth detections

TODO: properly extract LastDirSyncTimeNew as dateTime and compare this value to now() to highlight extremely long refresh tokens to highlight extraordinarily long refresh token validation timeframes