### PR TITLE
Fixed typo in dotnet.exe value

### DIFF
--- a/Detections/MultipleDataSources/PotentialBuildProcessCompromiseMDE.yaml
+++ b/Detections/MultipleDataSources/PotentialBuildProcessCompromiseMDE.yaml
@@ -26,7 +26,7 @@ query: |
   // How close together build events and file modifications should occur to alert (make this smaller to reduce FPs)
   let time_window = 5m;
   // Edit this to include build processes used
-  let build_processes = dynamic(["MSBuild.exe", "dontnet.exe", "VBCSCompiler.exe"]);
+  let build_processes = dynamic(["MSBuild.exe", "dotnet.exe", "VBCSCompiler.exe"]);
   // Include any processes that you want to allow to edit files during/around the build process
   let allow_list = dynamic([]);
   DeviceProcessEvents

--- a/Detections/SecurityEvent/PotentialBuildProcessCompromise.yaml
+++ b/Detections/SecurityEvent/PotentialBuildProcessCompromise.yaml
@@ -28,7 +28,7 @@ query: |
   // How close together build events and file modifications should occur to alert (make this smaller to reduce FPs)
   let time_window = 5m;
   // Edit this to include build processes used
-  let build_processes = dynamic(["MSBuild.exe", "dontnet.exe", "VBCSCompiler.exe"]);
+  let build_processes = dynamic(["MSBuild.exe", "dotnet.exe", "VBCSCompiler.exe"]);
   // Include any processes that you want to allow to edit files during/around the build process
   let allow_list = dynamic([""]);
   SecurityEvent


### PR DESCRIPTION
Fixed a typo that in the name of a process to be monitored.