### PR TITLE
Daspiker playbook get mde process activity within30 mins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "powershell.codeFormatting.addWhitespaceAroundPipe": true
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "FSharp.suggestGitignore": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
-    "FSharp.suggestGitignore": false
-}

--- a/Playbooks/Get-MDEProcessActivityWithin30Mins/azuredeploy.json
+++ b/Playbooks/Get-MDEProcessActivityWithin30Mins/azuredeploy.json
@@ -1,0 +1,767 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+   "parameters": {
+        "PlaybookName": {
+            "defaultValue": "<PlaybookName>",
+            "type": "string"
+        },
+        "UserName": {
+            "defaultValue": "<username>@<domain>",
+            "type": "string"
+        },
+        "TenantID": {
+            "defaultValue": "<TenantID>",
+            "type": "string"
+        },
+        "ClientID": {
+            "defaultValue": "<M365 API ClientID>",
+            "type": "string"
+        },
+        "Secret": {
+            "defaultValue": "<M365 API Secret>",
+            "type": "string"
+        },
+        "WorkspaceID": {
+            "defaultValue": "<Log Analytics Workspace ID>",
+            "type": "string"
+        },
+        "WorkspaceKey": {
+            "defaultValue": "<Log Analytics Workspace Key>",
+            "type": "string"
+        }
+    },
+    "variables": {
+        "DefenderForEndpointConnectionName": "[concat('defenderforendpoint-', parameters('PlaybookName'))]",
+        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
+        "AzureLogAnalyticsConnectionName": "[concat('azureloganalytics-', parameters('PlaybookName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('DefenderForEndpointConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[parameters('UserName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/wdatp')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[parameters('UserName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('AzureLogAnalyticsConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "LAConnection",
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azureloganalyticsdatacollector')]"
+                },
+                "parameterValues":{
+                    "username":"[parameters('WorkspaceID')]", 
+                    "password":"[parameters('WorkspaceKey')]"
+                },
+                "customParameterValues": {}
+            }
+        },
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('PlaybookName')]",
+            "location": "eastus",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/connections', variables('DefenderForEndpointConnectionName'))]",
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                "[resourceId('Microsoft.Web/connections', variables('AzureLogAnalyticsConnectionName'))]"
+            ],
+            "properties": {
+                "state": "Enabled",
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        }
+                    },
+                    "triggers": {
+                        "When_a_response_to_an_Azure_Sentinel_alert_is_triggered": {
+                            "type": "ApiConnectionWebhook",
+                            "inputs": {
+                                "body": {
+                                    "callback_url": "@{listCallbackUrl()}"
+                                },
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                    }
+                                },
+                                "path": "/subscribe"
+                            }
+                        }
+                    },
+                    "actions": {
+                        "Alert_-_Get_incident": {
+                            "runAfter": {},
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/Incidents/subscriptions/@{encodeURIComponent(triggerBody()?['WorkspaceSubscriptionId'])}/resourceGroups/@{encodeURIComponent(triggerBody()?['WorkspaceResourceGroup'])}/workspaces/@{encodeURIComponent(triggerBody()?['WorkspaceId'])}/alerts/@{encodeURIComponent(triggerBody()?['SystemAlertId'])}"
+                            }
+                        },
+                        "Entities_-_Get_Hosts": {
+                            "runAfter": {
+                                "Alert_-_Get_incident": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "body": "@triggerBody()?['Entities']",
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                    }
+                                },
+                                "method": "post",
+                                "path": "/entities/host"
+                            }
+                        },
+                        "For_each": {
+                            "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
+                            "actions": {
+                                "Condition_2": {
+                                    "actions": {
+                                        "Add_comment_to_incident_(V3)_3": {
+                                            "runAfter": {},
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": {
+                                                    "incidentArmId": "@body('Alert_-_Get_incident')?['id']",
+                                                    "message": "<p>@{variables('results')} Process Actions within 30 mins of this Incident<br>\nKQL query : IncidentProcessActions_CL | where IncidentID_d == @{body('Alert_-_Get_incident')?['properties']?['incidentNumber']}</p>"
+                                                },
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/Incidents/Comment"
+                                            }
+                                        },
+                                        "For_each_2": {
+                                            "foreach": "@body('Parse_JSON')?['Results']",
+                                            "actions": {
+                                                "Send_Data": {
+                                                    "runAfter": {},
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": "@{addProperty(items('For_each_2'), 'IncidentID', body('Alert_-_Get_incident')?['properties']?['incidentNumber'] )}",
+                                                        "headers": {
+                                                            "Log-Type": "IncidentProcessActions_CL"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azureloganalyticsdatacollector']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/api/logs"
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Add_comment_to_incident_(V3)_3": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach"
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Set_variable_2": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "else": {
+                                        "actions": {
+                                            "Add_comment_to_incident_(V3)_4": {
+                                                "runAfter": {},
+                                                "type": "ApiConnection",
+                                                "inputs": {
+                                                    "body": {
+                                                        "incidentArmId": "@body('Alert_-_Get_incident')?['id']",
+                                                        "message": "<p>No Process Actions found within 30 minutes of this incident</p>"
+                                                    },
+                                                    "host": {
+                                                        "connection": {
+                                                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                        }
+                                                    },
+                                                    "method": "post",
+                                                    "path": "/Incidents/Comment"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "greaterOrEquals": [
+                                                    "@variables('results')",
+                                                    1
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "If"
+                                },
+                                "HTTP": {
+                                    "runAfter": {
+                                        "Machines_-_Get_single_machine": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Http",
+                                    "inputs": {
+                                        "authentication": {
+                                            "audience": "https://api.security.microsoft.com",
+                                            "clientId": "[parameters('ClientID')]",
+                                            "secret": "[parameters('Secret')]",
+                                            "tenant": "[parameters('TenantID')]",
+                                            "type": "ActiveDirectoryOAuth"
+                                        },
+                                        "body": {
+                                            "Query": "let timeOfEvent = datetime('@{body('Alert_-_Get_incident')?['properties']?['createdTimeUtc']}'); let offset = 30; let timeOfEventOffset = datetime_add('minute',offset,timeOfEvent); let device = '@{body('Machines_-_Get_single_machine')?['id']}'; DeviceProcessEvents | where Timestamp between (timeOfEvent .. timeOfEventOffset) | where DeviceId == device"
+                                        },
+                                        "headers": {
+                                            "Content-Type": "application/json"
+                                        },
+                                        "method": "POST",
+                                        "uri": "https://api.security.microsoft.com/api/advancedHunting/run"
+                                    }
+                                },
+                                "Machines_-_Get_single_machine": {
+                                    "runAfter": {},
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['wdatp']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/api/machines/@{encodeURIComponent(items('For_each')?['HostName'])}"
+                                    }
+                                },
+                                "Parse_JSON": {
+                                    "runAfter": {
+                                        "HTTP": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "ParseJson",
+                                    "inputs": {
+                                        "content": "@body('HTTP')",
+                                        "schema": {
+                                            "properties": {
+                                                "body": {
+                                                    "properties": {
+                                                        "Results": {
+                                                            "items": {
+                                                                "properties": {
+                                                                    "AccountDomain": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "AccountName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "AccountObjectId": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "AccountSid": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "AccountUpn": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ActionType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "AdditionalFields": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "AppGuardContainerId": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "DeviceId": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "DeviceName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "FileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "FileSize": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "FolderPath": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessAccountDomain": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessAccountName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessAccountObjectId": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessAccountSid": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessAccountUpn": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessCommandLine": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessCreationTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessFileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessFileSize": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "InitiatingProcessFolderPath": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessId": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "InitiatingProcessIntegrityLevel": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessLogonId": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "InitiatingProcessMD5": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessParentCreationTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessParentFileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessParentId": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "InitiatingProcessSHA1": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessSHA256": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessSignatureStatus": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessSignerType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessTokenElevation": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessVersionInfoCompanyName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessVersionInfoFileDescription": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessVersionInfoInternalFileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessVersionInfoOriginalFileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessVersionInfoProductName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "InitiatingProcessVersionInfoProductVersion": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "LogonId": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "MD5": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessCommandLine": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessCreationTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessId": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "ProcessIntegrityLevel": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessTokenElevation": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessVersionInfoCompanyName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessVersionInfoFileDescription": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessVersionInfoInternalFileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessVersionInfoOriginalFileName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessVersionInfoProductName": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ProcessVersionInfoProductVersion": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ReportId": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "SHA1": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "SHA256": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "Timestamp": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "Timestamp",
+                                                                    "DeviceId",
+                                                                    "DeviceName",
+                                                                    "ActionType",
+                                                                    "FileName",
+                                                                    "FolderPath",
+                                                                    "SHA1",
+                                                                    "SHA256",
+                                                                    "MD5",
+                                                                    "FileSize",
+                                                                    "ProcessVersionInfoCompanyName",
+                                                                    "ProcessVersionInfoProductName",
+                                                                    "ProcessVersionInfoProductVersion",
+                                                                    "ProcessVersionInfoInternalFileName",
+                                                                    "ProcessVersionInfoOriginalFileName",
+                                                                    "ProcessVersionInfoFileDescription",
+                                                                    "ProcessId",
+                                                                    "ProcessCommandLine",
+                                                                    "ProcessIntegrityLevel",
+                                                                    "ProcessTokenElevation",
+                                                                    "ProcessCreationTime",
+                                                                    "AccountDomain",
+                                                                    "AccountName",
+                                                                    "AccountSid",
+                                                                    "AccountUpn",
+                                                                    "AccountObjectId",
+                                                                    "LogonId",
+                                                                    "InitiatingProcessAccountDomain",
+                                                                    "InitiatingProcessAccountName",
+                                                                    "InitiatingProcessAccountSid",
+                                                                    "InitiatingProcessAccountUpn",
+                                                                    "InitiatingProcessAccountObjectId",
+                                                                    "InitiatingProcessLogonId",
+                                                                    "InitiatingProcessIntegrityLevel",
+                                                                    "InitiatingProcessTokenElevation",
+                                                                    "InitiatingProcessSHA1",
+                                                                    "InitiatingProcessSHA256",
+                                                                    "InitiatingProcessMD5",
+                                                                    "InitiatingProcessFileName",
+                                                                    "InitiatingProcessFileSize",
+                                                                    "InitiatingProcessVersionInfoCompanyName",
+                                                                    "InitiatingProcessVersionInfoProductName",
+                                                                    "InitiatingProcessVersionInfoProductVersion",
+                                                                    "InitiatingProcessVersionInfoInternalFileName",
+                                                                    "InitiatingProcessVersionInfoOriginalFileName",
+                                                                    "InitiatingProcessVersionInfoFileDescription",
+                                                                    "InitiatingProcessId",
+                                                                    "InitiatingProcessCommandLine",
+                                                                    "InitiatingProcessCreationTime",
+                                                                    "InitiatingProcessFolderPath",
+                                                                    "InitiatingProcessParentId",
+                                                                    "InitiatingProcessParentFileName",
+                                                                    "InitiatingProcessParentCreationTime",
+                                                                    "InitiatingProcessSignerType",
+                                                                    "InitiatingProcessSignatureStatus",
+                                                                    "ReportId",
+                                                                    "AppGuardContainerId",
+                                                                    "AdditionalFields"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "Schema": {
+                                                            "items": {
+                                                                "properties": {
+                                                                    "Name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "Type": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "Name",
+                                                                    "Type"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "Stats": {
+                                                            "properties": {
+                                                                "ExecutionTime": {
+                                                                    "type": "number"
+                                                                },
+                                                                "dataset_statistics": {
+                                                                    "items": {
+                                                                        "properties": {
+                                                                            "table_row_count": {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "table_size": {
+                                                                                "type": "integer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "table_row_count",
+                                                                            "table_size"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                },
+                                                                "resource_usage": {
+                                                                    "properties": {
+                                                                        "cache": {
+                                                                            "properties": {
+                                                                                "disk": {
+                                                                                    "properties": {
+                                                                                        "hits": {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        "misses": {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        "total": {
+                                                                                            "type": "integer"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "memory": {
+                                                                                    "properties": {
+                                                                                        "hits": {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        "misses": {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        "total": {
+                                                                                            "type": "integer"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "cpu": {
+                                                                            "properties": {
+                                                                                "kernel": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "total cpu": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "user": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "memory": {
+                                                                            "properties": {
+                                                                                "peak_per_node": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "headers": {
+                                                    "properties": {
+                                                        "Content-Length": {
+                                                            "type": "string"
+                                                        },
+                                                        "Content-Type": {
+                                                            "type": "string"
+                                                        },
+                                                        "Date": {
+                                                            "type": "string"
+                                                        },
+                                                        "Server": {
+                                                            "type": "string"
+                                                        },
+                                                        "Strict-Transport-Security": {
+                                                            "type": "string"
+                                                        },
+                                                        "x-content-type-options": {
+                                                            "type": "string"
+                                                        },
+                                                        "x-request-id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "statusCode": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "Set_variable": {
+                                    "runAfter": {
+                                        "Parse_JSON": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "results",
+                                        "value": "@length(body('Parse_JSON')?['Results'])"
+                                    }
+                                },
+                                "Set_variable_2": {
+                                    "runAfter": {
+                                        "Set_variable": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "resultJSON",
+                                        "value": "@{body('Parse_JSON')?['Results']}"
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_variable_2": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Foreach"
+                        },
+                        "Initialize_variable": {
+                            "runAfter": {
+                                "Entities_-_Get_Hosts": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "results",
+                                        "type": "integer",
+                                        "value": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_variable_2": {
+                            "runAfter": {
+                                "Initialize_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "resultJSON",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "$connections": {
+                        "value": {
+                            "wdatp": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('DefenderForEndpointConnectionName'))]",
+                                "connectionName": "[variables('DefenderForEndpointConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/wdatp')]"
+                            },
+                            "azuresentinel": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                "connectionName": "[variables('AzureSentinelConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                            },
+                            "azureloganalyticsdatacollector": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureLogAnalyticsConnectionName'))]",
+                                "connectionName": "[variables('AzureLogAnalyticsConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azureloganalyticsdatacollector')]"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/Playbooks/Get-MDEProcessActivityWithin30Mins/readme.md
+++ b/Playbooks/Get-MDEProcessActivityWithin30Mins/readme.md
@@ -1,0 +1,30 @@
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FGet-MDEProcessActivityWithin30Mins%2Fazuredeploy.json)
+[![Deploy to Azure Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.png)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FGet-MDEProcessActivityWithin30Mins%2Fazuredeploy.json)
+
+# Get-MDEProcessActivityWithin30Mins
+author: Dennis Pike
+
+## Overview
+This Playbook queries Microsoft Defender for Endpoint telemetry data via the Microsoft 365 Defender Advanced Hunting API for all Process Events (Read, Write, Modify, Delete) that occur within 30 minutes of the incident and adds a comment to the incident specifying the number of Process Events and KQL query that will list all of the events.
+
+## Required Paramaters
+- Region<br />
+- Playbook Name<br />
+- User Name - this is used to pre-populate the username used in the various Azure connections <br />
+
+An Azure AD App registration with required API permissions and secret will needed to provide the following parameters
+https://docs.microsoft.com/microsoft-365/security/mtp/api-advanced-hunting?view=o365-worldwide<br />
+
+- Tenant ID<br />
+- Client ID<br />
+- Secret<br />
+
+The File Events are stored in a Log Analytics Workspace (preferable the one you have Sentinel enabled on) so you will need the Workspace ID and Workspace Key which can be found under Sentinel > Settings > Workspace Settings > Agents Management
+
+- Workspace ID<br />
+- Workspace Key<br />
+
+### Necessary configuration steps
+
+Once this Playbooks template is deployed, you will need to go into the Logic App, edit it and click on each of the steps that require an authenticated connection to your tenant and complete the connection process.  These steps will have and exclamation point showing that the connection needs to be completed.  Make sure to also open the "For each" step and the "Condition 2" step within it which also contains steps that require authenticated connections.
+

--- a/Playbooks/Get-MDEProcessActivityWithin30Mins/readme.md
+++ b/Playbooks/Get-MDEProcessActivityWithin30Mins/readme.md
@@ -5,7 +5,7 @@
 author: Dennis Pike
 
 ## Overview
-This Playbook queries Microsoft Defender for Endpoint telemetry data via the Microsoft 365 Defender Advanced Hunting API for all Process Events (Read, Write, Modify, Delete) that occur within 30 minutes of the incident and adds a comment to the incident specifying the number of Process Events and KQL query that will list all of the events.
+This Playbook queries Microsoft Defender for Endpoint telemetry data via the Microsoft 365 Defender Advanced Hunting API for all Process Events that occur within 30 minutes of the incident and adds a comment to the incident specifying the number of Process Events and KQL query that will list all of the events.
 
 ## Required Paramaters
 - Region<br />
@@ -19,7 +19,7 @@ https://docs.microsoft.com/microsoft-365/security/mtp/api-advanced-hunting?view=
 - Client ID<br />
 - Secret<br />
 
-The File Events are stored in a Log Analytics Workspace (preferable the one you have Sentinel enabled on) so you will need the Workspace ID and Workspace Key which can be found under Sentinel > Settings > Workspace Settings > Agents Management
+The Process Events are stored in a Log Analytics Workspace (preferable the one you have Sentinel enabled on) so you will need the Workspace ID and Workspace Key which can be found under Sentinel > Settings > Workspace Settings > Agents Management
 
 - Workspace ID<br />
 - Workspace Key<br />


### PR DESCRIPTION
Fixes #

New Playbook Get-MDEProcessActivityWithin30Mins

## Proposed Changes

  -This Playbook queries Microsoft Defender for Endpoint telemetry data via the Microsoft 365 Defender Advanced Hunting API for all Process Events that occur within 30 minutes of the incident and adds a comment to the incident specifying the number of Process Events and KQL query that will list all of the events.
  -
  -
