### PR TITLE
rebranding of detections

### DIFF
--- a/Detections/W3CIISLog/MaliciousAlertLinkedWebRequests.yaml
+++ b/Detections/W3CIISLog/MaliciousAlertLinkedWebRequests.yaml
@@ -1,7 +1,7 @@
 id: fbfbf530-506b-49a4-81ad-4030885a195c
-name: Malicious web application requests linked with MDATP alerts
+name: Malicious web application requests linked with Microsoft Defender for Endpoint (formerly Microsoft Defender ATP) alerts
 description: |
-  'Takes MDATP alerts where web scripts are present in the evidence and correlates with requests made to those scripts
+  'Takes Microsoft Defender for Endpoint (formerly Microsoft Defender ATP) alerts where web scripts are present in the evidence and correlates with requests made to those scripts
   in the WCSIISLog to surface new alerts for potentially malicious web request activity.
   The lookback for alerts is set to 1h and the lookback for W3CIISLogs is set to 7d. A sample set of popular web script extensions
   has been provided in scriptExtensions that should be tailored to your environment.'


### PR DESCRIPTION
Fixes #
Changing MDATP to the new "Microsoft Defender for Endpoint"
This is a part of the rebranding track in Microsoft 
## Proposed Changes

  -
  -
  -
