### PR TITLE
Ubiquiti Unifi Parser Fixes

### DIFF
--- a/Solutions/Ubiquiti/Analytic Rules/UbiquitiDestinationInTiList.yaml
+++ b/Solutions/Ubiquiti/Analytic Rules/UbiquitiDestinationInTiList.yaml
@@ -28,7 +28,7 @@ query: |
   | where ipv4_is_private(SrcIpAddr)
   | where ipv4_is_private(DstIpAddr) == 'False'
   | where DstIpAddr in (malicious_ips)
-  | where DvcAction =~ 'Accepted'
+  | where DvcAction =~ 'Accepted' or DvcAction =~ 'Other'
   | extend IPCustomEntity = SrcIpAddr
 entityMappings:
   - entityType: IP

--- a/Solutions/Ubiquiti/Parsers/Ubiquiti.txt
+++ b/Solutions/Ubiquiti/Parsers/Ubiquiti.txt
@@ -4,10 +4,10 @@
 // Reference : Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 let EventData = Ubiquiti_CL
 | extend EventVendor = 'Ubiquiti'
-| extend EventTime = extract(@'\<\d+\>(.*)\s\w+,[A-Fa-f0-9]{12}', 1, Message)
-| extend DvcType = extract(@'\d+\:\d+\:\d+\s(\w+),[A-Fa-f0-9]{12}' , 1, Message)
-| extend DvcMacAddr = replace(@'(:)$', @'', replace(@'(\w{2})', @'\1:', extract(@',([A-Fa-f0-9]{12}),v' , 1, Message)))
-| extend FirmwareVersion = extract(@'[A-Fa-f0-9]{12},v(.*?)\:', 1, Message);
+| extend EventTime = extract(@'\<\d+\>(\w+\s+\w+\s+\d+:\d+:\d+)\s\w+,', 1, Message)
+| extend DvcType = iif(extract(@'\d+\:\d+\:\d+\s(\w+),[A-Fa-f0-9]{12}', 1, Message)!="", extract(@'\d+\:\d+\:\d+\s(\w+),[A-Fa-f0-9]{12}', 1, Message), extract(@'\d+\:\d+\:\d+\s[A-Fa-f0-9]{12},([A-Za-z-]+)-', 1, Message))
+| extend DvcMacAddr = replace(@'(:)$', @'', replace(@'(\w{2})', @'\1:', extract(@'([A-Fa-f0-9]{12}),' , 1, Message)))
+| extend FirmwareVersion = iif(extract(@'[A-Fa-f0-9]{12},v(.*?)\:', 1, Message)!="", extract(@'[A-Fa-f0-9]{12},v(.*?)\:', 1, Message), extract(@'[A-Fa-f0-9]{12},[A-Za-z-]+([\d\.\+]+)[\:\s]', 1, Message));
 let ubiquiti_dropbear_events =() {
 EventData
 | where Message contains 'dropbear'
@@ -20,7 +20,7 @@ let ubiquiti_hostapd_events =() {
 EventData
 | where Message contains 'hostapd'
 | extend EventCategory = 'hostapd'
-| extend WlanId = extract(@'hostapd:\s(\w+)\s', 1, Message)
+| extend WlanId = extract(@'hostapd:\s(\w+)', 1, Message)
 | extend SrcType = extract(@':\s(\w+)\s[A-Fa-f0-9:]{17}', 1, Message)
 | extend SrcMacAddr = extract(@':\s(\w+)\s([A-Fa-f0-9:]{17})', 2, Message)
 | extend DstMacAddr = extract(@'addr=([a-fA-F0-9:]{17})', 1, Message)
@@ -29,7 +29,7 @@ EventData
 };
 let ubiquiti_firewall_events =() {
 EventData
-| where Message matches regex @'kernel:\s+\[\S+-\w\]'
+| where Message matches regex @'kernel:\s+\[.+\]\s+IN=\w+\s+OUT=\w+\s+'
 | extend EventCategory = 'firewall'
 | extend FlowId = extract(@'ID=(.*?)\s', 1, Message)
 | extend DvcInboundInterface = extract(@'IN=(.*?)\s', 1, Message)
@@ -58,11 +58,12 @@ EventData
 let ubiquiti_dns_timeout_events =() {
 EventData
 | where Message contains "DNS request timed out"
+| extend EventCategory = 'dnstimeout'
 | extend EventMessage = 'DNS request timed out'
 | extend SrcType = extract(@'\[(\w+):\s[a-fA-F0-9:]{17}\]', 1, Message)
 | extend DvcMacAddr = extract(@'\[\w+:\s([a-fA-F0-9:]{17})\]', 1, Message)
 | extend DnsQuery = extract(@'QUERY:(.*?)\]', 1, Message)
-| extend DnsServer = extract(@'DNS_SERVER(\s)?:(.*?)\]', 1, Message)
+| extend DnsServer = extract(@'DNS_SERVER\s?:(.*?)\]', 1, Message)
 };
 let ubiquiti_stahtd_events =() {
 EventData
@@ -76,7 +77,7 @@ EventData
 };
 let ubiquiti_EVT_AP_STA_ASSOC_TRACKER_DBG =() {
 EventData
-| where Message contains 'libubnt'
+//| where Message contains 'libubnt'
 | where Message contains 'EVT_AP_STA_ASSOC_TRACKER_DBG'
 | extend EventCategory = 'libubnt'
 | extend WlanId = extract(@'vap:\s(.*?)', 1, Message)
@@ -86,7 +87,7 @@ EventData
 };
 let ubiquiti_EVENT_STA_ =() {
 EventData
-| where Message contains 'libubnt'
+//| where Message contains 'libubnt'
 | where Message contains 'EVENT_STA_'
 | extend EventCategory = 'libubnt'
 | extend WlanId = extract(@'EVENT_STA_(JOIN|LEAVE|IP)\s(\w+):', 2, Message)


### PR DESCRIPTION
Fixes #2677 

## Proposed Changes
- Updated EventTime parsing to handle alternate log format from some v5 Unifi devices (e.g. "<4>Jul 14 17:44:32 fcecda13e5c7,UAP-AC-LR-5.43.38+12731: " vs. "<4>Jul 14 17:44:35 U7PG2,7483c2b9d7c2,v4.3.28.11361:")
- Updated DvcType to try looking for the device type after the MAC address if it isn't found at the beginning of the string (for v5 Unifi devices)
- Updated DvcMacAddr parsing to work regardless if the MAC comes before or after the device type
- Updated FirmwareVersion parsing to look for the firmware after the device type if it isn't found after the MAC (for v5 Unifi devices)
- Removed unneeded whitespace from WlanId hostapd pattern match that caused the WlanId to be omitted from some log entries
- Updated firewall matching regex to also work for UDM firewall logs (see https://community.ui.com/questions/Unifi-Syslog-Firewall-UDM-pro-vs-USG-Not-compatible-with-Azure-Sentinel/1b9e0366-a5c6-42b9-9893-9ffcceff49cd)
- Added event category for DNS Timeout messages
- Removed errant grouping from DNSServer extract that caused it to provide a null output
- Commented out libubnt constraint from STA log messages, as the string "libubnt" does not appear in STA messages from newer Unifi devices
- Updated Unifi Malicious IP rule to match on firewall format from Ubiquiti UDM devices