### PR TITLE
Update MailPermissionsAddedToApplication.yaml

### DIFF
--- a/Detections/AuditLogs/MailPermissionsAddedToApplication.yaml
+++ b/Detections/AuditLogs/MailPermissionsAddedToApplication.yaml
@@ -1,7 +1,7 @@
 id: 2560515c-07d1-434e-87fb-ebe3af267760
 name: Mail.Read Permissions Granted to Application
 description: |
-  'This query look for applications that have been granted permissions to Read Mail (Permissions field has Mail.Read) and subsequently has been consented to. This can help identify applications that have been abused to gain access to mailboxes.'
+  'This query look for applications that have been granted (Delegated or App/Role) permissions to Read Mail (Permissions field has Mail.Read) and subsequently has been consented to. This can help identify applications that have been abused to gain access to mailboxes.'
 severity: Medium
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -21,7 +21,7 @@ query: |
 
   AuditLogs
   | where Category =~ "ApplicationManagement"
-  | where ActivityDisplayName =~ "Add delegated permission grant"
+  | where ActivityDisplayName has_any ("Add delegated permission grant","Add app role assignment to service principal")
   | where Result =~ "success"
   | where tostring(InitiatedBy.user.userPrincipalName) has "@" or tostring(InitiatedBy.app.displayName) has "@"
   | extend props = parse_json(tostring(TargetResources[0].modifiedProperties))


### PR DESCRIPTION
Adding coverage for App/Role permissions added to an OAuth Application.

Application permissions are used by apps that run without a signed-in user present. These permissions are of type "Role" and grant the app the full set of privileges offered by the scope. For example, if the AppRole permissions "Mail.Read" is added to an application,  this allows the app to read mail in all mailboxes. Delegated permission "Mail.Read" would ONLY allow an app to access the signed-in user mailbox. 

Adding AppRoles permissions to an existing OAuth Application has a higher risk for an organization.
