### PR TITLE
Fix McAfee ePO parser for ePO 5.10

### DIFF
--- a/Solutions/McAfeeePO/Parsers/McAfeeEPOEvent.txt
+++ b/Solutions/McAfeeePO/Parsers/McAfeeEPOEvent.txt
@@ -5,6 +5,7 @@
 let mcafee_epoevent =() {
 Syslog
 | where SyslogMessage contains '<EPOevent>'
+    or ProcessName contains 'EPOEvents' //for EPO verion 5.10 at least, this is the format now
 | extend EventVendor = 'McAfee'
 | extend EventProduct = 'McAfee ePO'
 | extend DvcHostname = extract(@'\<MachineName\>(.*?)\<\/MachineName\>', 1, SyslogMessage)


### PR DESCRIPTION
Updated McAfeeEPOEvent.txt parser with new syntax for at least ePO 5.10 which doesn't include our current parsing of the Syslog message.

Fixes #

## Proposed Changes

  -
  -
  -
