### PR TITLE
Validate workspace given as parameter

### DIFF
--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -125,7 +125,7 @@ def handle_error(e, error_response_str):
 
 def check_multi_homing(workspace_id):
     """
-    Check if there is already an agent install and connected to a different worksapce
+    Check if there is already an agent install and connected to a different workspace
     """
 
     grep1 = subprocess.Popen(["grep", "-ri", "WORKSPACE_ID=", oms_agent_extract_ws_id_url], stdout=subprocess.PIPE)


### PR DESCRIPTION
Adding a check in the Troubleshooting script to validate the agent is indeed connected to the workspace given as parameter from the customer. The check is copied from a similar one in the installation script called- "check_multi_homing" (fixed documentation typo as well)