### PR TITLE
Updating CustomTable for DeviceInfo.json

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/DeviceInfo.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DeviceInfo.json
@@ -3,51 +3,51 @@
   "Properties": [
     {
       "Name": "TenantId",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "AdditionalFields",
-      "Type": "dynamic"
+      "Type": "Dynamic"
     },
     {
       "Name": "ClientVersion",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "DeviceId",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "DeviceName",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "DeviceObjectId",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "IsAzureADJoined",
-      "Type": "bool"
+      "Type": "Bool"
     },
     {
       "Name": "LoggedOnUsers",
-      "Type": "dynamic"
+      "Type": "Dynamic"
     },
     {
       "Name": "MachineGroup",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "OSArchitecture",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "OSBuild",
-      "Type": "long"
+      "Type": "Int"
     },
     {
       "Name": "OSPlatform",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "OSVersion",
@@ -55,31 +55,31 @@
     },
     {
       "Name": "PublicIP",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "RegistryDeviceTag",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "ReportId",
-      "Type": "long"
+      "Type": "Int"
     },
     {
       "Name": "TimeGenerated",
-      "Type": "datetime"
+      "Type": "DateTime"
     },
     {
       "Name": "Timestamp",
-      "Type": "datetime"
+      "Type": "DateTime"
     },
     {
       "Name": "SourceSystem",
-      "Type": "string"
+      "Type": "String"
     },
     {
       "Name": "Type",
-      "Type": "string"
+      "Type": "String"
     }
   ]
 }

--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -13,11 +13,6 @@
     "id": "f2dd4a3a-ebac-4994-9499-1a859938c947",
     "templateName": "Time series anomaly for data size transferred to public internet",
     "validationFailReason": "The name 'DestinationIP' does not refer to any known column, table, variable or function."
-  },
-  {
-    "id": "e70fa6e0-796a-4e85-9420-98b17b0bb749",
-    "templateName": "Solorigate Defender Detections",
-    "validationFailReason": "The name 'DeviceInfo' refers to more than one column or variable"
   }
 ]
 


### PR DESCRIPTION
Initial missing capital letter on Type may be causing the JSON to not be used in validation of detection id - e70fa6e0-796a-4e85-9420-98b17b0bb749

Fixes #

## Proposed Changes

  -
  -
  -
