### PR TITLE
Cisco Umbrella - fix US Gov changes

### DIFF
--- a/DataConnectors/CiscoUmbrella/ciscoUmbrellaDataConn/__init__.py
+++ b/DataConnectors/CiscoUmbrella/ciscoUmbrellaDataConn/__init__.py
@@ -419,8 +419,8 @@ class UmbrellaClient:
 
 
 class AzureSentinelConnector:
-    def __init__(self, log_analitics_uri, customer_id, shared_key, log_type, queue_size=200, bulks_number=10, queue_size_bytes=25 * (2**20)):
-        self.log_analitics_uri = log_analitics_uri
+    def __init__(self, log_analytics_uri, customer_id, shared_key, log_type, queue_size=200, bulks_number=10, queue_size_bytes=25 * (2**20)):
+        self.log_analytics_uri = log_analytics_uri
         self.customer_id = customer_id
         self.shared_key = shared_key
         self.log_type = log_type
@@ -487,7 +487,7 @@ class AzureSentinelConnector:
         rfc1123date = datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')
         content_length = len(body)
         signature = self._build_signature(customer_id, shared_key, rfc1123date, content_length, method, content_type, resource)
-        uri = self.log_analitics_uri + resource + '?api-version=2016-04-01'
+        uri = self.log_analytics_uri + resource + '?api-version=2016-04-01'
 
         headers = {
             'content-type': content_type,


### PR DESCRIPTION
# Fixes

- Fixed sending events to log analytics (variable logAnalyticsUri must be passed to AzureSentinelConnector class instead of being used as global variable because the data are sent to log analytics in another thread and global variables are not visible)
