### PR TITLE
Update Sysmon parsing to correct syntax and projection errors

### DIFF
--- a/Parsers/Sysmon/Sysmon-AllVersions_Parser.txt
+++ b/Parsers/Sysmon/Sysmon-AllVersions_Parser.txt
@@ -6,16 +6,16 @@
 // If you want to print configuration schema definition of sysmon. Execute below command from command shell or powershell terminal
 // Sysmon.exe -s
 //
-// You can further customize config XML definition and install sysmon with it via below command. 
+// You can further customize config XML definition and install sysmon with it via below command.
 // Sample Sysmon config XML from Swift on Security's GitHub page : https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml
-// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l  
+// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l
 // -n : Log all network connections and -l: log loading of modules.
 //
 // Parser Notes:
 // This parser works against all versions unless original event manifest is changed
-// 
 //
-// Usage Instruction : 
+//
+// Usage Instruction :
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias (e.g. Sysmon_Normalized).
 // Function usually takes 10-15 minutes to activate. You can then use function alias from any other queries (e.g. Sysmon_Normalized | take 10).
 // Reference :
@@ -26,16 +26,130 @@ Event
 | where Source == "Microsoft-Windows-Sysmon"
 | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
 | extend EventData = parse_xml(EventData).DataItem.EventData.Data
-| mv-expand bagexpansion=array EventData
+| mv-expand bagexpansion = array EventData
 | evaluate bag_unpack(EventData)
-| extend Key=tostring(['@Name']), Value=['#text']
-| evaluate pivot(Key, any(Value), TimeGenerated, Source, EventLog, Computer, EventLevel, EventLevelName, EventID, UserName, RenderedDescription, MG, ManagementGroupName, Type, _ResourceId)
-| extend RuleName = column_ifexists("RuleName", ""), TechniqueId = column_ifexists("TechniqueId", ""),  TechniqueName = column_ifexists("TechniqueName", "")
+| extend
+    Key = tostring(['@Name']),
+    Value=['#text']
+| evaluate pivot(
+    Key,
+    any(Value),
+    TimeGenerated,
+    Source,
+    EventLog,
+    Computer,
+    EventLevel,
+    EventLevelName,
+    EventID,
+    UserName,
+    RenderedDescription,
+    MG,
+    ManagementGroupName,
+    Type,
+    _ResourceId
+    )
+| extend
+    CallTrace = column_ifexists("CallTrace", tostring("")),
+    Device = column_ifexists("Device", tostring("")),
+    GrantedAccess = column_ifexists("GrantedAccess", tostring("")),
+    NewThreadId = column_ifexists("NewThreadId", tolong("")),
+    PipeName = column_ifexists("PipeName", tostring("")),
+    PreviousCreationUtcTime = column_ifexists("PreviousCreationUtcTime", todatetime("")),
+    RuleName = column_ifexists("RuleName", tostring("")),
+    SourceProcessGuid = column_ifexists("SourceProcessGuid", tostring("")),
+    SourceProcessGUID = column_ifexists("SourceProcessGUID", tostring("")),
+    SourceProcessId = column_ifexists("SourceProcessId", tolong("")),
+    SourceThreadId = column_ifexists("SourceThreadId", tolong("")),
+    SourceImage = column_ifexists("SourceImage", tostring("")),
+    StartAddress = column_ifexists("StartAddress", tostring("")),
+    StartFunction = column_ifexists("StartFunction", tostring("")),
+    StartModule = column_ifexists("StartModule", tostring("")),
+    TargetImage = column_ifexists("TargetImage", tostring("")),
+    TargetProcessGuid = column_ifexists("TargetProcessGuid", tostring("")),
+    TargetProcessGUID = column_ifexists("TargetProcessGUID", tostring("")),
+    TargetProcessId = column_ifexists("TargetProcessId", tolong("")),
+    TechniqueId = column_ifexists("TechniqueId", tostring("")),
+    TechniqueName = column_ifexists("TechniqueName", tostring(""))
 | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project TimeGenerated, Source, EventLog, Computer, EventLevel, EventLevelName, EventID, UserName, RenderedDescription, MG, ManagementGroupName, Type, _ResourceId, 
-Archived, CallTrace, CommandLine, Company, CreationUtcTime, CurrentDirectory, Description, DestinationHostname, DestinationIp, DestinationIsIpv6, DestinationPort, DestinationPortName, 
-Details, Device, EventType, FileVersion, GrantedAccess, Hashes, Image, ImageLoaded, Initiated, IntegrityLevel, IsExecutable, LogonGuid, LogonId, NewThreadId, OriginalFileName, 
-ParentCommandLine, ParentImage, ParentProcessGuid, ParentProcessId, PipeName, PreviousCreationUtcTime, ProcessGuid, ProcessId, Product, Protocol, QueryName, QueryResults, QueryStatus,  
- RuleName, Signature, SignatureStatus, Signed, SourceHostname, SourceImage, SourceIp, SourceIsIpv6, SourcePort, SourcePortName, SourceProcessGuid, SourceProcessGUID, SourceProcessId, 
- SourceThreadId, StartAddress, StartFunction, StartModule, TargetFilename, TargetImage, TargetObject, TargetProcessGuid, TargetProcessGUID, TargetProcessId, TerminalSessionId, User, 
- UtcTime, TechniqueId, TechniqueName
+| project
+    _ResourceId,
+    Archived,
+    CallTrace,
+    CommandLine,
+    Company,
+    Computer,
+    CreationUtcTime,
+    CurrentDirectory,
+    Description,
+    DestinationHostname,
+    DestinationIp,
+    DestinationIsIpv6,
+    DestinationPort,
+    DestinationPortName,
+    Details,
+    Device,
+    EventID,
+    EventLevel,
+    EventLevelName,
+    EventLog,
+    EventType,
+    FileVersion,
+    GrantedAccess,
+    Hashes,
+    Image,
+    ImageLoaded,
+    Initiated,
+    IntegrityLevel,
+    IsExecutable,
+    LogonGuid,
+    LogonId,
+    ManagementGroupName,
+    MG,
+    NewThreadId,
+    OriginalFileName,
+    ParentCommandLine,
+    ParentImage,
+    ParentProcessGuid,
+    ParentProcessId,
+    PipeName,
+    PreviousCreationUtcTime,
+    ProcessGuid,
+    ProcessId,
+    Product,
+    Protocol,
+    QueryName,
+    QueryResults,
+    QueryStatus,
+    RenderedDescription,
+    RuleName,
+    Signature,
+    SignatureStatus,
+    Signed,
+    Source,
+    SourceHostname,
+    SourceImage,
+    SourceIp,
+    SourceIsIpv6,
+    SourcePort,
+    SourcePortName,
+    SourceProcessGuid,
+    SourceProcessGUID,
+    SourceProcessId,
+    SourceThreadId,
+    StartAddress,
+    StartFunction,
+    StartModule,
+    TargetFilename,
+    TargetImage,
+    TargetObject,
+    TargetProcessGuid,
+    TargetProcessGUID,
+    TargetProcessId,
+    TechniqueId,
+    TechniqueName,
+    TerminalSessionId,
+    TimeGenerated,
+    Type,
+    User,
+    UserName,
+    UtcTime

--- a/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
@@ -6,10 +6,10 @@
 // If you want to print configuration schema definition of sysmon. Execute below command from command shell or powershell terminal
 // Sysmon.exe -s
 //
-// You can further customize config XML definition and install sysmon with it via below command. 
+// You can further customize config XML definition and install sysmon with it via below command.
 // Sample Sysmon config XML from Swift on Security's GitHub page : https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml
 // To parse DNS Events with sysmon 10, use alpha version: https://github.com/SwiftOnSecurity/sysmon-config/blob/master/z-AlphaVersion.xml
-// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l  
+// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l
 // -n : Log all network connections and -l: log loading of modules.
 //
 // Parser Notes:
@@ -17,272 +17,513 @@
 // 2. technique_id and technique_name will only be parsed/available if deployed via above mentioned sample sysmon XML config.
 // 3. Make sure to use alpha version to parse DNS Events if you are using Sysmon v 10 or higher.
 //
-// Usage Instruction : 
+// Usage Instruction :
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias (e.g. Sysmon_Normalized).
 // Function usually takes 10-15 minutes to activate. You can then use function alias from any other queries (e.g. Sysmon_Normalized | take 10).
-// References : 
+// References :
 // Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 // Tech Community Blog on KQL Functions : https://techcommunity.microsoft.com/t5/Azure-Sentinel/Using-KQL-functions-to-speed-up-analysis-in-Azure-Sentinel/ba-p/712381
 //
 //
 let EventData = Event
-| where Source == "Microsoft-Windows-Sysmon"
-| extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
-| extend EvData = parse_xml(EventData)
-| extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData
-;
+    | where Source == "Microsoft-Windows-Sysmon"
+    | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
+    | project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+    | extend EvData = parse_xml(EventData)
+    | extend EventDetail = EvData.DataItem.EventData.Data
+    | project-away EventData, EvData;
 let SysmonEvent1_ProcessCreate=() {
-let processEvents = EventData
-| where EventID == 1
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-FileVersion = EventDetail.[5].["#text"], Description = EventDetail.[6].["#text"], Product = EventDetail.[7].["#text"], Company = EventDetail.[8].["#text"], OriginalFileName = EventDetail.[9].["#text"],
-CommandLine = EventDetail.[10].["#text"], CurrentDirectory = EventDetail.[11].["#text"], User = EventDetail.[12].["#text"], LogonGuid = EventDetail.[13].["#text"],
-LogonId = EventDetail.[14].["#text"], TerminalSessionId = EventDetail.[15].["#text"], IntegrityLevel = EventDetail.[16].["#text"], Hashes = EventDetail.[17].["#text"], 
-ParentProcessGuid = EventDetail.[18].["#text"], ParentProcessId = EventDetail.[19].["#text"], ParentImage = EventDetail.[20].["#text"], ParentCommandLine = EventDetail.[21].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 1
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            FileVersion = EventDetail.[5].["#text"],
+            Description = EventDetail.[6].["#text"],
+            Product = EventDetail.[7].["#text"],
+            Company = EventDetail.[8].["#text"],
+            OriginalFileName = EventDetail.[9].["#text"],
+            CommandLine = EventDetail.[10].["#text"],
+            CurrentDirectory = EventDetail.[11].["#text"],
+            User = EventDetail.[12].["#text"],
+            LogonGuid = EventDetail.[13].["#text"],
+            LogonId = EventDetail.[14].["#text"],
+            TerminalSessionId = EventDetail.[15].["#text"],
+            IntegrityLevel = EventDetail.[16].["#text"],
+            Hashes = EventDetail.[17].["#text"],
+            ParentProcessGuid = EventDetail.[18].["#text"],
+            ParentProcessId = EventDetail.[19].["#text"],
+            ParentImage = EventDetail.[20].["#text"],
+            ParentCommandLine = EventDetail.[21].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent2_FileCreateTime=() {
-let processEvents = EventData
-| where EventID == 2
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], PreviousCreationUtcTime = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 2
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent3_NetworkConnect=() {
-let processEvents = EventData
-| where EventID == 3
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-User = EventDetail.[5].["#text"], Protocol = EventDetail.[6].["#text"], Initiated = EventDetail.[7].["#text"], SourceIsIpv6 = EventDetail.[8].["#text"], SourceIp = EventDetail.[9].["#text"], 
-SourceHostname = EventDetail.[10].["#text"], SourcePort = EventDetail.[11].["#text"], SourcePortName = EventDetail.[12].["#text"], DestinationIsIpv6 = EventDetail.[13].["#text"], 
-DestinationIp = EventDetail.[14].["#text"], DestinationHostname = EventDetail.[15].["#text"], DestinationPort = EventDetail.[16].["#text"], DestinationPortName = EventDetail.[17].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 3
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            User = EventDetail.[5].["#text"],
+            Protocol = EventDetail.[6].["#text"],
+            Initiated = EventDetail.[7].["#text"],
+            SourceIsIpv6 = EventDetail.[8].["#text"],
+            SourceIp = EventDetail.[9].["#text"],
+            SourceHostname = EventDetail.[10].["#text"],
+            SourcePort = EventDetail.[11].["#text"],
+            SourcePortName = EventDetail.[12].["#text"],
+            DestinationIsIpv6 = EventDetail.[13].["#text"],
+            DestinationIp = EventDetail.[14].["#text"],
+            DestinationHostname = EventDetail.[15].["#text"],
+            DestinationPort = EventDetail.[16].["#text"],
+            DestinationPortName = EventDetail.[17].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent4_ServiceStateChange=() {
-let processEvents = EventData
-| where EventID == 4
-| extend UtcTime = EventDetail.[0].["#text"], State = EventDetail.[1].["#text"], Schema = EventDetail.[2].["#text"], SchemaVersion = EventDetail.[3].["#text"]
-| project-away EventDetail
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 4
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            State = EventDetail.[1].["#text"],
+            Schema = EventDetail.[2].["#text"],
+            SchemaVersion = EventDetail.[3].["#text"]
+        | project-away EventDetail;
+    processEvents;
 };
 let SysmonEvent5_ProcessTerminate=() {
-let processEvents = EventData
-| where EventID == 5
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 5
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent6_DriverLoad=() {
-let processEvents = EventData
-| where EventID == 6
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ImageLoaded = EventDetail.[2].["#text"], Hashes = EventDetail.[3].["#text"],
-Signed = EventDetail.[4].["#text"], Signature = EventDetail.[5].["#text"], SignatureStatus = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 6
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ImageLoaded = EventDetail.[2].["#text"],
+            Hashes = EventDetail.[3].["#text"],
+            Signed = EventDetail.[4].["#text"],
+            Signature = EventDetail.[5].["#text"],
+            SignatureStatus = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent7_ImageLoad=() {
-let processEvents = EventData
-| where EventID == 7
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], 
-ImageLoaded = EventDetail.[5].["#text"], FileVersion = EventDetail.[6].["#text"], Description = EventDetail.[7].["#text"], Product = EventDetail.[8].["#text"], Company = EventDetail.[9].["#text"], OriginalFileName = EventDetail.[10].["#text"], 
-Hashes = EventDetail.[11].["#text"], Signed = EventDetail.[12].["#text"], Signature = EventDetail.[13].["#text"], SignatureStatus = EventDetail.[14].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 7
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            ImageLoaded = EventDetail.[5].["#text"],
+            FileVersion = EventDetail.[6].["#text"],
+            Description = EventDetail.[7].["#text"],
+            Product = EventDetail.[8].["#text"],
+            Company = EventDetail.[9].["#text"],
+            OriginalFileName = EventDetail.[10].["#text"],
+            Hashes = EventDetail.[11].["#text"],
+            Signed = EventDetail.[12].["#text"],
+            Signature = EventDetail.[13].["#text"],
+            SignatureStatus = EventDetail.[14].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent8_CreateRemoteThread=() {
-let processEvents = EventData
-| where EventID == 8
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGuid = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"],
-SourceImage = EventDetail.[4].["#text"], TargetProcessGuid = EventDetail.[5].["#text"], TargetProcessId = EventDetail.[6].["#text"], TargetImage = EventDetail.[7].["#text"],
-NewThreadId = EventDetail.[8].["#text"], StartAddress = EventDetail.[9].["#text"], StartModule = EventDetail.[10].["#text"], StartFunction = EventDetail.[11].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 8
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGuid = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceImage = EventDetail.[4].["#text"],
+            TargetProcessGuid = EventDetail.[5].["#text"],
+            TargetProcessId = EventDetail.[6].["#text"],
+            TargetImage = EventDetail.[7].["#text"],
+            NewThreadId = EventDetail.[8].["#text"],
+            StartAddress = EventDetail.[9].["#text"],
+            StartModule = EventDetail.[10].["#text"],
+            StartFunction = EventDetail.[11].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent9_RawAccessRead=() {
-let processEvents = EventData
-| where EventID == 9
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Device = EventDetail.[5].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 9
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            Device = EventDetail.[5].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent10_ProcessAccess=() {
-let processEvents = EventData
-| where EventID == 10
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGUID = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], 
-SourceThreadId = EventDetail.[4].["#text"], SourceImage = EventDetail.[5].["#text"], TargetProcessGUID = EventDetail.[6].["#text"], TargetProcessId = EventDetail.[7].["#text"], 
-TargetImage = EventDetail.[8].["#text"], GrantedAccess = EventDetail.[9].["#text"], CallTrace = EventDetail.[10].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 10
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGUID = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceThreadId = EventDetail.[4].["#text"],
+            SourceImage = EventDetail.[5].["#text"],
+            TargetProcessGUID = EventDetail.[6].["#text"],
+            TargetProcessId = EventDetail.[7].["#text"],
+            TargetImage = EventDetail.[8].["#text"],
+            GrantedAccess = EventDetail.[9].["#text"],
+            CallTrace = EventDetail.[10].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent11_FileCreate=() {
-let processEvents = EventData
-| where EventID == 11
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 11
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent12_RegistryObjectAddDel=() {
-let processEvents = EventData
-| where EventID == 12
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 12
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent13__RegistrySetValue=() {
-let processEvents = EventData
-| where EventID == 13
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], Details = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 13
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            Details = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent14_RegistryObjectRename=() {
-let processEvents = EventData
-| where EventID == 14
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], NewName = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 14
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            NewName = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent15_FileCreateStreamHash=() {
-let processEvents = EventData
-| where EventID == 15
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-Image = EventDetail.[4].["#text"], TargetFileName = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], Hash = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 15
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFileName = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            Hash = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent16_ConfigChange=() {
-let processEvents = EventData
-| where EventID == 16
-| extend UtcTime = EventDetail.[0].["#text"], Configuration = EventDetail.[1].["#text"], ConfigurationFileHash = EventDetail.[2].["#text"]
-| project-away EventDetail
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 16
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            Configuration = EventDetail.[1].["#text"],
+            ConfigurationFileHash = EventDetail.[2].["#text"]
+        | project-away EventDetail;
+    processEvents;
 };
 let SysmonEvent17_CreateNamedPipe=() {
-let processEvents = EventData
-| where EventID == 17
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], 
-Image = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 17
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            PipeName = EventDetail.[5].["#text"],
+            Image = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent18_ConnectNamedPipe=() {
-let processEvents = EventData
-| where EventID == 18
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], 
-Image = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 18
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            PipeName = EventDetail.[5].["#text"],
+            Image = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent19_WMIEventFilter=() {
-let processEvents = EventData
-| where EventID == 19
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], EventNamespace = EventDetail.[5].["#text"], Name = EventDetail.[6].["#text"], Query = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 19
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            EventNamespace = EventDetail.[5].["#text"],
+            Name = EventDetail.[6].["#text"],
+            Query = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent20_WMIEventConsumer=() {
-let processEvents = EventData
-| where EventID == 20
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], Name = EventDetail.[5].["#text"], Type = EventDetail.[6].["#text"], Destination = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 20
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Name = EventDetail.[5].["#text"],
+            Type = EventDetail.[6].["#text"],
+            Destination = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent21_WMIEventConsumerToFilter=() {
-let processEvents = EventData
-| where EventID == 21
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], Consumer = EventDetail.[5].["#text"], Filter = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 21
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Consumer = EventDetail.[5].["#text"],
+            Filter = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent22_DNSEvents=() {
-let processEvents = EventData
-| where EventID == 22
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-QueryName = EventDetail.[4].["#text"], QueryStatus = EventDetail.[5].["#text"], QueryResults = EventDetail.[6].["#text"], Image = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 22
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            QueryName = EventDetail.[4].["#text"],
+            QueryStatus = EventDetail.[5].["#text"],
+            QueryResults = EventDetail.[6].["#text"],
+            Image = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
-(union isfuzzy=true
-SysmonEvent1_ProcessCreate, SysmonEvent2_FileCreateTime, SysmonEvent3_NetworkConnect, SysmonEvent4_ServiceStateChange, SysmonEvent5_ProcessTerminate, 
-SysmonEvent6_DriverLoad, SysmonEvent7_ImageLoad, SysmonEvent8_CreateRemoteThread, SysmonEvent9_RawAccessRead, SysmonEvent10_ProcessAccess, 
-SysmonEvent11_FileCreate, SysmonEvent12_RegistryObjectAddDel, SysmonEvent13_RegistrySetValue, SysmonEvent14_RegistryObjectRename, 
-SysmonEvent15_FileCreateStreamHash, SysmonEvent16_ConfigChange, SysmonEvent17_CreateNamedPipe, SysmonEvent18_ConnectNamedPipe, 
-SysmonEvent19_WMIEventFilter, SysmonEvent20_WMIEventConsumer, SysmonEvent21_WMIEventConsumerToFilter, SysmonEvent22_DNSEvents)
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
-| project TimeGenerated, Source, EventID, Computer, UserName, RenderedDescription, UtcTime, ProcessGuid, ProcessId, Image, FileVersion, OriginalFileName, 
-Description, Product, Company, CommandLine, CurrentDirectory, User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, ParentProcessGuid, 
-ParentProcessId, ParentImage, ParentCommandLine, TechniqueId, TechniqueName, ParsedHashes, State, Schema, SchemaVersion, ImageLoaded, 
-Hashes, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, 
-NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace, 
-TargetFilename, CreationUtcTime, EventType, TargetObject, NewName, TargetFileName, Hash, Configuration, ConfigurationFileHash, PipeName, Operation, 
-EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, 
-SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName, RuleName, PreviousCreationUtcTime, Details
+(
+    union isfuzzy=true
+        SysmonEvent1_ProcessCreate,
+        SysmonEvent2_FileCreateTime,
+        SysmonEvent3_NetworkConnect,
+        SysmonEvent4_ServiceStateChange,
+        SysmonEvent5_ProcessTerminate,
+        SysmonEvent6_DriverLoad,
+        SysmonEvent7_ImageLoad,
+        SysmonEvent8_CreateRemoteThread,
+        SysmonEvent9_RawAccessRead,
+        SysmonEvent10_ProcessAccess,
+        SysmonEvent11_FileCreate,
+        SysmonEvent12_RegistryObjectAddDel,
+        SysmonEvent13_RegistrySetValue,
+        SysmonEvent14_RegistryObjectRename,
+        SysmonEvent15_FileCreateStreamHash,
+        SysmonEvent16_ConfigChange,
+        SysmonEvent17_CreateNamedPipe,
+        SysmonEvent18_ConnectNamedPipe,
+        SysmonEvent19_WMIEventFilter,
+        SysmonEvent20_WMIEventConsumer,
+        SysmonEvent21_WMIEventConsumerToFilter,
+        SysmonEvent22_DNSEvents
+)
+| extend
+    Details = column_ifexists("Details", ""),
+    RuleName = column_ifexists("RuleName", ""),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
+| project
+    CallTrace,
+    CommandLine,
+    Company,
+    Computer,
+    Configuration,
+    ConfigurationFileHash,
+    Consumer,
+    CreationUtcTime,
+    CurrentDirectory,
+    Description,
+    Destination,
+    DestinationHostname,
+    DestinationIp,
+    DestinationIsIpv6,
+    DestinationPort,
+    DestinationPortName,
+    Details,
+    Device,
+    EventID,
+    EventNamespace,
+    EventType,
+    FileVersion,
+    Filter,
+    GrantedAccess,
+    Hash,
+    Hashes,
+    Image,
+    ImageLoaded,
+    Initiated,
+    IntegrityLevel,
+    LogonGuid,
+    LogonId,
+    Name,
+    NewName,
+    NewThreadId,
+    Operation,
+    OriginalFileName,
+    ParentCommandLine,
+    ParentImage,
+    ParentProcessGuid,
+    ParentProcessId,
+    ParsedHashes,
+    PipeName,
+    PreviousCreationUtcTime,
+    ProcessGuid,
+    ProcessId,
+    Product,
+    Protocol,
+    Query,
+    QueryName,
+    QueryResults,
+    QueryStatus,
+    RenderedDescription,
+    RuleName,
+    Schema,
+    SchemaVersion,
+    Signature,
+    SignatureStatus,
+    Signed,
+    Source,
+    SourceHostname,
+    SourceImage,
+    SourceIp,
+    SourceIsIpv6,
+    SourcePort,
+    SourcePortName,
+    SourceProcessGuid,
+    SourceProcessGUID,
+    SourceProcessId,
+    SourceThreadId,
+    StartAddress,
+    StartFunction,
+    StartModule,
+    State,
+    TargetFilename,
+    TargetFileName,
+    TargetImage,
+    TargetObject,
+    TargetProcessGuid,
+    TargetProcessGUID,
+    TargetProcessId,
+    TechniqueId,
+    TechniqueName,
+    TerminalSessionId,
+    TimeGenerated,
+    Type,
+    User,
+    UserName,
+    UtcTime

--- a/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
@@ -36,28 +36,28 @@ let SysmonEvent1_ProcessCreate=() {
     let processEvents = EventData
         | where EventID == 1
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            FileVersion = EventDetail.[5].["#text"],
-            Description = EventDetail.[6].["#text"],
-            Product = EventDetail.[7].["#text"],
-            Company = EventDetail.[8].["#text"],
-            OriginalFileName = EventDetail.[9].["#text"],
-            CommandLine = EventDetail.[10].["#text"],
-            CurrentDirectory = EventDetail.[11].["#text"],
-            User = EventDetail.[12].["#text"],
-            LogonGuid = EventDetail.[13].["#text"],
-            LogonId = EventDetail.[14].["#text"],
-            TerminalSessionId = EventDetail.[15].["#text"],
-            IntegrityLevel = EventDetail.[16].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            FileVersion = tostring(EventDetail.[5].["#text"]),
+            Description = tostring(EventDetail.[6].["#text"]),
+            Product = tostring(EventDetail.[7].["#text"]),
+            Company = tostring(EventDetail.[8].["#text"]),
+            OriginalFileName = tostring(EventDetail.[9].["#text"]),
+            CommandLine = tostring(EventDetail.[10].["#text"]),
+            CurrentDirectory = tostring(EventDetail.[11].["#text"]),
+            User = tostring(EventDetail.[12].["#text"]),
+            LogonGuid = tostring(EventDetail.[13].["#text"]),
+            LogonId = tolong(EventDetail.[14].["#text"]),
+            TerminalSessionId = tolong(EventDetail.[15].["#text"]),
+            IntegrityLevel = tostring(EventDetail.[16].["#text"]),
             Hashes = EventDetail.[17].["#text"],
-            ParentProcessGuid = EventDetail.[18].["#text"],
-            ParentProcessId = EventDetail.[19].["#text"],
-            ParentImage = EventDetail.[20].["#text"],
-            ParentCommandLine = EventDetail.[21].["#text"]
+            ParentProcessGuid = tostring(EventDetail.[18].["#text"]),
+            ParentProcessId = tolong(EventDetail.[19].["#text"]),
+            ParentImage = tostring(EventDetail.[20].["#text"]),
+            ParentCommandLine = tostring(EventDetail.[21].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -68,14 +68,14 @@ let SysmonEvent2_FileCreateTime=() {
     let processEvents = EventData
         | where EventID == 2
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -86,24 +86,24 @@ let SysmonEvent3_NetworkConnect=() {
     let processEvents = EventData
         | where EventID == 3
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            User = EventDetail.[5].["#text"],
-            Protocol = EventDetail.[6].["#text"],
-            Initiated = EventDetail.[7].["#text"],
-            SourceIsIpv6 = EventDetail.[8].["#text"],
-            SourceIp = EventDetail.[9].["#text"],
-            SourceHostname = EventDetail.[10].["#text"],
-            SourcePort = EventDetail.[11].["#text"],
-            SourcePortName = EventDetail.[12].["#text"],
-            DestinationIsIpv6 = EventDetail.[13].["#text"],
-            DestinationIp = EventDetail.[14].["#text"],
-            DestinationHostname = EventDetail.[15].["#text"],
-            DestinationPort = EventDetail.[16].["#text"],
-            DestinationPortName = EventDetail.[17].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            User = tostring(EventDetail.[5].["#text"]),
+            Protocol = tostring(EventDetail.[6].["#text"]),
+            Initiated = tostring(EventDetail.[7].["#text"]),
+            SourceIsIpv6 = tostring(EventDetail.[8].["#text"]),
+            SourceIp = tostring(EventDetail.[9].["#text"]),
+            SourceHostname = tostring(EventDetail.[10].["#text"]),
+            SourcePort = tolong(EventDetail.[11].["#text"]),
+            SourcePortName = tostring(EventDetail.[12].["#text"]),
+            DestinationIsIpv6 = tostring(EventDetail.[13].["#text"]),
+            DestinationIp = tostring(EventDetail.[14].["#text"]),
+            DestinationHostname = tostring(EventDetail.[15].["#text"]),
+            DestinationPort = tolong(EventDetail.[16].["#text"]),
+            DestinationPortName = tostring(EventDetail.[17].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -112,10 +112,10 @@ let SysmonEvent4_ServiceStateChange=() {
     let processEvents = EventData
         | where EventID == 4
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            State = EventDetail.[1].["#text"],
-            Schema = EventDetail.[2].["#text"],
-            SchemaVersion = EventDetail.[3].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            State = tostring(EventDetail.[1].["#text"]),
+            Schema = tostring(EventDetail.[2].["#text"]),
+            SchemaVersion = tostring(EventDetail.[3].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -123,11 +123,11 @@ let SysmonEvent5_ProcessTerminate=() {
     let processEvents = EventData
         | where EventID == 5
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -136,13 +136,13 @@ let SysmonEvent6_DriverLoad=() {
     let processEvents = EventData
         | where EventID == 6
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ImageLoaded = EventDetail.[2].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ImageLoaded = tostring(EventDetail.[2].["#text"]),
             Hashes = EventDetail.[3].["#text"],
-            Signed = EventDetail.[4].["#text"],
-            Signature = EventDetail.[5].["#text"],
-            SignatureStatus = EventDetail.[6].["#text"]
+            Signed = tostring(EventDetail.[4].["#text"]),
+            Signature = tostring(EventDetail.[5].["#text"]),
+            SignatureStatus = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -153,21 +153,21 @@ let SysmonEvent7_ImageLoad=() {
     let processEvents = EventData
         | where EventID == 7
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            ImageLoaded = EventDetail.[5].["#text"],
-            FileVersion = EventDetail.[6].["#text"],
-            Description = EventDetail.[7].["#text"],
-            Product = EventDetail.[8].["#text"],
-            Company = EventDetail.[9].["#text"],
-            OriginalFileName = EventDetail.[10].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            ImageLoaded = tostring(EventDetail.[5].["#text"]),
+            FileVersion = tostring(EventDetail.[6].["#text"]),
+            Description = tostring(EventDetail.[7].["#text"]),
+            Product = tostring(EventDetail.[8].["#text"]),
+            Company = tostring(EventDetail.[9].["#text"]),
+            OriginalFileName = tostring(EventDetail.[10].["#text"]),
             Hashes = EventDetail.[11].["#text"],
-            Signed = EventDetail.[12].["#text"],
-            Signature = EventDetail.[13].["#text"],
-            SignatureStatus = EventDetail.[14].["#text"]
+            Signed = tostring(EventDetail.[12].["#text"]),
+            Signature = tostring(EventDetail.[13].["#text"]),
+            SignatureStatus = tostring(EventDetail.[14].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -178,18 +178,18 @@ let SysmonEvent8_CreateRemoteThread=() {
     let processEvents = EventData
         | where EventID == 8
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGuid = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceImage = EventDetail.[4].["#text"],
-            TargetProcessGuid = EventDetail.[5].["#text"],
-            TargetProcessId = EventDetail.[6].["#text"],
-            TargetImage = EventDetail.[7].["#text"],
-            NewThreadId = EventDetail.[8].["#text"],
-            StartAddress = EventDetail.[9].["#text"],
-            StartModule = EventDetail.[10].["#text"],
-            StartFunction = EventDetail.[11].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGuid = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceImage = tostring(EventDetail.[4].["#text"]),
+            TargetProcessGuid = tostring(EventDetail.[5].["#text"]),
+            TargetProcessId = tolong(EventDetail.[6].["#text"]),
+            TargetImage = tostring(EventDetail.[7].["#text"]),
+            NewThreadId = tolong(EventDetail.[8].["#text"]),
+            StartAddress = tostring(EventDetail.[9].["#text"]),
+            StartModule = tostring(EventDetail.[10].["#text"]),
+            StartFunction = tostring(EventDetail.[11].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -198,12 +198,12 @@ let SysmonEvent9_RawAccessRead=() {
     let processEvents = EventData
         | where EventID == 9
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            Device = EventDetail.[5].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            Device = tostring(EventDetail.[5].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -212,17 +212,17 @@ let SysmonEvent10_ProcessAccess=() {
     let processEvents = EventData
         | where EventID == 10
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGUID = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceThreadId = EventDetail.[4].["#text"],
-            SourceImage = EventDetail.[5].["#text"],
-            TargetProcessGUID = EventDetail.[6].["#text"],
-            TargetProcessId = EventDetail.[7].["#text"],
-            TargetImage = EventDetail.[8].["#text"],
-            GrantedAccess = EventDetail.[9].["#text"],
-            CallTrace = EventDetail.[10].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGUID = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceThreadId = tolong(EventDetail.[4].["#text"]),
+            SourceImage = tostring(EventDetail.[5].["#text"]),
+            TargetProcessGUID = tostring(EventDetail.[6].["#text"]),
+            TargetProcessId = tolong(EventDetail.[7].["#text"]),
+            TargetImage = tostring(EventDetail.[8].["#text"]),
+            GrantedAccess = tostring(EventDetail.[9].["#text"]),
+            CallTrace = tostring(EventDetail.[10].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -231,13 +231,13 @@ let SysmonEvent11_FileCreate=() {
     let processEvents = EventData
         | where EventID == 11
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -246,13 +246,13 @@ let SysmonEvent12_RegistryObjectAddDel=() {
     let processEvents = EventData
         | where EventID == 12
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -261,14 +261,14 @@ let SysmonEvent13_RegistrySetValue=() {
     let processEvents = EventData
         | where EventID == 13
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            Details = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            Details = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -277,14 +277,14 @@ let SysmonEvent14_RegistryObjectRename=() {
     let processEvents = EventData
         | where EventID == 14
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            NewName = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            NewName = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -293,14 +293,14 @@ let SysmonEvent15_FileCreateStreamHash=() {
     let processEvents = EventData
         | where EventID == 15
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFileName = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            Hash = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFileName = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            Hash = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -309,9 +309,9 @@ let SysmonEvent16_ConfigChange=() {
     let processEvents = EventData
         | where EventID == 16
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            Configuration = EventDetail.[1].["#text"],
-            ConfigurationFileHash = EventDetail.[2].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            Configuration = tostring(EventDetail.[1].["#text"]),
+            ConfigurationFileHash = tostring(EventDetail.[2].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -319,13 +319,13 @@ let SysmonEvent17_CreateNamedPipe=() {
     let processEvents = EventData
         | where EventID == 17
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            PipeName = EventDetail.[5].["#text"],
-            Image = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            PipeName = tostring(EventDetail.[5].["#text"]),
+            Image = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -334,13 +334,13 @@ let SysmonEvent18_ConnectNamedPipe=() {
     let processEvents = EventData
         | where EventID == 18
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            PipeName = EventDetail.[5].["#text"],
-            Image = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            PipeName = tostring(EventDetail.[5].["#text"]),
+            Image = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -349,14 +349,14 @@ let SysmonEvent19_WMIEventFilter=() {
     let processEvents = EventData
         | where EventID == 19
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            EventNamespace = EventDetail.[5].["#text"],
-            Name = EventDetail.[6].["#text"],
-            Query = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            EventNamespace = tostring(EventDetail.[5].["#text"]),
+            Name = tostring(EventDetail.[6].["#text"]),
+            Query = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -365,14 +365,14 @@ let SysmonEvent20_WMIEventConsumer=() {
     let processEvents = EventData
         | where EventID == 20
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Name = EventDetail.[5].["#text"],
-            Type = EventDetail.[6].["#text"],
-            Destination = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Name = tostring(EventDetail.[5].["#text"]),
+            Type = tostring(EventDetail.[6].["#text"]),
+            Destination = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -381,13 +381,13 @@ let SysmonEvent21_WMIEventConsumerToFilter=() {
     let processEvents = EventData
         | where EventID == 21
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Consumer = EventDetail.[5].["#text"],
-            Filter = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Consumer = tostring(EventDetail.[5].["#text"]),
+            Filter = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -396,14 +396,14 @@ let SysmonEvent22_DNSEvents=() {
     let processEvents = EventData
         | where EventID == 22
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            QueryName = EventDetail.[4].["#text"],
-            QueryStatus = EventDetail.[5].["#text"],
-            QueryResults = EventDetail.[6].["#text"],
-            Image = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            QueryName = tostring(EventDetail.[4].["#text"]),
+            QueryStatus = tostring(EventDetail.[5].["#text"]),
+            QueryResults = tostring(EventDetail.[6].["#text"]),
+            Image = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -434,9 +434,30 @@ let SysmonEvent22_DNSEvents=() {
         SysmonEvent22_DNSEvents
 )
 | extend
-    Details = column_ifexists("Details", ""),
-    RuleName = column_ifexists("RuleName", ""),
-    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
+    CommandLine = column_ifexists("CommandLine", tostring("")),
+    Company = column_ifexists("Company", tostring("")),
+    CurrentDirectory = column_ifexists("CurrentDirectory", tostring("")),
+    Description = column_ifexists("Description", tostring("")),
+    Details = column_ifexists("Details", tostring("")),
+    FileVersion = column_ifexists("FileVersion", tostring("")),
+    Hashes = column_ifexists("Hashes", dynamic([])),
+    ImageLoaded = column_ifexists("ImageLoaded", tostring("")),
+    IntegrityLevel = column_ifexists("IntegrityLevel", tostring("")),
+    LogonGuid = column_ifexists("LogonGuid", tostring("")),
+    LogonId = column_ifexists("LogonId", tolong("")),
+    OriginalFileName = column_ifexists("OriginalFileName", tostring("")),
+    ParentCommandLine = column_ifexists("ParentCommandLine", tostring("")),
+    ParentImage = column_ifexists("ParentImage", tostring("")),
+    ParentProcessGuid = column_ifexists("ParentProcessGuid", tostring("")),
+    ParentProcessId = column_ifexists("ParentProcessId", tolong("")),
+    ParsedHashes = column_ifexists("ParsedHashes", dynamic({})),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", todatetime("")),
+    Product = column_ifexists("Product", tostring("")),
+    RuleName = column_ifexists("RuleName", tostring("")),
+    Signature = column_ifexists("Signature", tostring("")),
+    SignatureStatus = column_ifexists("SignatureStatus", tostring("")),
+    Signed = column_ifexists("Signed", tostring("")),
+    TerminalSessionId = column_ifexists("TerminalSessionId", tolong(""))
 | project
     CallTrace,
     CommandLine,

--- a/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
@@ -77,8 +77,6 @@ let SysmonEvent2_FileCreateTime=() {
             CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
             PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
-        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
 };

--- a/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
@@ -257,7 +257,7 @@ let SysmonEvent12_RegistryObjectAddDel=() {
         | project-away EventDetail, RuleName;
     processEvents;
 };
-let SysmonEvent13__RegistrySetValue=() {
+let SysmonEvent13_RegistrySetValue=() {
     let processEvents = EventData
         | where EventID == 13
         | extend

--- a/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v10.42-Parser.txt
@@ -59,7 +59,7 @@ let SysmonEvent1_ProcessCreate=() {
             ParentImage = tostring(EventDetail.[20].["#text"]),
             ParentCommandLine = tostring(EventDetail.[21].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -142,7 +142,7 @@ let SysmonEvent6_DriverLoad=() {
             Signature = tostring(EventDetail.[5].["#text"]),
             SignatureStatus = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -167,7 +167,7 @@ let SysmonEvent7_ImageLoad=() {
             Signature = tostring(EventDetail.[13].["#text"]),
             SignatureStatus = tostring(EventDetail.[14].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;

--- a/Parsers/Sysmon/Sysmon-v11.0.txt
+++ b/Parsers/Sysmon/Sysmon-v11.0.txt
@@ -6,10 +6,10 @@
 // If you want to print configuration schema definition of sysmon. Execute below command from command shell or powershell terminal
 // Sysmon.exe -s
 //
-// You can further customize config XML definition and install sysmon with it via below command. 
+// You can further customize config XML definition and install sysmon with it via below command.
 // Sample Sysmon config XML from Swift on Security's GitHub page : https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml
 // To parse DNS Events with sysmon 10, use alpha version: https://github.com/SwiftOnSecurity/sysmon-config/blob/master/z-AlphaVersion.xml
-// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l  
+// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l
 // -n : Log all network connections and -l: log loading of modules.
 //
 // Parser Notes:
@@ -17,286 +17,538 @@
 // 2. technique_id and technique_name will only be parsed/available if deployed via above mentioned sample sysmon XML config.
 // 3. Make sure to use alpha version to parse DNS Events if you are using Sysmon v 10 or higher.
 //
-// Usage Instruction : 
+// Usage Instruction :
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias (e.g. Sysmon_Normalized).
 // Function usually takes 10-15 minutes to activate. You can then use function alias from any other queries (e.g. Sysmon_Normalized | take 10).
-// References : 
+// References :
 // Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 // Tech Community Blog on KQL Functions : https://techcommunity.microsoft.com/t5/Azure-Sentinel/Using-KQL-functions-to-speed-up-analysis-in-Azure-Sentinel/ba-p/712381
 //
 //
 let EventData = Event
-| where Source == "Microsoft-Windows-Sysmon"
-| extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
-| extend EvData = parse_xml(EventData)
-| extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData
-;
+    | where Source == "Microsoft-Windows-Sysmon"
+    | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
+    | project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+    | extend EvData = parse_xml(EventData)
+    | extend EventDetail = EvData.DataItem.EventData.Data
+    | project-away EventData, EvData;
 let SysmonEvent1_ProcessCreate=() {
-let processEvents = EventData
-| where EventID == 1
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-FileVersion = EventDetail.[5].["#text"], Description = EventDetail.[6].["#text"], Product = EventDetail.[7].["#text"], Company = EventDetail.[8].["#text"], OriginalFileName = EventDetail.[9].["#text"],
-CommandLine = EventDetail.[10].["#text"], CurrentDirectory = EventDetail.[11].["#text"], User = EventDetail.[12].["#text"], LogonGuid = EventDetail.[13].["#text"],
-LogonId = EventDetail.[14].["#text"], TerminalSessionId = EventDetail.[15].["#text"], IntegrityLevel = EventDetail.[16].["#text"], Hashes = EventDetail.[17].["#text"], 
-ParentProcessGuid = EventDetail.[18].["#text"], ParentProcessId = EventDetail.[19].["#text"], ParentImage = EventDetail.[20].["#text"], ParentCommandLine = EventDetail.[21].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 1
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            FileVersion = EventDetail.[5].["#text"],
+            Description = EventDetail.[6].["#text"],
+            Product = EventDetail.[7].["#text"],
+            Company = EventDetail.[8].["#text"],
+            OriginalFileName = EventDetail.[9].["#text"],
+            CommandLine = EventDetail.[10].["#text"],
+            CurrentDirectory = EventDetail.[11].["#text"],
+            User = EventDetail.[12].["#text"],
+            LogonGuid = EventDetail.[13].["#text"],
+            LogonId = EventDetail.[14].["#text"],
+            TerminalSessionId = EventDetail.[15].["#text"],
+            IntegrityLevel = EventDetail.[16].["#text"],
+            Hashes = EventDetail.[17].["#text"],
+            ParentProcessGuid = EventDetail.[18].["#text"],
+            ParentProcessId = EventDetail.[19].["#text"],
+            ParentImage = EventDetail.[20].["#text"],
+            ParentCommandLine = EventDetail.[21].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent2_FileCreateTime=() {
-let processEvents = EventData
-| where EventID == 2
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], PreviousCreationUtcTime = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 2
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent3_NetworkConnect=() {
-let processEvents = EventData
-| where EventID == 3
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-User = EventDetail.[5].["#text"], Protocol = EventDetail.[6].["#text"], Initiated = EventDetail.[7].["#text"], SourceIsIpv6 = EventDetail.[8].["#text"], SourceIp = EventDetail.[9].["#text"], 
-SourceHostname = EventDetail.[10].["#text"], SourcePort = EventDetail.[11].["#text"], SourcePortName = EventDetail.[12].["#text"], DestinationIsIpv6 = EventDetail.[13].["#text"], 
-DestinationIp = EventDetail.[14].["#text"], DestinationHostname = EventDetail.[15].["#text"], DestinationPort = EventDetail.[16].["#text"], DestinationPortName = EventDetail.[17].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 3
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            User = EventDetail.[5].["#text"],
+            Protocol = EventDetail.[6].["#text"],
+            Initiated = EventDetail.[7].["#text"],
+            SourceIsIpv6 = EventDetail.[8].["#text"],
+            SourceIp = EventDetail.[9].["#text"],
+            SourceHostname = EventDetail.[10].["#text"],
+            SourcePort = EventDetail.[11].["#text"],
+            SourcePortName = EventDetail.[12].["#text"],
+            DestinationIsIpv6 = EventDetail.[13].["#text"],
+            DestinationIp = EventDetail.[14].["#text"],
+            DestinationHostname = EventDetail.[15].["#text"],
+            DestinationPort = EventDetail.[16].["#text"],
+            DestinationPortName = EventDetail.[17].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent4_ServiceStateChange=() {
-let processEvents = EventData
-| where EventID == 4
-| extend UtcTime = EventDetail.[0].["#text"], State = EventDetail.[1].["#text"], Schema = EventDetail.[2].["#text"], SchemaVersion = EventDetail.[3].["#text"]
-| project-away EventDetail
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 4
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            State = EventDetail.[1].["#text"],
+            Schema = EventDetail.[2].["#text"],
+            SchemaVersion = EventDetail.[3].["#text"]
+        | project-away EventDetail;
+    processEvents;
 };
 let SysmonEvent5_ProcessTerminate=() {
-let processEvents = EventData
-| where EventID == 5
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 5
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent6_DriverLoad=() {
-let processEvents = EventData
-| where EventID == 6
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ImageLoaded = EventDetail.[2].["#text"], Hashes = EventDetail.[3].["#text"],
-Signed = EventDetail.[4].["#text"], Signature = EventDetail.[5].["#text"], SignatureStatus = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 6
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ImageLoaded = EventDetail.[2].["#text"],
+            Hashes = EventDetail.[3].["#text"],
+            Signed = EventDetail.[4].["#text"],
+            Signature = EventDetail.[5].["#text"],
+            SignatureStatus = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent7_ImageLoad=() {
-let processEvents = EventData
-| where EventID == 7
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], 
-ImageLoaded = EventDetail.[5].["#text"], FileVersion = EventDetail.[6].["#text"], Description = EventDetail.[7].["#text"], Product = EventDetail.[8].["#text"], Company = EventDetail.[9].["#text"], OriginalFileName = EventDetail.[10].["#text"], 
-Hashes = EventDetail.[11].["#text"], Signed = EventDetail.[12].["#text"], Signature = EventDetail.[13].["#text"], SignatureStatus = EventDetail.[14].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 7
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            ImageLoaded = EventDetail.[5].["#text"],
+            FileVersion = EventDetail.[6].["#text"],
+            Description = EventDetail.[7].["#text"],
+            Product = EventDetail.[8].["#text"],
+            Company = EventDetail.[9].["#text"],
+            OriginalFileName = EventDetail.[10].["#text"],
+            Hashes = EventDetail.[11].["#text"],
+            Signed = EventDetail.[12].["#text"],
+            Signature = EventDetail.[13].["#text"],
+            SignatureStatus = EventDetail.[14].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent8_CreateRemoteThread=() {
-let processEvents = EventData
-| where EventID == 8
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGuid = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"],
-SourceImage = EventDetail.[4].["#text"], TargetProcessGuid = EventDetail.[5].["#text"], TargetProcessId = EventDetail.[6].["#text"], TargetImage = EventDetail.[7].["#text"],
-NewThreadId = EventDetail.[8].["#text"], StartAddress = EventDetail.[9].["#text"], StartModule = EventDetail.[10].["#text"], StartFunction = EventDetail.[11].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 8
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGuid = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceImage = EventDetail.[4].["#text"],
+            TargetProcessGuid = EventDetail.[5].["#text"],
+            TargetProcessId = EventDetail.[6].["#text"],
+            TargetImage = EventDetail.[7].["#text"],
+            NewThreadId = EventDetail.[8].["#text"],
+            StartAddress = EventDetail.[9].["#text"],
+            StartModule = EventDetail.[10].["#text"],
+            StartFunction = EventDetail.[11].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent9_RawAccessRead=() {
-let processEvents = EventData
-| where EventID == 9
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Device = EventDetail.[5].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 9
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            Device = EventDetail.[5].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent10_ProcessAccess=() {
-let processEvents = EventData
-| where EventID == 10
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGUID = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], 
-SourceThreadId = EventDetail.[4].["#text"], SourceImage = EventDetail.[5].["#text"], TargetProcessGUID = EventDetail.[6].["#text"], TargetProcessId = EventDetail.[7].["#text"], 
-TargetImage = EventDetail.[8].["#text"], GrantedAccess = EventDetail.[9].["#text"], CallTrace = EventDetail.[10].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 10
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGUID = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceThreadId = EventDetail.[4].["#text"],
+            SourceImage = EventDetail.[5].["#text"],
+            TargetProcessGUID = EventDetail.[6].["#text"],
+            TargetProcessId = EventDetail.[7].["#text"],
+            TargetImage = EventDetail.[8].["#text"],
+            GrantedAccess = EventDetail.[9].["#text"],
+            CallTrace = EventDetail.[10].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent11_FileCreate=() {
-let processEvents = EventData
-| where EventID == 11
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 11
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent12_RegistryObjectAddDel=() {
-let processEvents = EventData
-| where EventID == 12
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 12
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent13__RegistrySetValue=() {
-let processEvents = EventData
-| where EventID == 13
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], Details = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 13
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            Details = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent14_RegistryObjectRename=() {
-let processEvents = EventData
-| where EventID == 14
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], NewName = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 14
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            NewName = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent15_FileCreateStreamHash=() {
-let processEvents = EventData
-| where EventID == 15
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-Image = EventDetail.[4].["#text"], TargetFileName = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], Hash = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 15
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFileName = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            Hash = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent16_ConfigChange=() {
-let processEvents = EventData
-| where EventID == 16
-| extend UtcTime = EventDetail.[0].["#text"], Configuration = EventDetail.[1].["#text"], ConfigurationFileHash = EventDetail.[2].["#text"]
-| project-away EventDetail
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 16
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            Configuration = EventDetail.[1].["#text"],
+            ConfigurationFileHash = EventDetail.[2].["#text"]
+        | project-away EventDetail;
+    processEvents;
 };
 let SysmonEvent17_CreateNamedPipe=() {
-let processEvents = EventData
-| where EventID == 17
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], 
-Image = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 17
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            PipeName = EventDetail.[5].["#text"],
+            Image = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent18_ConnectNamedPipe=() {
-let processEvents = EventData
-| where EventID == 18
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], 
-Image = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 18
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            PipeName = EventDetail.[5].["#text"],
+            Image = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent19_WMIEventFilter=() {
-let processEvents = EventData
-| where EventID == 19
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], EventNamespace = EventDetail.[5].["#text"], Name = EventDetail.[6].["#text"], Query = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 19
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            EventNamespace = EventDetail.[5].["#text"],
+            Name = EventDetail.[6].["#text"],
+            Query = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent20_WMIEventConsumer=() {
-let processEvents = EventData
-| where EventID == 20
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], Name = EventDetail.[5].["#text"], Type = EventDetail.[6].["#text"], Destination = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 20
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Name = EventDetail.[5].["#text"],
+            Type = EventDetail.[6].["#text"],
+            Destination = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent21_WMIEventConsumerToFilter=() {
-let processEvents = EventData
-| where EventID == 21
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], Consumer = EventDetail.[5].["#text"], Filter = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 21
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Consumer = EventDetail.[5].["#text"],
+            Filter = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent22_DNSEvents=() {
-let processEvents = EventData
-| where EventID == 22
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-QueryName = EventDetail.[4].["#text"], QueryStatus = EventDetail.[5].["#text"], QueryResults = EventDetail.[6].["#text"], Image = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 22
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            QueryName = EventDetail.[4].["#text"],
+            QueryStatus = EventDetail.[5].["#text"],
+            QueryResults = EventDetail.[6].["#text"],
+            Image = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent23_FileDeleteEvents=() {
-let processEvents = EventData
-| where EventID == 23
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetFilename = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], IsExecutable = EventDetail.[8].["#text"], Archived = EventDetail.[9].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 23
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetFilename = EventDetail.[6].["#text"],
+            Hashes = EventDetail.[7].["#text"],
+            IsExecutable = EventDetail.[8].["#text"],
+            Archived = EventDetail.[9].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (
+            summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
+            )
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
-(union isfuzzy=true
-SysmonEvent1_ProcessCreate, SysmonEvent2_FileCreateTime, SysmonEvent3_NetworkConnect, SysmonEvent4_ServiceStateChange, SysmonEvent5_ProcessTerminate, 
-SysmonEvent6_DriverLoad, SysmonEvent7_ImageLoad, SysmonEvent8_CreateRemoteThread, SysmonEvent9_RawAccessRead, SysmonEvent10_ProcessAccess, 
-SysmonEvent11_FileCreate, SysmonEvent12_RegistryObjectAddDel, SysmonEvent13_RegistrySetValue, SysmonEvent14_RegistryObjectRename, 
-SysmonEvent15_FileCreateStreamHash, SysmonEvent16_ConfigChange, SysmonEvent17_CreateNamedPipe, SysmonEvent18_ConnectNamedPipe, 
-SysmonEvent19_WMIEventFilter, SysmonEvent20_WMIEventConsumer, SysmonEvent21_WMIEventConsumerToFilter, SysmonEvent22_DNSEvents, SysmonEvent23_FileDeleteEvents)
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
-| project TimeGenerated, Source, EventID, Computer, UserName, RenderedDescription, UtcTime, ProcessGuid, ProcessId, Image, FileVersion, OriginalFileName, 
-Description, Product, Company, CommandLine, CurrentDirectory, User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, ParentProcessGuid, 
-ParentProcessId, ParentImage, ParentCommandLine, TechniqueId, TechniqueName, ParsedHashes, State, Schema, SchemaVersion, ImageLoaded, 
-Hashes, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, 
-NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace, 
-TargetFilename, CreationUtcTime, EventType, TargetObject, NewName, TargetFileName, Hash, Configuration, ConfigurationFileHash, PipeName, Operation, 
-EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, Protocol, Initiated, SourceIsIpv6, SourceIp, 
-SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName, RuleName, IsExecutable, Archived, PreviousCreationUtcTime, Details
+(
+    union isfuzzy=true
+        SysmonEvent1_ProcessCreate,
+        SysmonEvent2_FileCreateTime,
+        SysmonEvent3_NetworkConnect,
+        SysmonEvent4_ServiceStateChange,
+        SysmonEvent5_ProcessTerminate,
+        SysmonEvent6_DriverLoad,
+        SysmonEvent7_ImageLoad,
+        SysmonEvent8_CreateRemoteThread,
+        SysmonEvent9_RawAccessRead,
+        SysmonEvent10_ProcessAccess,
+        SysmonEvent11_FileCreate,
+        SysmonEvent12_RegistryObjectAddDel,
+        SysmonEvent13_RegistrySetValue,
+        SysmonEvent14_RegistryObjectRename,
+        SysmonEvent15_FileCreateStreamHash,
+        SysmonEvent16_ConfigChange,
+        SysmonEvent17_CreateNamedPipe,
+        SysmonEvent18_ConnectNamedPipe,
+        SysmonEvent19_WMIEventFilter,
+        SysmonEvent20_WMIEventConsumer,
+        SysmonEvent21_WMIEventConsumerToFilter,
+        SysmonEvent22_DNSEvents,
+        SysmonEvent23_FileDeleteEvents
+)
+| extend
+    Details = column_ifexists("Details", ""),
+    RuleName = column_ifexists("RuleName", ""),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
+| project
+    Archived,
+    CallTrace,
+    CommandLine,
+    Company,
+    Computer,
+    Configuration,
+    ConfigurationFileHash,
+    Consumer,
+    CreationUtcTime,
+    CurrentDirectory,
+    Description,
+    Destination,
+    DestinationHostname,
+    DestinationIp,
+    DestinationIsIpv6,
+    DestinationPort,
+    DestinationPortName,
+    Details,
+    Device,
+    EventID,
+    EventNamespace,
+    EventType,
+    FileVersion,
+    Filter,
+    GrantedAccess,
+    Hash,
+    Hashes,
+    Image,
+    ImageLoaded,
+    Initiated,
+    IntegrityLevel,
+    IsExecutable,
+    LogonGuid,
+    LogonId,
+    Name,
+    NewName,
+    NewThreadId,
+    Operation,
+    OriginalFileName,
+    ParentCommandLine,
+    ParentImage,
+    ParentProcessGuid,
+    ParentProcessId,
+    ParsedHashes,
+    PipeName,
+    PreviousCreationUtcTime,
+    ProcessGuid,
+    ProcessId,
+    Product,
+    Protocol,
+    Query,
+    QueryName,
+    QueryResults,
+    QueryStatus,
+    RenderedDescription,
+    RuleName,
+    Schema,
+    SchemaVersion,
+    Signature,
+    SignatureStatus,
+    Signed,
+    Source,
+    SourceHostname,
+    SourceImage,
+    SourceIp,
+    SourceIsIpv6,
+    SourcePort,
+    SourcePortName,
+    SourceProcessGuid,
+    SourceProcessGUID,
+    SourceProcessId,
+    SourceThreadId,
+    StartAddress,
+    StartFunction,
+    StartModule,
+    State,
+    TargetFilename,
+    TargetFileName,
+    TargetImage,
+    TargetObject,
+    TargetProcessGuid,
+    TargetProcessGUID,
+    TargetProcessId,
+    TechniqueId,
+    TechniqueName,
+    TerminalSessionId,
+    TimeGenerated,
+    Type,
+    User,
+    UserName,
+    UtcTime

--- a/Parsers/Sysmon/Sysmon-v11.0.txt
+++ b/Parsers/Sysmon/Sysmon-v11.0.txt
@@ -77,8 +77,6 @@ let SysmonEvent2_FileCreateTime=() {
             CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
             PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
-        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
 };

--- a/Parsers/Sysmon/Sysmon-v11.0.txt
+++ b/Parsers/Sysmon/Sysmon-v11.0.txt
@@ -257,7 +257,7 @@ let SysmonEvent12_RegistryObjectAddDel=() {
         | project-away EventDetail, RuleName;
     processEvents;
 };
-let SysmonEvent13__RegistrySetValue=() {
+let SysmonEvent13_RegistrySetValue=() {
     let processEvents = EventData
         | where EventID == 13
         | extend

--- a/Parsers/Sysmon/Sysmon-v11.0.txt
+++ b/Parsers/Sysmon/Sysmon-v11.0.txt
@@ -36,28 +36,28 @@ let SysmonEvent1_ProcessCreate=() {
     let processEvents = EventData
         | where EventID == 1
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            FileVersion = EventDetail.[5].["#text"],
-            Description = EventDetail.[6].["#text"],
-            Product = EventDetail.[7].["#text"],
-            Company = EventDetail.[8].["#text"],
-            OriginalFileName = EventDetail.[9].["#text"],
-            CommandLine = EventDetail.[10].["#text"],
-            CurrentDirectory = EventDetail.[11].["#text"],
-            User = EventDetail.[12].["#text"],
-            LogonGuid = EventDetail.[13].["#text"],
-            LogonId = EventDetail.[14].["#text"],
-            TerminalSessionId = EventDetail.[15].["#text"],
-            IntegrityLevel = EventDetail.[16].["#text"],
-            Hashes = EventDetail.[17].["#text"],
-            ParentProcessGuid = EventDetail.[18].["#text"],
-            ParentProcessId = EventDetail.[19].["#text"],
-            ParentImage = EventDetail.[20].["#text"],
-            ParentCommandLine = EventDetail.[21].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            FileVersion = tostring(EventDetail.[5].["#text"]),
+            Description = tostring(EventDetail.[6].["#text"]),
+            Product = tostring(EventDetail.[7].["#text"]),
+            Company = tostring(EventDetail.[8].["#text"]),
+            OriginalFileName = tostring(EventDetail.[9].["#text"]),
+            CommandLine = tostring(EventDetail.[10].["#text"]),
+            CurrentDirectory = tostring(EventDetail.[11].["#text"]),
+            User = tostring(EventDetail.[12].["#text"]),
+            LogonGuid = tostring(EventDetail.[13].["#text"]),
+            LogonId = tostring(EventDetail.[14].["#text"]),
+            TerminalSessionId = tostring(EventDetail.[15].["#text"]),
+            IntegrityLevel = tostring(EventDetail.[16].["#text"]),
+            Hashes = tostring(EventDetail.[17].["#text"]),
+            ParentProcessGuid = tostring(EventDetail.[18].["#text"]),
+            ParentProcessId = tolong(EventDetail.[19].["#text"]),
+            ParentImage = tostring(EventDetail.[20].["#text"]),
+            ParentCommandLine = tostring(EventDetail.[21].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -68,14 +68,14 @@ let SysmonEvent2_FileCreateTime=() {
     let processEvents = EventData
         | where EventID == 2
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -86,24 +86,24 @@ let SysmonEvent3_NetworkConnect=() {
     let processEvents = EventData
         | where EventID == 3
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            User = EventDetail.[5].["#text"],
-            Protocol = EventDetail.[6].["#text"],
-            Initiated = EventDetail.[7].["#text"],
-            SourceIsIpv6 = EventDetail.[8].["#text"],
-            SourceIp = EventDetail.[9].["#text"],
-            SourceHostname = EventDetail.[10].["#text"],
-            SourcePort = EventDetail.[11].["#text"],
-            SourcePortName = EventDetail.[12].["#text"],
-            DestinationIsIpv6 = EventDetail.[13].["#text"],
-            DestinationIp = EventDetail.[14].["#text"],
-            DestinationHostname = EventDetail.[15].["#text"],
-            DestinationPort = EventDetail.[16].["#text"],
-            DestinationPortName = EventDetail.[17].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            User = tostring(EventDetail.[5].["#text"]),
+            Protocol = tostring(EventDetail.[6].["#text"]),
+            Initiated = tostring(EventDetail.[7].["#text"]),
+            SourceIsIpv6 = tostring(EventDetail.[8].["#text"]),
+            SourceIp = tostring(EventDetail.[9].["#text"]),
+            SourceHostname = tostring(EventDetail.[10].["#text"]),
+            SourcePort = tolong(EventDetail.[11].["#text"]),
+            SourcePortName = tostring(EventDetail.[12].["#text"]),
+            DestinationIsIpv6 = tostring(EventDetail.[13].["#text"]),
+            DestinationIp = tostring(EventDetail.[14].["#text"]),
+            DestinationHostname = tostring(EventDetail.[15].["#text"]),
+            DestinationPort = tolong(EventDetail.[16].["#text"]),
+            DestinationPortName = tostring(EventDetail.[17].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -112,10 +112,10 @@ let SysmonEvent4_ServiceStateChange=() {
     let processEvents = EventData
         | where EventID == 4
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            State = EventDetail.[1].["#text"],
-            Schema = EventDetail.[2].["#text"],
-            SchemaVersion = EventDetail.[3].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            State = tostring(EventDetail.[1].["#text"]),
+            Schema = tostring(EventDetail.[2].["#text"]),
+            SchemaVersion = tostring(EventDetail.[3].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -123,11 +123,11 @@ let SysmonEvent5_ProcessTerminate=() {
     let processEvents = EventData
         | where EventID == 5
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -136,13 +136,13 @@ let SysmonEvent6_DriverLoad=() {
     let processEvents = EventData
         | where EventID == 6
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ImageLoaded = EventDetail.[2].["#text"],
-            Hashes = EventDetail.[3].["#text"],
-            Signed = EventDetail.[4].["#text"],
-            Signature = EventDetail.[5].["#text"],
-            SignatureStatus = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ImageLoaded = tostring(EventDetail.[2].["#text"]),
+            Hashes = tostring(EventDetail.[3].["#text"]),
+            Signed = tostring(EventDetail.[4].["#text"]),
+            Signature = tostring(EventDetail.[5].["#text"]),
+            SignatureStatus = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -153,21 +153,21 @@ let SysmonEvent7_ImageLoad=() {
     let processEvents = EventData
         | where EventID == 7
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            ImageLoaded = EventDetail.[5].["#text"],
-            FileVersion = EventDetail.[6].["#text"],
-            Description = EventDetail.[7].["#text"],
-            Product = EventDetail.[8].["#text"],
-            Company = EventDetail.[9].["#text"],
-            OriginalFileName = EventDetail.[10].["#text"],
-            Hashes = EventDetail.[11].["#text"],
-            Signed = EventDetail.[12].["#text"],
-            Signature = EventDetail.[13].["#text"],
-            SignatureStatus = EventDetail.[14].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            ImageLoaded = tostring(EventDetail.[5].["#text"]),
+            FileVersion = tostring(EventDetail.[6].["#text"]),
+            Description = tostring(EventDetail.[7].["#text"]),
+            Product = tostring(EventDetail.[8].["#text"]),
+            Company = tostring(EventDetail.[9].["#text"]),
+            OriginalFileName = tostring(EventDetail.[10].["#text"]),
+            Hashes = tostring(EventDetail.[11].["#text"]),
+            Signed = tostring(EventDetail.[12].["#text"]),
+            Signature = tostring(EventDetail.[13].["#text"]),
+            SignatureStatus = tostring(EventDetail.[14].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -178,18 +178,18 @@ let SysmonEvent8_CreateRemoteThread=() {
     let processEvents = EventData
         | where EventID == 8
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGuid = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceImage = EventDetail.[4].["#text"],
-            TargetProcessGuid = EventDetail.[5].["#text"],
-            TargetProcessId = EventDetail.[6].["#text"],
-            TargetImage = EventDetail.[7].["#text"],
-            NewThreadId = EventDetail.[8].["#text"],
-            StartAddress = EventDetail.[9].["#text"],
-            StartModule = EventDetail.[10].["#text"],
-            StartFunction = EventDetail.[11].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGuid = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceImage = tostring(EventDetail.[4].["#text"]),
+            TargetProcessGuid = tostring(EventDetail.[5].["#text"]),
+            TargetProcessId = tolong(EventDetail.[6].["#text"]),
+            TargetImage = tostring(EventDetail.[7].["#text"]),
+            NewThreadId = tolong(EventDetail.[8].["#text"]),
+            StartAddress = tostring(EventDetail.[9].["#text"]),
+            StartModule = tostring(EventDetail.[10].["#text"]),
+            StartFunction = tostring(EventDetail.[11].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -198,12 +198,12 @@ let SysmonEvent9_RawAccessRead=() {
     let processEvents = EventData
         | where EventID == 9
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            Device = EventDetail.[5].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            Device = tostring(EventDetail.[5].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -212,17 +212,17 @@ let SysmonEvent10_ProcessAccess=() {
     let processEvents = EventData
         | where EventID == 10
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGUID = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceThreadId = EventDetail.[4].["#text"],
-            SourceImage = EventDetail.[5].["#text"],
-            TargetProcessGUID = EventDetail.[6].["#text"],
-            TargetProcessId = EventDetail.[7].["#text"],
-            TargetImage = EventDetail.[8].["#text"],
-            GrantedAccess = EventDetail.[9].["#text"],
-            CallTrace = EventDetail.[10].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGUID = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceThreadId = tolong(EventDetail.[4].["#text"]),
+            SourceImage = tostring(EventDetail.[5].["#text"]),
+            TargetProcessGUID = tostring(EventDetail.[6].["#text"]),
+            TargetProcessId = tolong(EventDetail.[7].["#text"]),
+            TargetImage = tostring(EventDetail.[8].["#text"]),
+            GrantedAccess = tostring(EventDetail.[9].["#text"]),
+            CallTrace = tostring(EventDetail.[10].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -231,13 +231,13 @@ let SysmonEvent11_FileCreate=() {
     let processEvents = EventData
         | where EventID == 11
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -246,13 +246,13 @@ let SysmonEvent12_RegistryObjectAddDel=() {
     let processEvents = EventData
         | where EventID == 12
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -261,14 +261,14 @@ let SysmonEvent13_RegistrySetValue=() {
     let processEvents = EventData
         | where EventID == 13
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            Details = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            Details = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -277,14 +277,14 @@ let SysmonEvent14_RegistryObjectRename=() {
     let processEvents = EventData
         | where EventID == 14
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            NewName = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            NewName = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -293,14 +293,14 @@ let SysmonEvent15_FileCreateStreamHash=() {
     let processEvents = EventData
         | where EventID == 15
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFileName = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            Hash = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFileName = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            Hash = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -309,9 +309,9 @@ let SysmonEvent16_ConfigChange=() {
     let processEvents = EventData
         | where EventID == 16
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            Configuration = EventDetail.[1].["#text"],
-            ConfigurationFileHash = EventDetail.[2].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            Configuration = tostring(EventDetail.[1].["#text"]),
+            ConfigurationFileHash = tostring(EventDetail.[2].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -319,13 +319,13 @@ let SysmonEvent17_CreateNamedPipe=() {
     let processEvents = EventData
         | where EventID == 17
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            PipeName = EventDetail.[5].["#text"],
-            Image = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            PipeName = tostring(EventDetail.[5].["#text"]),
+            Image = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -334,13 +334,13 @@ let SysmonEvent18_ConnectNamedPipe=() {
     let processEvents = EventData
         | where EventID == 18
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            PipeName = EventDetail.[5].["#text"],
-            Image = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            PipeName = tostring(EventDetail.[5].["#text"]),
+            Image = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -349,14 +349,14 @@ let SysmonEvent19_WMIEventFilter=() {
     let processEvents = EventData
         | where EventID == 19
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            EventNamespace = EventDetail.[5].["#text"],
-            Name = EventDetail.[6].["#text"],
-            Query = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            EventNamespace = tostring(EventDetail.[5].["#text"]),
+            Name = tostring(EventDetail.[6].["#text"]),
+            Query = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -365,14 +365,14 @@ let SysmonEvent20_WMIEventConsumer=() {
     let processEvents = EventData
         | where EventID == 20
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Name = EventDetail.[5].["#text"],
-            Type = EventDetail.[6].["#text"],
-            Destination = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Name = tostring(EventDetail.[5].["#text"]),
+            Type = tostring(EventDetail.[6].["#text"]),
+            Destination = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -381,13 +381,13 @@ let SysmonEvent21_WMIEventConsumerToFilter=() {
     let processEvents = EventData
         | where EventID == 21
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Consumer = EventDetail.[5].["#text"],
-            Filter = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Consumer = tostring(EventDetail.[5].["#text"]),
+            Filter = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -396,14 +396,14 @@ let SysmonEvent22_DNSEvents=() {
     let processEvents = EventData
         | where EventID == 22
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            QueryName = EventDetail.[4].["#text"],
-            QueryStatus = EventDetail.[5].["#text"],
-            QueryResults = EventDetail.[6].["#text"],
-            Image = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            QueryName = tostring(EventDetail.[4].["#text"]),
+            QueryStatus = tostring(EventDetail.[5].["#text"]),
+            QueryResults = tostring(EventDetail.[6].["#text"]),
+            Image = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -412,21 +412,19 @@ let SysmonEvent23_FileDeleteEvents=() {
     let processEvents = EventData
         | where EventID == 23
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetFilename = EventDetail.[6].["#text"],
-            Hashes = EventDetail.[7].["#text"],
-            IsExecutable = EventDetail.[8].["#text"],
-            Archived = EventDetail.[9].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetFilename = tostring(EventDetail.[6].["#text"]),
+            Hashes = tostring(EventDetail.[7].["#text"]),
+            IsExecutable = tostring(EventDetail.[8].["#text"]),
+            Archived = tostring(EventDetail.[9].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
-        | mv-apply Hashes on (
-            summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-            )
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
 };

--- a/Parsers/Sysmon/Sysmon-v11.0.txt
+++ b/Parsers/Sysmon/Sysmon-v11.0.txt
@@ -50,10 +50,10 @@ let SysmonEvent1_ProcessCreate=() {
             CurrentDirectory = tostring(EventDetail.[11].["#text"]),
             User = tostring(EventDetail.[12].["#text"]),
             LogonGuid = tostring(EventDetail.[13].["#text"]),
-            LogonId = tostring(EventDetail.[14].["#text"]),
-            TerminalSessionId = tostring(EventDetail.[15].["#text"]),
+            LogonId = tolong(EventDetail.[14].["#text"]),
+            TerminalSessionId = tolong(EventDetail.[15].["#text"]),
             IntegrityLevel = tostring(EventDetail.[16].["#text"]),
-            Hashes = tostring(EventDetail.[17].["#text"]),
+            Hashes = EventDetail.[17].["#text"],
             ParentProcessGuid = tostring(EventDetail.[18].["#text"]),
             ParentProcessId = tolong(EventDetail.[19].["#text"]),
             ParentImage = tostring(EventDetail.[20].["#text"]),
@@ -139,7 +139,7 @@ let SysmonEvent6_DriverLoad=() {
             RuleName = tostring(EventDetail.[0].["#text"]),
             UtcTime = todatetime(EventDetail.[1].["#text"]),
             ImageLoaded = tostring(EventDetail.[2].["#text"]),
-            Hashes = tostring(EventDetail.[3].["#text"]),
+            Hashes = EventDetail.[3].["#text"],
             Signed = tostring(EventDetail.[4].["#text"]),
             Signature = tostring(EventDetail.[5].["#text"]),
             SignatureStatus = tostring(EventDetail.[6].["#text"])
@@ -164,7 +164,7 @@ let SysmonEvent7_ImageLoad=() {
             Product = tostring(EventDetail.[8].["#text"]),
             Company = tostring(EventDetail.[9].["#text"]),
             OriginalFileName = tostring(EventDetail.[10].["#text"]),
-            Hashes = tostring(EventDetail.[11].["#text"]),
+            Hashes = EventDetail.[11].["#text"],
             Signed = tostring(EventDetail.[12].["#text"]),
             Signature = tostring(EventDetail.[13].["#text"]),
             SignatureStatus = tostring(EventDetail.[14].["#text"])
@@ -419,8 +419,8 @@ let SysmonEvent23_FileDeleteEvents=() {
             User = tostring(EventDetail.[4].["#text"]),
             Image = tostring(EventDetail.[5].["#text"]),
             TargetFilename = tostring(EventDetail.[6].["#text"]),
-            Hashes = tostring(EventDetail.[7].["#text"]),
-            IsExecutable = tostring(EventDetail.[8].["#text"]),
+            Hashes = EventDetail.[7].["#text"],
+            IsExecutable = tobool(EventDetail.[8].["#text"]),
             Archived = tostring(EventDetail.[9].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
@@ -455,9 +455,32 @@ let SysmonEvent23_FileDeleteEvents=() {
         SysmonEvent23_FileDeleteEvents
 )
 | extend
-    Details = column_ifexists("Details", ""),
-    RuleName = column_ifexists("RuleName", ""),
-    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
+    Archived = column_ifexists("Archived", tostring("")),
+    CommandLine = column_ifexists("CommandLine", tostring("")),
+    Company = column_ifexists("Company", tostring("")),
+    CurrentDirectory = column_ifexists("CurrentDirectory", tostring("")),
+    Description = column_ifexists("Description", tostring("")),
+    Details = column_ifexists("Details", tostring("")),
+    FileVersion = column_ifexists("FileVersion", tostring("")),
+    Hashes = column_ifexists("Hashes", dynamic([])),
+    ImageLoaded = column_ifexists("ImageLoaded", tostring("")),
+    IntegrityLevel = column_ifexists("IntegrityLevel", tostring("")),
+    IsExecutable = column_ifexists("IsExecutable", tobool("")),
+    LogonGuid = column_ifexists("LogonGuid", tostring("")),
+    LogonId = column_ifexists("LogonId", tolong("")),
+    OriginalFileName = column_ifexists("OriginalFileName", tostring("")),
+    ParentCommandLine = column_ifexists("ParentCommandLine", tostring("")),
+    ParentImage = column_ifexists("ParentImage", tostring("")),
+    ParentProcessGuid = column_ifexists("ParentProcessGuid", tostring("")),
+    ParentProcessId = column_ifexists("ParentProcessId", tolong("")),
+    ParsedHashes = column_ifexists("ParsedHashes", dynamic({})),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", todatetime("")),
+    Product = column_ifexists("Product", tostring("")),
+    RuleName = column_ifexists("RuleName", tostring("")),
+    Signature = column_ifexists("Signature", tostring("")),
+    SignatureStatus = column_ifexists("SignatureStatus", tostring("")),
+    Signed = column_ifexists("Signed", tostring("")),
+    TerminalSessionId = column_ifexists("TerminalSessionId", tolong(""))
 | project
     Archived,
     CallTrace,

--- a/Parsers/Sysmon/Sysmon-v11.0.txt
+++ b/Parsers/Sysmon/Sysmon-v11.0.txt
@@ -59,7 +59,7 @@ let SysmonEvent1_ProcessCreate=() {
             ParentImage = tostring(EventDetail.[20].["#text"]),
             ParentCommandLine = tostring(EventDetail.[21].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -142,7 +142,7 @@ let SysmonEvent6_DriverLoad=() {
             Signature = tostring(EventDetail.[5].["#text"]),
             SignatureStatus = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -167,7 +167,7 @@ let SysmonEvent7_ImageLoad=() {
             Signature = tostring(EventDetail.[13].["#text"]),
             SignatureStatus = tostring(EventDetail.[14].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -421,7 +421,7 @@ let SysmonEvent23_FileDeleteEvents=() {
             IsExecutable = tobool(EventDetail.[8].["#text"]),
             Archived = tostring(EventDetail.[9].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;

--- a/Parsers/Sysmon/Sysmon-v12.0.txt
+++ b/Parsers/Sysmon/Sysmon-v12.0.txt
@@ -6,320 +6,552 @@
 // If you want to print configuration schema definition of sysmon. Execute below command from command shell or powershell terminal
 // Sysmon.exe -s
 //
-// You can further customize config XML definition and install sysmon with it via below command. 
+// You can further customize config XML definition and install sysmon with it via below command.
 // Sample Sysmon config XML from Swift on Security's GitHub page : https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml
 // To parse DNS Events with sysmon 10, use alpha version: https://github.com/SwiftOnSecurity/sysmon-config/blob/master/z-AlphaVersion.xml
-// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l  
+// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l
 // -n : Log all network connections and -l: log loading of modules.
 //
 // Parser Notes:
 // This parser was auto-generated based on Sysmon XML config file via tool - ossemSysmonKQLParser.py
 // Reference: https://github.com/OTRF/OSSEM/blob/master/resources/tools/ossemSysmonKQLParser.py
-// 
 //
-// Usage Instruction : 
+//
+// Usage Instruction :
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias (e.g. Sysmon_Normalized).
 // Function usually takes 10-15 minutes to activate. You can then use function alias from any other queries (e.g. Sysmon_Normalized | take 10).
-// References : 
+// References :
 // Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 // Tech Community Blog on KQL Functions : https://techcommunity.microsoft.com/t5/Azure-Sentinel/Using-KQL-functions-to-speed-up-analysis-in-Azure-Sentinel/ba-p/712381
 //
 //
 let EventData = Event
-| where Source == "Microsoft-Windows-Sysmon"
-| extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
-| extend EvData = parse_xml(EventData)
-| extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData  ;
-let SYSMON_ERROR_255=()
-{
+    | where Source == "Microsoft-Windows-Sysmon"
+    | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
+    | project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+    | extend EvData = parse_xml(EventData)
+    | extend EventDetail = EvData.DataItem.EventData.Data
+    | project-away EventData, EvData;
+let SYSMON_ERROR_255=() {
     let processEvents = EventData
-    | where EventID == 255
-    | extend UtcTime = EventDetail.[0].["#text"], ID = EventDetail.[1].["#text"], Description = EventDetail.[2].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 255
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            ID = EventDetail.[1].["#text"],
+            Description = EventDetail.[2].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_CREATE_PROCESS_1=()
-{
+let SYSMON_CREATE_PROCESS_1=() {
     let processEvents = EventData
-    | where EventID == 1
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    Image = EventDetail.[4].["#text"], FileVersion = EventDetail.[5].["#text"], Description = EventDetail.[6].["#text"], Product = EventDetail.[7].["#text"], 
-    Company = EventDetail.[8].["#text"], OriginalFileName = EventDetail.[9].["#text"], CommandLine = EventDetail.[10].["#text"], CurrentDirectory = EventDetail.[11].["#text"], 
-    User = EventDetail.[12].["#text"], LogonGuid = EventDetail.[13].["#text"], LogonId = EventDetail.[14].["#text"], TerminalSessionId = EventDetail.[15].["#text"],
-    IntegrityLevel = EventDetail.[16].["#text"], Hashes = EventDetail.[17].["#text"], ParentProcessGuid = EventDetail.[18].["#text"], ParentProcessId = EventDetail.[19].["#text"], 
-    ParentImage = EventDetail.[20].["#text"], ParentCommandLine = EventDetail.[21].["#text"]
-    | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-    | mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-    | project-away EventDetail  ;
+        | where EventID == 1
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            FileVersion = EventDetail.[5].["#text"],
+            Description = EventDetail.[6].["#text"],
+            Product = EventDetail.[7].["#text"],
+            Company = EventDetail.[8].["#text"],
+            OriginalFileName = EventDetail.[9].["#text"],
+            CommandLine = EventDetail.[10].["#text"],
+            CurrentDirectory = EventDetail.[11].["#text"],
+            User = EventDetail.[12].["#text"],
+            LogonGuid = EventDetail.[13].["#text"],
+            LogonId = EventDetail.[14].["#text"],
+            TerminalSessionId = EventDetail.[15].["#text"],
+            IntegrityLevel = EventDetail.[16].["#text"],
+            Hashes = EventDetail.[17].["#text"],
+            ParentProcessGuid = EventDetail.[18].["#text"],
+            ParentProcessId = EventDetail.[19].["#text"],
+            ParentImage = EventDetail.[20].["#text"],
+            ParentCommandLine = EventDetail.[21].["#text"]
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_FILE_TIME_2=()
-{
+let SYSMON_FILE_TIME_2=() {
     let processEvents = EventData
-    | where EventID == 2
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-    Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], PreviousCreationUtcTime = EventDetail.[7].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 2
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_NETWORK_CONNECT_3=()
-{
+let SYSMON_NETWORK_CONNECT_3=() {
     let processEvents = EventData
-    | where EventID == 3
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-    Image = EventDetail.[4].["#text"], User = EventDetail.[5].["#text"], Protocol = EventDetail.[6].["#text"], Initiated = EventDetail.[7].["#text"], 
-    SourceIsIpv6 = EventDetail.[8].["#text"], SourceIp = EventDetail.[9].["#text"], SourceHostname = EventDetail.[10].["#text"], SourcePort = EventDetail.[11].["#text"], 
-    SourcePortName = EventDetail.[12].["#text"], DestinationIsIpv6 = EventDetail.[13].["#text"], DestinationIp = EventDetail.[14].["#text"], 
-    DestinationHostname = EventDetail.[15].["#text"], DestinationPort = EventDetail.[16].["#text"], DestinationPortName = EventDetail.[17].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 3
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            User = EventDetail.[5].["#text"],
+            Protocol = EventDetail.[6].["#text"],
+            Initiated = EventDetail.[7].["#text"],
+            SourceIsIpv6 = EventDetail.[8].["#text"],
+            SourceIp = EventDetail.[9].["#text"],
+            SourceHostname = EventDetail.[10].["#text"],
+            SourcePort = EventDetail.[11].["#text"],
+            SourcePortName = EventDetail.[12].["#text"],
+            DestinationIsIpv6 = EventDetail.[13].["#text"],
+            DestinationIp = EventDetail.[14].["#text"],
+            DestinationHostname = EventDetail.[15].["#text"],
+            DestinationPort = EventDetail.[16].["#text"],
+            DestinationPortName = EventDetail.[17].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_SERVICE_STATE_CHANGE_4=()
-{
+let SYSMON_SERVICE_STATE_CHANGE_4=() {
     let processEvents = EventData
-    | where EventID == 4
-    | extend UtcTime = EventDetail.[0].["#text"], State = EventDetail.[1].["#text"], Version = EventDetail.[2].["#text"], SchemaVersion = EventDetail.[3].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 4
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            State = EventDetail.[1].["#text"],
+            Version = EventDetail.[2].["#text"],
+            SchemaVersion = EventDetail.[3].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_PROCESS_TERMINATE_5=()
-{
+let SYSMON_PROCESS_TERMINATE_5=() {
     let processEvents = EventData
-    | where EventID == 5
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 5
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_DRIVER_LOAD_6=()
-{
+let SYSMON_DRIVER_LOAD_6=() {
     let processEvents = EventData
-    | where EventID == 6
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ImageLoaded = EventDetail.[2].["#text"], Hashes = EventDetail.[3].["#text"], 
-    Signed = EventDetail.[4].["#text"], Signature = EventDetail.[5].["#text"], SignatureStatus = EventDetail.[6].["#text"]
-    | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-    | mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-    | project-away EventDetail  ;
+        | where EventID == 6
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ImageLoaded = EventDetail.[2].["#text"],
+            Hashes = EventDetail.[3].["#text"],
+            Signed = EventDetail.[4].["#text"],
+            Signature = EventDetail.[5].["#text"],
+            SignatureStatus = EventDetail.[6].["#text"]
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_IMAGE_LOAD_7=()
-{
+let SYSMON_IMAGE_LOAD_7=() {
     let processEvents = EventData
-    | where EventID == 7
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    Image = EventDetail.[4].["#text"], ImageLoaded = EventDetail.[5].["#text"], FileVersion = EventDetail.[6].["#text"], Description = EventDetail.[7].["#text"], 
-    Product = EventDetail.[8].["#text"], Company = EventDetail.[9].["#text"], OriginalFileName = EventDetail.[10].["#text"], Hashes = EventDetail.[11].["#text"], 
-    Signed = EventDetail.[12].["#text"], Signature = EventDetail.[13].["#text"], SignatureStatus = EventDetail.[14].["#text"]
-    | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-    | mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-    | project-away EventDetail  ;
+        | where EventID == 7
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            ImageLoaded = EventDetail.[5].["#text"],
+            FileVersion = EventDetail.[6].["#text"],
+            Description = EventDetail.[7].["#text"],
+            Product = EventDetail.[8].["#text"],
+            Company = EventDetail.[9].["#text"],
+            OriginalFileName = EventDetail.[10].["#text"],
+            Hashes = EventDetail.[11].["#text"],
+            Signed = EventDetail.[12].["#text"],
+            Signature = EventDetail.[13].["#text"],
+            SignatureStatus = EventDetail.[14].["#text"]
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_CREATE_REMOTE_THREAD_8=()
-{
+let SYSMON_CREATE_REMOTE_THREAD_8=() {
     let processEvents = EventData
-    | where EventID == 8
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGuid = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], 
-    SourceImage = EventDetail.[4].["#text"], TargetProcessGuid = EventDetail.[5].["#text"], TargetProcessId = EventDetail.[6].["#text"], TargetImage = EventDetail.[7].["#text"],
-    NewThreadId = EventDetail.[8].["#text"], StartAddress = EventDetail.[9].["#text"], StartModule = EventDetail.[10].["#text"], StartFunction = EventDetail.[11].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 8
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGuid = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceImage = EventDetail.[4].["#text"],
+            TargetProcessGuid = EventDetail.[5].["#text"],
+            TargetProcessId = EventDetail.[6].["#text"],
+            TargetImage = EventDetail.[7].["#text"],
+            NewThreadId = EventDetail.[8].["#text"],
+            StartAddress = EventDetail.[9].["#text"],
+            StartModule = EventDetail.[10].["#text"],
+            StartFunction = EventDetail.[11].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_RAWACCESS_READ_9=()
-{
+let SYSMON_RAWACCESS_READ_9=() {
     let processEvents = EventData
-    | where EventID == 9
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    Image = EventDetail.[4].["#text"], Device = EventDetail.[5].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 9
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            Device = EventDetail.[5].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_ACCESS_PROCESS_10=()
-{
+let SYSMON_ACCESS_PROCESS_10=() {
     let processEvents = EventData
-    | where EventID == 10
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGUID = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], 
-    SourceThreadId = EventDetail.[4].["#text"], SourceImage = EventDetail.[5].["#text"], TargetProcessGUID = EventDetail.[6].["#text"], TargetProcessId = EventDetail.[7].["#text"], 
-    TargetImage = EventDetail.[8].["#text"], GrantedAccess = EventDetail.[9].["#text"], CallTrace = EventDetail.[10].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 10
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGUID = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceThreadId = EventDetail.[4].["#text"],
+            SourceImage = EventDetail.[5].["#text"],
+            TargetProcessGUID = EventDetail.[6].["#text"],
+            TargetProcessId = EventDetail.[7].["#text"],
+            TargetImage = EventDetail.[8].["#text"],
+            GrantedAccess = EventDetail.[9].["#text"],
+            CallTrace = EventDetail.[10].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_FILE_CREATE_11=()
-{
+let SYSMON_FILE_CREATE_11=() {
     let processEvents = EventData
-    | where EventID == 11
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 11
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_REG_KEY_12=()
-{
+let SYSMON_REG_KEY_12=() {
     let processEvents = EventData
-    | where EventID == 12
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], 
-    ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 12
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_REG_SETVALUE_13=()
-{
+let SYSMON_REG_SETVALUE_13=() {
     let processEvents = EventData
-    | where EventID == 13
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], 
-    ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], Details = EventDetail.[7].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 13
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            Details = EventDetail.[7].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_REG_NAME_14=()
-{
+let SYSMON_REG_NAME_14=() {
     let processEvents = EventData
-    | where EventID == 14
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], 
-    ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], NewName = EventDetail.[7].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 14
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            NewName = EventDetail.[7].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_FILE_CREATE_STREAM_HASH_15=()
-{
+let SYSMON_FILE_CREATE_STREAM_HASH_15=() {
     let processEvents = EventData
-    | where EventID == 15
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], Hash = EventDetail.[7].["#text"], 
-    Contents = EventDetail.[8].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 15
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            Hash = EventDetail.[7].["#text"],
+            Contents = EventDetail.[8].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_SERVICE_CONFIGURATION_CHANGE_16=()
-{
+let SYSMON_SERVICE_CONFIGURATION_CHANGE_16=() {
     let processEvents = EventData
-    | where EventID == 16
-    | extend UtcTime = EventDetail.[0].["#text"], Configuration = EventDetail.[1].["#text"], ConfigurationFileHash = EventDetail.[2].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 16
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            Configuration = EventDetail.[1].["#text"],
+            ConfigurationFileHash = EventDetail.[2].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_CREATE_NAMEDPIPE_17=()
-{
+let SYSMON_CREATE_NAMEDPIPE_17=() {
     let processEvents = EventData
-    | where EventID == 17
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], 
-    ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], Image = EventDetail.[6].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 17
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            PipeName = EventDetail.[5].["#text"],
+            Image = EventDetail.[6].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_CONNECT_NAMEDPIPE_18=()
-{
+let SYSMON_CONNECT_NAMEDPIPE_18=() {
     let processEvents = EventData
-    | where EventID == 18
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], 
-    ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], Image = EventDetail.[6].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 18
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            PipeName = EventDetail.[5].["#text"],
+            Image = EventDetail.[6].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_WMI_FILTER_19=()
-{
+let SYSMON_WMI_FILTER_19=() {
     let processEvents = EventData
-    | where EventID == 19
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], 
-    User = EventDetail.[4].["#text"], EventNamespace = EventDetail.[5].["#text"], Name = EventDetail.[6].["#text"], Query = EventDetail.[7].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 19
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            EventNamespace = EventDetail.[5].["#text"],
+            Name = EventDetail.[6].["#text"],
+            Query = EventDetail.[7].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_WMI_CONSUMER_20=()
-{
+let SYSMON_WMI_CONSUMER_20=() {
     let processEvents = EventData
-    | where EventID == 20
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], 
-    User = EventDetail.[4].["#text"], Name = EventDetail.[5].["#text"], Type = EventDetail.[6].["#text"], Destination = EventDetail.[7].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 20
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Name = EventDetail.[5].["#text"],
+            Type = EventDetail.[6].["#text"],
+            Destination = EventDetail.[7].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_WMI_BINDING_21=()
-{
+let SYSMON_WMI_BINDING_21=() {
     let processEvents = EventData
-    | where EventID == 21
-    | extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], 
-    User = EventDetail.[4].["#text"], Consumer = EventDetail.[5].["#text"], Filter = EventDetail.[6].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 21
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Consumer = EventDetail.[5].["#text"],
+            Filter = EventDetail.[6].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_DNS_QUERY_22=()
-{
+let SYSMON_DNS_QUERY_22=() {
     let processEvents = EventData
-    | where EventID == 22
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    QueryName = EventDetail.[4].["#text"], QueryStatus = EventDetail.[5].["#text"], QueryResults = EventDetail.[6].["#text"], Image = EventDetail.[7].["#text"]
-    | project-away EventDetail  ;
+        | where EventID == 22
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            QueryName = EventDetail.[4].["#text"],
+            QueryStatus = EventDetail.[5].["#text"],
+            QueryResults = EventDetail.[6].["#text"],
+            Image = EventDetail.[7].["#text"]
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_FILE_DELETE_23=()
-{
+let SYSMON_FILE_DELETE_23=() {
     let processEvents = EventData
-    | where EventID == 23
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    User = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetFilename = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], IsExecutable = EventDetail.[8].["#text"], 
-    Archived = EventDetail.[9].["#text"]
-    | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-    | mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-    | project-away EventDetail  ;
+        | where EventID == 23
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetFilename = EventDetail.[6].["#text"],
+            Hashes = EventDetail.[7].["#text"],
+            IsExecutable = EventDetail.[8].["#text"],
+            Archived = EventDetail.[9].["#text"]
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail;
     processEvents;
-    
 };
-let SYSMON_CLIPBOARD_24=()
-{
+let SYSMON_CLIPBOARD_24=() {
     let processEvents = EventData
-    | where EventID == 24
-    | extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], 
-    Image = EventDetail.[4].["#text"], Session = EventDetail.[5].["#text"], ClientInfo = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], Archived = EventDetail.[8].["#text"]
-    | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-    | mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-    | project-away EventDetail  ;
+        | where EventID == 24
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            Session = EventDetail.[5].["#text"],
+            ClientInfo = EventDetail.[6].["#text"],
+            Hashes = EventDetail.[7].["#text"],
+            Archived = EventDetail.[8].["#text"]
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail;
     processEvents;
-    
 };
-(union isfuzzy=true  SYSMON_ERROR_255, SYSMON_CREATE_PROCESS_1, SYSMON_FILE_TIME_2, SYSMON_NETWORK_CONNECT_3, SYSMON_SERVICE_STATE_CHANGE_4, SYSMON_PROCESS_TERMINATE_5, 
-SYSMON_DRIVER_LOAD_6, SYSMON_IMAGE_LOAD_7, SYSMON_CREATE_REMOTE_THREAD_8, SYSMON_RAWACCESS_READ_9, SYSMON_ACCESS_PROCESS_10, SYSMON_FILE_CREATE_11, SYSMON_REG_KEY_12, 
-SYSMON_REG_SETVALUE_13, SYSMON_REG_NAME_14, SYSMON_FILE_CREATE_STREAM_HASH_15, SYSMON_SERVICE_CONFIGURATION_CHANGE_16, SYSMON_CREATE_NAMEDPIPE_17, SYSMON_CONNECT_NAMEDPIPE_18, 
-SYSMON_WMI_FILTER_19, SYSMON_WMI_CONSUMER_20, SYSMON_WMI_BINDING_21, SYSMON_DNS_QUERY_22, SYSMON_FILE_DELETE_23, SYSMON_CLIPBOARD_24)
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""), Hashes = column_ifexists("Hashes", "")
-| project EventID, UtcTime, ID, Description, RuleName, ProcessGuid, ProcessId, Image, FileVersion, Product, Company, OriginalFileName, CommandLine, CurrentDirectory, 
-User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, Hashes, ParsedHashes, ParentProcessGuid, ParentProcessId, ParentImage, ParentCommandLine, TargetFilename, CreationUtcTime, 
-PreviousCreationUtcTime, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname,
-DestinationPort, DestinationPortName, State, Version, SchemaVersion, ImageLoaded, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, 
-TargetProcessGuid, TargetProcessId, TargetImage, NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, 
-GrantedAccess, CallTrace, EventType, TargetObject, Details, NewName, Hash, Contents, Configuration, ConfigurationFileHash, PipeName, Operation, EventNamespace, Name, 
-Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, IsExecutable, Archived, Session, ClientInfo
+(
+    union isfuzzy=true
+        SYSMON_ERROR_255,
+        SYSMON_CREATE_PROCESS_1,
+        SYSMON_FILE_TIME_2,
+        SYSMON_NETWORK_CONNECT_3,
+        SYSMON_SERVICE_STATE_CHANGE_4,
+        SYSMON_PROCESS_TERMINATE_5,
+        SYSMON_DRIVER_LOAD_6,
+        SYSMON_IMAGE_LOAD_7,
+        SYSMON_CREATE_REMOTE_THREAD_8,
+        SYSMON_RAWACCESS_READ_9,
+        SYSMON_ACCESS_PROCESS_10,
+        SYSMON_FILE_CREATE_11,
+        SYSMON_REG_KEY_12,
+        SYSMON_REG_SETVALUE_13,
+        SYSMON_REG_NAME_14,
+        SYSMON_FILE_CREATE_STREAM_HASH_15,
+        SYSMON_SERVICE_CONFIGURATION_CHANGE_16,
+        SYSMON_CREATE_NAMEDPIPE_17,
+        SYSMON_CONNECT_NAMEDPIPE_18,
+        SYSMON_WMI_FILTER_19,
+        SYSMON_WMI_CONSUMER_20,
+        SYSMON_WMI_BINDING_21,
+        SYSMON_DNS_QUERY_22,
+        SYSMON_FILE_DELETE_23,
+        SYSMON_CLIPBOARD_24
+)
+| extend
+    Details = column_ifexists("Details", ""),
+    RuleName = column_ifexists("RuleName", ""),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
+    Hashes = column_ifexists("Hashes", "")
+| project
+    Archived,
+    CallTrace,
+    ClientInfo,
+    CommandLine,
+    Company,
+    Configuration,
+    ConfigurationFileHash,
+    Consumer,
+    Contents,
+    CreationUtcTime,
+    CurrentDirectory,
+    Description,
+    Destination,
+    DestinationHostname,
+    DestinationIp,
+    DestinationIsIpv6,
+    DestinationPort,
+    DestinationPortName,
+    Details,
+    Device,
+    EventID,
+    EventNamespace,
+    EventType,
+    FileVersion,
+    Filter,
+    GrantedAccess,
+    Hash,
+    Hashes,
+    ID,
+    Image,
+    ImageLoaded,
+    Initiated,
+    IntegrityLevel,
+    IsExecutable,
+    LogonGuid,
+    LogonId,
+    Name,
+    NewName,
+    NewThreadId,
+    Operation,
+    OriginalFileName,
+    ParentCommandLine,
+    ParentImage,
+    ParentProcessGuid,
+    ParentProcessId,
+    ParsedHashes,
+    PipeName,
+    PreviousCreationUtcTime,
+    ProcessGuid,
+    ProcessId,
+    Product,
+    Protocol,
+    Query,
+    QueryName,
+    QueryResults,
+    QueryStatus,
+    RuleName,
+    SchemaVersion,
+    Session,
+    Signature,
+    SignatureStatus,
+    Signed,
+    SourceHostname,
+    SourceImage,
+    SourceIp,
+    SourceIsIpv6,
+    SourcePort,
+    SourcePortName,
+    SourceProcessGuid,
+    SourceProcessGUID,
+    SourceProcessId,
+    SourceThreadId,
+    StartAddress,
+    StartFunction,
+    StartModule,
+    State,
+    TargetFilename,
+    TargetImage,
+    TargetObject,
+    TargetProcessGuid,
+    TargetProcessGUID,
+    TargetProcessId,
+    TerminalSessionId,
+    Type,
+    User,
+    UtcTime,
+    Version

--- a/Parsers/Sysmon/Sysmon-v12.0.txt
+++ b/Parsers/Sysmon/Sysmon-v12.0.txt
@@ -36,9 +36,9 @@ let SYSMON_ERROR_255=() {
     let processEvents = EventData
         | where EventID == 255
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            ID = EventDetail.[1].["#text"],
-            Description = EventDetail.[2].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            ID = tostring(EventDetail.[1].["#text"]),
+            Description = tostring(EventDetail.[2].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -46,28 +46,28 @@ let SYSMON_CREATE_PROCESS_1=() {
     let processEvents = EventData
         | where EventID == 1
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            FileVersion = EventDetail.[5].["#text"],
-            Description = EventDetail.[6].["#text"],
-            Product = EventDetail.[7].["#text"],
-            Company = EventDetail.[8].["#text"],
-            OriginalFileName = EventDetail.[9].["#text"],
-            CommandLine = EventDetail.[10].["#text"],
-            CurrentDirectory = EventDetail.[11].["#text"],
-            User = EventDetail.[12].["#text"],
-            LogonGuid = EventDetail.[13].["#text"],
-            LogonId = EventDetail.[14].["#text"],
-            TerminalSessionId = EventDetail.[15].["#text"],
-            IntegrityLevel = EventDetail.[16].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            FileVersion = tostring(EventDetail.[5].["#text"]),
+            Description = tostring(EventDetail.[6].["#text"]),
+            Product = tostring(EventDetail.[7].["#text"]),
+            Company = tostring(EventDetail.[8].["#text"]),
+            OriginalFileName = tostring(EventDetail.[9].["#text"]),
+            CommandLine = tostring(EventDetail.[10].["#text"]),
+            CurrentDirectory = tostring(EventDetail.[11].["#text"]),
+            User = tostring(EventDetail.[12].["#text"]),
+            LogonGuid = tostring(EventDetail.[13].["#text"]),
+            LogonId = tolong(EventDetail.[14].["#text"]),
+            TerminalSessionId = tolong(EventDetail.[15].["#text"]),
+            IntegrityLevel = tostring(EventDetail.[16].["#text"]),
             Hashes = EventDetail.[17].["#text"],
-            ParentProcessGuid = EventDetail.[18].["#text"],
-            ParentProcessId = EventDetail.[19].["#text"],
-            ParentImage = EventDetail.[20].["#text"],
-            ParentCommandLine = EventDetail.[21].["#text"]
+            ParentProcessGuid = tostring(EventDetail.[18].["#text"]),
+            ParentProcessId = tolong(EventDetail.[19].["#text"]),
+            ParentImage = tostring(EventDetail.[20].["#text"]),
+            ParentCommandLine = tostring(EventDetail.[21].["#text"])
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
@@ -77,14 +77,14 @@ let SYSMON_FILE_TIME_2=() {
     let processEvents = EventData
         | where EventID == 2
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -92,24 +92,24 @@ let SYSMON_NETWORK_CONNECT_3=() {
     let processEvents = EventData
         | where EventID == 3
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            User = EventDetail.[5].["#text"],
-            Protocol = EventDetail.[6].["#text"],
-            Initiated = EventDetail.[7].["#text"],
-            SourceIsIpv6 = EventDetail.[8].["#text"],
-            SourceIp = EventDetail.[9].["#text"],
-            SourceHostname = EventDetail.[10].["#text"],
-            SourcePort = EventDetail.[11].["#text"],
-            SourcePortName = EventDetail.[12].["#text"],
-            DestinationIsIpv6 = EventDetail.[13].["#text"],
-            DestinationIp = EventDetail.[14].["#text"],
-            DestinationHostname = EventDetail.[15].["#text"],
-            DestinationPort = EventDetail.[16].["#text"],
-            DestinationPortName = EventDetail.[17].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            User = tostring(EventDetail.[5].["#text"]),
+            Protocol = tostring(EventDetail.[6].["#text"]),
+            Initiated = tostring(EventDetail.[7].["#text"]),
+            SourceIsIpv6 = tostring(EventDetail.[8].["#text"]),
+            SourceIp = tostring(EventDetail.[9].["#text"]),
+            SourceHostname = tostring(EventDetail.[10].["#text"]),
+            SourcePort = tolong(EventDetail.[11].["#text"]),
+            SourcePortName = tostring(EventDetail.[12].["#text"]),
+            DestinationIsIpv6 = tostring(EventDetail.[13].["#text"]),
+            DestinationIp = tostring(EventDetail.[14].["#text"]),
+            DestinationHostname = tostring(EventDetail.[15].["#text"]),
+            DestinationPort = tolong(EventDetail.[16].["#text"]),
+            DestinationPortName = tostring(EventDetail.[17].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -117,10 +117,10 @@ let SYSMON_SERVICE_STATE_CHANGE_4=() {
     let processEvents = EventData
         | where EventID == 4
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            State = EventDetail.[1].["#text"],
-            Version = EventDetail.[2].["#text"],
-            SchemaVersion = EventDetail.[3].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            State = tostring(EventDetail.[1].["#text"]),
+            Version = tostring(EventDetail.[2].["#text"]),
+            SchemaVersion = tostring(EventDetail.[3].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -128,11 +128,11 @@ let SYSMON_PROCESS_TERMINATE_5=() {
     let processEvents = EventData
         | where EventID == 5
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -140,13 +140,13 @@ let SYSMON_DRIVER_LOAD_6=() {
     let processEvents = EventData
         | where EventID == 6
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ImageLoaded = EventDetail.[2].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ImageLoaded = tostring(EventDetail.[2].["#text"]),
             Hashes = EventDetail.[3].["#text"],
-            Signed = EventDetail.[4].["#text"],
-            Signature = EventDetail.[5].["#text"],
-            SignatureStatus = EventDetail.[6].["#text"]
+            Signed = tostring(EventDetail.[4].["#text"]),
+            Signature = tostring(EventDetail.[5].["#text"]),
+            SignatureStatus = tostring(EventDetail.[6].["#text"])
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
@@ -156,21 +156,21 @@ let SYSMON_IMAGE_LOAD_7=() {
     let processEvents = EventData
         | where EventID == 7
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            ImageLoaded = EventDetail.[5].["#text"],
-            FileVersion = EventDetail.[6].["#text"],
-            Description = EventDetail.[7].["#text"],
-            Product = EventDetail.[8].["#text"],
-            Company = EventDetail.[9].["#text"],
-            OriginalFileName = EventDetail.[10].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            ImageLoaded = tostring(EventDetail.[5].["#text"]),
+            FileVersion = tostring(EventDetail.[6].["#text"]),
+            Description = tostring(EventDetail.[7].["#text"]),
+            Product = tostring(EventDetail.[8].["#text"]),
+            Company = tostring(EventDetail.[9].["#text"]),
+            OriginalFileName = tostring(EventDetail.[10].["#text"]),
             Hashes = EventDetail.[11].["#text"],
-            Signed = EventDetail.[12].["#text"],
-            Signature = EventDetail.[13].["#text"],
-            SignatureStatus = EventDetail.[14].["#text"]
+            Signed = tostring(EventDetail.[12].["#text"]),
+            Signature = tostring(EventDetail.[13].["#text"]),
+            SignatureStatus = tostring(EventDetail.[14].["#text"])
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
@@ -180,18 +180,18 @@ let SYSMON_CREATE_REMOTE_THREAD_8=() {
     let processEvents = EventData
         | where EventID == 8
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGuid = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceImage = EventDetail.[4].["#text"],
-            TargetProcessGuid = EventDetail.[5].["#text"],
-            TargetProcessId = EventDetail.[6].["#text"],
-            TargetImage = EventDetail.[7].["#text"],
-            NewThreadId = EventDetail.[8].["#text"],
-            StartAddress = EventDetail.[9].["#text"],
-            StartModule = EventDetail.[10].["#text"],
-            StartFunction = EventDetail.[11].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGuid = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceImage = tostring(EventDetail.[4].["#text"]),
+            TargetProcessGuid = tostring(EventDetail.[5].["#text"]),
+            TargetProcessId = tolong(EventDetail.[6].["#text"]),
+            TargetImage = tostring(EventDetail.[7].["#text"]),
+            NewThreadId = tolong(EventDetail.[8].["#text"]),
+            StartAddress = tostring(EventDetail.[9].["#text"]),
+            StartModule = tostring(EventDetail.[10].["#text"]),
+            StartFunction = tostring(EventDetail.[11].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -199,12 +199,12 @@ let SYSMON_RAWACCESS_READ_9=() {
     let processEvents = EventData
         | where EventID == 9
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            Device = EventDetail.[5].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            Device = tostring(EventDetail.[5].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -212,17 +212,17 @@ let SYSMON_ACCESS_PROCESS_10=() {
     let processEvents = EventData
         | where EventID == 10
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGUID = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceThreadId = EventDetail.[4].["#text"],
-            SourceImage = EventDetail.[5].["#text"],
-            TargetProcessGUID = EventDetail.[6].["#text"],
-            TargetProcessId = EventDetail.[7].["#text"],
-            TargetImage = EventDetail.[8].["#text"],
-            GrantedAccess = EventDetail.[9].["#text"],
-            CallTrace = EventDetail.[10].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGUID = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceThreadId = tolong(EventDetail.[4].["#text"]),
+            SourceImage = tostring(EventDetail.[5].["#text"]),
+            TargetProcessGUID = tostring(EventDetail.[6].["#text"]),
+            TargetProcessId = tolong(EventDetail.[7].["#text"]),
+            TargetImage = tostring(EventDetail.[8].["#text"]),
+            GrantedAccess = tostring(EventDetail.[9].["#text"]),
+            CallTrace = tostring(EventDetail.[10].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -230,13 +230,13 @@ let SYSMON_FILE_CREATE_11=() {
     let processEvents = EventData
         | where EventID == 11
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -244,13 +244,13 @@ let SYSMON_REG_KEY_12=() {
     let processEvents = EventData
         | where EventID == 12
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -258,14 +258,14 @@ let SYSMON_REG_SETVALUE_13=() {
     let processEvents = EventData
         | where EventID == 13
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            Details = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            Details = tostring(EventDetail.[7].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -273,14 +273,14 @@ let SYSMON_REG_NAME_14=() {
     let processEvents = EventData
         | where EventID == 14
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            NewName = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            NewName = tostring(EventDetail.[7].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -288,15 +288,15 @@ let SYSMON_FILE_CREATE_STREAM_HASH_15=() {
     let processEvents = EventData
         | where EventID == 15
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            Hash = EventDetail.[7].["#text"],
-            Contents = EventDetail.[8].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            Hash = tostring(EventDetail.[7].["#text"]),
+            Contents = tostring(EventDetail.[8].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -304,9 +304,9 @@ let SYSMON_SERVICE_CONFIGURATION_CHANGE_16=() {
     let processEvents = EventData
         | where EventID == 16
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            Configuration = EventDetail.[1].["#text"],
-            ConfigurationFileHash = EventDetail.[2].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            Configuration = tostring(EventDetail.[1].["#text"]),
+            ConfigurationFileHash = tostring(EventDetail.[2].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -314,13 +314,13 @@ let SYSMON_CREATE_NAMEDPIPE_17=() {
     let processEvents = EventData
         | where EventID == 17
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            PipeName = EventDetail.[5].["#text"],
-            Image = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            PipeName = tostring(EventDetail.[5].["#text"]),
+            Image = tostring(EventDetail.[6].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -328,13 +328,13 @@ let SYSMON_CONNECT_NAMEDPIPE_18=() {
     let processEvents = EventData
         | where EventID == 18
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            PipeName = EventDetail.[5].["#text"],
-            Image = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            PipeName = tostring(EventDetail.[5].["#text"]),
+            Image = tostring(EventDetail.[6].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -342,14 +342,14 @@ let SYSMON_WMI_FILTER_19=() {
     let processEvents = EventData
         | where EventID == 19
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            EventNamespace = EventDetail.[5].["#text"],
-            Name = EventDetail.[6].["#text"],
-            Query = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            EventNamespace = tostring(EventDetail.[5].["#text"]),
+            Name = tostring(EventDetail.[6].["#text"]),
+            Query = tostring(EventDetail.[7].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -357,14 +357,14 @@ let SYSMON_WMI_CONSUMER_20=() {
     let processEvents = EventData
         | where EventID == 20
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Name = EventDetail.[5].["#text"],
-            Type = EventDetail.[6].["#text"],
-            Destination = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Name = tostring(EventDetail.[5].["#text"]),
+            Type = tostring(EventDetail.[6].["#text"]),
+            Destination = tostring(EventDetail.[7].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -372,13 +372,13 @@ let SYSMON_WMI_BINDING_21=() {
     let processEvents = EventData
         | where EventID == 21
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Consumer = EventDetail.[5].["#text"],
-            Filter = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Consumer = tostring(EventDetail.[5].["#text"]),
+            Filter = tostring(EventDetail.[6].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -386,14 +386,14 @@ let SYSMON_DNS_QUERY_22=() {
     let processEvents = EventData
         | where EventID == 22
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            QueryName = EventDetail.[4].["#text"],
-            QueryStatus = EventDetail.[5].["#text"],
-            QueryResults = EventDetail.[6].["#text"],
-            Image = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            QueryName = tostring(EventDetail.[4].["#text"]),
+            QueryStatus = tostring(EventDetail.[5].["#text"]),
+            QueryResults = tostring(EventDetail.[6].["#text"]),
+            Image = tostring(EventDetail.[7].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -401,16 +401,16 @@ let SYSMON_FILE_DELETE_23=() {
     let processEvents = EventData
         | where EventID == 23
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetFilename = EventDetail.[6].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetFilename = tostring(EventDetail.[6].["#text"]),
             Hashes = EventDetail.[7].["#text"],
-            IsExecutable = EventDetail.[8].["#text"],
-            Archived = EventDetail.[9].["#text"]
+            IsExecutable = tobool(EventDetail.[8].["#text"]),
+            Archived = tostring(EventDetail.[9].["#text"])
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
@@ -420,15 +420,15 @@ let SYSMON_CLIPBOARD_24=() {
     let processEvents = EventData
         | where EventID == 24
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            Session = EventDetail.[5].["#text"],
-            ClientInfo = EventDetail.[6].["#text"],
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            Session = tostring(EventDetail.[5].["#text"]),
+            ClientInfo = tostring(EventDetail.[6].["#text"]),
             Hashes = EventDetail.[7].["#text"],
-            Archived = EventDetail.[8].["#text"]
+            Archived = tostring(EventDetail.[8].["#text"])
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
@@ -463,10 +463,33 @@ let SYSMON_CLIPBOARD_24=() {
         SYSMON_CLIPBOARD_24
 )
 | extend
-    Details = column_ifexists("Details", ""),
-    RuleName = column_ifexists("RuleName", ""),
-    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
-    Hashes = column_ifexists("Hashes", "")
+    Archived = column_ifexists("Archived", tostring("")),
+    ClientInfo = column_ifexists("ClientInfo", tostring("")),
+    CommandLine = column_ifexists("CommandLine", tostring("")),
+    Company = column_ifexists("Company", tostring("")),
+    CurrentDirectory = column_ifexists("CurrentDirectory", tostring("")),
+    Details = column_ifexists("Details", tostring("")),
+    FileVersion = column_ifexists("FileVersion", tostring("")),
+    Hashes = column_ifexists("Hashes", dynamic([])),
+    ImageLoaded = column_ifexists("ImageLoaded", tostring("")),
+    IntegrityLevel = column_ifexists("IntegrityLevel", tostring("")),
+    IsExecutable = column_ifexists("IsExecutable", tobool("")),
+    LogonGuid = column_ifexists("LogonGuid", tostring("")),
+    LogonId = column_ifexists("LogonId", tolong("")),
+    OriginalFileName = column_ifexists("OriginalFileName", tostring("")),
+    ParentCommandLine = column_ifexists("ParentCommandLine", tostring("")),
+    ParentImage = column_ifexists("ParentImage", tostring("")),
+    ParentProcessGuid = column_ifexists("ParentProcessGuid", tostring("")),
+    ParentProcessId = column_ifexists("ParentProcessId", tolong("")),
+    ParsedHashes = column_ifexists("ParsedHashes", dynamic({})),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", todatetime("")),
+    Product = column_ifexists("Product", tostring("")),
+    RuleName = column_ifexists("RuleName", tostring("")),
+    Session = column_ifexists("Session", tostring("")),
+    Signature = column_ifexists("Signature", tostring("")),
+    SignatureStatus = column_ifexists("SignatureStatus", tostring("")),
+    Signed = column_ifexists("Signed", tostring("")),
+    TerminalSessionId = column_ifexists("TerminalSessionId", tolong(""))
 | project
     Archived,
     CallTrace,

--- a/Parsers/Sysmon/Sysmon-v12.0.txt
+++ b/Parsers/Sysmon/Sysmon-v12.0.txt
@@ -68,7 +68,7 @@ let SYSMON_CREATE_PROCESS_1=() {
             ParentProcessId = tolong(EventDetail.[19].["#text"]),
             ParentImage = tostring(EventDetail.[20].["#text"]),
             ParentCommandLine = tostring(EventDetail.[21].["#text"])
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
     processEvents;
@@ -147,7 +147,7 @@ let SYSMON_DRIVER_LOAD_6=() {
             Signed = tostring(EventDetail.[4].["#text"]),
             Signature = tostring(EventDetail.[5].["#text"]),
             SignatureStatus = tostring(EventDetail.[6].["#text"])
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
     processEvents;
@@ -171,7 +171,7 @@ let SYSMON_IMAGE_LOAD_7=() {
             Signed = tostring(EventDetail.[12].["#text"]),
             Signature = tostring(EventDetail.[13].["#text"]),
             SignatureStatus = tostring(EventDetail.[14].["#text"])
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
     processEvents;
@@ -411,7 +411,7 @@ let SYSMON_FILE_DELETE_23=() {
             Hashes = EventDetail.[7].["#text"],
             IsExecutable = tobool(EventDetail.[8].["#text"]),
             Archived = tostring(EventDetail.[9].["#text"])
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
     processEvents;
@@ -429,7 +429,7 @@ let SYSMON_CLIPBOARD_24=() {
             ClientInfo = tostring(EventDetail.[6].["#text"]),
             Hashes = EventDetail.[7].["#text"],
             Archived = tostring(EventDetail.[8].["#text"])
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail;
     processEvents;

--- a/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
@@ -74,8 +74,6 @@ let SysmonEvent2_FileCreateTime=() {
             CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
             PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
-        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
 };

--- a/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
@@ -50,7 +50,7 @@ let SysmonEvent1_ProcessCreate=() {
             LogonId = tostring(EventDetail.[13].["#text"]),
             TerminalSessionId = tolong(EventDetail.[14].["#text"]),
             IntegrityLevel = tostring(EventDetail.[15].["#text"]),
-            Hashes = dynamic(EventDetail.[16].["#text"]),
+            Hashes = EventDetail.[16].["#text"],
             ParentProcessGuid = tostring(EventDetail.[17].["#text"]),
             ParentProcessId = tolong(EventDetail.[18].["#text"]),
             ParentImage = tostring(EventDetail.[19].["#text"]),
@@ -136,7 +136,7 @@ let SysmonEvent6_DriverLoad=() {
             RuleName = tostring(EventDetail.[0].["#text"]),
             UtcTime = todatetime(EventDetail.[1].["#text"]),
             ImageLoaded = tostring(EventDetail.[2].["#text"]),
-            Hashes = dynamic(EventDetail.[3].["#text"]),
+            Hashes = EventDetail.[3].["#text"],
             Signed = tostring(EventDetail.[4].["#text"]),
             Signature = tostring(EventDetail.[5].["#text"]),
             SignatureStatus = tostring(EventDetail.[6].["#text"])
@@ -160,7 +160,7 @@ let SysmonEvent7_ImageLoad=() {
             Description = tostring(EventDetail.[7].["#text"]),
             Product = tostring(EventDetail.[8].["#text"]),
             Company = tostring(EventDetail.[9].["#text"]),
-            Hashes = dynamic(EventDetail.[10].["#text"]),
+            Hashes = EventDetail.[10].["#text"],
             Signed = tostring(EventDetail.[11].["#text"]),
             Signature = tostring(EventDetail.[12].["#text"]),
             SignatureStatus = tostring(EventDetail.[13].["#text"])
@@ -411,9 +411,29 @@ let SysmonEvent21_WMIEventConsumerToFilter=() {
         SysmonEvent21_WMIEventConsumerToFilter
 )
 | extend
+    CommandLine = column_ifexists("CommandLine", tostring("")),
+    Company = column_ifexists("Company", tostring("")),
+    CurrentDirectory = column_ifexists("CurrentDirectory", tostring("")),
+    Description = column_ifexists("Description", tostring("")),
     Details = column_ifexists("Details", tostring("")),
+    FileVersion = column_ifexists("FileVersion", tostring("")),
+    Hashes = column_ifexists("Hashes", dynamic([])),
+    ImageLoaded = column_ifexists("ImageLoaded", tostring("")),
+    IntegrityLevel = column_ifexists("IntegrityLevel", tostring("")),
+    LogonGuid = column_ifexists("LogonGuid", tostring("")),
+    LogonId = column_ifexists("LogonId", tolong("")),
+    ParentCommandLine = column_ifexists("ParentCommandLine", tostring("")),
+    ParentImage = column_ifexists("ParentImage", tostring("")),
+    ParentProcessGuid = column_ifexists("ParentProcessGuid", tostring("")),
+    ParentProcessId = column_ifexists("ParentProcessId", tolong("")),
+    ParsedHashes = column_ifexists("ParsedHashes", dynamic({})),
+    PreviousCreationUtcTime = column_ifexists("PreviousCreationUtcTime", todatetime("")),
+    Product = column_ifexists("Product", tostring("")),
     RuleName = column_ifexists("RuleName", tostring("")),
-    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", todatetime(""))
+    Signature = column_ifexists("Signature", tostring("")),
+    SignatureStatus = column_ifexists("SignatureStatus", tostring("")),
+    Signed = column_ifexists("Signed", tostring("")),
+    TerminalSessionId = column_ifexists("TerminalSessionId", tolong(""))
 | project
     CallTrace,
     CommandLine,

--- a/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
@@ -34,27 +34,27 @@ let SysmonEvent1_ProcessCreate=() {
     let processEvents = EventData
         | where EventID == 1
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            FileVersion = EventDetail.[5].["#text"],
-            Description = EventDetail.[6].["#text"],
-            Product = EventDetail.[7].["#text"],
-            Company = EventDetail.[8].["#text"],
-            CommandLine = EventDetail.[9].["#text"],
-            CurrentDirectory = EventDetail.[10].["#text"],
-            User = EventDetail.[11].["#text"],
-            LogonGuid = EventDetail.[12].["#text"],
-            LogonId = EventDetail.[13].["#text"],
-            TerminalSessionId = EventDetail.[14].["#text"],
-            IntegrityLevel = EventDetail.[15].["#text"],
-            Hashes = EventDetail.[16].["#text"],
-            ParentProcessGuid = EventDetail.[17].["#text"],
-            ParentProcessId = EventDetail.[18].["#text"],
-            ParentImage = EventDetail.[19].["#text"],
-            ParentCommandLine = EventDetail.[20].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            FileVersion = tostring(EventDetail.[5].["#text"]),
+            Description = tostring(EventDetail.[6].["#text"]),
+            Product = tostring(EventDetail.[7].["#text"]),
+            Company = tostring(EventDetail.[8].["#text"]),
+            CommandLine = tostring(EventDetail.[9].["#text"]),
+            CurrentDirectory = tostring(EventDetail.[10].["#text"]),
+            User = tostring(EventDetail.[11].["#text"]),
+            LogonGuid = tostring(EventDetail.[12].["#text"]),
+            LogonId = tostring(EventDetail.[13].["#text"]),
+            TerminalSessionId = tolong(EventDetail.[14].["#text"]),
+            IntegrityLevel = tostring(EventDetail.[15].["#text"]),
+            Hashes = dynamic(EventDetail.[16].["#text"]),
+            ParentProcessGuid = tostring(EventDetail.[17].["#text"]),
+            ParentProcessId = tolong(EventDetail.[18].["#text"]),
+            ParentImage = tostring(EventDetail.[19].["#text"]),
+            ParentCommandLine = tostring(EventDetail.[20].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -65,14 +65,14 @@ let SysmonEvent2_FileCreateTime=() {
     let processEvents = EventData
         | where EventID == 2
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            PreviousCreationUtcTime = todatetime(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -83,24 +83,24 @@ let SysmonEvent3_NetworkConnect=() {
     let processEvents = EventData
         | where EventID == 3
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            User = EventDetail.[5].["#text"],
-            Protocol = EventDetail.[6].["#text"],
-            Initiated = EventDetail.[7].["#text"],
-            SourceIsIpv6 = EventDetail.[8].["#text"],
-            SourceIp = EventDetail.[9].["#text"],
-            SourceHostname = EventDetail.[10].["#text"],
-            SourcePort = EventDetail.[11].["#text"],
-            SourcePortName = EventDetail.[12].["#text"],
-            DestinationIsIpv6 = EventDetail.[13].["#text"],
-            DestinationIp = EventDetail.[14].["#text"],
-            DestinationHostname = EventDetail.[15].["#text"],
-            DestinationPort = EventDetail.[16].["#text"],
-            DestinationPortName = EventDetail.[17].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            User = tostring(EventDetail.[5].["#text"]),
+            Protocol = tostring(EventDetail.[6].["#text"]),
+            Initiated = tostring(EventDetail.[7].["#text"]),
+            SourceIsIpv6 = tostring(EventDetail.[8].["#text"]),
+            SourceIp = tostring(EventDetail.[9].["#text"]),
+            SourceHostname = tostring(EventDetail.[10].["#text"]),
+            SourcePort = tolong(EventDetail.[11].["#text"]),
+            SourcePortName = tostring(EventDetail.[12].["#text"]),
+            DestinationIsIpv6 = tostring(EventDetail.[13].["#text"]),
+            DestinationIp = tostring(EventDetail.[14].["#text"]),
+            DestinationHostname = tostring(EventDetail.[15].["#text"]),
+            DestinationPort = tolong(EventDetail.[16].["#text"]),
+            DestinationPortName = tostring(EventDetail.[17].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -109,10 +109,10 @@ let SysmonEvent4_ServiceStateChange=() {
     let processEvents = EventData
         | where EventID == 4
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            State = EventDetail.[1].["#text"],
-            Schema = EventDetail.[2].["#text"],
-            SchemaVersion = EventDetail.[3].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            State = tostring(EventDetail.[1].["#text"]),
+            Schema = tostring(EventDetail.[2].["#text"]),
+            SchemaVersion = tostring(EventDetail.[3].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -120,11 +120,11 @@ let SysmonEvent5_ProcessTerminate=() {
     let processEvents = EventData
         | where EventID == 5
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -133,13 +133,13 @@ let SysmonEvent6_DriverLoad=() {
     let processEvents = EventData
         | where EventID == 6
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ImageLoaded = EventDetail.[2].["#text"],
-            Hashes = EventDetail.[3].["#text"],
-            Signed = EventDetail.[4].["#text"],
-            Signature = EventDetail.[5].["#text"],
-            SignatureStatus = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ImageLoaded = tostring(EventDetail.[2].["#text"]),
+            Hashes = dynamic(EventDetail.[3].["#text"]),
+            Signed = tostring(EventDetail.[4].["#text"]),
+            Signature = tostring(EventDetail.[5].["#text"]),
+            SignatureStatus = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -150,20 +150,20 @@ let SysmonEvent7_ImageLoad=() {
     let processEvents = EventData
         | where EventID == 7
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            ImageLoaded = EventDetail.[5].["#text"],
-            FileVersion = EventDetail.[6].["#text"],
-            Description = EventDetail.[7].["#text"],
-            Product = EventDetail.[8].["#text"],
-            Company = EventDetail.[9].["#text"],
-            Hashes = EventDetail.[10].["#text"],
-            Signed = EventDetail.[11].["#text"],
-            Signature = EventDetail.[12].["#text"],
-            SignatureStatus = EventDetail.[13].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            ImageLoaded = tostring(EventDetail.[5].["#text"]),
+            FileVersion = tostring(EventDetail.[6].["#text"]),
+            Description = tostring(EventDetail.[7].["#text"]),
+            Product = tostring(EventDetail.[8].["#text"]),
+            Company = tostring(EventDetail.[9].["#text"]),
+            Hashes = dynamic(EventDetail.[10].["#text"]),
+            Signed = tostring(EventDetail.[11].["#text"]),
+            Signature = tostring(EventDetail.[12].["#text"]),
+            SignatureStatus = tostring(EventDetail.[13].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
@@ -174,18 +174,18 @@ let SysmonEvent8_CreateRemoteThread=() {
     let processEvents = EventData
         | where EventID == 8
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGuid = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceImage = EventDetail.[4].["#text"],
-            TargetProcessGuid = EventDetail.[5].["#text"],
-            TargetProcessId = EventDetail.[6].["#text"],
-            TargetImage = EventDetail.[7].["#text"],
-            NewThreadId = EventDetail.[8].["#text"],
-            StartAddress = EventDetail.[9].["#text"],
-            StartModule = EventDetail.[10].["#text"],
-            StartFunction = EventDetail.[11].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGuid = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceImage = tostring(EventDetail.[4].["#text"]),
+            TargetProcessGuid = tostring(EventDetail.[5].["#text"]),
+            TargetProcessId = tolong(EventDetail.[6].["#text"]),
+            TargetImage = tostring(EventDetail.[7].["#text"]),
+            NewThreadId = tolong(EventDetail.[8].["#text"]),
+            StartAddress = tostring(EventDetail.[9].["#text"]),
+            StartModule = tostring(EventDetail.[10].["#text"]),
+            StartFunction = tostring(EventDetail.[11].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -194,12 +194,12 @@ let SysmonEvent9_RawAccessRead=() {
     let processEvents = EventData
         | where EventID == 9
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            Device = EventDetail.[5].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            Device = tostring(EventDetail.[5].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -208,17 +208,17 @@ let SysmonEvent10_ProcessAccess=() {
     let processEvents = EventData
         | where EventID == 10
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            SourceProcessGUID = EventDetail.[2].["#text"],
-            SourceProcessId = EventDetail.[3].["#text"],
-            SourceThreadId = EventDetail.[4].["#text"],
-            SourceImage = EventDetail.[5].["#text"],
-            TargetProcessGUID = EventDetail.[6].["#text"],
-            TargetProcessId = EventDetail.[7].["#text"],
-            TargetImage = EventDetail.[8].["#text"],
-            GrantedAccess = EventDetail.[9].["#text"],
-            CallTrace = EventDetail.[10].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            SourceProcessGUID = tostring(EventDetail.[2].["#text"]),
+            SourceProcessId = tolong(EventDetail.[3].["#text"]),
+            SourceThreadId = tolong(EventDetail.[4].["#text"]),
+            SourceImage = tostring(EventDetail.[5].["#text"]),
+            TargetProcessGUID = tostring(EventDetail.[6].["#text"]),
+            TargetProcessId = tolong(EventDetail.[7].["#text"]),
+            TargetImage = tostring(EventDetail.[8].["#text"]),
+            GrantedAccess = tostring(EventDetail.[9].["#text"]),
+            CallTrace = tostring(EventDetail.[10].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -227,13 +227,13 @@ let SysmonEvent11_FileCreate=() {
     let processEvents = EventData
         | where EventID == 11
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFilename = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFilename = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -242,13 +242,13 @@ let SysmonEvent12_RegistryObjectAddDel=() {
     let processEvents = EventData
         | where EventID == 12
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -257,14 +257,14 @@ let SysmonEvent13_RegistrySetValue=() {
     let processEvents = EventData
         | where EventID == 13
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            Details = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            Details = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -273,14 +273,14 @@ let SysmonEvent14_RegistryObjectRename=() {
     let processEvents = EventData
         | where EventID == 14
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            ProcessGuid = EventDetail.[3].["#text"],
-            ProcessId = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"],
-            TargetObject = EventDetail.[6].["#text"],
-            NewName = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            ProcessGuid = tostring(EventDetail.[3].["#text"]),
+            ProcessId = tolong(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"]),
+            TargetObject = tostring(EventDetail.[6].["#text"]),
+            NewName = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -289,14 +289,14 @@ let SysmonEvent15_FileCreateStreamHash=() {
     let processEvents = EventData
         | where EventID == 15
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            Image = EventDetail.[4].["#text"],
-            TargetFileName = EventDetail.[5].["#text"],
-            CreationUtcTime = EventDetail.[6].["#text"],
-            Hash = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            Image = tostring(EventDetail.[4].["#text"]),
+            TargetFileName = tostring(EventDetail.[5].["#text"]),
+            CreationUtcTime = todatetime(EventDetail.[6].["#text"]),
+            Hash = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -305,9 +305,9 @@ let SysmonEvent16_ConfigChange=() {
     let processEvents = EventData
         | where EventID == 16
         | extend
-            UtcTime = EventDetail.[0].["#text"],
-            Configuration = EventDetail.[1].["#text"],
-            ConfigurationFileHash = EventDetail.[2].["#text"]
+            UtcTime = todatetime(EventDetail.[0].["#text"]),
+            Configuration = tostring(EventDetail.[1].["#text"]),
+            ConfigurationFileHash = tostring(EventDetail.[2].["#text"])
         | project-away EventDetail;
     processEvents;
 };
@@ -315,12 +315,12 @@ let SysmonEvent17_CreateNamedPipe=() {
     let processEvents = EventData
         | where EventID == 17
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            PipeName = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            PipeName = tostring(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -329,12 +329,12 @@ let SysmonEvent18_ConnectNamedPipe=() {
     let processEvents = EventData
         | where EventID == 18
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            UtcTime = EventDetail.[1].["#text"],
-            ProcessGuid = EventDetail.[2].["#text"],
-            ProcessId = EventDetail.[3].["#text"],
-            PipeName = EventDetail.[4].["#text"],
-            Image = EventDetail.[5].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            UtcTime = todatetime(EventDetail.[1].["#text"]),
+            ProcessGuid = tostring(EventDetail.[2].["#text"]),
+            ProcessId = tolong(EventDetail.[3].["#text"]),
+            PipeName = tostring(EventDetail.[4].["#text"]),
+            Image = tostring(EventDetail.[5].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -343,14 +343,14 @@ let SysmonEvent19_WMIEventFilter=() {
     let processEvents = EventData
         | where EventID == 19
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            EventNamespace = EventDetail.[5].["#text"],
-            Name = EventDetail.[6].["#text"],
-            Query = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            EventNamespace = tostring(EventDetail.[5].["#text"]),
+            Name = tostring(EventDetail.[6].["#text"]),
+            Query = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -359,14 +359,14 @@ let SysmonEvent20_WMIEventConsumer=() {
     let processEvents = EventData
         | where EventID == 20
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Name = EventDetail.[5].["#text"],
-            Type = EventDetail.[6].["#text"],
-            Destination = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Name = tostring(EventDetail.[5].["#text"]),
+            Type = tostring(EventDetail.[6].["#text"]),
+            Destination = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -375,13 +375,13 @@ let SysmonEvent21_WMIEventConsumerToFilter=() {
     let processEvents = EventData
         | where EventID == 21
         | extend
-            RuleName = EventDetail.[0].["#text"],
-            EventType = EventDetail.[1].["#text"],
-            UtcTime = EventDetail.[2].["#text"],
-            Operation = EventDetail.[3].["#text"],
-            User = EventDetail.[4].["#text"],
-            Consumer = EventDetail.[5].["#text"],
-            Filter = EventDetail.[7].["#text"]
+            RuleName = tostring(EventDetail.[0].["#text"]),
+            EventType = tostring(EventDetail.[1].["#text"]),
+            UtcTime = todatetime(EventDetail.[2].["#text"]),
+            Operation = tostring(EventDetail.[3].["#text"]),
+            User = tostring(EventDetail.[4].["#text"]),
+            Consumer = tostring(EventDetail.[5].["#text"]),
+            Filter = tostring(EventDetail.[7].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
         | project-away EventDetail, RuleName;
     processEvents;
@@ -411,9 +411,9 @@ let SysmonEvent21_WMIEventConsumerToFilter=() {
         SysmonEvent21_WMIEventConsumerToFilter
 )
 | extend
-    Details = column_ifexists("Details", ""),
-    RuleName = column_ifexists("RuleName", ""),
-    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
+    Details = column_ifexists("Details", tostring("")),
+    RuleName = column_ifexists("RuleName", tostring("")),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", todatetime(""))
 | project
     CallTrace,
     CommandLine,

--- a/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
@@ -6,16 +6,16 @@
 // If you want to print configuration schema definition of sysmon. Execute below command from command shell or powershell terminal
 // Sysmon.exe -s
 //
-// You can further customize config XML definition and install sysmon with it via below command. 
+// You can further customize config XML definition and install sysmon with it via below command.
 // Sample Sysmon config XML from Swift on Security's GitHub page : https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml
-// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l  
+// Sysmon.exe -i sysmonconfig-export.xml -accepteula -h sha1,md5,sha256 -n -l
 // -n : Log all network connections and -l: log loading of modules.
 //
 // Parser Notes:
 // 1. This parser works against sysmon version 9, Schema version 4.21
 // 2. technique_id and technique_name will only be parsed/available if deployed via above mentioned sample sysmon XML config or any other with ATT&CK mapping already available.
 //
-// Usage Instruction : 
+// Usage Instruction :
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias (e.g. Sysmon_Normalized).
 // Function usually takes 10-15 minutes to activate. You can then use function alias from any other queries (e.g. Sysmon_Normalized | take 10).
 // Reference :
@@ -23,253 +23,480 @@
 // Tech Community Blog on KQL Functions : https://techcommunity.microsoft.com/t5/Azure-Sentinel/Using-KQL-functions-to-speed-up-analysis-in-Azure-Sentinel/ba-p/712381
 //
 let EventData = Event
-| where Source == "Microsoft-Windows-Sysmon"
-| extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
-| extend EvData = parse_xml(EventData)
-| extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData
+    | where Source == "Microsoft-Windows-Sysmon"
+    | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
+    | project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+    | extend EvData = parse_xml(EventData)
+    | extend EventDetail = EvData.DataItem.EventData.Data
+    | project-away EventData, EvData
 ;
 let SysmonEvent1_ProcessCreate=() {
-let processEvents = EventData
-| where EventID == 1
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-FileVersion = EventDetail.[5].["#text"], Description = EventDetail.[6].["#text"], Product = EventDetail.[7].["#text"], Company = EventDetail.[8].["#text"],
-CommandLine = EventDetail.[9].["#text"], CurrentDirectory = EventDetail.[10].["#text"], User = EventDetail.[11].["#text"], LogonGuid = EventDetail.[12].["#text"],
-LogonId = EventDetail.[13].["#text"], TerminalSessionId = EventDetail.[14].["#text"], IntegrityLevel = EventDetail.[15].["#text"], Hashes = EventDetail.[16].["#text"], 
-ParentProcessGuid = EventDetail.[17].["#text"], ParentProcessId = EventDetail.[18].["#text"], ParentImage = EventDetail.[19].["#text"], ParentCommandLine = EventDetail.[20].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 1
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            FileVersion = EventDetail.[5].["#text"],
+            Description = EventDetail.[6].["#text"],
+            Product = EventDetail.[7].["#text"],
+            Company = EventDetail.[8].["#text"],
+            CommandLine = EventDetail.[9].["#text"],
+            CurrentDirectory = EventDetail.[10].["#text"],
+            User = EventDetail.[11].["#text"],
+            LogonGuid = EventDetail.[12].["#text"],
+            LogonId = EventDetail.[13].["#text"],
+            TerminalSessionId = EventDetail.[14].["#text"],
+            IntegrityLevel = EventDetail.[15].["#text"],
+            Hashes = EventDetail.[16].["#text"],
+            ParentProcessGuid = EventDetail.[17].["#text"],
+            ParentProcessId = EventDetail.[18].["#text"],
+            ParentImage = EventDetail.[19].["#text"],
+            ParentCommandLine = EventDetail.[20].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent2_FileCreateTime=() {
-let processEvents = EventData
-| where EventID == 2
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], PreviousCreationUtcTime = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 2
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            PreviousCreationUtcTime = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent3_NetworkConnect=() {
-let processEvents = EventData
-| where EventID == 3
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"],
-User = EventDetail.[5].["#text"], Protocol = EventDetail.[6].["#text"], Initiated = EventDetail.[7].["#text"], SourceIsIpv6 = EventDetail.[8].["#text"], SourceIp = EventDetail.[9].["#text"], 
-SourceHostname = EventDetail.[10].["#text"], SourcePort = EventDetail.[11].["#text"], SourcePortName = EventDetail.[12].["#text"], DestinationIsIpv6 = EventDetail.[13].["#text"], 
-DestinationIp = EventDetail.[14].["#text"], DestinationHostname = EventDetail.[15].["#text"], DestinationPort = EventDetail.[16].["#text"], DestinationPortName = EventDetail.[17].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 3
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            User = EventDetail.[5].["#text"],
+            Protocol = EventDetail.[6].["#text"],
+            Initiated = EventDetail.[7].["#text"],
+            SourceIsIpv6 = EventDetail.[8].["#text"],
+            SourceIp = EventDetail.[9].["#text"],
+            SourceHostname = EventDetail.[10].["#text"],
+            SourcePort = EventDetail.[11].["#text"],
+            SourcePortName = EventDetail.[12].["#text"],
+            DestinationIsIpv6 = EventDetail.[13].["#text"],
+            DestinationIp = EventDetail.[14].["#text"],
+            DestinationHostname = EventDetail.[15].["#text"],
+            DestinationPort = EventDetail.[16].["#text"],
+            DestinationPortName = EventDetail.[17].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent4_ServiceStateChange=() {
-let processEvents = EventData
-| where EventID == 4
-| extend UtcTime = EventDetail.[0].["#text"], State = EventDetail.[1].["#text"], Schema = EventDetail.[2].["#text"], SchemaVersion = EventDetail.[3].["#text"]
-| project-away EventDetail
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 4
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            State = EventDetail.[1].["#text"],
+            Schema = EventDetail.[2].["#text"],
+            SchemaVersion = EventDetail.[3].["#text"]
+        | project-away EventDetail;
+    processEvents;
 };
 let SysmonEvent5_ProcessTerminate=() {
-let processEvents = EventData
-| where EventID == 5
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 5
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent6_DriverLoad=() {
-let processEvents = EventData
-| where EventID == 6
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ImageLoaded = EventDetail.[2].["#text"], Hashes = EventDetail.[3].["#text"],
-Signed = EventDetail.[4].["#text"], Signature = EventDetail.[5].["#text"], SignatureStatus = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 6
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ImageLoaded = EventDetail.[2].["#text"],
+            Hashes = EventDetail.[3].["#text"],
+            Signed = EventDetail.[4].["#text"],
+            Signature = EventDetail.[5].["#text"],
+            SignatureStatus = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent7_ImageLoad=() {
-let processEvents = EventData
-| where EventID == 7
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], 
-ImageLoaded = EventDetail.[5].["#text"], FileVersion = EventDetail.[6].["#text"], Description = EventDetail.[7].["#text"], Product = EventDetail.[8].["#text"], Company = EventDetail.[9].["#text"], 
-Hashes = EventDetail.[10].["#text"], Signed = EventDetail.[11].["#text"], Signature = EventDetail.[12].["#text"], SignatureStatus = EventDetail.[13].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), Hashes)
-| mv-apply Hashes on ( 
-    summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))
-    )
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 7
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            ImageLoaded = EventDetail.[5].["#text"],
+            FileVersion = EventDetail.[6].["#text"],
+            Description = EventDetail.[7].["#text"],
+            Product = EventDetail.[8].["#text"],
+            Company = EventDetail.[9].["#text"],
+            Hashes = EventDetail.[10].["#text"],
+            Signed = EventDetail.[11].["#text"],
+            Signature = EventDetail.[12].["#text"],
+            SignatureStatus = EventDetail.[13].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent8_CreateRemoteThread=() {
-let processEvents = EventData
-| where EventID == 8
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGuid = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"],
-SourceImage = EventDetail.[4].["#text"], TargetProcessGuid = EventDetail.[5].["#text"], TargetProcessId = EventDetail.[6].["#text"], TargetImage = EventDetail.[7].["#text"],
-NewThreadId = EventDetail.[8].["#text"], StartAddress = EventDetail.[9].["#text"], StartModule = EventDetail.[10].["#text"], StartFunction = EventDetail.[11].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 8
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGuid = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceImage = EventDetail.[4].["#text"],
+            TargetProcessGuid = EventDetail.[5].["#text"],
+            TargetProcessId = EventDetail.[6].["#text"],
+            TargetImage = EventDetail.[7].["#text"],
+            NewThreadId = EventDetail.[8].["#text"],
+            StartAddress = EventDetail.[9].["#text"],
+            StartModule = EventDetail.[10].["#text"],
+            StartFunction = EventDetail.[11].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent9_RawAccessRead=() {
-let processEvents = EventData
-| where EventID == 9
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Device = EventDetail.[5].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 9
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            Device = EventDetail.[5].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent10_ProcessAccess=() {
-let processEvents = EventData
-| where EventID == 10
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGUID = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], 
-SourceThreadId = EventDetail.[4].["#text"], SourceImage = EventDetail.[5].["#text"], TargetProcessGUID = EventDetail.[6].["#text"], TargetProcessId = EventDetail.[7].["#text"], 
-TargetImage = EventDetail.[8].["#text"], GrantedAccess = EventDetail.[9].["#text"], CallTrace = EventDetail.[10].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 10
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            SourceProcessGUID = EventDetail.[2].["#text"],
+            SourceProcessId = EventDetail.[3].["#text"],
+            SourceThreadId = EventDetail.[4].["#text"],
+            SourceImage = EventDetail.[5].["#text"],
+            TargetProcessGUID = EventDetail.[6].["#text"],
+            TargetProcessId = EventDetail.[7].["#text"],
+            TargetImage = EventDetail.[8].["#text"],
+            GrantedAccess = EventDetail.[9].["#text"],
+            CallTrace = EventDetail.[10].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent11_FileCreate=() {
-let processEvents = EventData
-| where EventID == 11
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 11
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFilename = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent12_RegistryObjectAddDel=() {
-let processEvents = EventData
-| where EventID == 12
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 12
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent13_RegistrySetValue=() {
-let processEvents = EventData
-| where EventID == 13
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], Details = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 13
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            Details = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent14_RegistryObjectRename=() {
-let processEvents = EventData
-| where EventID == 14
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"],
-ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], NewName = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 14
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            ProcessGuid = EventDetail.[3].["#text"],
+            ProcessId = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"],
+            TargetObject = EventDetail.[6].["#text"],
+            NewName = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent15_FileCreateStreamHash=() {
-let processEvents = EventData
-| where EventID == 15
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"],
-Image = EventDetail.[4].["#text"], TargetFileName = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], Hash = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 15
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            Image = EventDetail.[4].["#text"],
+            TargetFileName = EventDetail.[5].["#text"],
+            CreationUtcTime = EventDetail.[6].["#text"],
+            Hash = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent16_ConfigChange=() {
-let processEvents = EventData
-| where EventID == 16
-| extend UtcTime = EventDetail.[0].["#text"], Configuration = EventDetail.[1].["#text"], ConfigurationFileHash = EventDetail.[2].["#text"]
-| project-away EventDetail
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 16
+        | extend
+            UtcTime = EventDetail.[0].["#text"],
+            Configuration = EventDetail.[1].["#text"],
+            ConfigurationFileHash = EventDetail.[2].["#text"]
+        | project-away EventDetail;
+    processEvents;
 };
 let SysmonEvent17_CreateNamedPipe=() {
-let processEvents = EventData
-| where EventID == 17
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], PipeName = EventDetail.[4].["#text"], 
-Image = EventDetail.[5].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 17
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            PipeName = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent18_ConnectNamedPipe=() {
-let processEvents = EventData
-| where EventID == 18
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], PipeName = EventDetail.[4].["#text"], 
-Image = EventDetail.[5].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 18
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            UtcTime = EventDetail.[1].["#text"],
+            ProcessGuid = EventDetail.[2].["#text"],
+            ProcessId = EventDetail.[3].["#text"],
+            PipeName = EventDetail.[4].["#text"],
+            Image = EventDetail.[5].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent19_WMIEventFilter=() {
-let processEvents = EventData
-| where EventID == 19
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], EventNamespace = EventDetail.[5].["#text"], Name = EventDetail.[6].["#text"], Query = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 19
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            EventNamespace = EventDetail.[5].["#text"],
+            Name = EventDetail.[6].["#text"],
+            Query = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent20_WMIEventConsumer=() {
-let processEvents = EventData
-| where EventID == 20
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"],Name = EventDetail.[5].["#text"],Type = EventDetail.[6].["#text"],Destination = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 20
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Name = EventDetail.[5].["#text"],
+            Type = EventDetail.[6].["#text"],
+            Destination = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
 let SysmonEvent21_WMIEventConsumerToFilter=() {
-let processEvents = EventData
-| where EventID == 21
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"],
-User = EventDetail.[4].["#text"], Consumer = EventDetail.[5].["#text"], Filter = EventDetail.[7].["#text"]
-| parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName 
-| project-away EventDetail, RuleName 
-;
-processEvents;
+    let processEvents = EventData
+        | where EventID == 21
+        | extend
+            RuleName = EventDetail.[0].["#text"],
+            EventType = EventDetail.[1].["#text"],
+            UtcTime = EventDetail.[2].["#text"],
+            Operation = EventDetail.[3].["#text"],
+            User = EventDetail.[4].["#text"],
+            Consumer = EventDetail.[5].["#text"],
+            Filter = EventDetail.[7].["#text"]
+        | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
+        | project-away EventDetail, RuleName;
+    processEvents;
 };
-(union isfuzzy=true
-SysmonEvent1_ProcessCreate, SysmonEvent2_FileCreateTime, SysmonEvent3_NetworkConnect, SysmonEvent4_ServiceStateChange, SysmonEvent5_ProcessTerminate,
-SysmonEvent6_DriverLoad, SysmonEvent7_ImageLoad, SysmonEvent8_CreateRemoteThread, SysmonEvent9_RawAccessRead, SysmonEvent10_ProcessAccess,
-SysmonEvent11_FileCreate, SysmonEvent12_RegistryObjectAddDel, SysmonEvent13_RegistrySetValue, SysmonEvent14_RegistryObjectRename,
-SysmonEvent15_FileCreateStreamHash, SysmonEvent16_ConfigChange, SysmonEvent17_CreateNamedPipe, SysmonEvent18_ConnectNamedPipe, 
-SysmonEvent19_WMIEventFilter, SysmonEvent20_WMIEventConsumer, SysmonEvent21_WMIEventConsumerToFilter)
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
-| project TimeGenerated, Source, EventID, Computer, UserName, RenderedDescription, UtcTime, ProcessGuid, ProcessId, Image, FileVersion,
-Description, Product, Company, CommandLine, CurrentDirectory, User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, ParentProcessGuid,
-ParentProcessId, ParentImage, ParentCommandLine, TechniqueId, TechniqueName, ParsedHashes, State, Schema, SchemaVersion, ImageLoaded,
-Hashes, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage,
-NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace,
-TargetFilename, CreationUtcTime, EventType, TargetObject, NewName, TargetFileName, Hash, Configuration, ConfigurationFileHash, PipeName, Operation,
-EventNamespace, Name, Query, Type, Destination, Consumer, Filter, RuleName, PreviousCreationUtcTime, Protocol, Initiated, SourceIsIpv6, SourceIp, 
-SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName, Details
+(
+    union isfuzzy=true
+        SysmonEvent1_ProcessCreate,
+        SysmonEvent2_FileCreateTime,
+        SysmonEvent3_NetworkConnect,
+        SysmonEvent4_ServiceStateChange,
+        SysmonEvent5_ProcessTerminate,
+        SysmonEvent6_DriverLoad,
+        SysmonEvent7_ImageLoad,
+        SysmonEvent8_CreateRemoteThread,
+        SysmonEvent9_RawAccessRead,
+        SysmonEvent10_ProcessAccess,
+        SysmonEvent11_FileCreate,
+        SysmonEvent12_RegistryObjectAddDel,
+        SysmonEvent13_RegistrySetValue,
+        SysmonEvent14_RegistryObjectRename,
+        SysmonEvent15_FileCreateStreamHash,
+        SysmonEvent16_ConfigChange,
+        SysmonEvent17_CreateNamedPipe,
+        SysmonEvent18_ConnectNamedPipe,
+        SysmonEvent19_WMIEventFilter,
+        SysmonEvent20_WMIEventConsumer,
+        SysmonEvent21_WMIEventConsumerToFilter
+)
+| extend
+    Details = column_ifexists("Details", ""),
+    RuleName = column_ifexists("RuleName", ""),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
+| project
+    CallTrace,
+    CommandLine,
+    Company,
+    Computer,
+    Configuration,
+    ConfigurationFileHash,
+    Consumer,
+    CreationUtcTime,
+    CurrentDirectory,
+    Description,
+    Destination,
+    DestinationHostname,
+    DestinationIp,
+    DestinationIsIpv6,
+    DestinationPort,
+    DestinationPortName,
+    Details,
+    Device,
+    EventID,
+    EventNamespace,
+    EventType,
+    FileVersion,
+    Filter,
+    GrantedAccess,
+    Hash,
+    Hashes,
+    Image,
+    ImageLoaded,
+    Initiated,
+    IntegrityLevel,
+    LogonGuid,
+    LogonId,
+    Name,
+    NewName,
+    NewThreadId,
+    Operation,
+    ParentCommandLine,
+    ParentImage,
+    ParentProcessGuid,
+    ParentProcessId,
+    ParsedHashes,
+    PipeName,
+    PreviousCreationUtcTime,
+    ProcessGuid,
+    ProcessId,
+    Product,
+    Protocol,
+    Query,
+    RenderedDescription,
+    RuleName,
+    Schema,
+    SchemaVersion,
+    Signature,
+    SignatureStatus,
+    Signed,
+    Source,
+    SourceHostname,
+    SourceImage,
+    SourceIp,
+    SourceIsIpv6,
+    SourcePort,
+    SourcePortName,
+    SourceProcessGuid,
+    SourceProcessGUID,
+    SourceProcessId,
+    SourceThreadId,
+    StartAddress,
+    StartFunction,
+    StartModule,
+    State,
+    TargetFilename,
+    TargetFileName,
+    TargetImage,
+    TargetObject,
+    TargetProcessGuid,
+    TargetProcessGUID,
+    TargetProcessId,
+    TechniqueId,
+    TechniqueName,
+    TerminalSessionId,
+    TimeGenerated,
+    Type,
+    User,
+    UserName,
+    UtcTime

--- a/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
+++ b/Parsers/Sysmon/Sysmon-v9.10-Parser.txt
@@ -56,7 +56,7 @@ let SysmonEvent1_ProcessCreate=() {
             ParentImage = tostring(EventDetail.[19].["#text"]),
             ParentCommandLine = tostring(EventDetail.[20].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -139,7 +139,7 @@ let SysmonEvent6_DriverLoad=() {
             Signature = tostring(EventDetail.[5].["#text"]),
             SignatureStatus = tostring(EventDetail.[6].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;
@@ -163,7 +163,7 @@ let SysmonEvent7_ImageLoad=() {
             Signature = tostring(EventDetail.[12].["#text"]),
             SignatureStatus = tostring(EventDetail.[13].["#text"])
         | parse RuleName with * 'technique_id=' TechniqueId ',' * 'technique_name=' TechniqueName
-        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), Hashes)
+        | extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key", "value"]), tostring(Hashes))
         | mv-apply Hashes on (summarize ParsedHashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
         | project-away EventDetail, RuleName;
     processEvents;


### PR DESCRIPTION
When attempting to utilize the sysmon parsers we ran into many errors that should not typically exist.  These were duplicated in many different log analytics workspaces, empty and with sysmon data.  Depending on the type of data that existed in the workspace we would encounter different errors.

## Proposed Changes

  - Renames incorrectly named data function `SysmonEvent13__RegistrySetValue` to `SysmonEvent13_RegistrySetValue`
  - Remove extraneous actions on `Hashes` when then column was not available
  - Use scalar types rather than dynamic when possible to avoid outer unions adding the hungarian notation `_type` suffix to column names
  - Formatting for readability and easier maintenance
  - Add many `column_ifexists` due to use of `project` on columns that are not always available

---

The use of the `project` following the `union`, only for intellisense, seems to add undue complexity to these parsers.  Removing the trailing `project` would be ideal but we have gone ahead and worked around the failures that it causes by adding `column_ifexists` when an error was produced.

---
internal reference: XDR-370