### PR TITLE
Update GitHub hunting query for correct column name.

### DIFF
--- a/Hunting Queries/GitHub/Oauth App Restrictions Disabled.yaml
+++ b/Hunting Queries/GitHub/Oauth App Restrictions Disabled.yaml
@@ -14,4 +14,4 @@ query: |
   GitHubAudit
   | where TimeGenerated > ago(timeframe)
   | where Action == "org.disable_oauth_app_restrictions"
-  | project TimeGenerated, Action, Actor, Location
+  | project TimeGenerated, Action, Actor, Country


### PR DESCRIPTION
Column name is Country instead of Location in latest updates to the GH Function connector.

Fixes #

## Proposed Changes

  - Swap Location > Country to be compatible with latest GH function changes.
