### PR TITLE
Add bulk Alert Rule Action PowerShell script sample

### DIFF
--- a/Tools/Az.SecurityInsights-Samples/Alert Rule Actions/Add Action to All Azure Sentinel Analytics Rules/README.md
+++ b/Tools/Az.SecurityInsights-Samples/Alert Rule Actions/Add Action to All Azure Sentinel Analytics Rules/README.md
@@ -1,0 +1,32 @@
+# Add Action to All Azure Sentinel Analytics Rules
+Author: Matt Burrough
+
+**Objective:** Perform a bulk addition of an action to all Azure Sentinel rules <br/>
+
+**Notes:**
+* Does not apply actions to rules of Kind "Error"
+* Skips any rules that already have an action for the specified Logic App applied
+
+<br/>
+
+**Prerequisites:**
+The following Azure PowerShell modules are required and will be installed if missing:
+* Az.Accounts
+* Az.SecurityInsights
+<br/><br/>
+
+#### Script Parameters
+The script will prompt you for the following parameter values:
+* *subscriptionId* - the subscription ID where your Azure Sentinel workspace resides in
+* *sentinelRG* - the Azure resource group name where the Azure Sentinel workspace resides in
+* *workspaceName* - the name of the Azure Sentinel workspace
+* *logicAppName* - the name of the Logic App to use for the rules
+* *logicAppRG* - the Azure resource group name where the Logic App resides [Optional, defaults to the same resource group as specified for Sentinel]
+* *triggerName* - name of the Logic App trigger [Optional, if not specified, the default trigger name "When_a_response_to_an_Azure_Sentinel_alert_is_triggered" is used]
+<br/><br/>
+
+#### Running the script 
+After your have downloaded the sample script, you can run the script with parameters as follows:
+```powershell
+.\addAzureSentinelAlertAction.ps1 -subscriptionId "0c8c4515-d563-4eb7-96fa-a5a2b8f6806c" -sentinelRG "mySentinelRG" -workspaceName "Sentinelworkspace" -logicAppName "SentinelAlerts"
+```

--- a/Tools/Az.SecurityInsights-Samples/Alert Rule Actions/Add Action to All Azure Sentinel Analytics Rules/addAzureSentinelAlertAction.ps1
+++ b/Tools/Az.SecurityInsights-Samples/Alert Rule Actions/Add Action to All Azure Sentinel Analytics Rules/addAzureSentinelAlertAction.ps1
@@ -1,0 +1,106 @@
+﻿param (
+    [parameter(Mandatory = $true)]
+    #The subscription that holds your Azure Sentinel workspace
+    [string] $subscriptionId,
+    [parameter(Mandatory = $true)]
+    # The resource group name which holds your Azure Sentinel workspace
+    [string] $sentinelRG,
+    [parameter(Mandatory = $true)]
+    # The Azure Sentinel workspace name
+    [string] $workspaceName,
+    [parameter(Mandatory = $true)]
+    # The name of the Logic App to use for the rules
+    [string] $logicAppName,
+    [parameter(Mandatory = $false)]
+    # The resource group name which holds your Logic App. If not specified, the Sentinel resource group name is assumed.
+    [string] $logicAppRG = $sentinelRG,
+    [parameter(Mandatory = $false)]
+    # The name of the Logic App trigger. If not specified, the default trigger name "When_a_response_to_an_Azure_Sentinel_alert_is_triggered" is used.
+    [string] $triggerName = "When_a_response_to_an_Azure_Sentinel_alert_is_triggered"
+)
+
+# PowerShell version detection, module detection, and subscription context logic used from: 
+# https://github.com/Azure/Azure-Sentinel/blob/master/Tools/Az.SecurityInsights-Samples/Alert%20Rules/Export%20Analytics%20Rules/exportAzureSentinelRules.ps1
+
+$ErrorActionPreference = "Stop"
+
+# Check powershell version, needs to be 5 or higher
+if ($host.Version.Major -lt 5) {
+    Write-Host "Supported PowerShell version for this script is 5 or above" -ForegroundColor Red
+    Write-Host "Aborting...." -ForegroundColor Red
+    break
+}
+
+#Check if the Az.SecurityInsights module is installed, if not install it
+#This will auto install the Az.Accounts module if it is not installed
+$AzSecurityInsightsModule = Get-InstalledModule -Name Az.SecurityInsights -ErrorAction SilentlyContinue
+if ($AzSecurityInsightsModule -eq $null) {
+    Write-Warning "The Az.SecurityInsights PowerShell module is not found"
+        #check for Admin Privleges
+        $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+
+        if (-not ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+            #Not an Admin, install to current user
+            Write-Warning -Message "Can not install the Az.SecurityInsights module. You are not running as Administrator"
+            Write-Warning -Message "Installing Az.SecurityInsights module to current user Scope"
+            Install-Module Az.SecurityInsights -Scope CurrentUser -Force
+        }
+        Else {
+            #Admin, install to all users
+            Write-Warning -Message "Installing the Az.SecurityInsights module to all users"
+            Install-Module -Name Az.SecurityInsights -Force
+            Import-Module -Name Az.SecurityInsights -Force
+        }
+}
+
+#Check the Azure subscription context
+$subIdContext = (Get-AzContext).Subscription.Id 
+if ($subIdContext -ne $subscriptionId) {
+    $setSub = Set-AzContext -SubscriptionName $subscriptionId -ErrorAction SilentlyContinue
+    if ($setSub -eq $Null) {
+        Write-Warning "$subscriptionId is not set, please login and run this script again"
+        Login-AzAccount
+        break
+    }
+}
+
+try {
+    #Get the Logic App and its trigger URI
+    $logicapp = Get-AzLogicApp -ResourceGroupName $logicAppRG -Name $logicAppName
+    $triggerUri = Get-AzLogicAppTriggerCallbackUrl -ResourceGroupName $logicAppRG -Name $logicAppName -TriggerName $triggerName
+
+    #Get the active rules from the Sentinel workspace
+    $rules = Get-AzSentinelAlertRule -ResourceGroupName $sentinelRG -WorkspaceName $workspaceName
+    foreach($rule in $rules)
+    {
+        #Don't try to add the action to rules where Kind==Error
+        if($rule.Kind -eq "Error")
+        {
+            Write-Warning "Skipping rule $($rule.Name) because rule is of kind Error"
+        }
+        else
+        {
+            #Check to make sure the rule doesn't already have an action for this app, since each rule can only have one instance of an action
+            $applyAction = $true
+            $actions = Get-AzSentinelAlertRuleAction -ResourceGroupName $sentinelRG -WorkspaceName $workspaceName -AlertRuleId $($rule.Name)
+            foreach($action in $actions)
+            {
+                if($($action.LogicAppResourceId) -eq $($logicapp.Id)) {
+                    Write-Warning "Skipping rule $($rule.Name) because it already contains an action for this Logic App."
+                    $applyAction = $false
+                    break
+                }
+            }
+            
+            if($applyAction) {
+                #Apply the action to the rule
+                Write-Host "Adding action to $($rule.Name)"
+                New-AzSentinelAlertRuleAction -ResourceGroupName $sentinelRG -WorkspaceName $workspaceName -AlertRuleId $($rule.Name) -LogicAppResourceId $($logicapp.Id) -TriggerUri $($triggerUri.Value)
+            }
+        }
+    }
+}
+catch {
+    Write-Warning "An error occured while trying to add actions: $($_.Exception.Message)"
+    break
+}

--- a/Tools/Az.SecurityInsights-Samples/Alert Rule Actions/README.md
+++ b/Tools/Az.SecurityInsights-Samples/Alert Rule Actions/README.md
@@ -1,0 +1,4 @@
+# Alert Rule Action samples
+
+[Add Action to All Azure Sentinel Analytics Rules Sample](https://github.com/Azure/Azure-Sentinel/tree/master/Tools/Az.SecurityInsights-Samples/Alert%20Rule%20Actions/Add%20Action%20to%20All%20Azure%20Sentinel%20Analytics%20Rules)
+<br/>

--- a/Tools/Az.SecurityInsights-Samples/README.md
+++ b/Tools/Az.SecurityInsights-Samples/README.md
@@ -7,7 +7,7 @@ Download from <a href="https://www.powershellgallery.com/packages/Az.SecurityIns
 The samples are divided into the following sections:
 
 * [Alert Rules](https://github.com/Azure/Azure-Sentinel/tree/master/Tools/Az.SecurityInsights-Samples/Alert%20Rules)
-* Alert Rules Actions (coming soon)
+* [Alert Rules Actions](https://github.com/Azure/Azure-Sentinel/tree/master/Tools/Az.SecurityInsights-Samples/Alert%20Rule%20Actions)
 * Data Connectors (coming soon)
 * Incidents (coming soon)
 


### PR DESCRIPTION
## Proposed Changes

  - Adds a sample PowerShell script to apply an alert rule action to all active rules, as suggested by Javier [here](https://techcommunity.microsoft.com/t5/azure-sentinel/how-to-mass-apply-a-playbook-to-all-analytic-rules-at-once/m-p/2070715).
