### PR TITLE
InfobloxNIOS Parser - DHCPAck Fix

### DIFF
--- a/Parsers/InfobloxNIOS/InfobloxNIOS.txt
+++ b/Parsers/InfobloxNIOS/InfobloxNIOS.txt
@@ -185,7 +185,7 @@ let dnszone = RawData
     | project-away RawData_subString, dnszone_substring, dnszone;
 let dnsclient = RawData 
     | where ProcessName == "named" and Log_Type == "client"
-    | extend dnsclient = extract_all(@"^(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\sview\s(\S+)\:\s((UDP|TCP)\:\s?)??query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
+    | extend dnsclient = extract_all(@"(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\s(?:view\s)?(\S+)?(?:\:\s)?((UDP|TCP)\:\s?)??query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
     | mv-expand todynamic(dnsclient)
     | extend Client_IP = tostring(dnsclient[1]),
         Port = tostring(dnsclient[2]),

--- a/Parsers/InfobloxNIOS/InfobloxNIOS.txt
+++ b/Parsers/InfobloxNIOS/InfobloxNIOS.txt
@@ -68,13 +68,13 @@ let dhcprelease = RawData
     | project-away RawData_subString, dhcprelease;
 let dhcpack = RawData
     | where ProcessName == "dhcpd" and Log_Type == "DHCPACK"
-    | extend dhcpack = extract_all(@"(^\s\w+\s(\S+))\sto\s(\S+)\s\((\S+)\)\svia\s(\S+)(\srelay\s(\S+))?(\slease-duration\s(\d+))?(\s\(([a-zA-Z]+)\))?(\sUID\s(\S+))?", dynamic([1,2,3,4,5,6,7,8,9,10,11]), RawData_subString)
+    | extend dhcpack = extract_all(@"(\s\w+\s(\S+))\sto\s(\S+)\svia\s(\S+)(\srelay\s(\S+))?(\slease-duration\s(\d+))?(\s\(([a-zA-Z]+)\))?(\suid\s(\S+))?", dynamic([1,2,3,4,5,6,7,8,9,10,11]), RawData_subString)
     | mv-expand todynamic(dhcpack)
     | extend IPAddress = tostring(dhcpack[1]), 
         Client_MAC_Address = tostring(dhcpack[2]),
         Interface = tostring(dhcpack[4]),
-        Relay = tostring(dhcpack[6]), 
-        LeaseDuration = tostring(dhcpack[8]),
+        Relay = tostring(dhcpack[5]), 
+        LeaseDuration = tostring(dhcpack[7]),
         Client_Hostname = tostring(dhcpack[3]),
         State = tostring(dhcpack[10])
     | extend dhcpack2 = extract_all(@"to\s(\S+)\s\((\S+)\)\svia\s(\S+)", dynamic([1,2,3]), RawData_subString)

--- a/Parsers/InfobloxNIOS/InfobloxNIOS.txt
+++ b/Parsers/InfobloxNIOS/InfobloxNIOS.txt
@@ -185,7 +185,7 @@ let dnszone = RawData
     | project-away RawData_subString, dnszone_substring, dnszone;
 let dnsclient = RawData 
     | where ProcessName == "named" and Log_Type == "client"
-    | extend dnsclient = extract_all(@"^(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\s(view\s(\S+)\:\s(UDP|TCP)\:\s?)?query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
+    | extend dnsclient = extract_all(@"^(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\sview\s(\S+)\:\s((UDP|TCP)\:\s?)??query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
     | mv-expand todynamic(dnsclient)
     | extend Client_IP = tostring(dnsclient[1]),
         Port = tostring(dnsclient[2]),

--- a/Parsers/InfobloxNIOS/InfobloxNIOS.txt
+++ b/Parsers/InfobloxNIOS/InfobloxNIOS.txt
@@ -113,7 +113,7 @@ let dhcpexpire = RawData
     | project-away RawData_subString, dhcpexpire;
 let dhcpsession = RawData
     | where ProcessName == "dhcpd" and Log_Type == "r-l-e"
-    | extend dhcpsession = extract_all(@"\:([0-9.]+)\,([a-zA-Z]+)\,([a-zA-Z0-9-]+)\,([a-z0-9:]+)\,([0-9]+)\,([0-9]+)\,([0-9]+)?\,([\w$\s]+)\,([0-9.]+)\,([0-9]+)\,([0-9-.]+)", dynamic([1,2,3,4,5,6,7,8,9,10,11]), RawData_subString)
+    | extend dhcpsession = extract_all(@"\:?([0-9.]+)\,([a-zA-Z]+)\,([a-zA-Z0-9-]+)\,([a-z0-9:]+)\,([0-9]+)\,([0-9]+)\,([0-9]+)?\,([\w$\s]+)\,([0-9.]+)\,([0-9]+)\,([0-9-.]+)", dynamic([1,2,3,4,5,6,7,8,9,10,11]), RawData_subString)
     | mv-expand todynamic(dhcpsession)
     | extend Dest_IP = tostring(dhcpsession[0]),  
         Signature = tostring(dhcpsession[1]),
@@ -185,7 +185,7 @@ let dnszone = RawData
     | project-away RawData_subString, dnszone_substring, dnszone;
 let dnsclient = RawData 
     | where ProcessName == "named" and Log_Type == "client"
-    | extend dnsclient = extract_all(@"^(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\sview\s(\S+)\:\s((UDP|TCP)\:\s?)??query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
+    | extend dnsclient = extract_all(@"^(\@[a-z0-9]+\s)?([0-9\.]+)\#(\d+)(\s\((\S+)\))?\:\s(view\s(\S+)\:\s(UDP|TCP)\:\s?)?query\:\s(\S+)\s(\S+)\s(\S+)(\sresponse:\s([A-Z]+))?\s(\S+)(.*)",dynamic([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]), RawData_subString)
     | mv-expand todynamic(dnsclient)
     | extend Client_IP = tostring(dnsclient[1]),
         Port = tostring(dnsclient[2]),


### PR DESCRIPTION
This change aims to fix the DHCPAck log parsing in the InfobloxNIOS Parser.

Fixes #
  - Modified the regex which parses DHCPAck logs
  - Modified the capture groups used for `Relay` and `LeaseDuration`
  - Update regex in DNSClient Parsing to make view portion optional, to ensure current data can be matched.
- "r-l-e" type of logs raw string field is not starting with ' ':' hence making it as Optional