### PR TITLE
Case sensitivity in JOIN operation leading to unexpected results

### DIFF
--- a/Detections/SecurityEvent/UserAccountAdd-Removed.yaml
+++ b/Detections/SecurityEvent/UserAccountAdd-Removed.yaml
@@ -32,7 +32,7 @@ query: |
   | parse EventData with * '"MemberName">' AccountAdded ",OU" * 
   | where isnotempty(AccountAdded)
   | extend GroupAddedTo = TargetUserName, AddingAccount = Account 
-  | extend  AccountAdded_GroupAddedTo_AddingAccount = strcat(AccountAdded, "||", GroupAddedTo, "||", AddingAccount )
+  | extend  AccountAdded_GroupAddedTo_AddingAccount = tolower(strcat(AccountAdded, "||", GroupAddedTo, "||", AddingAccount ))
   | project AccountAdded_GroupAddedTo_AddingAccount, AccountAddedTime = TimeGenerated;
   let AC_Remove = 
   SecurityEvent
@@ -42,7 +42,7 @@ query: |
   | parse EventData with * '"MemberName">' AccountRemoved ",OU" * 
   | where isnotempty(AccountRemoved)
   | extend GroupRemovedFrom = TargetUserName, RemovingAccount = Account
-  | extend AccountRemoved_GroupRemovedFrom_RemovingAccount = strcat(AccountRemoved, "||", GroupRemovedFrom, "||", RemovingAccount)
+  | extend AccountRemoved_GroupRemovedFrom_RemovingAccount = tolower(strcat(AccountRemoved, "||", GroupRemovedFrom, "||", RemovingAccount))
   | project AccountRemoved_GroupRemovedFrom_RemovingAccount, AccountRemovedTime = TimeGenerated, Computer, RemovedAccountId = tolower(AccountRemoved), 
   RemovedByUser = SubjectUserName, RemovedByUserLogonId = SubjectLogonId,  GroupRemovedFrom = TargetUserName, TargetDomainName; 
   AC_Add 


### PR DESCRIPTION
When I run the query in my lab, here's what I found.

Output from the temp table AC_Add has two rows.
--------------------------------------------------------
AccountAdded_GroupAddedTo_AddingAccount
cn=Joe Pesci||Domain Admins||contoso\labadmin
CN=Joe Pesci||Administrators||contoso\labadmin

Notice how the string 'cn' is in lower case in the case of user addition to 'Domain Admins'

Output from the temp table AC_Remove has two rows.
------------------------------------------------------------
AccountRemoved_GroupRemovedFrom_RemovingAccount
CN=Joe Pesci||Domain Admins||contoso\labadmin
CN=Joe Pesci||Administrators||contoso\labadmin

Notice how the string 'CN' is in upper case in the case of user removal from 'Domain Admins'

I expected the query (when run as a whole) to show 2 results. Rather, output contained only 1 row.
------------------------------------------------------------------------------------------------------------
AccountAdded_GroupAddedTo_AddingAccount
CN=Joe Pesci||Administrators||contoso\labadmin


This is because of the case sensitivity which must be accounted for before we do the join operation.

Fixes #

## Proposed Changes

  -
  -
  -
