### PR TITLE
Set Connectors in Deployment Queue to Private Preview

### DIFF
--- a/DataConnectors/CyberpionSecurityLogs.json
+++ b/DataConnectors/CyberpionSecurityLogs.json
@@ -31,7 +31,7 @@
     }
   ],
   "availability": {
-    "status": 1,
+    "status": 2,
     "isPreview": true
   },
   "permissions": {

--- a/DataConnectors/CyberpionSecurityLogs.json
+++ b/DataConnectors/CyberpionSecurityLogs.json
@@ -49,7 +49,7 @@
       },
       {
         "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
-        "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+        "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
         "providerDisplayName": "Keys",
         "scope": "Workspace",
         "requiredPermissions": {

--- a/DataConnectors/ForcepointCloudSecurityGateway.json
+++ b/DataConnectors/ForcepointCloudSecurityGateway.json
@@ -44,7 +44,7 @@
         }
     ],
     "availability": {
-        "status": 1,
+        "status": 2,
         "isPreview": true
     },
     "permissions": {

--- a/DataConnectors/NXLogBSMmacOS.json
+++ b/DataConnectors/NXLogBSMmacOS.json
@@ -57,7 +57,7 @@
             },
             {
                 "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
-                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
                 "providerDisplayName": "Keys",
                 "scope": "Workspace",
                 "requiredPermissions": {

--- a/DataConnectors/NXLogBSMmacOS.json
+++ b/DataConnectors/NXLogBSMmacOS.json
@@ -39,7 +39,7 @@
         }
     ],
     "availability": {
-        "status": 1,
+        "status": 2,
         "isPreview": true
     },
     "permissions": {


### PR DESCRIPTION
## Proposed Changes

  - Setting Connectors (Cyberpion Security Logs, Forcepoint Cloud Security Gateway, and NX Log BSM MacOS)  to use Feature Flag availability, in preparation for deployment.
     - Only availability need be set here, as a default Private Preview feature flag is generated in the automation.
  - Slight modification to permissions text in Cyberpion and NX Log connector files to satisfy validation.