### PR TITLE
Align WatchGuard parser to Azure Sentinel CIM

### DIFF
--- a/Parsers/WatchGuardFirebox.txt
+++ b/Parsers/WatchGuardFirebox.txt
@@ -14,30 +14,39 @@
 //
 // REFERENCES: 
 // Using functions in Azure monitor log queries: https://docs.microsoft.com/azure/azure-monitor/log-query/functions
-let fromat_result = (source_arry:dynamic)
-{
+let fromat_result = (source_arry: dynamic) {
     let source_ips = array_concat(source_arry[0], source_arry[1]);
-    iif(source_ips[2]=="", strcat(source_ips[0],source_ips[1]), strcat(source_ips[0], dynamic(","),source_ips[2]))
+    iif(source_ips[2] == "", strcat(source_ips[0], source_ips[1]), strcat(source_ips[0], dynamic(","), source_ips[2]))
 };
 Syslog
-| extend PolicyName = replace("-00","",extract(@"\s\(([-\w\s]*?(-00|\sPolicy|DVCP-BOVPN-Allow-in))\)$",1,SyslogMessage, typeof(string))),
-PolicyAction = extract("msg_id=\".*?\"\\s(\\w+?)\\s.*(Policy|-00|DVCP-BOVPN-Allow-in)\\)$",1,SyslogMessage),
-ProxyName = extract("Proxy.*?: ([\\w\\s]+)",1,SyslogMessage),
-Application = extract("app_name=\"(.*?)\"",1,SyslogMessage),
-MessageId = extract("msg_id=\"(.*?)\"",1,SyslogMessage),
-EventMessage = extract("msg=\"(.*?)\"",1,SyslogMessage),
-LoginUser =  extract("Authentication of .*?\\[(.*?)@.*?\\].*?\\s",1,SyslogMessage),
-Interface = extract("msg_id=\"3100-002C\" \\[(.*)\\]",1,SyslogMessage),
-InterfaceStatus = extract("Interface link status changed to ([\\w\\s]+)",1,SyslogMessage),
-BOVPNInterface = extract("msg_id=\"0207-0001\".*\'(.*)\'",1,SyslogMessage), 
-BOVPNStatus = extract("BOVPN IPSec tunnel is (.*). local",1,SyslogMessage), 
-GeoDst = extract("geo_dst=\"(.*?)\"",1,SyslogMessage),
-GeoSrc = extract("geo_src=\"(.*?)\"",1,SyslogMessage),
-SentBytes = extract("sent_bytes=\"(.*?)\"",1,SyslogMessage),
-RcvdBytes = extract("rcvd_bytes=\"(.*?)\"",1,SyslogMessage),
-FireboxVersion = extract("Watchguard loggerd (.*?) ",1,SyslogMessage),
-FireboxManageUser = extract("Management user (.*?)@",1,SyslogMessage),
-SrcIpAddr = fromat_result(extract_all(@"(:\s(?P<srcIp1>(\d{1,3}\.){3}\d{1,3}):\d{1,5}\s->\s)|(\s(?P<srcIp2>(\d{1,3}\.){3}\d{1,3})\s(\d{1,3}\.){3}\d{1,3}\s)", dynamic(['srcIp1', 'srcIp2']), SyslogMessage)),
-DstIpAddr = fromat_result(extract_all(@"(:\d{1,5}\s->\s(?P<destIp1>(\d{1,3}\.){3}\d{1,3}):\d{1,5}\s)|(\s(\d{1,3}\.){3}\d{1,3}\s(?P<destIp2>(\d{1,3}\.){3}\d{1,3})\s)", dynamic(['destIp1', 'destIp2']), SyslogMessage)),
-SrcPortNumber = fromat_result(extract_all(@"(:\s(\d{1,3}\.){3}\d{1,3}:(?P<srcPort1>\d{1,5})\s->\s)|(\s(\d{1,3}\.){3}\d{1,3}\s(\d{1,3}\.){3}\d{1,3}\s(?P<srcPort2>\d{1,5})\s)", dynamic(['srcPort1', 'srcPort2']), SyslogMessage)),
-DstPortNumber = fromat_result(extract_all(@"(:\d{1,5}\s->\s(\d{1,3}\.){3}\d{1,3}:(?P<destPort1>\d{1,5})\s)|(\s(\d{1,3}\.){3}\d{1,3}\s(\d{1,3}\.){3}\d{1,3}\s\d{1,5}\s(?P<destPort2>\d{1,5})\s)", dynamic(['destPort1', 'destPort2']), SyslogMessage))
+| extend
+    PolicyName = replace("-00", "", extract(@"\s\(([-\w\s]*?(-00|\sPolicy|DVCP-BOVPN-Allow-in))\)$", 1, SyslogMessage, typeof(string)))
+    , PolicyAction = extract("msg_id=\".*?\"\\s(\\w+?)\\s.*(Policy|-00|DVCP-BOVPN-Allow-in)\\)$", 1, SyslogMessage)
+    , ProxyName = extract("Proxy.*?: ([\\w\\s]+)", 1, SyslogMessage)
+    , Application = extract("app_name=\"(.*?)\"", 1, SyslogMessage)
+    , MessageId = extract("msg_id=\"(.*?)\"", 1, SyslogMessage)
+    , EventMessage = extract("msg=\"(.*?)\"", 1, SyslogMessage)
+    , EventVendor = "Watchguard"
+    , EventProduct = "Firebox"
+    , EventType="Traffic"
+    , EventSchemaVersion="1.0.0"
+    , EventProductVersion = extract("Watchguard loggerd (.*?) ", 1, SyslogMessage)
+    , SrcUserName =  extract("Authentication of .*?\\[(.*?)@.*?\\].*?\\s", 1, SyslogMessage)
+    , DvcInboundInterface = extract("msg_id=\"3100-002C\" \\[(.*)\\]", 1, SyslogMessage)
+    , InterfaceStatus = extract("Interface link status changed to ([\\w\\s]+)", 1, SyslogMessage)
+    , BOVPNInterface = extract("msg_id=\"0207-0001\".*\'(.*)\'", 1, SyslogMessage)
+    , BOVPNStatus = extract("BOVPN IPSec tunnel is (.*). local", 1, SyslogMessage)
+    , DstGeoCountry = extract("geo_dst=\"(.*?)\"", 1, SyslogMessage)
+    , SrcGeoCountry = extract("geo_src=\"(.*?)\"", 1, SyslogMessage)
+    , SrcBytes = todouble(extract("sent_bytes=\"(.*?)\"", 1, SyslogMessage))
+    , DstBytes = todouble(extract("rcvd_bytes=\"(.*?)\"", 1, SyslogMessage))
+    , FireboxManageUser = extract("Management user (.*?)@", 1, SyslogMessage)
+    , SrcIpAddr = fromat_result(extract_all(@"(:\s(?P<srcIp1>(\d{1,3}\.){3}\d{1,3}):\d{1,5}\s->\s)|(\s(?P<srcIp2>(\d{1,3}\.){3}\d{1,3})\s(\d{1,3}\.){3}\d{1,3}\s)", dynamic(['srcIp1', 'srcIp2']), SyslogMessage))
+    , DstIpAddr = fromat_result(extract_all(@"(:\d{1,5}\s->\s(?P<destIp1>(\d{1,3}\.){3}\d{1,3}):\d{1,5}\s)|(\s(\d{1,3}\.){3}\d{1,3}\s(?P<destIp2>(\d{1,3}\.){3}\d{1,3})\s)", dynamic(['destIp1', 'destIp2']), SyslogMessage))
+    , SrcPortNumber = fromat_result(extract_all(@"(:\s(\d{1,3}\.){3}\d{1,3}:(?P<srcPort1>\d{1,5})\s->\s)|(\s(\d{1,3}\.){3}\d{1,3}\s(\d{1,3}\.){3}\d{1,3}\s(?P<srcPort2>\d{1,5})\s)", dynamic(['srcPort1', 'srcPort2']), SyslogMessage))
+    , DstPortNumber = fromat_result(extract_all(@"(:\d{1,5}\s->\s(\d{1,3}\.){3}\d{1,3}:(?P<destPort1>\d{1,5})\s)|(\s(\d{1,3}\.){3}\d{1,3}\s(\d{1,3}\.){3}\d{1,3}\s\d{1,5}\s(?P<destPort2>\d{1,5})\s)", dynamic(['destPort1', 'destPort2']), SyslogMessage))
+| extend
+    DvcAction = case(PolicyAction has "Allow", "Allow", PolicyAction has "Deny", "Deny", PolicyAction has "Drop", "Drop", "")
+    , EventResult = case(PolicyAction has "Allow", "Success", "Failure")
+    , EventTimeIngested = ingestion_time()
+    , EventCount = toint(1)


### PR DESCRIPTION
I really appreciate the work being done to align log sources to the OSSEM CDM 👍

This PR updates the WatchGuard parser to align with the [Azure Sentinel common information model](https://docs.microsoft.com/en-us/azure/sentinel/normalization).

There are no publicly deployed analytics currently using this parser, however I can understand if there's hesitancy to change an existing parser. Happy to discuss the canonical approach and create a secondary "normalisation" parser to avoid breaking changes. On that topic:
1. Should all vendor parsers use vernacular associated to that log source and then project-rename in a dedicated normalisation parser? E.g. Like the parsers in [Azure-Sentinel/Parsers/Normalized Schema - Networking (v1.0.0)](https://github.com/Azure/Azure-Sentinel/tree/master/Parsers/Normalized%20Schema%20-%20Networking%20(v1.0.0))
2. Or, for all new log sources should we look to write parsers that align to the CIM rather than having a 2nd layer of abstraction?

## Field changes
### Added
- `EventVendor`
- `EventProduct`
- `EventResult`
- `EventSchemaVersion`
- `EventTimeIngested`
- `EventType`
- `DvcAction`
- `EventCount`

### Renamed
- `FireboxVersion` -> `EventProductVersion`
- `LoginUser` -> `SrcUserName`
- `Interface` -> `DvcInboundInterface`
- `GeoDst` -> `DstGeoCountry`
- `GeoSrc` -> `SrcGeoCountry`
- `SentBytes` -> `SrcBytes`
- `RcvdBytes` -> `DstBytes`