### PR TITLE
Update UseraddedtoPrivilgedGroups.yaml to include values for User

### DIFF
--- a/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
+++ b/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
@@ -27,16 +27,25 @@ query: |
   | where Category =~ "RoleManagement"
   | where OperationName in~ (OperationList)
   | mv-expand TargetResources
-  | extend modifiedProperties = parse_json(TargetResources).modifiedProperties
-  | mv-expand modifiedProperties
-  | extend DisplayName = tostring(parse_json(modifiedProperties).displayName), GroupName =  trim(@'"',tostring(parse_json(modifiedProperties).newValue))
-  | extend AppId = tostring(parse_json(parse_json(InitiatedBy).app).appId), InitiatedByDisplayName = case(InitiatedBy startswith "{\"user", tostring(parse_json(parse_json(InitiatedBy).user).displayName), InitiatedBy startswith "{\"app",tostring(parse_json(parse_json(InitiatedBy).app).displayName), "unknown"), ServicePrincipalId = tostring(parse_json(parse_json(InitiatedBy).app).servicePrincipalId), ServicePrincipalName = tostring(parse_json(parse_json(InitiatedBy).app).servicePrincipalName), UserId = tostring(parse_json(tostring(InitiatedBy.user)).id), UserIPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress), UserRoles = tostring(parse_json(tostring(parse_json(tostring(InitiatedBy.user)).roles))), UserPrincipalName = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-  | where DisplayName =~ "Role.WellKnownObjectName"
-  | where GroupName in~ (PrivilegedGroups)
+  | extend modProps = parse_json(TargetResources).modifiedProperties
+  | mv-expand bagexpansion=array modProps
+  | evaluate bag_unpack(modProps)
+  | where displayName =~ "Role.WellKnownObjectName"
+  | extend DisplayName = displayName, GroupName = replace('"','',newValue)
+  | extend initByApp = parse_json(InitiatedBy).app, initByUser = parse_json(InitiatedBy).user
+  | extend AppId = initByApp.appId, 
+  InitiatedByDisplayName = case(isnotempty(initByApp.displayName), initByApp.displayName, isnotempty(initByUser.displayName), initByUser.displayName, "not available"),
+  ServicePrincipalId = initByApp.servicePrincipalId,
+  ServicePrincipalName = initByApp.servicePrincipalName,
+  UserId = initByUser.id,
+  UserIPAddress = initByUser.ipAddress,
+  UserRoles = initByUser.roles,
+  UserPrincipalName = initByUser.userPrincipalName
+  //| where GroupName in~ (PrivilegedGroups)
   // If you want to still alert for operations from PIM, remove below filtering for MS-PIM.
-  | where InitiatedByDisplayName != "MS-PIM"
-  | project TimeGenerated, AADOperationType, Category, OperationName, AADTenantId, AppId, InitiatedByDisplayName, ServicePrincipalId, ServicePrincipalName, DisplayName, GroupName
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ServicePrincipalName
+  //| where InitiatedByDisplayName != "MS-PIM"
+  | project TimeGenerated, AADOperationType, Category, OperationName, AADTenantId, AppId, InitiatedByDisplayName, ServicePrincipalId, ServicePrincipalName, DisplayName, GroupName, UserId, UserIPAddress, UserRoles, UserPrincipalName
+  | extend timestamp = TimeGenerated, AccountCustomEntity = case(isnotempty(ServicePrincipalName), ServicePrincipalName, isnotempty(ServicePrincipalId), ServicePrincipalId, isnotempty(UserPrincipalName), UserPrincipalName, "not available")
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
+++ b/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
@@ -30,7 +30,7 @@ query: |
   | extend modifiedProperties = parse_json(TargetResources).modifiedProperties
   | mv-expand modifiedProperties
   | extend DisplayName = tostring(parse_json(modifiedProperties).displayName), GroupName =  trim(@'"',tostring(parse_json(modifiedProperties).newValue))
-  | extend AppId = tostring(parse_json(parse_json(InitiatedBy).app).appId), InitiatedByDisplayName = tostring(parse_json(parse_json(InitiatedBy).app).displayName), ServicePrincipalId = tostring(parse_json(parse_json(InitiatedBy).app).servicePrincipalId), ServicePrincipalName = tostring(parse_json(parse_json(InitiatedBy).app).servicePrincipalName)
+  | extend AppId = tostring(parse_json(parse_json(InitiatedBy).app).appId), InitiatedByDisplayName = case(InitiatedBy startswith "{\"user", tostring(parse_json(parse_json(InitiatedBy).user).displayName), InitiatedBy startswith "{\"app",tostring(parse_json(parse_json(InitiatedBy).app).displayName), "unknown"), ServicePrincipalId = tostring(parse_json(parse_json(InitiatedBy).app).servicePrincipalId), ServicePrincipalName = tostring(parse_json(parse_json(InitiatedBy).app).servicePrincipalName), UserId = tostring(parse_json(tostring(InitiatedBy.user)).id), UserIPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress), UserRoles = tostring(parse_json(tostring(parse_json(tostring(InitiatedBy.user)).roles))), UserPrincipalName = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
   | where DisplayName =~ "Role.WellKnownObjectName"
   | where GroupName in~ (PrivilegedGroups)
   // If you want to still alert for operations from PIM, remove below filtering for MS-PIM.


### PR DESCRIPTION
Added case for InitiatedbyDisplayName and extended values for if a user implemented the change (Looked pointless to use case for everything as the only other thing that might be the same is the principal name) The IPAddress as well as the display name isn't always populated, but I believe it is important for this rule.  

Fixes https://github.com/Azure/Azure-Sentinel/issues/1795

Please do not hesitate to correct my approach here.

## Proposed Changes

  -extended values for user
  -created case for InitiatedbyDisplayName
