### PR TITLE
Add validations on playbook template metadata

### DIFF
--- a/.script/playbooksValidator.ts
+++ b/.script/playbooksValidator.ts
@@ -5,6 +5,7 @@ import { isValidSchema } from "./utils/jsonSchemaChecker";
 import * as logger from "./utils/logger";
 import { ArmTemplate, ArmTemplateResource } from "./utils/playbookCheckers/Models/armTemplateModels";
 import { PlaybookTemplateMetadata } from "./utils/playbookCheckers/Models/playbookTemplateMetadata";
+import { validateTemplateMetadata } from "./utils/playbookCheckers/playbookArmTemplateMetadataChecker";
 import { validateTemplateParameters } from "./utils/playbookCheckers/playbookArmTemplateParametersChecker";
 import { getTemplatePlaybookResources } from "./utils/playbookCheckers/playbookARMTemplateUtils";
 import { validatePlaybookResource } from "./utils/playbookCheckers/playbookResourceChecker";
@@ -31,6 +32,7 @@ function validateARMTemplateSchema(playbookARMTemplate: ArmTemplate<PlaybookTemp
 
 function validateARMTemplateWithPlaybookResource(filePath: string, playbookARMTemplate: ArmTemplate<PlaybookTemplateMetadata>): void {
     validateTemplateParameters(filePath, playbookARMTemplate);
+    validateTemplateMetadata(filePath, playbookARMTemplate);
     validatePlaybookResource(filePath, playbookARMTemplate);
 }
 

--- a/.script/tests/playbooksValidatorTest/playbooksValidator.test.ts
+++ b/.script/tests/playbooksValidatorTest/playbooksValidator.test.ts
@@ -11,11 +11,11 @@ describe("Playbooks validator", () => {
   });
 
   it(`Should pass when playbook template doesn't belong to the gallery`, async () => {
-    await checkValid(".script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplate.json");
+    await checkValid(".script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplateNotForGallery.json");
   });
 
   it(`Should pass when playbook template is using using capitalized parameter types`, async () => {
-    await checkValid(".script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplateNotForGallery.json");
+    await checkValid(".script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithCapitalizedParameterType.json");
   });
 
   it(`Should throw an exception when template is missing 'PlaybookName' parameter`, async () => {

--- a/.script/tests/playbooksValidatorTest/playbooksValidator.test.ts
+++ b/.script/tests/playbooksValidatorTest/playbooksValidator.test.ts
@@ -10,8 +10,12 @@ describe("Playbooks validator", () => {
     await checkValid(".script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplate.json");
   });
 
+  it(`Should pass when playbook template doesn't belong to the gallery`, async () => {
+    await checkValid(".script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplate.json");
+  });
+
   it(`Should pass when playbook template is using using capitalized parameter types`, async () => {
-    await checkValid(".script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithCapitalizedParameterType.json");
+    await checkValid(".script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplateNotForGallery.json");
   });
 
   it(`Should throw an exception when template is missing 'PlaybookName' parameter`, async () => {
@@ -20,6 +24,10 @@ describe("Playbooks validator", () => {
 
   it(`Should throw an exception when playbook resource location isn't taken from resource group location`, async () => {
     await checkInvalid(".script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithHardcodedPlaybookLocation.json");
+  });
+
+  it(`Should throw an exception when playbook metadata has invalid entity types`, async () => {
+    await checkInvalid(".script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithInvalidEntityTypes.json");
   });
 
   async function checkInvalid(filePath: string): Promise<Chai.PromisedAssertion> {

--- a/.script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithHardcodedPlaybookLocation.json
+++ b/.script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithHardcodedPlaybookLocation.json
@@ -7,8 +7,8 @@
         "lastUpdateTime": "2021-05-02T08:52:02.264Z",
         "entities": ["Account"],
         "tags": ["Response"],
-        "source": {
-            "kind": "Microsoft"
+        "support": {
+            "tier": "Microsoft"
         },
         "author": {
             "name": "Nicholas DiCola"

--- a/.script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithInvalidEntityTypes.json
+++ b/.script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithInvalidEntityTypes.json
@@ -5,7 +5,7 @@
         "title": "Block AAD user sign-in",
         "description": "This playbook will disable the user in Azure Active Directory and add a comment to the incident",
         "lastUpdateTime": "2021-05-02T08:52:02.264Z",
-        "entities": ["Account"],
+        "entities": ["Account", "IPs"],
         "tags": ["Response"],
         "support": {
             "tier": "Microsoft"
@@ -17,7 +17,7 @@
     "parameters": {
         "PlaybookName": {
             "defaultValue": "Block-AADUser",
-            "type": "String",
+            "type": "string",
             "metadata": {
                 "description": "Name of the playbook resource"
             }

--- a/.script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithNoPlaybookNameParameter.json
+++ b/.script/tests/playbooksValidatorTest/testFiles/playbookTemplateWithNoPlaybookNameParameter.json
@@ -7,8 +7,8 @@
         "lastUpdateTime": "2021-05-02T08:52:02.264Z",
         "entities": ["Account"],
         "tags": ["Response"],
-        "source": {
-            "kind": "Microsoft"
+        "support": {
+            "tier": "Microsoft"
         },
         "author": {
             "name": "Nicholas DiCola"

--- a/.script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplate.json
+++ b/.script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplate.json
@@ -7,8 +7,8 @@
         "lastUpdateTime": "2021-05-02T08:52:02.264Z",
         "entities": ["Account"],
         "tags": ["Response"],
-        "source": {
-            "kind": "Microsoft"
+        "support": {
+            "tier": "Microsoft"
         },
         "author": {
             "name": "Nicholas DiCola"

--- a/.script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplateNotForGallery.json
+++ b/.script/tests/playbooksValidatorTest/testFiles/validPlaybookTemplateNotForGallery.json
@@ -2,25 +2,13 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "metadata":{
-        "title": "Block AAD user sign-in",
-        "description": "This playbook will disable the user in Azure Active Directory and add a comment to the incident",
-        "lastUpdateTime": "2021-05-02T08:52:02.264Z",
-        "entities": ["Account"],
-        "tags": ["Response"],
-        "support": {
-            "tier": "Microsoft"
-        },
-        "author": {
-            "name": "Nicholas DiCola"
-        }
+        "comment": "Block AAD user sign-in",
+        "author": "Some author"
     },
     "parameters": {
         "PlaybookName": {
             "defaultValue": "Block-AADUser",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the playbook resource"
-            }
+            "type": "string"
         }
     },
     "variables": {

--- a/.script/utils/playbookCheckers/Models/playbookTemplateMetadata.ts
+++ b/.script/utils/playbookCheckers/Models/playbookTemplateMetadata.ts
@@ -1,4 +1,35 @@
 export interface PlaybookTemplateMetadata {
-  comments: string;
-  author: string;
+  title: string;
+  description: string;
+  prerequisites?: string | string[];
+  prerequisitesDeployTemplateFile?: string;
+  lastUpdateTime: string;
+  entities?: string[];
+  tags?: string[],
+  support: { tier: string; link?: string };
+  author: { name: string };
 }
+
+export const PlaybookMetadataSupportedEntityTypes: string[] = [
+  "account",
+  "host",
+  "ip",
+  "url",
+  "azureresource",
+  "cloudapplication",
+  "dnsresolution",
+  "file",
+  "filehash",
+  "hostlogonsession",
+  "iotdevice",
+  "malware",
+  "networkconnection",
+  "process",
+  "registrykey",
+  "registryvalue",
+  "securitygroup",
+  "mailbox",
+  "mailcluster",
+  "mailmessage",
+  "submissionmail"
+];

--- a/.script/utils/playbookCheckers/playbookARMTemplateUtils.ts
+++ b/.script/utils/playbookCheckers/playbookARMTemplateUtils.ts
@@ -12,6 +12,14 @@ export function getTemplatePlaybookResources(armTemplate: ArmTemplate<any>): Arm
     return armTemplate?.resources.filter((resource: ArmTemplateResource) => resource.type === "Microsoft.Logic/workflows");
 }
 
+export function isPlaybookUsingGalleryMetadata(armTemplate: ArmTemplate<any>): boolean {
+    return !isNullOrUndefined(armTemplate?.metadata?.title) && !isNullOrUndefined(armTemplate?.metadata?.description) && !isNullOrUndefined(armTemplate?.metadata?.author);
+}
+
 export function isNullOrUndefined(value: any): boolean {
     return value === undefined || value === null; 
+}
+
+export function isNullOrWhitespace(value: string): boolean {
+    return isNullOrUndefined(value) || value.trim().length === 0;
 }

--- a/.script/utils/playbookCheckers/playbookArmTemplateMetadataChecker.ts
+++ b/.script/utils/playbookCheckers/playbookArmTemplateMetadataChecker.ts
@@ -1,0 +1,51 @@
+import { PlaybookValidationError } from "../validationError";
+import { ArmTemplate } from "./Models/armTemplateModels";
+import { PlaybookMetadataSupportedEntityTypes, PlaybookTemplateMetadata } from "./Models/playbookTemplateMetadata";
+import { isNullOrWhitespace, isPlaybookUsingGalleryMetadata } from "./playbookARMTemplateUtils";
+
+export function validateTemplateMetadata(filePath: string, playbookARMTemplate: ArmTemplate<PlaybookTemplateMetadata>): void {
+    if (!isPlaybookUsingGalleryMetadata(playbookARMTemplate)) {
+        return;
+    }
+
+    validateMetadataMandatoryFieldsAreNotEmpty(filePath, playbookARMTemplate);
+    validateMetdataLastUpdateTimeIsValidTimestamp(filePath, playbookARMTemplate)
+    validateMetdataEntitiesContainsValidEntityTypes(filePath, playbookARMTemplate)
+}
+
+function validateMetadataMandatoryFieldsAreNotEmpty(filePath: string, playbookARMTemplate: ArmTemplate<PlaybookTemplateMetadata>): void {
+    if (isNullOrWhitespace(playbookARMTemplate.metadata.title)) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' missing required field 'title' in metadata.`);
+    }
+    if (isNullOrWhitespace(playbookARMTemplate.metadata.description)) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' missing required field 'description' in metadata.`);
+    }
+    if (isNullOrWhitespace(playbookARMTemplate.metadata.lastUpdateTime)) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' missing required field 'lastUpdateTime' in metadata.`);
+    }
+    if (isNullOrWhitespace(playbookARMTemplate.metadata.support?.tier)) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' missing required field 'support/tier' in metadata.`);
+    }
+    if (isNullOrWhitespace(playbookARMTemplate.metadata.author?.name)) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' missing required field 'author/name' in metadata.`);
+    }
+}
+
+function validateMetdataLastUpdateTimeIsValidTimestamp(filePath: string, playbookARMTemplate: ArmTemplate<PlaybookTemplateMetadata>): void {
+    let parsedLastUpdateTime: Date = new Date(playbookARMTemplate.metadata.lastUpdateTime);
+    if (isNaN(parsedLastUpdateTime.getTime())) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' metadata field 'lastUpdateTime' is not a valid timestamp.`);
+    }
+}
+
+function validateMetdataEntitiesContainsValidEntityTypes(filePath: string, playbookARMTemplate: ArmTemplate<PlaybookTemplateMetadata>): void {
+    if (!playbookARMTemplate.metadata.entities) {
+        return;
+    }
+
+    let invalidEntityTypes: string[] = playbookARMTemplate.metadata.entities
+        .filter((entityType: string) => !PlaybookMetadataSupportedEntityTypes.includes(entityType.toLowerCase()));
+    if (invalidEntityTypes.length > 0) {
+        throw new PlaybookValidationError(`Playbook template '${filePath}' metadata field 'entities' contains invalid entity types '${invalidEntityTypes.join("','")}'. Supported entity types: '${PlaybookMetadataSupportedEntityTypes.join("','")}'.`);
+    }
+}


### PR DESCRIPTION
If playbook template contains metadata in the new schema (title, description, etc.) validate that the metadata is valid:
* Mandatory fields are provided
* Update time is a valid timestamp
* Entities are valid and from the list of supported entity types