### PR TITLE
Playbooks/Send-UrlReport - fix deploy to Azure buttons, readme typos

### DIFF
--- a/Playbooks/Send-UrlReport/ReadMe.md
+++ b/Playbooks/Send-UrlReport/ReadMe.md
@@ -1,7 +1,12 @@
 # Send-URLreport
 author: yaniv Shasha and Yehuda Tognder
 
-This playbook will take each URL entity and query VirusTotal for URL Report (https://developers.virustotal.com/reference#url-report).  You will need to register to thier community for an API key.
+This playbook will take each URL entity and query the VirusTotal v2 API for URL Report (https://developers.virustotal.com/reference#url-report).  You will need to register to their community for an API key.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)]("https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FSend-UrlReport%2Fazuredeploy.json)
-[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)]("https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FSend-UrlReport%2Fazuredeploy.json)
+# Deploy to Azure
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FSend-UrlReport%2Fazuredeploy.json" target="_blank">
+<img src="https://aka.ms/deploytoazurebutton""/>
+</a>
+<a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FSend-UrlReport%2Fazuredeploy.json" target="_blank">
+<img src="https://aka.ms/deploytoazuregovbutton"/>
+</a>


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Fix Deploy to Azure buttons in ReadMe.md for Playbooks/Send-UrlReport
  - Fix a few typos, add point about it being for the VirusTotal v2 API
