### PR TITLE
Create KVPairExtraction

### DIFF
--- a/Parsers/KVPairExtraction
+++ b/Parsers/KVPairExtraction
@@ -1,0 +1,5 @@
+| extend kvpairs=parse_json(extract_all("([^\\d\\s]+)=(\\S+),\\s", dynamic([1,2]), SyslogMessage))
+| mv-apply kvpairs on (
+    summarize make_bag(pack(tostring(kvpairs[0]), kvpairs[1]))
+)
+| evaluate bag_unpack(bag_)

--- a/Parsers/KVPairExtraction
+++ b/Parsers/KVPairExtraction
@@ -1,3 +1,31 @@
+// Title:           Key value pair extractor
+// Author:          Christopher Kerry
+// Version:         1.2
+// Last Updated:    18/03/2021
+// Comment:         Changed KQL to match template
+//  
+// DESCRIPTION:
+// This KQL extracts key value pairs from data and transforms them into columns and values without you having to specify them.
+//
+// USAGE:
+// 1. Copy the query below and paste into the Logs query window where you need it to extract the key value pairs.
+// 2. In the query window, on the first line of this KQL, change the SyslogMessage field in the extend to match the field you want to extrac the key value pairs
+//    from.
+// 3. Tweak the regex in the first line to suit the key value pairs in your logs. You want to enclose the key and the value in seperate capture fields
+//    and then alter the dynamic([1,2]) to pull the correct capture fields through. e.g. You may want to capture the 3rd and 5th capture fields so yours would be
+//    dynamic([3,5]). A tool like regex101.com can be useful here, make sure you switch to the Golang/Re2 mode.
+// 4. Run the query and your key/value pairs should be extracted
+//
+//
+// REFERENCE: 
+// KQL Overview: https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/
+//
+// LOG SAMPLES:
+// This parser assumes the key value pairs are in this format:
+// 
+//      keyone=value1, keytwo=value1, keythree=value3, 
+//
+//
 | extend kvpairs=parse_json(extract_all("([^\\d\\s]+)=(\\S+),\\s", dynamic([1,2]), SyslogMessage))
 | mv-apply kvpairs on (
     summarize make_bag(pack(tostring(replace('-', '', tostring(kvpairs[0]))), kvpairs[1]))

--- a/Parsers/KVPairExtraction
+++ b/Parsers/KVPairExtraction
@@ -1,5 +1,5 @@
 | extend kvpairs=parse_json(extract_all("([^\\d\\s]+)=(\\S+),\\s", dynamic([1,2]), SyslogMessage))
 | mv-apply kvpairs on (
-    summarize make_bag(pack(tostring(kvpairs[0]), kvpairs[1]))
+    summarize make_bag(pack(tostring(replace('-', '', tostring(kvpairs[0]))), kvpairs[1]))
 )
 | evaluate bag_unpack(bag_)

--- a/Parsers/KVPairExtraction
+++ b/Parsers/KVPairExtraction
@@ -9,7 +9,7 @@
 //
 // USAGE:
 // 1. Copy the query below and paste into the Logs query window where you need it to extract the key value pairs.
-// 2. In the query window, on the first line of this KQL, change the SyslogMessage field in the extend to match the field you want to extrac the key value pairs
+// 2. In the query window, on the first line of this KQL, change the SyslogMessage field in the extend to match the field you want to extract the key value pairs
 //    from.
 // 3. Tweak the regex in the first line to suit the key value pairs in your logs. You want to enclose the key and the value in seperate capture fields
 //    and then alter the dynamic([1,2]) to pull the correct capture fields through. e.g. You may want to capture the 3rd and 5th capture fields so yours would be
@@ -18,7 +18,7 @@
 //
 //
 // REFERENCE: 
-// KQL Overview: https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/
+// KQL Overview: https://docs.microsoft.com/azure/data-explorer/kusto/query/
 //
 // LOG SAMPLES:
 // This parser assumes the key value pairs are in this format:


### PR DESCRIPTION
Extracts key value pairs such as the below and then stores them as separate fields. Tweak the regex in the extend for your log source if required. Tested on Cisco ISE logs
DestinationIPAddress=10.0.0.1, UserName=Test, AcsSessionID=SomeSession

Fixes #

## Proposed Changes

  -
  -
  -
