### PR TITLE
Update CorelightForcedExternalOutboundSMB.yaml

### DIFF
--- a/Solutions/Corelight/Analytic Rules/CorelightForcedExternalOutboundSMB.yaml
+++ b/Solutions/Corelight/Analytic Rules/CorelightForcedExternalOutboundSMB.yaml
@@ -20,7 +20,7 @@ query: |
   | where EventType =~ 'conn'
   | where ZeekConnLocalSrc == 'True'
   | where ZeekConnLocalDst == 'False'
-  | where NetworkConnectionHistory hasprefix 'Sh' or NetworkApplication hasprefix 'smb'
+  | where NetworkConnectionHistory hasprefix 'Sh' and NetworkApplication hasprefix 'smb'
   | extend IPCustomEntity = SrcIpAddr
 entityMappings:
   - entityType: IP


### PR DESCRIPTION
Eliminate false positives in Corelight - Forced External Outbound SMB rule

Fixes Azure/Azure-Sentinel#2445

## Proposed Changes
 - Change the 'or' to an 'and' in the rule logic

