### PR TITLE
GWorkspace connector should send all the events to Sentinel

### DIFF
--- a/DataConnectors/GoogleWorkspaceReports/GWorkspaceReportsAPISentinelConnector/__init__.py
+++ b/DataConnectors/GoogleWorkspaceReports/GWorkspaceReportsAPISentinelConnector/__init__.py
@@ -131,15 +131,15 @@ def expand_data(obj):
     for event in obj:
         for nested in event["events"]:
             if 'name' in nested:
-                event.update({'event_name': nested["name"]})
+                nested.update({'event_name': nested["name"]})
             if 'type' in nested:
-                event.update({'event_type': nested["type"]})
+                nested.update({'event_type': nested["type"]})
             if 'parameters' in nested:
                 for parameter in nested["parameters"]:
                     if 'name' in parameter:
                         for param_name in ["value", "boolValue", "multiValue", "multiMessageValue", "multiIntValue", "messageValue", "intValue"]:
                             if param_name in parameter:
-                                event.update({parameter["name"]: parameter[param_name]})
+                                nested.update({parameter["name"]: parameter[param_name]})
     return obj
 
 def gen_chunks_to_object(data,chunksize=100):


### PR DESCRIPTION
Fixes #
Fix for issue : GWorkspace connector may send only some of the events to Sentinel  :https://github.com/Azure/Azure-Sentinel/issues/2624

After Fix : 
[GWorkspace_ReportsAPI_driveUpdated_CL.txt](https://github.com/Azure/Azure-Sentinel/files/6878419/GWorkspace_ReportsAPI_driveUpdated_CL.txt)


## Proposed Changes

  -
  -
  -
