### PR TITLE
Removing unneeded time stamp from the query

### DIFF
--- a/Detections/GitHub/Security Vulnerability in Repo.yaml
+++ b/Detections/GitHub/Security Vulnerability in Repo.yaml
@@ -9,8 +9,6 @@ triggerOperator: gt
 triggerThreshold: 0
 query: |
 
-  let timeframe = 14d;
   GitHubRepo
-  | where TimeGenerated > ago(timeframe)
   | where Action == "vulnerabilityAlert"
   | project TimeGenerated, DismmisedAt, Reason, vulnerableManifestFilename, Description, Link, PublishedAt, Severity, Summary


### PR DESCRIPTION
The time stamp is redundant as it is already enforced by the "QueryPeriod" parameter.

Fixes #

## Proposed Changes

  -
  -
  -
