### PR TITLE
Fixing a Typo for SysmonEvent13_RegistrySetValue function

### DIFF
--- a/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
@@ -170,7 +170,7 @@ ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], Target
 ;
 processEvents;
 };
-let SysmonEvent13__RegistrySetValue=() {
+let SysmonEvent13_RegistrySetValue=() {
 let processEvents = EventData
 | where EventID == 13
 | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],


### PR DESCRIPTION
Hello, there was a typo in let SysmonEvent13_RegistrySetValue function. In the original there was an extra underscore like this: SysmonEvent13__RegistrySetValue=() while the projected value was with only one underscore like this: SysmonEvent13_RegistrySetValue.

Fixes #

## Proposed Changes

  -
  -
  -
