### PR TITLE
🐛 Fix typo in new CloudShell detection

### DIFF
--- a/Detections/AzureActivity/New-CloudShell-User.yaml
+++ b/Detections/AzureActivity/New-CloudShell-User.yaml
@@ -21,7 +21,7 @@ query: |
   AzureActivity
   | extend message = tostring(parse_json(Properties).message)
   | extend AppId = tostring(parse_json(Claims).appid)
-  | where Appid contains "c44b4083-3bb0-49c1-b47d-974e53cbdf3c"
+  | where AppId contains "c44b4083-3bb0-49c1-b47d-974e53cbdf3c"
   | where OperationName =~ "Microsoft.Portal/consoles/write"
   | extend timestamp = TimeGenerated, AccountCustomEntity = Caller, IPCustomEntity = CallerIpAddress
 


### PR DESCRIPTION
Fixes #1497 

## Proposed Changes

  - Fix `AppId` typo in `Detections/AzureActivity/New-CloudShell-User.yaml`. Detection will return an error otherwise.
