### PR TITLE
Adding exploration queries for user access to Azure Subscriptions directly or transitively via Service Principals or AAD group memberships

### DIFF
--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedDirectly.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedDirectly.yaml
@@ -1,0 +1,30 @@
+Id: d103d814-eb0f-4395-af45-7f5697e598aa
+DisplayName: "Subscriptions owned by the user"
+Description: "Returns all subscriptions owned directly by the user"
+InputEntityType: Account 
+InputFields:
+  - AadUserId 
+OutputEntityTypes:
+  - AzureResource  
+QueryPeriodBefore: 7d 
+QueryPeriodAfter: 0
+DataSources:
+  - UserAccessAnalytics
+Tactics:
+  - LateralMovement 
+query: |  
+	let GetUserOwnedSubscriptions = (v_Account_AadUserId:string) { 
+	UserAccessAnalytics  
+		| where SourceEntityId =~ v_Account_AadUserId
+		| where TargetEntityType == "AzureSubscription"
+		| where AccessLevel == "Owner"
+		| project TimeGenerated, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId, AzureResource_Aux_SubsName = TargetEntityName
+		| summarize arg_max(TimeGenerated, *) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
+	};
+	GetUserOwnedSubscriptions("{{Account_AadUserId}}")
+
+
+
+
+
+

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedDirectly.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedDirectly.yaml
@@ -13,12 +13,12 @@ DataSources:
 Tactics:
   - LateralMovement 
 query: |  
-	let GetUserOwnedSubscriptions = (v_Account_AadUserId:string) { 
-	UserAccessAnalytics  
-		| where SourceEntityId =~ v_Account_AadUserId
-		| where TargetEntityType == "AzureSubscription"
-		| where AccessLevel == "Owner"
-		| project TimeGenerated, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId, AzureResource_Aux_SubsName = TargetEntityName
-		| summarize arg_max(TimeGenerated, *) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
-	};
-	GetUserOwnedSubscriptions("{{Account_AadUserId}}")
+    let GetUserOwnedSubscriptions = (v_Account_AadUserId:string) { 
+    UserAccessAnalytics  
+        | where SourceEntityId =~ v_Account_AadUserId
+        | where TargetEntityType == "AzureSubscription"
+        | where AccessLevel == "Owner"
+        | project TimeGenerated, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId, AzureResource_Aux_SubsName = TargetEntityName
+        | summarize arg_max(TimeGenerated, *) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
+    };
+    GetUserOwnedSubscriptions("{{Account_AadUserId}}")

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedDirectly.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedDirectly.yaml
@@ -22,9 +22,3 @@ query: |
 		| summarize arg_max(TimeGenerated, *) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
 	};
 	GetUserOwnedSubscriptions("{{Account_AadUserId}}")
-
-
-
-
-
-

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaAadGroups.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaAadGroups.yaml
@@ -1,0 +1,43 @@
+Id: 3ffccd66-95b7-4437-9487-0297b40203e8
+DisplayName: "Subscriptions transitively owned by the user via AAD Group memberships"
+Description: "Returns all subscriptions owned transitively by the user via Azure Active Directory Group memberships"
+InputEntityType: Account 
+InputFields:
+  - AadUserId 
+OutputEntityTypes:
+  - AzureResource  
+QueryPeriodBefore: 7d 
+QueryPeriodAfter: 0
+DataSources:
+  - UserAccessAnalytics
+Tactics:
+  - LateralMovement 
+query: |  
+	let GetUserOwnedSubsViaGroups = ( v_Account_AadUserId:string) { 
+		let UserGroupAccess = UserAccessAnalytics
+			| where SourceEntityId =~ v_Account_AadUserId			
+			| where TargetEntityType == "Group"
+			| project TimeGenerated, GroupId = TargetEntityId, GroupName = TargetEntityName
+			| summarize arg_max(TimeGenerated, *) by GroupId, GroupName;
+		let GroupSubsAccess = 	UserAccessAnalytics
+			| where TargetEntityType == "AzureSubscription"
+			| where AccessLevel == "Owner"
+			| project TimeGenerated, GroupId = SourceEntityId,  GroupName = SourceEntityName, AzureResource_Aux_SubsName = TargetEntityName, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId
+			| summarize arg_max(TimeGenerated, *) by GroupId, GroupName, AzureResource_Aux_SubsName, AzureResource_ResourceId, AzureResource_SubscriptionId;
+		UserGroupAccess
+			| join kind = inner
+			GroupSubsAccess
+			on GroupId  
+			| project AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName, GroupName, GroupId
+			| summarize AzureResource_Aux_AADGroupIds = make_set(GroupId), AzureResource_Aux_AADGroupNames = make_set(GroupName) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
+			| order by array_length(AzureResource_Aux_AADGroupIds) asc
+	};
+	GetUserOwnedSubsViaGroups("{{Account_AadUserId}}")
+
+
+
+
+
+
+
+

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaAadGroups.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaAadGroups.yaml
@@ -33,11 +33,3 @@ query: |
 			| order by array_length(AzureResource_Aux_AADGroupIds) asc
 	};
 	GetUserOwnedSubsViaGroups("{{Account_AadUserId}}")
-
-
-
-
-
-
-
-

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaAadGroups.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaAadGroups.yaml
@@ -13,23 +13,23 @@ DataSources:
 Tactics:
   - LateralMovement 
 query: |  
-	let GetUserOwnedSubsViaGroups = ( v_Account_AadUserId:string) { 
-		let UserGroupAccess = UserAccessAnalytics
-			| where SourceEntityId =~ v_Account_AadUserId			
-			| where TargetEntityType == "Group"
-			| project TimeGenerated, GroupId = TargetEntityId, GroupName = TargetEntityName
-			| summarize arg_max(TimeGenerated, *) by GroupId, GroupName;
-		let GroupSubsAccess = 	UserAccessAnalytics
-			| where TargetEntityType == "AzureSubscription"
-			| where AccessLevel == "Owner"
-			| project TimeGenerated, GroupId = SourceEntityId,  GroupName = SourceEntityName, AzureResource_Aux_SubsName = TargetEntityName, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId
-			| summarize arg_max(TimeGenerated, *) by GroupId, GroupName, AzureResource_Aux_SubsName, AzureResource_ResourceId, AzureResource_SubscriptionId;
-		UserGroupAccess
-			| join kind = inner
-			GroupSubsAccess
-			on GroupId  
-			| project AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName, GroupName, GroupId
-			| summarize AzureResource_Aux_AADGroupIds = make_set(GroupId), AzureResource_Aux_AADGroupNames = make_set(GroupName) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
-			| order by array_length(AzureResource_Aux_AADGroupIds) asc
-	};
-	GetUserOwnedSubsViaGroups("{{Account_AadUserId}}")
+    let GetUserOwnedSubsViaGroups = ( v_Account_AadUserId:string) { 
+        let UserGroupAccess = UserAccessAnalytics
+            | where SourceEntityId =~ v_Account_AadUserId           
+            | where TargetEntityType == "Group"
+            | project TimeGenerated, GroupId = TargetEntityId, GroupName = TargetEntityName
+            | summarize arg_max(TimeGenerated, *) by GroupId, GroupName;
+        let GroupSubsAccess =   UserAccessAnalytics
+            | where TargetEntityType == "AzureSubscription"
+            | where AccessLevel == "Owner"
+            | project TimeGenerated, GroupId = SourceEntityId,  GroupName = SourceEntityName, AzureResource_Aux_SubsName = TargetEntityName, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId
+            | summarize arg_max(TimeGenerated, *) by GroupId, GroupName, AzureResource_Aux_SubsName, AzureResource_ResourceId, AzureResource_SubscriptionId;
+        UserGroupAccess
+            | join kind = inner
+            GroupSubsAccess
+            on GroupId  
+            | project AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName, GroupName, GroupId
+            | summarize AzureResource_Aux_AADGroupIds = make_set(GroupId), AzureResource_Aux_AADGroupNames = make_set(GroupName) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
+            | order by array_length(AzureResource_Aux_AADGroupIds) asc
+    };
+    GetUserOwnedSubsViaGroups("{{Account_AadUserId}}")

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaSPNs.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaSPNs.yaml
@@ -13,23 +13,23 @@ DataSources:
 Tactics:
   - LateralMovement 
 query: |  
-	let GetUserOwnedSubsViaSPN = (v_Account_AadUserId:string) { 
-		let UserSPNAccess = UserAccessAnalytics
-			| where SourceEntityId =~ v_Account_AadUserId
-			| where TargetEntityType == "ServicePrincipal"
-			| project TimeGenerated, ServicePrincipalId = TargetEntityId, ServicePrincipalName = TargetEntityName
-			| summarize arg_max(TimeGenerated, *) by ServicePrincipalId, ServicePrincipalName;
-		let SPNSubsAccess = UserAccessAnalytics
-			| where TargetEntityType == "AzureSubscription" 
-			| where AccessLevel == "Owner"
-			| project TimeGenerated, ServicePrincipalId = SourceEntityId, ServicePrincipalName = SourceEntityName,AzureResource_Aux_SubsName = TargetEntityName, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId
-			| summarize arg_max(TimeGenerated, *) by ServicePrincipalId, ServicePrincipalName, AzureResource_Aux_SubsName, AzureResource_ResourceId, AzureResource_SubscriptionId; 
-		UserSPNAccess
-			| join kind = inner
-			SPNSubsAccess
-			on ServicePrincipalId	
-			| project AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName, ServicePrincipalId, ServicePrincipalName
-			| summarize AzureResource_Aux_SPNIds=make_set(ServicePrincipalId), AzureResource_Aux_SPNNames= make_set(ServicePrincipalName) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
-			| order by array_length(AzureResource_Aux_SPNIds) asc	
-	};
-	GetUserOwnedSubsViaSPN("{{Account_AadUserId}}")
+    let GetUserOwnedSubsViaSPN = (v_Account_AadUserId:string) { 
+        let UserSPNAccess = UserAccessAnalytics
+            | where SourceEntityId =~ v_Account_AadUserId
+            | where TargetEntityType == "ServicePrincipal"
+            | project TimeGenerated, ServicePrincipalId = TargetEntityId, ServicePrincipalName = TargetEntityName
+            | summarize arg_max(TimeGenerated, *) by ServicePrincipalId, ServicePrincipalName;
+        let SPNSubsAccess = UserAccessAnalytics
+            | where TargetEntityType == "AzureSubscription" 
+            | where AccessLevel == "Owner"
+            | project TimeGenerated, ServicePrincipalId = SourceEntityId, ServicePrincipalName = SourceEntityName,AzureResource_Aux_SubsName = TargetEntityName, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId
+            | summarize arg_max(TimeGenerated, *) by ServicePrincipalId, ServicePrincipalName, AzureResource_Aux_SubsName, AzureResource_ResourceId, AzureResource_SubscriptionId; 
+        UserSPNAccess
+            | join kind = inner
+            SPNSubsAccess
+            on ServicePrincipalId   
+            | project AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName, ServicePrincipalId, ServicePrincipalName
+            | summarize AzureResource_Aux_SPNIds=make_set(ServicePrincipalId), AzureResource_Aux_SPNNames= make_set(ServicePrincipalName) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
+            | order by array_length(AzureResource_Aux_SPNIds) asc   
+    };
+    GetUserOwnedSubsViaSPN("{{Account_AadUserId}}")

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaSPNs.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaSPNs.yaml
@@ -1,0 +1,42 @@
+Id: 9c45beeb-5155-4326-8c76-25baf3fa2f6f
+DisplayName: "Subscriptions transitively owned by the user via Azure Service Principals"
+Description: "Returns all subscriptions owned transitively by the user via Azure Service Principals"
+InputEntityType: Account 
+InputFields:
+  - AadUserId 
+OutputEntityTypes:
+  - AzureResource  
+QueryPeriodBefore: 7d 
+QueryPeriodAfter: 0
+DataSources:
+  - UserAccessAnalytics
+Tactics:
+  - LateralMovement 
+query: |  
+	let GetUserOwnedSubsViaSPN = (v_Account_AadUserId:string) { 
+		let UserSPNAccess = UserAccessAnalytics
+			| where SourceEntityId =~ v_Account_AadUserId
+			| where TargetEntityType == "ServicePrincipal"
+			| project TimeGenerated, ServicePrincipalId = TargetEntityId, ServicePrincipalName = TargetEntityName
+			| summarize arg_max(TimeGenerated, *) by ServicePrincipalId, ServicePrincipalName;
+		let SPNSubsAccess = UserAccessAnalytics
+			| where TargetEntityType == "AzureSubscription" 
+			| where AccessLevel == "Owner"
+			| project TimeGenerated, ServicePrincipalId = SourceEntityId, ServicePrincipalName = SourceEntityName,AzureResource_Aux_SubsName = TargetEntityName, AzureResource_ResourceId = strcat("/subscriptions/", TargetEntityId), AzureResource_SubscriptionId = TargetEntityId
+			| summarize arg_max(TimeGenerated, *) by ServicePrincipalId, ServicePrincipalName, AzureResource_Aux_SubsName, AzureResource_ResourceId, AzureResource_SubscriptionId; 
+		UserSPNAccess
+			| join kind = inner
+			SPNSubsAccess
+			on ServicePrincipalId	
+			| project AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName, ServicePrincipalId, ServicePrincipalName
+			| summarize AzureResource_Aux_SPNIds=make_set(ServicePrincipalId), AzureResource_Aux_SPNNames= make_set(ServicePrincipalName) by AzureResource_ResourceId, AzureResource_SubscriptionId, AzureResource_Aux_SubsName
+			| order by array_length(AzureResource_Aux_SPNIds) asc	
+	};
+	GetUserOwnedSubsViaSPN("{{Account_AadUserId}}")
+
+
+
+
+
+
+

--- a/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaSPNs.yaml
+++ b/Exploration Queries/InputEntity_Account/UserAccount_SubsOwnedViaSPNs.yaml
@@ -33,10 +33,3 @@ query: |
 			| order by array_length(AzureResource_Aux_SPNIds) asc	
 	};
 	GetUserOwnedSubsViaSPN("{{Account_AadUserId}}")
-
-
-
-
-
-
-


### PR DESCRIPTION
Adding queries to return
  -  all Azure subscriptions owned directly by user
  -  all Azure subscriptions owned via Service Principals
  - all Azure subscriptions owned via Azure Active Directory group memberships
