### PR TITLE
ADFS DKM Master Key Export Update

### DIFF
--- a/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
+++ b/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
@@ -1,7 +1,7 @@
 id: 18e6a87e-9d06-4a4e-8b59-3469cd49552d
-name: ADFS Certificate Export 
+name: ADFS DKM Master Key Export
 description: | 
-  'Identifies an export of ADFS certificate material from an ADFS host.
+  'Identifies an export of the ADFS DKM Master Key from Active Directory.
    References: https://blogs.microsoft.com/on-the-issues/2020/12/13/customers-protect-nation-state-cyberattacks/, 
    https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html?1'
 severity: Medium 
@@ -20,11 +20,14 @@ tactics:
   - Collection
 relevantTechniques:
   - T1005
-query:  | 
-
-  (union isfuzzy=true (SecurityEvent
-  | where EventID == 4662
-  | where ObjectName contains "thumbnailPhoto"
+query:  |
+  (union isfuzzy=true (SecurityEvent 
+  | where EventID == 4662 
+  | where ObjectServer == 'DS'
+  | where OperationType == 'Object Access'
+  //| where ObjectName contains '<GUID of ADFS DKM Container>' This is unique to the domain.
+  | where ObjectType contains '5cb41ed0-0e4c-11d0-a286-00aa003049e2' // Contact Class
+  | where Properties contains '8d3bca50-1d7e-11d0-a081-00aa006c33ed' // Picture Attribute - Ldap-Display-Name: thumbnailPhoto
   | extend timestamp = TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = SubjectAccount),
   (DeviceEvents
   | where ActionType =~ "LdapSearch"


### PR DESCRIPTION
Fixes #

*  Rule name ADFS-Certificate-Export does not represent the behavior that we are trying to detect with the rule logic
* ADFS-Certificate-Export does not trigger (SecurityEvent datasource)

## Proposed Changes

### 1) Rule Name should be changed to ADFS-DKM-Masterkey-Export or ADFS-DKM-GroupKey-Export or ADFS-DKM-EncryptionKey-Export

* The token signing and decryption certificates are stored as PFX blobs in the ADFS database
* Certificates are encrypted using a technology called Distributed Key Manager (DKM)

ADFS DKM Master Keys are used during the following process:

* ADFS Service starts
* It reads service settings from the database (Windows Internal Database (WID))  in XML format
* As part of the process, it loads ADFS certificate collection (Reads certificate encrypted PFX blob (base64 encoded) from the XML object)
* Decodes Base64 string
* DKM Key is not used to decrypt certificate. Key is derived  (standard NIST SP 800-108)
* Derived key is used and certificate is decrypted

Therefore, the adversary needs the obtain the ADFS DKM Master Key to then use it in a similar way once it obtains a signing certificate. It can then decrypt it and use the signing certificate to sign SAML tokens.

The ADFS DKM master key(s) are stored in Active Directory.

One could read the DKM key as a byte array and convert it to a usable string from AD by running the following command (My lab environment):

```PowerShell
$key=(Get-ADObject -filter 'ObjectClass -eq "Contact" -and name -ne "CryptoPolicy"' -SearchBase "CN=ADFS,CN=Microsoft,CN=Program Data,DC=azsentinel,DC=local" -Properties thumbnailPhoto).thumbnailPhoto

[System.BitConverter]::ToString($key)
``` 

As you can see, the DKM Container path would be something like this `CN=ADFS,CN=Microsoft,CN=Program Data,DC=azsentinel,DC=local` . It will have its own GUID unique to the domain environment.

That's it! That's all the adversary would need to do then move to the next steps to decrypt signing certificates to then, once again, sign SAML tokens and use them to authenticate.

As you can see, this rule ONLY focuses on identifying the action of reading/exporting the DKM key and no the ADFS signing certificate. Therefore, I propose the name to be changed.

### 2) Rule logic (SecurityEvent Table section) needs to be adjusted to identify the right field names where it would find part of the indicators needed to detect someone accessing the DKM key in the DC.

**Pre-Requirements**:
* An Access Control Entry (ACE) in the System Access Control List (SACL) of the DKM container (Active Directory Object)
* Rule documentation: https://github.com/OTRF/Set-AuditRule/blob/master/rules/activedirectory/adfs_cryptopolicy_thumbnailphoto.yml
* Rule logic: 

```
Set-AuditRule -AdObjectPath 'AD:\CN=CryptoPolicy,CN=ADFS,CN=Microsoft,CN=Program Data,DC=azsentinel,DC=local' -WellKnownSidType NetworkSid -Rights GenericRead -InheritanceFlags None -AuditFlags Success -AttributeGUID '8d3bca50-1d7e-11d0-a081-00aa006c33ed'
```

**First Comments***
* Event 4662 does not translate the thumbnailPhoto GUI to the "thumbnailPhoto" string. That needs to be an enrichment
* **thumbnailPhoto Attribute GUID**: 8d3bca50-1d7e-11d0-a081-00aa006c33ed
* The attribute is not part of the object name. It is an attribute/property. Therefore, the value would show up in the filed name `Properties`
* We can filter events also by using the `ObjectType` GUID of class type `contact` and then look for the thumbnailPhoto GUID value. 

**Simulation:**

<img width="469" alt="image" src="https://user-images.githubusercontent.com/9653181/102711700-a3251000-4289-11eb-89e2-8ccd7e61f746.png">


** Event 4662 generated** (after setting the SACL)

<img width="693" alt="image" src="https://user-images.githubusercontent.com/9653181/102711858-a8cf2580-428a-11eb-8a48-dc3f58c24690.png">


The highlighted section is the `thumbnailPhoto` attribute.

**XML Representation** (This is where we do not get the objectName string and just the GUID

```xml
- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
- <System> 
<Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" /> 
<EventID>4662</EventID> 
<Version>0</Version> 
<Level>0</Level> 
<Task>14080</Task> 
<Opcode>0</Opcode> 
<Keywords>0x8020000000000000</Keywords> 
<TimeCreated SystemTime="2020-12-20T07:53:41.092054600Z" /> 
<EventRecordID>330446</EventRecordID> 
<Correlation /> 
<Execution ProcessID="708" ThreadID="836" /> 
<Channel>Security</Channel> 
<Computer>DC01.azsentinel.local</Computer> 
<Security /> 
</System> 
- <EventData> 
<Data Name="SubjectUserSid">S-1-5-21-1640822366-3528877384-3060188657-1103</Data> 
<Data Name="SubjectUserName">adfsuser</Data> 
<Data Name="SubjectDomainName">AZSENTINEL</Data> 
<Data Name="SubjectLogonId">0x4235ba</Data> 
<Data Name="ObjectServer">DS</Data> 
<Data Name="ObjectType">%{5cb41ed0-0e4c-11d0-a286-00aa003049e2}</Data> 
<Data Name="ObjectName">%{8cd0a7fa-b3c9-4572-85e5-9359c2783031}</Data> 
<Data Name="OperationType">Object Access</Data> 
<Data Name="HandleId">0x0</Data> 
<Data Name="AccessList">%%7684</Data> 
<Data Name="AccessMask">0x10</Data> 
<Data Name="Properties">%%7684 {77b5b886-944a-11d1-aebd-0000f80367c1} {8d3bca50-1d7e-11d0-a081-00aa006c33ed} {5cb41ed0-0e4c-11d0-a286-00aa003049e2}</Data> 
<Data Name="AdditionalInfo">-</Data> 
<Data Name="AdditionalInfo2" /> 
</EventData> 
</Event>
```

**Running new query**

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/9653181/102711902-13806100-428b-11eb-8403-a7f6a97575b5.png">


Remember that the DKM container's GUID is unique to the domain. Therefore, the query will need to be adjusted when it is used to provider additional context.

Let me know if you have any questions! Happy to do more testing :) 

## References
https://www.powershellgallery.com/packages/AADInternals/0.2.3/Content/Export-ADFSSigninCertificate.ps1
https://www.youtube.com/watch?v=5dj4vOqqGZw
https://www.microsoft.com/en-us/research/wp-content/uploads/2014/04/DKM-Verification.pdf
https://msresource.wordpress.com/2016/05/04/the-use-of-distributed-key-manager-dkm-in-active-directory-federation-services-ad-fs/
