### PR TITLE
CVE-2021-27065 Detection

### DIFF
--- a/Detections/SecurityEvent/ExchangeOABVirtualDirectoryAttributeContainingPotentialWebshell.yaml
+++ b/Detections/SecurityEvent/ExchangeOABVirtualDirectoryAttributeContainingPotentialWebshell.yaml
@@ -1,7 +1,9 @@
 id: faf1a6ff-53b5-4f92-8c55-4b20e9957594
 name: Exchange OAB Virtual Directory Attribute Containing Potential Webshell
 description: |
-  'This query uses Windows Event ID 5136 in order to detect potential webshell deployment by exploitation of CVE-2021-27065. This query looks for changes to the InternalHostName or ExternalHostName properties of Exchange OAB Virtual Directory objects in AD Directory Services where the new objects contain potential webshell objects. Ref: https://aka.ms/ExchangeVulns'
+  'This query uses Windows Event ID 5136 in order to detect potential webshell deployment by exploitation of CVE-2021-27065.
+  This query looks for changes to the InternalHostName or ExternalHostName properties of Exchange OAB Virtual Directory objects in AD Directory Services
+  where the new objects contain potential webshell objects. Ref: https://aka.ms/ExchangeVulns'
 severity: High
 requiredDataConnectors:
   - connectorId: SecurityEvents
@@ -17,21 +19,22 @@ relevantTechniques:
   - T1190
 query: |
   SecurityEvent
-  // Look for specific Directory Service Changes
+  // Look for specific Directory Service Changes and parse data
   | where EventID == 5136
-  | extend Data = parse_xml(EventData)
-  | extend ObjectClass = tostring( Data.EventData.Data[10].["#text"])
+  | extend EventData = parse_xml(EventData).EventData.Data
+  | mv-expand bagexpansion = array EventData
+  | evaluate bag_unpack(EventData)
+  | extend Key =tostring(['@Name']), Value = ['#text']
+  | evaluate pivot(Key, any(Value),TimeGenerated, EventID, Computer, Account, AccountType, EventSourceName, Activity, SubjectAccount)
   // Where changes relate to Exchange OAB
   | where ObjectClass =~ "msExchOABVirtualDirectory"
-  | extend AttributeLDAPDisplayName = tostring( Data.EventData.Data[11].["#text"])
   // Look for InternalHostName or ExternalHostName properties being changed
   | where AttributeLDAPDisplayName in ("msExchExternalHostName", "msExchInternalHostName")
-  | extend DN = tostring(Data.EventData.Data[8].["#text"])
-  | extend AttributeValue = tostring(Data.EventData.Data[13].["#text"])
   // Look for suspected webshell activity
   | where AttributeValue has "script"
-  | project-reorder TimeGenerated, Computer, Account, DN, AttributeLDAPDisplayName, AttributeValue
-  | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = Computer
+  | project-rename LastSeen = TimeGenerated
+  | project-reorder LastSeen, Computer, Account, ObjectDN, AttributeLDAPDisplayName, AttributeValue
+  | extend timestamp = LastSeen, AccountCustomEntity = Account, HostCustomEntity = Computer
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/SecurityEvent/ExchangeOABVirtualDirectoryAttributeContainingPotentialWebshell.yaml
+++ b/Detections/SecurityEvent/ExchangeOABVirtualDirectoryAttributeContainingPotentialWebshell.yaml
@@ -1,0 +1,43 @@
+id: faf1a6ff-53b5-4f92-8c55-4b20e9957594
+name: Exchange OAB Virtual Directory Attribute Containing Potential Webshell
+description: |
+  'This query uses Windows Event ID 5136 in order to detect potential webshell deployment by exploitation of CVE-2021-27065. This query looks for changes to the InternalHostName or ExternalHostName properties of Exchange OAB Virtual Directory objects in AD Directory Services where the new objects contain potential webshell objects. Ref: https://aka.ms/ExchangeVulns'
+severity: High
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1190
+query: |
+  SecurityEvent
+  // Look for specific Directory Service Changes
+  | where EventID == 5136
+  | extend Data = parse_xml(EventData)
+  | extend ObjectClass = tostring( Data.EventData.Data[10].["#text"])
+  // Where changes relate to Exchange OAB
+  | where ObjectClass =~ "msExchOABVirtualDirectory"
+  | extend AttributeLDAPDisplayName = tostring( Data.EventData.Data[11].["#text"])
+  // Look for InternalHostName or ExternalHostName properties being changed
+  | where AttributeLDAPDisplayName in ("msExchExternalHostName", "msExchInternalHostName")
+  | extend DN = tostring(Data.EventData.Data[8].["#text"])
+  | extend AttributeValue = tostring(Data.EventData.Data[13].["#text"])
+  // Look for suspected webshell activity
+  | where AttributeValue has "script"
+  | project-reorder TimeGenerated, Computer, Account, DN, AttributeLDAPDisplayName, AttributeValue
+  | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = Computer
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity


### PR DESCRIPTION
Detection of CVE-2021-27065 being exploited to drop webshells. Detection occurs on AD DS rather than Exchange sever.