### PR TITLE
Adding in Schema support for M365 tables

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/DeviceEvents.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DeviceEvents.json
@@ -1,0 +1,205 @@
+{
+  "Name": "DeviceEvents",
+  "Properties": [
+    {
+      "Name": "TenantId",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountDomain",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountName",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountSid",
+      "Type": "string"
+    },
+    {
+      "Name": "ActionType",
+      "Type": "string"
+    },
+    {
+      "Name": "AdditionalFields",
+      "Type": "dynamic"
+    },
+    {
+      "Name": "AppGuardContainerId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceName",
+      "Type": "string"
+    },
+    {
+      "Name": "FileName",
+      "Type": "string"
+    },
+    {
+      "Name": "FileOriginIP",
+      "Type": "string"
+    },
+    {
+      "Name": "FileOriginUrl",
+      "Type": "string"
+    },
+    {
+      "Name": "FolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountDomain",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountObjectId",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountSid",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountUpn",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessCommandLine",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessFolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessLogonId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessMD5",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessParentFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessParentId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessSHA1",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessSHA256",
+      "Type": "string"
+    },
+    {
+      "Name": "LocalIP",
+      "Type": "string"
+    },
+    {
+      "Name": "LocalPort",
+      "Type": "int"
+    },
+    {
+      "Name": "LogonId",
+      "Type": "long"
+    },
+    {
+      "Name": "MD5",
+      "Type": "string"
+    },
+    {
+      "Name": "MachineGroup",
+      "Type": "string"
+    },
+    {
+      "Name": "ProcessCommandLine",
+      "Type": "string"
+    },
+    {
+      "Name": "ProcessId",
+      "Type": "long"
+    },
+    {
+      "Name": "ProcessTokenElevation",
+      "Type": "string"
+    },
+    {
+      "Name": "RegistryKey",
+      "Type": "string"
+    },
+    {
+      "Name": "RegistryValueData",
+      "Type": "string"
+    },
+    {
+      "Name": "RegistryValueName",
+      "Type": "string"
+    },
+    {
+      "Name": "RemoteDeviceName",
+      "Type": "string"
+    },
+    {
+      "Name": "RemoteIP",
+      "Type": "string"
+    },
+    {
+      "Name": "RemotePort",
+      "Type": "int"
+    },
+    {
+      "Name": "RemoteUrl",
+      "Type": "string"
+    },
+    {
+      "Name": "ReportId",
+      "Type": "long"
+    },
+    {
+      "Name": "SHA1",
+      "Type": "string"
+    },
+    {
+      "Name": "SHA256",
+      "Type": "string"
+    },
+    {
+      "Name": "TimeGenerated",
+      "Type": "datetime"
+    },
+    {
+      "Name": "Timestamp",
+      "Type": "datetime"
+    },
+    {
+      "Name": "SourceSystem",
+      "Type": "string"
+    },
+    {
+      "Name": "Type",
+      "Type": "string"
+    }
+  ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DeviceFileEvents.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DeviceFileEvents.json
@@ -1,0 +1,209 @@
+{
+  "Name": "DeviceFileEvents",
+  "Properties": [
+    {
+      "Name": "TenantId",
+      "Type": "string"
+    },
+    {
+      "Name": "ActionType",
+      "Type": "string"
+    },
+    {
+      "Name": "AdditionalFields",
+      "Type": "dynamic"
+    },
+    {
+      "Name": "AppGuardContainerId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceName",
+      "Type": "string"
+    },
+    {
+      "Name": "FileName",
+      "Type": "string"
+    },
+    {
+      "Name": "FileOriginIP",
+      "Type": "string"
+    },
+    {
+      "Name": "FileOriginReferrerUrl",
+      "Type": "string"
+    },
+    {
+      "Name": "FileOriginUrl",
+      "Type": "string"
+    },
+    {
+      "Name": "FileSize",
+      "Type": "long"
+    },
+    {
+      "Name": "FolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountDomain",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountObjectId",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountSid",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountUpn",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessCommandLine",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessFolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessIntegrityLevel",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessMD5",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessParentFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessParentId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessSHA1",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessSHA256",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessTokenElevation",
+      "Type": "string"
+    },
+    {
+      "Name": "IsAzureInfoProtectionApplied",
+      "Type": "bool"
+    },
+    {
+      "Name": "MD5",
+      "Type": "string"
+    },
+    {
+      "Name": "MachineGroup",
+      "Type": "string"
+    },
+    {
+      "Name": "PreviousFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "PreviousFolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "ReportId",
+      "Type": "long"
+    },
+    {
+      "Name": "RequestAccountDomain",
+      "Type": "string"
+    },
+    {
+      "Name": "RequestAccountName",
+      "Type": "string"
+    },
+    {
+      "Name": "RequestAccountSid",
+      "Type": "string"
+    },
+    {
+      "Name": "RequestProtocol",
+      "Type": "string"
+    },
+    {
+      "Name": "RequestSourceIP",
+      "Type": "string"
+    },
+    {
+      "Name": "RequestSourcePort",
+      "Type": "int"
+    },
+    {
+      "Name": "SHA1",
+      "Type": "string"
+    },
+    {
+      "Name": "SHA256",
+      "Type": "string"
+    },
+    {
+      "Name": "SensitivityLabel",
+      "Type": "string"
+    },
+    {
+      "Name": "SensitivitySubLabel",
+      "Type": "string"
+    },
+    {
+      "Name": "ShareName",
+      "Type": "string"
+    },
+    {
+      "Name": "TimeGenerated",
+      "Type": "datetime"
+    },
+    {
+      "Name": "Timestamp",
+      "Type": "datetime"
+    },
+    {
+      "Name": "InitiatingProcessParentCreationTime",
+      "Type": "datetime"
+    },
+    {
+      "Name": "InitiatingProcessCreationTime",
+      "Type": "datetime"
+    },
+    {
+      "Name": "SourceSystem",
+      "Type": "string"
+    },
+    {
+      "Name": "Type",
+      "Type": "string"
+    }
+  ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DeviceProcessEvents.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DeviceProcessEvents.json
@@ -1,0 +1,193 @@
+{
+  "Name": "DeviceProcessEvents",
+  "Properties": [
+    {
+      "Name": "TenantId",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountDomain",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountName",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountObjectId",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountSid",
+      "Type": "string"
+    },
+    {
+      "Name": "AccountUpn",
+      "Type": "string"
+    },
+    {
+      "Name": "ActionType",
+      "Type": "string"
+    },
+    {
+      "Name": "AdditionalFields",
+      "Type": "dynamic"
+    },
+    {
+      "Name": "AppGuardContainerId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceName",
+      "Type": "string"
+    },
+    {
+      "Name": "FileName",
+      "Type": "string"
+    },
+    {
+      "Name": "FolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountDomain",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountObjectId",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountSid",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessAccountUpn",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessCommandLine",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessFolderPath",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessIntegrityLevel",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessLogonId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessMD5",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessParentFileName",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessParentId",
+      "Type": "long"
+    },
+    {
+      "Name": "InitiatingProcessSHA1",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessSHA256",
+      "Type": "string"
+    },
+    {
+      "Name": "InitiatingProcessTokenElevation",
+      "Type": "string"
+    },
+    {
+      "Name": "LogonId",
+      "Type": "long"
+    },
+    {
+      "Name": "MD5",
+      "Type": "string"
+    },
+    {
+      "Name": "MachineGroup",
+      "Type": "string"
+    },
+    {
+      "Name": "ProcessCommandLine",
+      "Type": "string"
+    },
+    {
+      "Name": "ProcessCreationTime",
+      "Type": "datetime"
+    },
+    {
+      "Name": "ProcessId",
+      "Type": "long"
+    },
+    {
+      "Name": "ProcessIntegrityLevel",
+      "Type": "string"
+    },
+    {
+      "Name": "ProcessTokenElevation",
+      "Type": "string"
+    },
+    {
+      "Name": "ReportId",
+      "Type": "long"
+    },
+    {
+      "Name": "SHA1",
+      "Type": "string"
+    },
+    {
+      "Name": "SHA256",
+      "Type": "string"
+    },
+    {
+      "Name": "TimeGenerated",
+      "Type": "datetime"
+    },
+    {
+      "Name": "Timestamp",
+      "Type": "datetime"
+    },
+    {
+      "Name": "InitiatingProcessParentCreationTime",
+      "Type": "datetime"
+    },
+    {
+      "Name": "InitiatingProcessCreationTime",
+      "Type": "datetime"
+    },
+    {
+      "Name": "SourceSystem",
+      "Type": "string"
+    },
+    {
+      "Name": "Type",
+      "Type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
In order to support detections that are being included for M365, we need to temporarily add the schema manually.

Fixes #

## Proposed Changes

  -
  -
  -
