### PR TITLE
Fix wrong API reference

### DIFF
--- a/Playbooks/Get-TenableVlun/azuredeploy.json
+++ b/Playbooks/Get-TenableVlun/azuredeploy.json
@@ -28,7 +28,7 @@
             "properties": {
                 "customParameterValues": {},
                 "api": {
-                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azureloganalyticsdatacollector')]"
                 }
             }
         },


### PR DESCRIPTION
Telemetry from playbooks with this name indicates that there is an error in this playbook template - the API calls for the action "Send Data" are sent to azuresentinel managed API instead of to azureloganalyticsdatacollector managed API

Fixes #

## Proposed Changes

  - The API connection resource for Log Analytics data collector should point to the right API: azureloganalyticsdatacollector
  -
  -
