### PR TITLE
✨ Add active colour and export to Excel

### DIFF
--- a/Workbooks/InvestigationInsights.json
+++ b/Workbooks/InvestigationInsights.json
@@ -1242,6 +1242,7 @@
                   "parameterType": 1
                 }
               ],
+              "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
               "crossComponentResources": [
@@ -1298,6 +1299,12 @@
                           "operator": "==",
                           "thresholdValue": "New",
                           "representation": "gray",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "==",
+                          "thresholdValue": "Active",
+                          "representation": "green",
                           "text": "{0}{1}"
                         },
                         {


### PR DESCRIPTION
## Proposed Changes

- Add an export to Excel button for the investigations details table
- Add a colour for `Active` investigations, previously both `Closed` and `Active` were the same blue colour.

<img width="278" alt="Screen Shot 2020-12-11 at 15 10 33" src="https://user-images.githubusercontent.com/939704/101920595-e9aca780-3bc3-11eb-8755-3789922e0265.png">

