### PR TITLE
Checking for column in case evaluate doesn't contain the new column.

### DIFF
--- a/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
+++ b/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
@@ -30,6 +30,7 @@ query: |
   | extend modProps = parse_json(TargetResources).modifiedProperties
   | mv-expand bagexpansion=array modProps
   | evaluate bag_unpack(modProps)
+  | extend displayName = column_ifexists("displayName", "NotAvailable"), newValue = column_ifexists("newValue", "NotAvailable")
   | where displayName =~ "Role.WellKnownObjectName"
   | extend DisplayName = displayName, GroupName = replace('"','',newValue)
   | extend initByApp = parse_json(InitiatedBy).app, initByUser = parse_json(InitiatedBy).user


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Adding in handling if column is not present after bag unpack
  - ```| extend displayName = column_ifexists("displayName", "NotAvailable"), newValue = column_ifexists("newValue", "NotAvailable")```
  -
