### PR TITLE
fixed casing on SrcIpAddr extract - lower case left field empty

### DIFF
--- a/Solutions/Ubiquiti/Parsers/Ubiquiti.txt
+++ b/Solutions/Ubiquiti/Parsers/Ubiquiti.txt
@@ -42,7 +42,7 @@ EventData
 | extend NetworkRuleName = extract(@'kernel:\s+\[(\S+)-\w\]', 1, Message)
 | extend DstMacAddr = extract(@'MAC=([a-fA-F0-9:]{17}):', 1, Message)
 | extend SrcMacAddr = extract(@'MAC=[a-fA-F0-9:]{17}:([a-fA-F0-9:]{17})\s', 1, Message)
-| extend SrcIpAddr = extract(@'src=(.*?)\s', 1, Message)
+| extend SrcIpAddr = extract(@'SRC=(.*?)\s', 1, Message)
 | extend SrcPortNumber = extract(@'SPT=(.*?)\s', 1, Message)
 | extend DstIpAddr = extract(@'DST=(.*?)\s', 1, Message)
 | extend DstPortNumber = extract(@'DPT=(.*?)\s', 1, Message)


### PR DESCRIPTION
Fixes #

SrcIpAddr field is empty due to casing of regex - fixed by using uppercase

## Proposed Changes

  -
  -
  -
