### PR TITLE
Using has_any will miss values

### DIFF
--- a/Detections/OfficeActivity/office_policytampering.yaml
+++ b/Detections/OfficeActivity/office_policytampering.yaml
@@ -21,13 +21,20 @@ relevantTechniques:
   - T1089
 query: |
   let timeframe = 1d;
+  let opList = OfficeActivity 
+  | where TimeGenerated >= ago(timeframe) 
+  | summarize by Operation
+  //| where Operation startswith "Remove-" or Operation startswith "Disable-"
+  | where Operation has_any ("Remove", "Disable")
+  | where Operation contains "AntiPhish" or Operation contains "SafeAttachment" or Operation contains "SafeLinks" or Operation contains "Dlp" or Operation contains "Audit"
+  | summarize make_set(Operation);
   OfficeActivity
   | where TimeGenerated >= ago(timeframe)
-  | where RecordType =~ "ExchangeAdmin"
-  | where UserType in~ ("Admin","DcAdmin") 
   // Only admin or global-admin can disable/remove policy
-  | where Operation startswith "Remove-" or Operation startswith "Disable-"
-  | where (Operation contains "AntiPhish" or Operation contains "SafeAttachment" or Operation contains "SafeLinks" or Operation contains "Dlp" or Operation contains "Audit")
+  | where RecordType =~ "ExchangeAdmin"
+  | where UserType in~ ("Admin","DcAdmin")
+  // Pass in interesting Operation list
+  | where Operation in~ (opList)
   | extend ClientIPOnly = case( 
   ClientIP has ".", tostring(split(ClientIP,":")[0]), 
   ClientIP has "[", tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),

--- a/Detections/OfficeActivity/office_policytampering.yaml
+++ b/Detections/OfficeActivity/office_policytampering.yaml
@@ -20,7 +20,6 @@ relevantTechniques:
   - T1098
   - T1089
 query: |
-
   let timeframe = 1d;
   OfficeActivity
   | where TimeGenerated >= ago(timeframe)
@@ -28,7 +27,7 @@ query: |
   | where UserType in~ ("Admin","DcAdmin") 
   // Only admin or global-admin can disable/remove policy
   | where Operation startswith "Remove-" or Operation startswith "Disable-"
-  | where Operation has_any ("AntiPhish", "SafeAttachment", "SafeLinks", "Dlp", "Audit")
+  | where (Operation contains "AntiPhish" or Operation contains "SafeAttachment" or Operation contains "SafeLinks" or Operation contains "Dlp" or Operation contains "Audit")
   | extend ClientIPOnly = case( 
   ClientIP has ".", tostring(split(ClientIP,":")[0]), 
   ClientIP has "[", tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),


### PR DESCRIPTION
Current query using has_any is looking for AntiPhish, SafeAttachment and will miss values like: 

AntiPhishingRule, 
AntiPhishingPolicy
SafeAttachmentPolicy
Etc.

We need to either use the full value (which I don't have and may change) or use a contains check to cater for the various values.  I have implemented the contains approach.

Fixes #

## Proposed Changes

  -use of contains for value checking. 
  -
  -
