### PR TITLE
Extending CERIUM and BARIUM MultipleDataSources to include Azure Firewall

### DIFF
--- a/Detections/MultipleDataSources/BariumDomainIOC112020.yaml
+++ b/Detections/MultipleDataSources/BariumDomainIOC112020.yaml
@@ -19,7 +19,10 @@ requiredDataConnectors:
       - CommonSecurityLog 
   - connectorId: MicrosoftThreatProtection
     dataTypes: 
-      - DeviceNetworkEvents 
+      - DeviceNetworkEvents
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics 
 queryFrequency: 1d 
 queryPeriod: 1d 
 triggerOperator: gt 
@@ -116,6 +119,23 @@ query:  |
   | where RemoteUrl  in~ (DomainNames)  
   | extend IPAddress = RemoteIP 
   | extend Computer = DeviceName 
+  ),
+  (AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallDnsProxy"
+  | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
+  | where Request_Name has_any (DomainNames)  
+  | extend DNSName = Request_Name
+  | extend IPAddress = ClientIP 
+  ),
+  (AzureDiagnostics 
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (DomainNames)  
+  | extend DNSName = DestinationHost 
+  | extend IPAddress = SourceHost
   ) 
   ) 
   | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPAddress 

--- a/Detections/MultipleDataSources/BariumIPIOC112020.yaml
+++ b/Detections/MultipleDataSources/BariumIPIOC112020.yaml
@@ -40,7 +40,10 @@ requiredDataConnectors:
       - AWSCloudTrail 
   - connectorId: MicrosoftThreatProtection
     dataTypes: 
-      - DeviceNetworkEvents 
+      - DeviceNetworkEvents
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics  
 queryFrequency: 1d 
 queryPeriod: 1d 
 triggerOperator: gt 
@@ -125,7 +128,27 @@ query:  |
   | where isnotempty(RemoteIP)  
   | where RemoteIP in (IPList)  
   | extend timestamp = TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName  
-  ) 
+  ),
+  (
+  AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallApplicationRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (IPList)  
+  | extend DestinationIP = DestinationHost 
+  | extend IPCustomEntity = SourceHost
+  ),
+  (
+  AzureDiagnostics
+  | where ResourceType == "AZUREFIREWALLS"
+  | where Category == "AzureFirewallNetworkRule"
+  | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
+  | where isnotempty(DestinationHost)
+  | where DestinationHost has_any (IPList)  
+  | extend DestinationIP = DestinationHost 
+  | extend IPCustomEntity = SourceHost
+  )
   ) 
 entityMappings:
   - entityType: Account

--- a/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
+++ b/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
@@ -17,6 +17,9 @@ requiredDataConnectors:
   - connectorId: PaloAltoNetworks
     dataTypes:
       - CommonSecurityLog
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt


### PR DESCRIPTION

Added AzureDiagnostics queries for Azure Firewall to the MultipleDataSources detections for: 1) CERIUMOct292020IOCs 2) BariumDomainIOC112020 3) BariumIPIOC112020

Fixes #

## Proposed Changes

  - Added AzureDiagnostics queries for Azure Firewall to all of the above 3 MultipleDataSources detections
  -
  -
