### PR TITLE
Extending Detection from MultipleDataSources to include Azure Firewall

### DIFF
--- a/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
+++ b/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
@@ -33,21 +33,18 @@ query: |
   | where isnotempty(FileHash)
   | where FileHash in (SHA256Hash) or DNSName =~ DomainNames
   | extend Account = SourceUserID, Computer = DeviceName, IPAddress = SourceIP
-  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
   ),
   (DnsEvents 
   | extend DNSName = Name
   | where isnotempty(DNSName)
   | where DNSName =~ DomainNames
   | extend IPAddress = ClientIP
-  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
   ),
   (VMConnection 
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | where isnotempty(DNSName)
   | where DNSName =~ DomainNames
   | extend IPAddress = RemoteIp
-  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
   ),
   (AzureDiagnostics
   | where ResourceType == "AZUREFIREWALLS"

--- a/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
+++ b/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
@@ -33,18 +33,38 @@ query: |
   | where isnotempty(FileHash)
   | where FileHash in (SHA256Hash) or DNSName =~ DomainNames
   | extend Account = SourceUserID, Computer = DeviceName, IPAddress = SourceIP
+  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
   ),
   (DnsEvents 
   | extend DNSName = Name
   | where isnotempty(DNSName)
   | where DNSName =~ DomainNames
   | extend IPAddress = ClientIP
+  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
   ),
   (VMConnection 
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | where isnotempty(DNSName)
   | where DNSName =~ DomainNames
   | extend IPAddress = RemoteIp
+  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
+  ),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | where Request_Name has_any (DomainNames)  
+  | extend DNSName = Request_Name
+  | extend IPAddress = ClientIP 
+  ),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (DomainNames)  
+  | extend DNSName = DestinationHost 
+  | extend IPAddress = SourceHost
   )
   )
   | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress

--- a/Detections/MultipleDataSources/GalliumIOCs.yaml
+++ b/Detections/MultipleDataSources/GalliumIOCs.yaml
@@ -21,6 +21,9 @@ requiredDataConnectors:
   - connectorId: SecurityEvents
     dataTypes:
       - SecurityEvent
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -65,7 +68,24 @@ query: |
   ),
   (SecurityAlert
   | where Entities has_any (SigNames)
-  | extend Computer = tostring(parse_json(Entities)[0].HostName) 
+  | extend Computer = tostring(parse_json(Entities)[0].HostName)
+  ),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | where Request_Name has_any (DomainNames)  
+  | extend DNSName = Request_Name
+  | extend IPAddress = ClientIP 
+  ),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (DomainNames)  
+  | extend DNSName = DestinationHost 
+  | extend IPAddress = SourceHost
   )
   )
   | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress

--- a/Detections/MultipleDataSources/IridiumIOCs.yaml
+++ b/Detections/MultipleDataSources/IridiumIOCs.yaml
@@ -25,9 +25,6 @@ requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
       - SigninLogs
-  - connectorId: AzureMonitor(WireData)
-    dataTypes:
-      - WireData
   - connectorId: AzureMonitor(IIS)
     dataTypes:
       - W3CIISLog

--- a/Detections/MultipleDataSources/IridiumIOCs.yaml
+++ b/Detections/MultipleDataSources/IridiumIOCs.yaml
@@ -37,6 +37,9 @@ requiredDataConnectors:
   - connectorId: AWS
     dataTypes:
       - AWSCloudTrail
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -105,6 +108,26 @@ query:  |
   | where isnotempty(SourceIpAddress)
   | where SourceIpAddress in (IPList)
   | extend timestamp = TimeGenerated, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
+  ),
+  (
+  AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (IPList)  
+  | extend DestinationIP = DestinationHost 
+  | extend IPCustomEntity = SourceHost
+  ),
+  (
+  AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallNetworkRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (IPList)  
+  | extend DestinationIP = DestinationHost 
+  | extend IPCustomEntity = SourceHost
   )
   )
 entityMappings:

--- a/Detections/MultipleDataSources/IridiumIOCs.yaml
+++ b/Detections/MultipleDataSources/IridiumIOCs.yaml
@@ -82,11 +82,6 @@ query:  |
   | where SourceIP in (IPList) or DestinationIP in (IPList) 
   | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None") 
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserName, HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
-  ), 
-  (WireData 
-  | where isnotempty(RemoteIP)
-  | where RemoteIP in (IPList)
-  | extend timestamp = TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = Computer
   ),
   (SigninLogs
   | where isnotempty(IPAddress)

--- a/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
+++ b/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
@@ -69,10 +69,10 @@ query: |
   | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host),
   (VMConnection 
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
-  | where isnotempty(SourceIP) or isnotempty(DestinationIP) or isnotempty(DNSName)
-  | where SourceIP in (IPList) or DestinationIP in (IPList) or DNSName in~ (DomainNames)
-  | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None") 
-  | extend timestamp = TimeGenerated , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None"), Host = Computer),
+  | where isnotempty(SourceIp) or isnotempty(DestinationIp) or isnotempty(DNSName)
+  | where SourceIp in (IPList) or DestinationIp in (IPList) or DNSName in~ (DomainNames)
+  | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None") 
+  | extend timestamp = TimeGenerated , IPCustomEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "None"), Host = Computer),
   (OfficeActivity
   | extend SourceIPAddress = ClientIP, Account = UserId
   | where  SourceIPAddress in (IPList)

--- a/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
+++ b/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
@@ -20,6 +20,9 @@ requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
       - OfficeActivity
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -73,7 +76,23 @@ query: |
   (OfficeActivity
   | extend SourceIPAddress = ClientIP, Account = UserId
   | where  SourceIPAddress in (IPList)
-  | extend timestamp = TimeGenerated , IPCustomEntity = SourceIPAddress , AccountCustomEntity = Account )
+  | extend timestamp = TimeGenerated , IPCustomEntity = SourceIPAddress , AccountCustomEntity = Account),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | where Request_Name has_any (DomainNames)  
+  | extend DNSName = Request_Name
+  | extend IPCustomEntity = ClientIP),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (DomainNames)  
+  | extend DNSName = DestinationHost 
+  | extend IPCustomEntity = SourceHost 
+  )
   )
 entityMappings:
   - entityType: Account

--- a/Detections/MultipleDataSources/STRONTIUMJuly2019IOCs.yaml
+++ b/Detections/MultipleDataSources/STRONTIUMJuly2019IOCs.yaml
@@ -38,7 +38,19 @@ query: |
   | extend IPAddress = ClientIP, DNSName = Name, Host = Computer),
   (VMConnection 
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
-  | extend IPAddress = RemoteIp, Host = Computer)
+  | extend IPAddress = RemoteIp, Host = Computer),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | extend DNSName = Request_Name
+  | extend IPAddress = ClientIP),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | extend DNSName = DestinationHost 
+  | extend IPAddress = SourceHost)
   )
   | where isnotempty(DNSName)
   | where DNSName  in~ (DomainNames)

--- a/Detections/MultipleDataSources/Solorigate-Network-Beacon.yaml
+++ b/Detections/MultipleDataSources/Solorigate-Network-Beacon.yaml
@@ -20,7 +20,10 @@ requiredDataConnectors:
       - CommonSecurityLog 
   - connectorId: MicrosoftThreatProtection 
     dataTypes: 
-      - DeviceNetworkEvents 
+      - DeviceNetworkEvents
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 6h 
 queryPeriod: 6h 
 triggerOperator: gt 
@@ -58,9 +61,25 @@ query:  |
     | extend DNSName = RemoteUrl
     | extend IPCustomEntity = RemoteIP 
     | extend HostCustomEntity = DeviceName 
+    ),
+  (AzureDiagnostics
+    | where ResourceType == "AZUREFIREWALLS"
+    | where Category == "AzureFirewallDnsProxy"
+    | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+    | where Request_Name has_any (domains)  
+    | extend DNSName = Request_Name
+    | extend IPCustomEntity = ClientIP 
+    ),
+  (AzureDiagnostics 
+    | where ResourceType == "AZUREFIREWALLS"
+    | where Category == "AzureFirewallApplicationRule"
+    | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+    | where isnotempty(DestinationHost)
+    | where DestinationHost has_any (domains)  
+    | extend DNSName = DestinationHost 
+    | extend IPCustomEntity = SourceHost
     ) 
     )
-    
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/MultipleDataSources/ThalliumIOCs.yaml
+++ b/Detections/MultipleDataSources/ThalliumIOCs.yaml
@@ -18,6 +18,9 @@ requiredDataConnectors:
   - connectorId: PaloAltoNetworks
     dataTypes:
       - CommonSecurityLog
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -45,9 +48,26 @@ query: |
   | where isnotempty(DNSName)
   | where DNSName  in~ (DomainNames)
   | extend IPAddress = RemoteIp
+  ),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | where Request_Name has_any (DomainNames)  
+  | extend DNSName = Request_Name
+  | extend IPAddress = ClientIP 
+  ),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (DomainNames)  
+  | extend DNSName = DestinationHost 
+  | extend IPAddress = SourceHost 
   )
   )
-  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress
+  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress 
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/MultipleDataSources/ZincJan272021IOCs.yaml
+++ b/Detections/MultipleDataSources/ZincJan272021IOCs.yaml
@@ -28,6 +28,9 @@ requiredDataConnectors:
   - connectorId: MicrosoftThreatProtection
     dataTypes:
       - DeviceNetworkEvents
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -67,7 +70,7 @@ query: |
   | where isnotempty(DNSName)
   | where DNSName  in~ (DomainNames)
   | extend IPAddress = RemoteIp
-  | project Type, TimeGenerated, Computer, IPAddress, DNSName 
+  | project Type, TimeGenerated, Computer, IPAddress, DNSName
   ),
   (Event
   //This query uses sysmon data depending on table name used this may need updataing
@@ -112,6 +115,23 @@ query: |
   | where ProcessName has_any ("powershell.exe", "rundll32.exe")
   | where (CommandLine has "is64bitoperatingsystem" and CommandLine has "Debug\\Browse") or (CommandLine has_any (tokens))
   | project Type, TimeGenerated, Computer, Account, ProcessName, CommandLine 
+  ),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | where Request_Name has_any (DomainNames)  
+  | extend DNSName = Request_Name
+  | extend IPAddress = ClientIP 
+  ),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (DomainNames)  
+  | extend DNSName = DestinationHost 
+  | extend IPAddress = SourceHost
   )
   )
   | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress

--- a/Detections/MultipleDataSources/ZincJan272021IOCs.yaml
+++ b/Detections/MultipleDataSources/ZincJan272021IOCs.yaml
@@ -42,30 +42,27 @@ relevantTechniques:
   - T1071.001
   - T1204
 query: |
-  let timeframe = 1d;
+
   let tokens = dynamic(["SSL_HandShaking", "ASN2_TYPE_new", "sql_blob_open", "cmsSetLogHandlerTHR", "ntSystemInfo", "SetWebFilterString", "CleanupBrokerString", "glInitSampler", "deflateSuffix", "ntWindowsProc"]);
   let DomainNames = dynamic(['codevexillium.org', 'angeldonationblog.com', 'investbooking.de', 'krakenfolio.com']);
   let SHA256Hash = dynamic(['58a74dceb2022cd8a358b92acd1b48a5e01c524c3b0195d7033e4bd55eff4495','e0e59bfc22876c170af65dcbf19f744ae560cc43b720b23b9d248f4505c02f3e','3d3195697521973efe0097a320cbce0f0f98d29d50e044f4505e1fbc043e8cf9', '0a2d81164d524be7022ba8fd4e1e8e01bfd65407148569d172e2171b5cd76cd4', '96d7a93f6691303d39a9cc270b8814151dfec5683e12094537fd580afdf2e5fe','dc4cf164635db06b2a0b62d313dbd186350bca6fc88438617411a68df13ec83c', '46efd5179e43c9cbf07dcec22ce0d5527e2402655aee3afc016e5c260650284a', '95e42a94d4df1e7e472998f43b9879eb34aaa93f3705d7d3ef9e3b97349d7008', '9d5320e883264a80ea214077f44b1d4b22155446ad5083f4b27d2ab5bd127ef5', '9fd05063ad203581a126232ac68027ca731290d17bd43b5d3311e8153c893fe3', 'ada7e80c9d09f3efb39b729af238fcdf375383caaf0e9e0aed303931dc73b720', 'edb1597789c7ed784b85367a36440bf05267ac786efe5a4044ec23e490864cee', '33665ce1157ddb7cd7e905e3356b39245dfba17b7a658bdbf02b6968656b9998', '3ab770458577eb72bd6239fe97c35e7eb8816bce5a4b47da7bd0382622854f7c', 'b630ad8ffa11003693ce8431d2f1c6b8b126cd32b657a4bfa9c0dbe70b007d6c', '53f3e55c1217dafb8801af7087e7d68b605e2b6dde6368fceea14496c8a9f3e5', '99c95b5272c5b11093eed3ef2272e304b7a9311a22ff78caeb91632211fcb777', 'f21abadef52b4dbd01ad330efb28ef50f8205f57916a26daf5de02249c0f24ef', '2cbdea62e26d06080d114bbd922d6368807d7c6b950b1421d0aa030eca7e85da', '079659fac6bd9a1ce28384e7e3a465be4380acade3b4a4a4f0e67fd0260e9447']);
   let SigNames = dynamic(["Backdoor:Script/ComebackerCompile.A!dha", "Trojan:Win64/Comebacker.A!dha", "Trojan:Win64/Comebacker.A.gen!dha", "Trojan:Win64/Comebacker.B.gen!dha", "Trojan:Win32/Comebacker.C.gen!dha", "Trojan:Win32/Klackring.A!dha", "Trojan:Win32/Klackring.B!dha"]);
   (union isfuzzy=true
-  (CommonSecurityLog 
-  | where TimeGenerated >= ago(timeframe) 
+  (CommonSecurityLog
   | parse Message with * '(' DNSName ')' * 
   | where isnotempty(FileHash)
   | where FileHash in~ (SHA256Hash) or DNSName in~ (DomainNames)
   | extend Account = SourceUserID, Computer = DeviceName, IPAddress = SourceIP
   | project Type, TimeGenerated, Computer, Account, IPAddress, FileHash, DNSName
   ),
-  (DnsEvents 
-  | where TimeGenerated >= ago(timeframe) 
+  (DnsEvents
   | extend DNSName = Name
   | where isnotempty(DNSName)
   | where DNSName  in~ (DomainNames)
   | extend DataType = "DnsEvents", IPAddress = ClientIP
   | project Type, TimeGenerated, Computer, IPAddress, DNSName
   ),
-  (VMConnection 
-  | where TimeGenerated >= ago(timeframe) 
+  (VMConnection
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | where isnotempty(DNSName)
   | where DNSName  in~ (DomainNames)
@@ -74,7 +71,6 @@ query: |
   ),
   (Event
   //This query uses sysmon data depending on table name used this may need updataing
-  | where TimeGenerated >= ago(timeframe)
   | where Source == "Microsoft-Windows-Sysmon"
   | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
@@ -85,33 +81,28 @@ query: |
   | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = Hashes
   | project Type, TimeGenerated, Computer, Account, FileHash
   ),
-  (DeviceFileEvents 
-  | where TimeGenerated >= ago(timeframe) 
+  (DeviceFileEvents
   | where SHA256 in~ (SHA256Hash)
   | extend Account = RequestAccountName, Computer = DeviceName, IPAddress = RequestSourceIP, CommandLine = InitiatingProcessCommandLine, FileHash = SHA256
   | project Type, TimeGenerated, Computer, Account, IPAddress, CommandLine, FileHash
   ),
-  (DeviceNetworkEvents 
-  | where TimeGenerated >= ago(timeframe)  
+  (DeviceNetworkEvents
   | where RemoteUrl in~ (DomainNames)
   | extend Computer = DeviceName, IPAddress = LocalIP, Account = InitiatingProcessAccountName
   | project Type, TimeGenerated, Computer, Account, IPAddress, RemoteUrl
   ),
   (SecurityAlert
-  | where TimeGenerated >= ago(timeframe)
   | where Entities has_any (SigNames)
   | extend Computer = tostring(parse_json(Entities)[0].HostName) 
   | project Type, TimeGenerated, Computer
   ),
-  (DeviceProcessEvents 
-  | where TimeGenerated >= ago(timeframe) 
+  (DeviceProcessEvents
   | where FileName =~ "powershell.exe" or FileName =~ "rundll32.exe"
   | where (ProcessCommandLine has "is64bitoperatingsystem" and ProcessCommandLine has "Debug\\Browse") or (ProcessCommandLine has_any (tokens))
   | extend Computer = DeviceName, Account = AccountName, CommandLine = ProcessCommandLine
   | project Type, TimeGenerated, Computer, Account, CommandLine, FileName
   ),
   (SecurityEvent
-  | where TimeGenerated >= ago(timeframe) 
   | where ProcessName has_any ("powershell.exe", "rundll32.exe")
   | where (CommandLine has "is64bitoperatingsystem" and CommandLine has "Debug\\Browse") or (CommandLine has_any (tokens))
   | project Type, TimeGenerated, Computer, Account, ProcessName, CommandLine 


### PR DESCRIPTION
Added AzureDiagnostics queries for Azure Firewall to the MultipleDataSources detections for: 1) CERIUMOct292020IOCs 2) GalliumIOCs 3) IridiumIOCs 4) PHOSPHORUSMarch2019IOCs 5) Solorigate-Network-Beacon 6) STRONTIUMJuly2019IOCs 7) THALLIUMIOCs 8) ZINCJan272021IOCs

Fixes #

## Proposed Changes

  - Added AzureDiagnostics queries for Azure Firewall to all of the above 8 MultipleDataSources detections
  -
  -
