### PR TITLE
ADFS DKM Master Key Export - Improved

### DIFF
--- a/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
+++ b/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
@@ -1,43 +1,13 @@
 id: 18e6a87e-9d06-4a4e-8b59-3469cd49552d
 name: ADFS DKM Master Key Export
 description: | 
-  Identifies an export of the ADFS DKM Master Key from Active Directory.
+  'Identifies an export of the ADFS DKM Master Key from Active Directory.
   References: https://blogs.microsoft.com/on-the-issues/2020/12/13/customers-protect-nation-state-cyberattacks/, 
   https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html?1
-
-  # Windows Security Event 4662 Requirement:
-  A SACL on the ADFS Policy Store DKM group AD object
-
-  1) Obtain ADFS Policy Store DKM Group distinguished name from ADFS server:
-  Open PowerShell Console on ADFS Server and run the following PowerShell commands:
-  
-  # Get the database connection string
-  $ADFS = Get-WmiObject -Namespace root/ADFS -Class SecurityTokenService
-  $conn = $ADFS.ConfigurationDatabaseConnectionString
-  Write-Verbose "ConnectionString: $conn"
-
-  # Read the service settings from the database
-  $SQLclient = new-object System.Data.SqlClient.SqlConnection -ArgumentList $conn
-  $SQLclient.Open()
-  $SQLcmd = $SQLclient.CreateCommand()
-  $SQLcmd.CommandText = "SELECT ServiceSettingsData from IdentityServerPolicy.ServiceSettings"
-  $SQLreader = $SQLcmd.ExecuteReader()
-  $SQLreader.Read() | Out-Null
-  $settings=$SQLreader.GetTextReader(0).ReadToEnd()
-  $SQLreader.Dispose()
-
-  # Read the XML
-  [xml]$xml=$settings
-
-  # Get ADFS Policy Store DKM group distinguished name
-  $group=$xml.ServiceSettingsData.PolicyStore.DkmSettings.Group
-  $container=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ContainerName
-  $parent=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ParentContainerDn
-  $base="CN=$group,$container,$parent"
-  $base
-
-  2) Get GUID of the AD object
-  3) Create Audit rule to monitor for GeneralRead rights from Everyone on Picture attribute (8d3bca50-1d7e-11d0-a081-00aa006c33ed) of the ADFS Policy Store DKM Group ogject
+  To understand further the details behind this detection, please review the details in the original PR and subequent PR update to this:
+  https://github.com/Azure/Azure-Sentinel/pull/1562#issue-551542469
+  https://github.com/Azure/Azure-Sentinel/pull/1512#issue-543053339
+  '
 severity: Medium 
 requiredDataConnectors: 
   - connectorId: SecurityEvents 

--- a/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
+++ b/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
@@ -1,9 +1,37 @@
 id: 18e6a87e-9d06-4a4e-8b59-3469cd49552d
 name: ADFS DKM Master Key Export
 description: | 
-  'Identifies an export of the ADFS DKM Master Key from Active Directory.
-   References: https://blogs.microsoft.com/on-the-issues/2020/12/13/customers-protect-nation-state-cyberattacks/, 
-   https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html?1'
+  Identifies an export of the ADFS DKM Master Key from Active Directory.
+  References: https://blogs.microsoft.com/on-the-issues/2020/12/13/customers-protect-nation-state-cyberattacks/, 
+  https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html?1
+
+  # Obtain ADFS Policy Store DKM Group distinguished name from ADFS server:
+  Open PowerShell Console on ADFS Server and run the following PowerShell commands:
+  
+  # Get the database connection string
+  $ADFS = Get-WmiObject -Namespace root/ADFS -Class SecurityTokenService
+  $conn = $ADFS.ConfigurationDatabaseConnectionString
+  Write-Verbose "ConnectionString: $conn"
+
+  # Read the service settings from the database
+  $SQLclient = new-object System.Data.SqlClient.SqlConnection -ArgumentList $conn
+  $SQLclient.Open()
+  $SQLcmd = $SQLclient.CreateCommand()
+  $SQLcmd.CommandText = "SELECT ServiceSettingsData from IdentityServerPolicy.ServiceSettings"
+  $SQLreader = $SQLcmd.ExecuteReader()
+  $SQLreader.Read() | Out-Null
+  $settings=$SQLreader.GetTextReader(0).ReadToEnd()
+  $SQLreader.Dispose()
+
+  # Read the XML
+  [xml]$xml=$settings
+
+  # Get ADFS Policy Store DKM group distinguished name
+  $group=$xml.ServiceSettingsData.PolicyStore.DkmSettings.Group
+  $container=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ContainerName
+  $parent=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ParentContainerDn
+  $base="CN=$group,$container,$parent"
+  $base
 severity: Medium 
 requiredDataConnectors: 
   - connectorId: SecurityEvents 
@@ -22,16 +50,17 @@ relevantTechniques:
   - T1005
 query:  |
   (union isfuzzy=true (SecurityEvent 
-  | where EventID == 4662 
+  | where EventID == 4662 // You need to create a SACL on the ADFS Policy Store DKM group for this event to be created. 
   | where ObjectServer == 'DS'
   | where OperationType == 'Object Access'
-  //| where ObjectName contains '<GUID of ADFS DKM Container>' This is unique to the domain.
+  //| where ObjectName contains '<GUID of ADFS Policy Store DKM Group object' This is unique to the domain. Check description for more details.
   | where ObjectType contains '5cb41ed0-0e4c-11d0-a286-00aa003049e2' // Contact Class
   | where Properties contains '8d3bca50-1d7e-11d0-a081-00aa006c33ed' // Picture Attribute - Ldap-Display-Name: thumbnailPhoto
   | extend timestamp = TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = SubjectAccount),
   (DeviceEvents
   | where ActionType =~ "LdapSearch"
   | where AdditionalFields.AttributeList contains "thumbnailPhoto"
+  | where AdditionalFields.DistinguishedName contains "CN=ADFS,CN=Microsoft,CN=Program Data" // Filter results to show only hits related to the ADFS AD container
   | extend timestamp = TimeGenerated, HostCustomEntity = DeviceName, AccountCustomEntity = InitiatingProcessAccountName)
   )
 entityMappings:

--- a/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
+++ b/Detections/MultipleDataSources/ADFS-DKM-MasterKey-Export.yaml
@@ -5,7 +5,10 @@ description: |
   References: https://blogs.microsoft.com/on-the-issues/2020/12/13/customers-protect-nation-state-cyberattacks/, 
   https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html?1
 
-  # Obtain ADFS Policy Store DKM Group distinguished name from ADFS server:
+  # Windows Security Event 4662 Requirement:
+  A SACL on the ADFS Policy Store DKM group AD object
+
+  1) Obtain ADFS Policy Store DKM Group distinguished name from ADFS server:
   Open PowerShell Console on ADFS Server and run the following PowerShell commands:
   
   # Get the database connection string
@@ -32,6 +35,9 @@ description: |
   $parent=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ParentContainerDn
   $base="CN=$group,$container,$parent"
   $base
+
+  2) Get GUID of the AD object
+  3) Create Audit rule to monitor for GeneralRead rights from Everyone on Picture attribute (8d3bca50-1d7e-11d0-a081-00aa006c33ed) of the ADFS Policy Store DKM Group ogject
 severity: Medium 
 requiredDataConnectors: 
   - connectorId: SecurityEvents 


### PR DESCRIPTION
Fixes #
* Requirements for SecurityEvent table query
* Several positives observed from the second part of the query (DeviceEvents - LdapSearch Action Type) in a production environment

## Proposed Changes
1)  Update description of detection

```
# Windows Security Event 4662 Requirement:
  A SACL on the ADFS Policy Store DKM group AD object

  1) Obtain ADFS Policy Store DKM Group distinguished name from ADFS server:
  Open PowerShell Console on ADFS Server and run the following PowerShell commands:
  
  # Get the database connection string
  $ADFS = Get-WmiObject -Namespace root/ADFS -Class SecurityTokenService
  $conn = $ADFS.ConfigurationDatabaseConnectionString
  Write-Verbose "ConnectionString: $conn"

  # Read the service settings from the database
  $SQLclient = new-object System.Data.SqlClient.SqlConnection -ArgumentList $conn
  $SQLclient.Open()
  $SQLcmd = $SQLclient.CreateCommand()
  $SQLcmd.CommandText = "SELECT ServiceSettingsData from IdentityServerPolicy.ServiceSettings"
  $SQLreader = $SQLcmd.ExecuteReader()
  $SQLreader.Read() | Out-Null
  $settings=$SQLreader.GetTextReader(0).ReadToEnd()
  $SQLreader.Dispose()

  # Read the XML
  [xml]$xml=$settings

  # Get ADFS Policy Store DKM group distinguished name
  $group=$xml.ServiceSettingsData.PolicyStore.DkmSettings.Group
  $container=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ContainerName
  $parent=$xml.ServiceSettingsData.PolicyStore.DkmSettings.ParentContainerDn
  $base="CN=$group,$container,$parent"
  $base

  2) Get GUID of the AD object
  3) Create Audit rule to monitor for GeneralRead rights from Everyone on Picture attribute (8d3bca50-1d7e-11d0-a081-00aa006c33ed) of the ADFS Policy Store DKM Group ogject
```
2) Add additional filter to DeviceEvents query `where AdditionalFields.DistinguishedName contains "CN=ADFS,CN=Microsoft,CN=Program Data"`

```
(union isfuzzy=true (SecurityEvent 
  | where EventID == 4662 // You need to create a SACL on the ADFS Policy Store DKM group for this event to be created. 
  | where ObjectServer == 'DS'
  | where OperationType == 'Object Access'
  //| where ObjectName contains '<GUID of ADFS Policy Store DKM Group object' This is unique to the domain. Check description for more details.
  | where ObjectType contains '5cb41ed0-0e4c-11d0-a286-00aa003049e2' // Contact Class
  | where Properties contains '8d3bca50-1d7e-11d0-a081-00aa006c33ed' // Picture Attribute - Ldap-Display-Name: thumbnailPhoto
  | extend timestamp = TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = SubjectAccount),
  (DeviceEvents
  | where ActionType =~ "LdapSearch"
  | where AdditionalFields.AttributeList contains "thumbnailPhoto"
  | where AdditionalFields.DistinguishedName contains "CN=ADFS,CN=Microsoft,CN=Program Data" // Filter results to show only hits related to the ADFS AD container
  | extend timestamp = TimeGenerated, HostCustomEntity = DeviceName, AccountCustomEntity = InitiatingProcessAccountName)
  )
```
