### PR TITLE
Add DuoSecurity Tables to validation

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityAdministrator_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityAdministrator_CL.json
@@ -1,0 +1,37 @@
+{
+  "Name": "DuoSecurityAdministration_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "RawData",
+      "Type": "String"
+    },
+    {
+      "Name": "action_s",
+      "Type": "String"
+    },
+    {
+      "Name": "isotimestamp_t",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "object_s",
+      "Type": "String"
+    },
+    {
+      "Name": "timestamp_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "username_s",
+      "Type": "String"
+    },
+    {
+      "Name": "description_s",
+      "Type": "String"
+    }
+  ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityAuthentication_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityAuthentication_CL.json
@@ -1,0 +1,113 @@
+{
+  "Name": "DuoSecurityAuthentication_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "access_device_browser_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_browser_version_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_ip_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_is_encryption_enabled_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_is_firewall_enabled_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_is_password_set_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_location_city_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_location_country_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_location_state_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_os_s",
+      "Type": "String"
+    },
+    {
+      "Name": "access_device_os_version_s",
+      "Type": "String"
+    },
+    {
+      "Name": "alias_s",
+      "Type": "String"
+    },
+    {
+      "Name": "application_key_s",
+      "Type": "String"
+    },
+    {
+      "Name": "application_name_s",
+      "Type": "String"
+    },
+    {
+      "Name": "email_s",
+      "Type": "String"
+    },
+    {
+      "Name": "event_type_s",
+      "Type": "String"
+    },
+    {
+      "Name": "isotimestamp_t",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "reason_s",
+      "Type": "String"
+    },
+    {
+      "Name": "result_s",
+      "Type": "String"
+    },
+    {
+      "Name": "timestamp_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "txid_g",
+      "Type": "String"
+    },
+    {
+      "Name": "user_groups_s",
+      "Type": "String"
+    },
+    {
+      "Name": "user_key_s",
+      "Type": "String"
+    },
+    {
+      "Name": "user_name_s",
+      "Type": "String"
+    },
+    {
+      "Name": "auth_device_name_s",
+      "Type": "String"
+    },
+    {
+      "Name": "factor_s",
+      "Type": "String"
+    }
+  ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityOfflineEnrollment_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityOfflineEnrollment_CL.json
@@ -1,0 +1,33 @@
+{
+  "Name": "DuoSecurityOfflineEnrollment_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "action_s",
+      "Type": "String"
+    },
+    {
+      "Name": "description_s",
+      "Type": "String"
+    },
+    {
+      "Name": "isotimestamp_t",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "object_s",
+      "Type": "String"
+    },
+    {
+      "Name": "timestamp_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "username_s",
+      "Type": "String"
+    }
+  ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityTelephony_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityTelephony_CL.json
@@ -1,0 +1,33 @@
+{
+  "Name": "DuoSecurityTelephony_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "context_s",
+      "Type": "String"
+    },
+    {
+      "Name": "credits_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "isotimestamp_t",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "phone_s",
+      "Type": "String"
+    },
+    {
+      "Name": "timestamp_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "type_s",
+      "Type": "String"
+    }
+  ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityTrustMonitor_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DuoSecurityTrustMonitor_CL.json
@@ -1,0 +1,181 @@
+{
+  "Name": "DuoSecurityTrustMonitor_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "explanations_s",
+      "Type": "String"
+    },
+    {
+      "Name": "from_common_netblock_b",
+      "Type": "Bool"
+    },
+    {
+      "Name": "from_new_user_b",
+      "Type": "Bool"
+    },
+    {
+      "Name": "low_risk_ip_b",
+      "Type": "Bool"
+    },
+    {
+      "Name": "priority_event_b",
+      "Type": "Bool"
+    },
+    {
+      "Name": "priority_reasons_s",
+      "Type": "String"
+    },
+    {
+      "Name": "sekey_s",
+      "Type": "String"
+    },
+    {
+      "Name": "state_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_browser_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_browser_version_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_ip_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_is_encryption_enabled_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_is_firewall_enabled_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_is_password_set_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_location_city_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_location_country_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_location_state_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_os_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_os_version_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_access_device_security_agents_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_alias_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_application_key_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_application_name_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_email_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_factor_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_isotimestamp_t",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "surfaced_auth_ood_software_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_reason_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_result_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_timestamp_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "surfaced_auth_txid_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_user_groups_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_user_key_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_auth_user_name_s",
+      "Type": "String"
+    },
+    {
+      "Name": "surfaced_timestamp_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "triage_event_uri_s",
+      "Type": "String"
+    },
+    {
+      "Name": "triaged_as_interesting_b",
+      "Type": "Bool"
+    },
+    {
+      "Name": "type_s",
+      "Type": "String"
+    },
+    {
+      "Name": "bypass_status_enabled_d",
+      "Type": "Real"
+    },
+    {
+      "Name": "enabled_by_key_s",
+      "Type": "String"
+    },
+    {
+      "Name": "enabled_by_name_s",
+      "Type": "String"
+    },
+    {
+      "Name": "enabled_for_key_s",
+      "Type": "String"
+    },
+    {
+      "Name": "enabled_for_name_s",
+      "Type": "String"
+    }
+  ]
+}

--- a/.script/tests/detectionTemplateSchemaValidation/ValidConnectorIds.json
+++ b/.script/tests/detectionTemplateSchemaValidation/ValidConnectorIds.json
@@ -47,6 +47,7 @@
   "DDOS",
   "DNS",
   "Darktrace",
+  "DuoSecurity",
   "Dynamics365",
   "ESETEnterpriseInspector",
   "ESETPROTECT",


### PR DESCRIPTION
## Proposed Changes
Add DuoSecurity CL schema to KQL validations. Needed for #1764 to complete pass