### PR TITLE
Corelight StringStartsWith Error fix

### DIFF
--- a/Solutions/Corelight/Analytic Rules/CorelightPossibleWebshell.yaml
+++ b/Solutions/Corelight/Analytic Rules/CorelightPossibleWebshell.yaml
@@ -20,7 +20,7 @@ query: |
   Corelight
   | where EventType =~ 'http'
   | where HttpRequestMethod in~ ('POST', 'PUT')
-  | where HttpStatusCode startswith '2'
+  | where toint(HttpStatusCode) between (200 .. 299)
   | where HttpRequestBodyBytes != 0 or HttpResponseBodyBytes != 0
   | extend fe = extract(@'.*(\.\w+)$', 1, UrlOriginal)
   | where fe in~ ('.jpg', '.jpeg', '.gif', '.png', '.icon', '.ico', '.xml', '.swf', '.svg', '.ppt', '.pttx', '.doc', '.docx', '.rtf', '.pdf', '.tif', '.zip', '.mov')

--- a/Solutions/Corelight/Analytic Rules/CorelightPossibleWebshellRarePOST.yaml
+++ b/Solutions/Corelight/Analytic Rules/CorelightPossibleWebshellRarePOST.yaml
@@ -21,7 +21,7 @@ query: |
   Corelight
   | where EventType =~ 'http'
   | where HttpRequestMethod in~ ('POST', 'PUT')
-  | where HttpStatusCode !startswith '4'
+  | where toint(HttpStatusCode) !between (400 .. 499)
   | where HttpRequestBodyBytes != 0 or HttpResponseBodyBytes != 0
   | extend fe = extract(@'.*(\.\w+)$', 1, UrlOriginal)
   | where fe in~ ('.aspx', '.asp', '.php', '.jsp', '.jspx', '.war', '.ashx', '.asmx', '.ascx', '.asx', '.cshtml', '.cfm', '.cfc', '.cfml', '.wss', '.do', '.action', '.pl', '.plx', '.pm', '.xs', '.t', '.pod', '.php-s', '.pht', '.phar', '.phps', '.php7', '.php5', '.php4', '.php3', '.phtml', '.py', '.rb', '.rhtml', '.cgi', '.dll', '.ayws', '.cgi', '.erb', '.rjs', '.hta', '.htc', '.cs', '.kt', '.lua', '.vbhtml')


### PR DESCRIPTION
Fixes #2446

## Proposed Changes
-Corrects the errors thrown when trying to create the Corelight webshell rules from the templates.