### PR TITLE
Add ApacheHTTP TI Rule

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/IPEntity_ApacheHTTPServer.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_ApacheHTTPServer.yaml
@@ -10,9 +10,9 @@ requiredDataConnectors:
   - connectorId: ThreatIntelligenceTaxii
     dataTypes:
       - ThreatIntelligenceIndicator
-  - connectorId: AzureMonitor(IIS)
+  - connectorId: ApacheHTTPServer
     dataTypes:
-      - ApacheHTTPServer
+      - ApacheHTTPServer_CL
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -20,32 +20,32 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
-let dt_lookBack = 1h;
-let ioc_lookBack = 14d;
-ThreatIntelligenceIndicator
-| where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
-| where Active == true
-// Picking up only IOC's that contain the entities we want
-| where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
-// As there is potentially more than 1 indicator type for matching IP, taking NetworkIP first, then others if that is empty.
-// Taking the first non-empty value based on potential IOC match availability
-| extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
-| extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
-| extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
-| join (
-    ApacheHTTPServer
-    | where TimeGenerated >= ago(dt_lookBack)
-    | where isnotempty(SrcIpAddr)
-    // renaming time column so it is clear the log this came from
-    | extend ApacheHTTPServer_TimeGenerated = TimeGenerated
-    )
-    on $left.TI_ipEntity == $right.SrcIpAddr
-| where ApacheHTTPServer_TimeGenerated >= TimeGenerated and ApacheHTTPServer_TimeGenerated < ExpirationDateTime
-| summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-| project LatestIndicatorTime, Description, Computer, HttpStatusCode, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
-    ApacheHTTPServer_TimeGenerated, TI_ipEntity, SrcIpAddr, SrcUserName, HttpUserAgentOriginal, NetworkIP, NetworkDestinationIP, NetworkSourceIP, UrlOriginal
-| extend timestamp = ApacheHTTPServer_TimeGenerated, IPCustomEntity = SrcIpAddr, HostCustomEntity = Computer, AccountCustomEntity = tostring(SrcUserName), URLCustomEntity = tostring(UrlOriginal)
+  
+  let dt_lookBack = 1h;
+  let ioc_lookBack = 14d;
+  ThreatIntelligenceIndicator
+  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
+  | where Active == true
+  // Picking up only IOC's that contain the entities we want
+  | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
+  // As there is potentially more than 1 indicator type for matching IP, taking NetworkIP first, then others if that is empty.
+  // Taking the first non-empty value based on potential IOC match availability
+  | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
+  | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
+  | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
+  | join (
+      ApacheHTTPServer
+      | where TimeGenerated >= ago(dt_lookBack)
+      | where isnotempty(SrcIpAddr)
+      // renaming time column so it is clear the log this came from
+      | extend ApacheHTTPServer_TimeGenerated = TimeGenerated
+  )
+  on $left.TI_ipEntity == $right.SrcIpAddr
+  | where ApacheHTTPServer_TimeGenerated >= TimeGenerated and ApacheHTTPServer_TimeGenerated < ExpirationDateTime
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | project LatestIndicatorTime, Description, Computer, HttpStatusCode, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
+      ApacheHTTPServer_TimeGenerated, TI_ipEntity, SrcIpAddr, SrcUserName, HttpUserAgentOriginal, NetworkIP, NetworkDestinationIP, NetworkSourceIP, UrlOriginal
+  | extend timestamp = ApacheHTTPServer_TimeGenerated, IPCustomEntity = SrcIpAddr, HostCustomEntity = Computer, AccountCustomEntity = tostring(SrcUserName), URLCustomEntity = tostring(UrlOriginal)
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_ApacheHTTPServer.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_ApacheHTTPServer.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
       - ThreatIntelligenceIndicator
   - connectorId: ApacheHTTPServer
     dataTypes:
-      - ApacheHTTPServer_CL
+      - ApacheHTTPServer
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -20,7 +20,7 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-  
+
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_ApacheHTTPServer.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_ApacheHTTPServer.yaml
@@ -1,0 +1,66 @@
+id: 4e7ecaef-6555-4cc5-bcb9-d7ead8428550
+name: (Preview) TI map IP entity to Apache HTTP
+description: |
+  'Identifies a match in Apache HTTP Log from any IP IOC from TI'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: AzureMonitor(IIS)
+    dataTypes:
+      - ApacheHTTPServer
+queryFrequency: 1h
+queryPeriod: 14d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Impact
+query: |
+
+let dt_lookBack = 1h;
+let ioc_lookBack = 14d;
+ThreatIntelligenceIndicator
+| where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
+| where Active == true
+// Picking up only IOC's that contain the entities we want
+| where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
+// As there is potentially more than 1 indicator type for matching IP, taking NetworkIP first, then others if that is empty.
+// Taking the first non-empty value based on potential IOC match availability
+| extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
+| extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
+| extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
+| join (
+    ApacheHTTPServer
+    | where TimeGenerated >= ago(dt_lookBack)
+    | where isnotempty(SrcIpAddr)
+    // renaming time column so it is clear the log this came from
+    | extend ApacheHTTPServer_TimeGenerated = TimeGenerated
+    )
+    on $left.TI_ipEntity == $right.SrcIpAddr
+| where ApacheHTTPServer_TimeGenerated >= TimeGenerated and ApacheHTTPServer_TimeGenerated < ExpirationDateTime
+| summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+| project LatestIndicatorTime, Description, Computer, HttpStatusCode, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
+    ApacheHTTPServer_TimeGenerated, TI_ipEntity, SrcIpAddr, SrcUserName, HttpUserAgentOriginal, NetworkIP, NetworkDestinationIP, NetworkSourceIP, UrlOriginal
+| extend timestamp = ApacheHTTPServer_TimeGenerated, IPCustomEntity = SrcIpAddr, HostCustomEntity = Computer, AccountCustomEntity = tostring(SrcUserName), URLCustomEntity = tostring(UrlOriginal)
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPCustomEntity
+  - entityType: URL
+    fieldMappings:
+      - identifier: Url
+        columnName: URLCustomEntity
+version: 1.0.0

--- a/Parsers/Apache/ApacheHTTPServer.txt
+++ b/Parsers/Apache/ApacheHTTPServer.txt
@@ -10,6 +10,7 @@ ApacheHTTPServer_CL
 | where RawData matches regex @'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*\[.*\]\s\"(GET|POST).*?\"\s([1-5][0-9]{2})\s(\d+)\s\"(.*?)\"\s\"(.*?)\".*'
 | extend EventProduct = 'Apache'
 | extend EventType = 'AccessLog'
+| extend Computer = Computer
 | extend EventData = split(RawData, '"')
 | extend SubEventData0 = split(trim_start(@' ', (trim_end(@' ', tostring(EventData[0])))), ' ')
 | extend SubEventData1 = split(EventData[1], ' ')
@@ -33,6 +34,7 @@ ApacheHTTPServer_CL
 | extend EventProduct = 'Apache'
 | extend EventType = 'ErrorLog'
 | extend EventSeverity = 'Error'
+| extend Computer = Computer
 | extend EventStartTime = todatetime(extract(@'\[\w{3}\s(.*?)\]', 1, RawData))
 | extend SrcIpAddr = extract(@'\[client (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\]', 1, RawData)
 | extend EventMessage = extract(@'\[client \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\]\s(.*)', 1, RawData)
@@ -43,6 +45,7 @@ union isfuzzy=true apache_accesslog_events, apache_errorlog_events
         , EventType
         , EventSeverity
         , EventStartTime
+        , Computer
         , SrcIpAddr
         , ClientIdentity
         , SrcUserName


### PR DESCRIPTION
This change adds a new "(Preview) TI map IP entity to Apache HTTP" rule, modeled after the existing TI rule for IIS logs. 

## Proposed Changes
  - New TI Rule for ApacheHTTPServer
  - Updated ApacheHTTPServer function to include the Computer value in its output
