### PR TITLE
Update ExplicitMFADeny.yaml

### DIFF
--- a/Detections/SigninLogs/ExplicitMFADeny.yaml
+++ b/Detections/SigninLogs/ExplicitMFADeny.yaml
@@ -19,7 +19,7 @@ query: |
   SigninLogs
   | where ResultType == 500121
   | where Status has "MFA Denied; user declined the authentication"
-  | extend AccountCustomEntity = AlternateSignInName
+  | extend AccountCustomEntity = UserPrincipalName
   | extend IPCustomEntity = IPAddress
   | extend URLCustomEntity = ClientAppUsed
 entityMappings:


### PR DESCRIPTION
The other rules are using this mapping (AccountCustomEntity = UserPrincipalName).
AlternateSignInName is not always present in the logs.

Fixes #
entities not showing up

## Proposed Changes

  - AccountCustomEntity = UserPrincipalName
  -
  -
