### PR TITLE
Fix GH hunting query, incorrect syntax.

### DIFF
--- a/Hunting Queries/GitHub/First Time User Invite and Add Member to Org.yaml
+++ b/Hunting Queries/GitHub/First Time User Invite and Add Member to Org.yaml
@@ -14,7 +14,7 @@ query: |
   let EndRunTime = StartTime - RunTime;
   let EndLearningTime = StartTime + LearningPeriod;
   let GitHubOrgMemberLogs = (GitHubAudit
-   where Action == "org.invite_member" or Action == "org.update_member" or Action == "org.add_member Action == "repo.add_member" Action == "team.add_member");
+  | where Action == "org.invite_member" or Action == "org.update_member" or Action == "org.add_member" or Action == "repo.add_member" or Action == "team.add_member");
   GitHubOrgMemberLogs
   | where TimeGenerated between (ago(EndLearningTime) .. ago(StartTime))
   | distinct Actor
@@ -23,4 +23,3 @@ query: |
     | where TimeGenerated between (ago(StartTime) .. ago(EndRunTime))
     | distinct Actor
   ) on Actor
-


### PR DESCRIPTION
The query does not run due to missing pipes and quote marks in the statement on line 17. This PR fixes it.

Fixes #

## Proposed Changes

  - Fix syntax of line 17 statement to be valid.