### PR TITLE
Getting parsing error when deploying the template

### DIFF
--- a/Playbooks/AzureFirewall/AzureFirewall-BlockIP-addToIPGroup/azuredeploy.json
+++ b/Playbooks/AzureFirewall/AzureFirewall-BlockIP-addToIPGroup/azuredeploy.json
@@ -82,7 +82,7 @@
           "token:grantType": "client_credentials"
         },
         "api": {
-          "id": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/customApis/', parameters('CustomConnectorName')]"
+          "id": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/customApis/', parameters('CustomConnectorName'))]"
         }
       }
     },


### PR DESCRIPTION
Deployment template language expression evaluation failed: 'Unable to parse language expression 'concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/customApis/', parameters('CustomConnectorName')': expected token 'RightParenthesis' and actual 'EndOfData'.'. Please see https://aka.ms/arm-template-expressions for usage details. (Code: InvalidTemplate)

Fixes #

## Proposed Changes

  -
  -
  -
