### PR TITLE
On Hold - Added normalization support for DEV-0322_SolarWinds_Serv-U_IOC

### DIFF
--- a/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
+++ b/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
@@ -60,8 +60,7 @@ query:  |
   let iocs = externaldata(DateAdded:string,IoC:string,Type:string,TLP:string) [@"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Sample%20Data/Feeds/DEV-0322_SolarWinds_Serv-U_IoC.csv"] with (format="csv", ignoreFirstRecord=True);
   let process = (iocs | where Type =~ "process" | project IoC);
   let parentprocess = (iocs | where Type =~ "parentprocess" | project IoC);
-  let IPList = (iocs | where Type =~ "ip"| project IoC);
-  let IPListDynamic = toscalar(IPList | summarize make_set(IoC));
+  let IPList = toscalar((iocs | where Type =~ "ip"| summarize make_set(IoC)));
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
   let IPRegexGroup = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})';
   (union isfuzzy=true
@@ -79,9 +78,8 @@ query:  |
   | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
   (imDns
-  | where has_any_ipv4 (DnsResponseName, IPListDynamic)
-  | extend DnsResponseAddresses = extract_all(IPRegexGroup, ResponseName)
-  | extend IPAddresses = set_intersect(IPListDynamic,DnsResponseAddresses)
+  | where has_any_ipv4 (DnsResponseName, IPList)
+  | extend IPAddresses = set_intersect(IPList,extract_all(IPRegexGroup, ResponseName))
   | project TimeGenerated, Dvc, DnsResponseName, DnsQuery, SrcIpAddr, DnsQueryTypeName, IPAddresses
   | extend DestinationIPAddress = IPAddresses[0], DNSName = DnsQuery, Host = Dvc
   | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
@@ -177,9 +175,9 @@ query:  |
   | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, IPCustomEntity = CommandLineIP
   ),
   (imProcessCreate
-  | where has_any_ipv4 (TargetProcessCommandLine, IPListDynamic) or (TargetProcessName has_any (process) and ActingProcessName has_any (parentprocess))
+  | where has_any_ipv4 (TargetProcessCommandLine, IPList) or (TargetProcessName has_any (process) and ActingProcessName has_any (parentprocess))
   | extend CommandLineAddresses = extract_all(IPRegexGroup, TargetProcessCommandLine)
-  | extend IPAddresses = set_intersect(IPListDynamic,CommandLineAddresses)
+  | extend IPAddresses = set_intersect(IPList,CommandLineAddresses)
   | project TimeGenerated, Dvc, TargetProcessName, ActingProcessName, TargetUsername, TargetProcessId, Type, TargetProcessCommandLine , IPAddresses, TargetProcessSHA256
   | extend HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256)
   )

--- a/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
+++ b/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
@@ -61,8 +61,7 @@ query:  |
   let process = (iocs | where Type =~ "process" | project IoC);
   let parentprocess = (iocs | where Type =~ "parentprocess" | project IoC);
   let IPList = toscalar((iocs | where Type =~ "ip"| summarize make_set(IoC)));
-  let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
-  let IPRegexGroup = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})';
+  let IPRegex = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})';
   (union isfuzzy=true
   (CommonSecurityLog
   | where SourceIP in (IPList) or DestinationIP in (IPList) or RequestURL has_any (IPList) or Message has_any (IPList)
@@ -79,8 +78,8 @@ query:  |
   ),
   (imDns
   | where has_any_ipv4 (DnsResponseName, IPList)
-  | extend IPAddresses = set_intersect(IPList,extract_all(IPRegexGroup, ResponseName))
-  | project TimeGenerated, Dvc, DnsResponseName, DnsQuery, SrcIpAddr, DnsQueryTypeName, IPAddresses
+  | extend IPAddresses = set_intersect(IPList,extract_all(IPRegex, ResponseName))
+  | project TimeGenerated, Dvc, DnsResponseName, DnsQuery, SrcIpAddr, IPAddresses, Type
   | extend DestinationIPAddress = IPAddresses[0], DNSName = DnsQuery, Host = Dvc
   | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
@@ -175,11 +174,11 @@ query:  |
   | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, IPCustomEntity = CommandLineIP
   ),
   (imProcessCreate
-  | where has_any_ipv4 (TargetProcessCommandLine, IPList) or (TargetProcessName has_any (process) and ActingProcessName has_any (parentprocess))
-  | extend CommandLineAddresses = extract_all(IPRegexGroup, TargetProcessCommandLine)
-  | extend IPAddresses = set_intersect(IPList,CommandLineAddresses)
-  | project TimeGenerated, Dvc, TargetProcessName, ActingProcessName, TargetUsername, TargetProcessId, Type, TargetProcessCommandLine , IPAddresses, TargetProcessSHA256
-  | extend HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256)
+  | where has_any_ipv4 (CommandLine, IPList) or (Process has_any (process) and ActingProcessName has_any (parentprocess))
+  | extend IPAddresses = set_intersect(IPList,extract_all(IPRegex, TargetProcessCommandLine))
+  | project TimeGenerated, Dvc, Process, ActingProcessName, User, TargetProcessId, Type, CommandLine , IPAddresses, TargetProcessSHA256
+  | extend HostCustomEntity = Dvc , AccountCustomEntity = User, ProcessCustomEntity = Process, IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256
+  )
   )
   | extend timestamp = TimeGenerated, AlertDetail = 'Dev-0322 IOC match'
 entityMappings:

--- a/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
+++ b/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
@@ -61,7 +61,7 @@ query:  |
   let process = (iocs | where Type =~ "process" | project IoC);
   let parentprocess = (iocs | where Type =~ "parentprocess" | project IoC);
   let IPList = (iocs | where Type =~ "ip"| project IoC);
-  let IPListDynamic = toscalar(IPList | summarize make_set(IoC));  
+  let IPListDynamic = toscalar(IPList | summarize make_set(IoC));
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
   let IPRegexGroup = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})';
   (union isfuzzy=true
@@ -69,13 +69,13 @@ query:  |
   | where SourceIP in (IPList) or DestinationIP in (IPList) or RequestURL has_any (IPList) or Message has_any (IPList)
   | project TimeGenerated, SourceIP, DestinationIP, Message, SourceUserID, RequestURL, Type
   | extend MessageIP = extract(IPRegex, 0, Message)
-  | extend IPMatch = case(SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", MessageIP in (IPList), "Message", RequestURL in (IPList), "RequestUrl","NoMatch"), AlertDetail = 'Dev-0322 IOC match'
+  | extend IPMatch = case(SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", MessageIP in (IPList), "Message", RequestURL in (IPList), "RequestUrl","NoMatch")
   | extend IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, IPMatch == "Message", MessageIP, IPMatch == "RequestUrl", RequestURL, "NoMatch"), AccountCustomEntity = SourceUserID
   ),
   (DnsEvents
-  | where IPAddresses in (IPList)  
+  | where IPAddresses in (IPList)
   | project TimeGenerated, Computer, IPAddresses, Name, ClientIP, Type
-  | extend DestinationIPAddress = IPAddresses, DNSName = Name, Host = Computer , AlertDetail = 'Dev-0322 IOC match'
+  | extend DestinationIPAddress = IPAddresses, DNSName = Name, Host = Computer
   | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
   (imDns
@@ -83,14 +83,14 @@ query:  |
   | extend DnsResponseAddresses = extract_all(IPRegexGroup, ResponseName)
   | extend IPAddresses = set_intersect(IPListDynamic,DnsResponseAddresses)
   | project TimeGenerated, Dvc, DnsResponseName, DnsQuery, SrcIpAddr, DnsQueryTypeName, IPAddresses
-  | extend DestinationIPAddress = IPAddresses[0], DNSName = DnsQuery, Host = Dvc , AlertDetail = 'Dev-0322 IOC match'
+  | extend DestinationIPAddress = IPAddresses[0], DNSName = DnsQuery, Host = Dvc
   | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
   (VMConnection
   | where SourceIp in (IPList) or DestinationIp in (IPList)
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | project TimeGenerated, Computer, Direction, ProcessName, SourceIp, DestinationIp, DestinationPort, RemoteDnsQuestions, DNSName,BytesSent, BytesReceived, RemoteCountry, Type
-  | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None") , AlertDetail = 'Dev-0322 IOC match'
+  | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None")
   | extend IPCustomEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "NoMatch"), HostCustomEntity = Computer, ProcessCustomEntity = ProcessName
   ),
   (Event
@@ -101,23 +101,23 @@ query:  |
   | extend SourceIP = EventDetail.[9].["#text"], DestinationIP = EventDetail.[14].["#text"], Image = EventDetail.[4].["#text"]
   | where SourceIP in (IPList) or DestinationIP in (IPList) 
   | project TimeGenerated, SourceIP, DestinationIP, Image, UserName, Computer, Type
-  | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None") , AlertDetail = 'Dev-0322 IOC match'
+  | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None")
   | extend AccountCustomEntity = UserName, ProcessCustomEntity = split(Image, '\\', -1)[-1], HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
-  ),  
+  ),
   (OfficeActivity
   | where ClientIP in (IPList) 
-  | project TimeGenerated, UserAgent, Operation, RecordType, UserId, ClientIP, AlertDetail = 'Dev-0322 IOC match', Type
+  | project TimeGenerated, UserAgent, Operation, RecordType, UserId, ClientIP, Type
   | extend IPCustomEntity = ClientIP, AccountCustomEntity = UserId
   ),
   (DeviceNetworkEvents
-  | where  RemoteIP in (IPList)
+  | where RemoteIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RemoteIP, RemoteUrl, RemotePort, LocalIP, Type
-  | extend IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName,  AlertDetail = 'Dev-0322 IOC match', UrlCustomEntity =RemoteUrl, ProcessCustomEntity = InitiatingProcessFileName
+  | extend IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName, UrlCustomEntity =RemoteUrl, ProcessCustomEntity = InitiatingProcessFileName
   ),
   (WindowsFirewall
   | where SourceIP in (IPList) or DestinationIP in (IPList) 
   | project TimeGenerated, Computer, CommunicationDirection, SourceIP, DestinationIP, SourcePort, DestinationPort, Type
-  | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None"), AlertDetail = 'Dev-0322 IOC match'
+  | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None")
   | extend HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
   ),
   (AzureDiagnostics
@@ -125,8 +125,8 @@ query:  |
   | where Category == "AzureFirewallDnsProxy"
   | project TimeGenerated,Resource, msg_s, Type
   | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
-  | where  ClientIP in (IPList)
-  | extend DNSName = Request_Name, IPCustomEntity = ClientIP, AlertDetail = 'Dev-0322 IOC match'
+  | where ClientIP in (IPList)
+  | extend DNSName = Request_Name, IPCustomEntity = ClientIP
   ),
   (AzureDiagnostics 
   | where ResourceType == "AZUREFIREWALLS"
@@ -135,7 +135,7 @@ query:  |
   | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
   | where isnotempty(DestinationHost)
   | where SourceHost in (IPList)
-  | extend DNSName = DestinationHost, IPCustomEntity = SourceHost, AlertDetail = 'Dev-0322 IOC match'
+  | extend DNSName = DestinationHost, IPCustomEntity = SourceHost
   ),
   (Event
   | where Source == "Microsoft-Windows-Sysmon"
@@ -145,45 +145,45 @@ query:  |
   | where ( ParentImage has_any (parentprocess) and Image has_any (process))
   | parse EventDetail with * 'SHA256=' SHA256 '",' *
   | project TimeGenerated, EventDetail, UserName, Computer, Type, Source, SHA256,Image, ParentImage 
-  | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256, AlertDetail = 'Dev-0322 IOC match'
+  | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256
   | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
   ),
   (DeviceFileEvents
   | extend CommandLineIP = extract(IPRegex, 0,InitiatingProcessCommandLine)
-  | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess))  or CommandLineIP in (IPList)
+  | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess)) or CommandLineIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RequestAccountName, RequestSourceIP, InitiatingProcessSHA256, Type, CommandLineIP
-  | extend Account = RequestAccountName, Computer = DeviceName, IPAddress = RequestSourceIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, AlertDetail = 'Dev-0322 IOC match'
+  | extend Account = RequestAccountName, Computer = DeviceName, IPAddress = RequestSourceIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256
   | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = CommandLineIP
   ),
   (DeviceEvents
   | extend CommandLineIP = extract(IPRegex, 0,InitiatingProcessCommandLine)
   | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess)) or CommandLineIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, InitiatingProcessSHA256, Type, CommandLineIP
-  | extend Account = InitiatingProcessAccountName, Computer = DeviceName, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, Image = InitiatingProcessFolderPath, AlertDetail = 'Dev-0322 IOC match'
+  | extend Account = InitiatingProcessAccountName, Computer = DeviceName, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, Image = InitiatingProcessFolderPath
   | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = CommandLineIP
   ),
   (DeviceProcessEvents
   | extend CommandLineIP = extract(IPRegex, 0,InitiatingProcessCommandLine)
-  | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess))  or CommandLineIP in (IPList)
-  | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName,  InitiatingProcessSHA256, Type, CommandLineIP, AccountName
-  | extend Account = AccountName, Computer = DeviceName, IPAddress = CommandLineIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, AlertDetail = 'Dev-0322 IOC match'
+  | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess)) or CommandLineIP in (IPList)
+  | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, InitiatingProcessSHA256, Type, CommandLineIP, AccountName
+  | extend Account = AccountName, Computer = DeviceName, IPAddress = CommandLineIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256
   | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = IPAddress
   ),
-  (  SecurityEvent
+  (SecurityEvent
   | where EventID == 4688
   | extend CommandLineIP = extract(IPRegex, 0, CommandLine)
-  | where CommandLineIP in (IPList) or (NewProcessName  has_any (process) and ParentProcessName has_any (parentprocess))
+  | where CommandLineIP in (IPList) or (NewProcessName has_any (process) and ParentProcessName has_any (parentprocess))
   | project TimeGenerated, Computer, NewProcessName, ParentProcessName, Account, NewProcessId, Type, CommandLine, CommandLineIP
-  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = CommandLineIP
+  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, IPCustomEntity = CommandLineIP
   ),
-  (  imProcessCreate
+  (imProcessCreate
   | where has_any_ipv4 (TargetProcessCommandLine, IPListDynamic) or (TargetProcessName has_any (process) and ActingProcessName has_any (parentprocess))
   | extend CommandLineAddresses = extract_all(IPRegexGroup, TargetProcessCommandLine)
   | extend IPAddresses = set_intersect(IPListDynamic,CommandLineAddresses)
   | project TimeGenerated, Dvc, TargetProcessName, ActingProcessName, TargetUsername, TargetProcessId, Type, TargetProcessCommandLine , IPAddresses, TargetProcessSHA256
-  | extend HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256  )
+  | extend HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256)
   )
-  | extend timestamp = TimeGenerated
+  | extend timestamp = TimeGenerated, AlertDetail = 'Dev-0322 IOC match'
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
+++ b/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
@@ -61,7 +61,9 @@ query:  |
   let process = (iocs | where Type =~ "process" | project IoC);
   let parentprocess = (iocs | where Type =~ "parentprocess" | project IoC);
   let IPList = (iocs | where Type =~ "ip"| project IoC);
+  let IPListDynamic = toscalar(IPList | summarize make_set(IoC));  
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
+  let IPRegexGroup = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})';
   (union isfuzzy=true
   (CommonSecurityLog
   | where SourceIP in (IPList) or DestinationIP in (IPList) or RequestURL has_any (IPList) or Message has_any (IPList)
@@ -74,6 +76,14 @@ query:  |
   | where IPAddresses in (IPList)  
   | project TimeGenerated, Computer, IPAddresses, Name, ClientIP, Type
   | extend DestinationIPAddress = IPAddresses, DNSName = Name, Host = Computer , AlertDetail = 'Dev-0322 IOC match'
+  | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
+  ),
+  (imDns
+  | where has_any_ipv4 (DnsResponseName, IPListDynamic)
+  | extend DnsResponseAddresses = extract_all(IPRegexGroup, ResponseName)
+  | extend IPAddresses = set_intersect(IPListDynamic,DnsResponseAddresses)
+  | project TimeGenerated, Dvc, DnsResponseName, DnsQuery, SrcIpAddr, DnsQueryTypeName, IPAddresses
+  | extend DestinationIPAddress = IPAddresses[0], DNSName = DnsQuery, Host = Dvc , AlertDetail = 'Dev-0322 IOC match'
   | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
   (VMConnection
@@ -165,7 +175,13 @@ query:  |
   | where CommandLineIP in (IPList) or (NewProcessName  has_any (process) and ParentProcessName has_any (parentprocess))
   | project TimeGenerated, Computer, NewProcessName, ParentProcessName, Account, NewProcessId, Type, CommandLine, CommandLineIP
   | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = CommandLineIP
-  )
+  ),
+  (  imProcessCreate
+  | where has_any_ipv4 (TargetProcessCommandLine, IPListDynamic) or (TargetProcessName has_any (process) and ActingProcessName has_any (parentprocess))
+  | extend CommandLineAddresses = extract_all(IPRegexGroup, TargetProcessCommandLine)
+  | extend IPAddresses = set_intersect(IPListDynamic,CommandLineAddresses)
+  | project TimeGenerated, Dvc, TargetProcessName, ActingProcessName, TargetUsername, TargetProcessId, Type, TargetProcessCommandLine , IPAddresses, TargetProcessSHA256
+  | extend timestamp = TimeGenerated, HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256  )
   )
 entityMappings:
   - entityType: Account
@@ -190,4 +206,4 @@ entityMappings:
         columnName: SHA256
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 2.0.0

--- a/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
+++ b/Detections/MultipleDataSources/DEV-0322_SolarWinds_Serv-U_IOC.yaml
@@ -70,13 +70,13 @@ query:  |
   | project TimeGenerated, SourceIP, DestinationIP, Message, SourceUserID, RequestURL, Type
   | extend MessageIP = extract(IPRegex, 0, Message)
   | extend IPMatch = case(SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", MessageIP in (IPList), "Message", RequestURL in (IPList), "RequestUrl","NoMatch"), AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, IPMatch == "Message", MessageIP, IPMatch == "RequestUrl", RequestURL, "NoMatch"), AccountCustomEntity = SourceUserID
+  | extend IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, IPMatch == "Message", MessageIP, IPMatch == "RequestUrl", RequestURL, "NoMatch"), AccountCustomEntity = SourceUserID
   ),
   (DnsEvents
   | where IPAddresses in (IPList)  
   | project TimeGenerated, Computer, IPAddresses, Name, ClientIP, Type
   | extend DestinationIPAddress = IPAddresses, DNSName = Name, Host = Computer , AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
+  | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
   (imDns
   | where has_any_ipv4 (DnsResponseName, IPListDynamic)
@@ -84,14 +84,14 @@ query:  |
   | extend IPAddresses = set_intersect(IPListDynamic,DnsResponseAddresses)
   | project TimeGenerated, Dvc, DnsResponseName, DnsQuery, SrcIpAddr, DnsQueryTypeName, IPAddresses
   | extend DestinationIPAddress = IPAddresses[0], DNSName = DnsQuery, Host = Dvc , AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
+  | extend IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
   ),
   (VMConnection
   | where SourceIp in (IPList) or DestinationIp in (IPList)
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | project TimeGenerated, Computer, Direction, ProcessName, SourceIp, DestinationIp, DestinationPort, RemoteDnsQuestions, DNSName,BytesSent, BytesReceived, RemoteCountry, Type
   | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None") , AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, IPCustomEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "NoMatch"), HostCustomEntity = Computer, ProcessCustomEntity = ProcessName
+  | extend IPCustomEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "NoMatch"), HostCustomEntity = Computer, ProcessCustomEntity = ProcessName
   ),
   (Event
   | where Source == "Microsoft-Windows-Sysmon"
@@ -102,23 +102,23 @@ query:  |
   | where SourceIP in (IPList) or DestinationIP in (IPList) 
   | project TimeGenerated, SourceIP, DestinationIP, Image, UserName, Computer, Type
   | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None") , AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserName, ProcessCustomEntity = split(Image, '\\', -1)[-1], HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
+  | extend AccountCustomEntity = UserName, ProcessCustomEntity = split(Image, '\\', -1)[-1], HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
   ),  
   (OfficeActivity
   | where ClientIP in (IPList) 
   | project TimeGenerated, UserAgent, Operation, RecordType, UserId, ClientIP, AlertDetail = 'Dev-0322 IOC match', Type
-  | extend timestamp = TimeGenerated, IPCustomEntity = ClientIP, AccountCustomEntity = UserId
+  | extend IPCustomEntity = ClientIP, AccountCustomEntity = UserId
   ),
   (DeviceNetworkEvents
   | where  RemoteIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RemoteIP, RemoteUrl, RemotePort, LocalIP, Type
-  | extend timestamp = TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName,  AlertDetail = 'Dev-0322 IOC match', UrlCustomEntity =RemoteUrl, ProcessCustomEntity = InitiatingProcessFileName
+  | extend IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName,  AlertDetail = 'Dev-0322 IOC match', UrlCustomEntity =RemoteUrl, ProcessCustomEntity = InitiatingProcessFileName
   ),
   (WindowsFirewall
   | where SourceIP in (IPList) or DestinationIP in (IPList) 
   | project TimeGenerated, Computer, CommunicationDirection, SourceIP, DestinationIP, SourcePort, DestinationPort, Type
   | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None"), AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
+  | extend HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
   ),
   (AzureDiagnostics
   | where ResourceType == "AZUREFIREWALLS"
@@ -126,7 +126,7 @@ query:  |
   | project TimeGenerated,Resource, msg_s, Type
   | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
   | where  ClientIP in (IPList)
-  | extend timestamp = TimeGenerated, DNSName = Request_Name, IPCustomEntity = ClientIP, AlertDetail = 'Dev-0322 IOC match'
+  | extend DNSName = Request_Name, IPCustomEntity = ClientIP, AlertDetail = 'Dev-0322 IOC match'
   ),
   (AzureDiagnostics 
   | where ResourceType == "AZUREFIREWALLS"
@@ -135,7 +135,7 @@ query:  |
   | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
   | where isnotempty(DestinationHost)
   | where SourceHost in (IPList)
-  | extend timestamp = TimeGenerated, DNSName = DestinationHost, IPCustomEntity = SourceHost, AlertDetail = 'Dev-0322 IOC match'
+  | extend DNSName = DestinationHost, IPCustomEntity = SourceHost, AlertDetail = 'Dev-0322 IOC match'
   ),
   (Event
   | where Source == "Microsoft-Windows-Sysmon"
@@ -146,43 +146,44 @@ query:  |
   | parse EventDetail with * 'SHA256=' SHA256 '",' *
   | project TimeGenerated, EventDetail, UserName, Computer, Type, Source, SHA256,Image, ParentImage 
   | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256, AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
+  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
   ),
   (DeviceFileEvents
   | extend CommandLineIP = extract(IPRegex, 0,InitiatingProcessCommandLine)
   | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess))  or CommandLineIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RequestAccountName, RequestSourceIP, InitiatingProcessSHA256, Type, CommandLineIP
   | extend Account = RequestAccountName, Computer = DeviceName, IPAddress = RequestSourceIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = CommandLineIP
+  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = CommandLineIP
   ),
   (DeviceEvents
   | extend CommandLineIP = extract(IPRegex, 0,InitiatingProcessCommandLine)
   | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess)) or CommandLineIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, InitiatingProcessSHA256, Type, CommandLineIP
   | extend Account = InitiatingProcessAccountName, Computer = DeviceName, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, Image = InitiatingProcessFolderPath, AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = CommandLineIP
+  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = CommandLineIP
   ),
   (DeviceProcessEvents
   | extend CommandLineIP = extract(IPRegex, 0,InitiatingProcessCommandLine)
   | where (InitiatingProcessFileName in (process) and InitiatingProcessParentFileName in (parentprocess))  or CommandLineIP in (IPList)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName,  InitiatingProcessSHA256, Type, CommandLineIP, AccountName
   | extend Account = AccountName, Computer = DeviceName, IPAddress = CommandLineIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, AlertDetail = 'Dev-0322 IOC match'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = IPAddress
+  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash, IPCustomEntity = IPAddress
   ),
   (  SecurityEvent
   | where EventID == 4688
   | extend CommandLineIP = extract(IPRegex, 0, CommandLine)
   | where CommandLineIP in (IPList) or (NewProcessName  has_any (process) and ParentProcessName has_any (parentprocess))
   | project TimeGenerated, Computer, NewProcessName, ParentProcessName, Account, NewProcessId, Type, CommandLine, CommandLineIP
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = CommandLineIP
+  | extend HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = CommandLineIP
   ),
   (  imProcessCreate
   | where has_any_ipv4 (TargetProcessCommandLine, IPListDynamic) or (TargetProcessName has_any (process) and ActingProcessName has_any (parentprocess))
   | extend CommandLineAddresses = extract_all(IPRegexGroup, TargetProcessCommandLine)
   | extend IPAddresses = set_intersect(IPListDynamic,CommandLineAddresses)
   | project TimeGenerated, Dvc, TargetProcessName, ActingProcessName, TargetUsername, TargetProcessId, Type, TargetProcessCommandLine , IPAddresses, TargetProcessSHA256
-  | extend timestamp = TimeGenerated, HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256  )
+  | extend HostCustomEntity = Dvc , AccountCustomEntity = TargetUsername, ProcessCustomEntity = TargetProcessName, AlertDetail = 'Dev-0322 IOC match', IPCustomEntity = IPAddresses[0], FileHashCustomEntity = TargetProcessSHA256  )
   )
+  | extend timestamp = TimeGenerated
 entityMappings:
   - entityType: Account
     fieldMappings:


### PR DESCRIPTION
Added sections for imDns and imProcess to the detection rule.

In addition, the following comments on this detection (I did not update based on them, just commenting):

 - "has_any_ipv4" is significantly more performant than "in" for IP Addresses.
 -  Whenever you extract IP addresses from a string, you take the first one, which enables evasion by just having the IoC as the second IP address on in the string.  Something along those lines will solve that:

```
	let IPListDynamic = toscalar(IPList | summarize make_set(IoC));  
	let IPRegexGroup = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})';
	imDns
	  | where has_any_ipv4 (DnsResponseName, IPListDynamic)
	  | extend DnsResponseAddresses = extract_all(IPRegexGroup, ResponseName)
	  | extend IPAddresses = set_intersect(IPListDynamic,DnsResponseAddresses)

```	
 - Specific to DnsEvents: IPAddresses can have multiple values, which will not enable a match if only one matches. Same solution as above will help

```
         DnsEvents 
         | where IPAddresses in (IPList)  
```

- AlertDetail, why? It is in the alert description anyways.
