### PR TITLE
UEBA queries - fix tactics to be with no white spaces

### DIFF
--- a/Hunting Queries/BehaviorAnalytics/Anomalous Activity Role Assignment.yaml
+++ b/Hunting Queries/BehaviorAnalytics/Anomalous Activity Role Assignment.yaml
@@ -3,7 +3,7 @@ name: Anomalous Activity Role Assignment
 description: |
     'Adversaries may circumvent mechanisms designed to control elevate privileges to gain higher-level permissions. The query below generates an output of all users performing an "action" operation regarding a access elevation, where one or more features of the activitiy deviates from the user, his peers or the tenant profile.'
 tactics:
-  - Privilege Escalation
+  - PrivilegeEscalation
 relevantTechniques:
   - T1548
 query: |

--- a/Hunting Queries/BehaviorAnalytics/Anomalous Defensive Mechanism Modification.yaml
+++ b/Hunting Queries/BehaviorAnalytics/Anomalous Defensive Mechanism Modification.yaml
@@ -7,7 +7,7 @@ requiredDataConnectors:
     dataTypes:
         - BehaviorAnalytics
 tactics:
-  - Defense Evasion
+  - DefenseEvasion
 relevantTechniques:
   - T1562
 query: |


### PR DESCRIPTION
Fixes #
Remove whitespace to match the enum that is used in portal