### PR TITLE
Update to include processname filter for Barracuda CGFWFirewallActivity Parser

### DIFF
--- a/Parsers/Barracuda/CGFWFirewallActivity
+++ b/Parsers/Barracuda/CGFWFirewallActivity
@@ -5,6 +5,7 @@
 
 Syslog
 | extend Type = extract("type=([\\w\\s]+)",1,SyslogMessage)
+| where ProcessName == "box_Firewall_Activity"
 , L4Protocol = extract("proto=([\\w\\s]+)",1,SyslogMessage)
 , SourceInterface = extract("srcIF=([\\w\\s]+)",1,SyslogMessage)
 , SourceIP = extract("srcIP=([\\d\\.]+)",1,SyslogMessage)

--- a/Parsers/Barracuda/CGFWFirewallActivity
+++ b/Parsers/Barracuda/CGFWFirewallActivity
@@ -4,8 +4,8 @@
 // Reference : Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 
 Syslog
-| extend Type = extract("type=([\\w\\s]+)",1,SyslogMessage)
 | where ProcessName == "box_Firewall_Activity"
+| extend Type = extract("type=([\\w\\s]+)",1,SyslogMessage)
 , L4Protocol = extract("proto=([\\w\\s]+)",1,SyslogMessage)
 , SourceInterface = extract("srcIF=([\\w\\s]+)",1,SyslogMessage)
 , SourceIP = extract("srcIP=([\\d\\.]+)",1,SyslogMessage)


### PR DESCRIPTION
Parser CGFWFirewallActivity is updated to include filter forbox_Firewall_Activity to get data only related to Barracuda Firewall.

