### PR TITLE
Update password_not_set.yaml with new Event ID

### DIFF
--- a/Detections/SecurityEvent/password_not_set.yaml
+++ b/Detections/SecurityEvent/password_not_set.yaml
@@ -2,8 +2,8 @@ id: 62085097-d113-459f-9ea7-30216f2ee6af
 name: AD user enabled and password not set within 48 hours
 description: |
   'Identifies when an account is enabled with a default password and the password is not set by the user within 48 hours.
-  Effectively, there is an event 4722 indicating an account was enabled and within 48 hours, no event 4723 occurs which 
-  indicates there was no attempt by the user to set the password. This will show any attempts (success or fail) that occur 
+  Effectively, there is an event 4722 indicating an account was enabled and within 48 hours, no event 4723 or 4724 occurs which 
+  indicates there was no attempt by the user to set or reset the password. This will show any attempts (success or fail) that occur 
   after 48 hours, which can indicate too long of a time period in setting the password to something that only the user knows.
   It is recommended that this time period is adjusted per your internal company policy.'
 severity: Low
@@ -33,7 +33,7 @@ query: |
   let userPwdSet = SecEvents
   // 4723: Attempt made by user to set password 4724: An attempt was made to reset an account's password
   | where EventID == 4723 or EventID == 4724
-  | project Time_Password_Change = TimeGenerated, TargetAccount, TargetSid, SubjectAccount_Password_Change = SubjectAccount, SubjectUserSid_Event4723 = SubjectUserSid, Activity_Password_Change = Activity, Computer_Password_Change = Computer;
+  | project Time_Password_Change = TimeGenerated, TargetAccount, TargetSid, SubjectAccount_Password_Change = SubjectAccount, SubjectUserSid_Password_Change = SubjectUserSid, Activity_Password_Change = Activity, Computer_Password_Change = Computer;
   userEnable | join kind=leftouter userPwdSet on TargetAccount, TargetSid
   | extend PasswordSetAttemptDelta_Min = datetime_diff('minute', Time_Password_Change, Time_Password_Change)
   | where PasswordSetAttemptDelta_Min > 2880 or isempty(PasswordSetAttemptDelta_Min)

--- a/Detections/SecurityEvent/password_not_set.yaml
+++ b/Detections/SecurityEvent/password_not_set.yaml
@@ -23,7 +23,7 @@ query: |
 
   let starttime = 3d;
   let SecEvents = materialize ( SecurityEvent | where TimeGenerated >= ago(starttime)
-  | where EventID in (4722,4723) | where TargetUserName !endswith "$"
+  | where EventID in (4722,4723,4724) | where TargetUserName !endswith "$"
   | project TimeGenerated, EventID, Activity, Computer, TargetAccount, TargetSid, SubjectAccount, SubjectUserSid);
   let userEnable = SecEvents
   | extend EventID4722Time = TimeGenerated
@@ -31,17 +31,17 @@ query: |
   | where EventID == 4722
   | project Time_Event4722 = TimeGenerated, TargetAccount, TargetSid, SubjectAccount_Event4722 = SubjectAccount, SubjectUserSid_Event4722 = SubjectUserSid, Activity_4722 = Activity, Computer_4722 = Computer;
   let userPwdSet = SecEvents
-  // 4723: Attempt made by user to set password
-  | where EventID == 4723
-  | project Time_Event4723 = TimeGenerated, TargetAccount, TargetSid, SubjectAccount_Event4723 = SubjectAccount, SubjectUserSid_Event4723 = SubjectUserSid, Activity_4723 = Activity, Computer_4723 = Computer;
+  // 4723: Attempt made by user to set password 4724: An attempt was made to reset an account's password
+  | where EventID == 4723 or EventID == 4724
+  | project Time_Password_Change = TimeGenerated, TargetAccount, TargetSid, SubjectAccount_Password_Change = SubjectAccount, SubjectUserSid_Event4723 = SubjectUserSid, Activity_Password_Change = Activity, Computer_Password_Change = Computer;
   userEnable | join kind=leftouter userPwdSet on TargetAccount, TargetSid
-  | extend PasswordSetAttemptDelta_Min = datetime_diff('minute', Time_Event4723, Time_Event4722)
+  | extend PasswordSetAttemptDelta_Min = datetime_diff('minute', Time_Password_Change, Time_Password_Change)
   | where PasswordSetAttemptDelta_Min > 2880 or isempty(PasswordSetAttemptDelta_Min)
   | project-away TargetAccount1, TargetSid1
-  | extend Reason = @"User either has not yet attempted to set the initial password after account was enabled or it occurred after 48 hours"
+  | extend Reason = @"User either has not yet attempted to change the initial password after account was enabled or it occurred after 48 hours"
   | order by Time_Event4722 asc 
   | extend timestamp = Time_Event4722, AccountCustomEntity = TargetAccount, HostCustomEntity = Computer_4722
-  | project-reorder Time_Event4722, Time_Event4723, PasswordSetAttemptDelta_Min, TargetAccount, TargetSid
+  | project-reorder Time_Event4722, Time_Password_Change, PasswordSetAttemptDelta_Min, TargetAccount, TargetSid
 entityMappings:
   - entityType: Account
     fieldMappings:


### PR DESCRIPTION
## Proposed Changes
  -Added event ID 4724 which indicates password reset attempt. 
  -Also changed the description and reason to match the change. 
  -Also changed the variable name for event ID 4723 to be generalized for event ID's 4723 and 4724


