### PR TITLE
Infoblox Parser - DNSClient Regex Fix

### DIFF
--- a/Parsers/InfobloxNIOS/InfobloxNIOS.txt
+++ b/Parsers/InfobloxNIOS/InfobloxNIOS.txt
@@ -185,7 +185,7 @@ let dnszone = RawData
     | project-away RawData_subString, dnszone_substring, dnszone;
 let dnsclient = RawData 
     | where ProcessName == "named" and Log_Type == "client"
-    | extend dnsclient = extract_all(@"^(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\sview\s(\S+)\:\s((UDP|TCP)\:\s?)??query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
+    | extend dnsclient = extract_all(@"(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\s(?:view\s)?(\S+)?(?:\:\s)?((UDP|TCP)\:\s?)??query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
     | mv-expand todynamic(dnsclient)
     | extend Client_IP = tostring(dnsclient[1]),
         Port = tostring(dnsclient[2]),


### PR DESCRIPTION
Fixes #
  - Update regex in DNSClient Parsing to make `view` portion optional, to ensure current data can be matched.