### PR TITLE
SimpleMemberName should account for case sensitivity

### DIFF
--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -36,7 +36,7 @@ query: |
   | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
   // Exclude Remote Desktop Users group: S-1-5-32-555
   | where TargetSid !in ("S-1-5-32-555")
-  | extend SimpleMemberName = tostring(split(tostring(split(MemberName, ",")[0]),"CN=")[1])
+  | extend SimpleMemberName = tostring(split(tostring(split(tolower(MemberName), ",")[0]),"cn=")[1])
   | project StartTimeUtc = TimeGenerated, EventID, Activity, Computer, SimpleMemberName, MemberName, MemberSid, TargetUserName, TargetDomainName, TargetSid, UserPrincipalName, SubjectUserName, SubjectUserSid
   | extend timestamp = StartTimeUtc, AccountCustomEntity = SimpleMemberName, HostCustomEntity = Computer
 entityMappings:


### PR DESCRIPTION
The definition of SimpleMemberName in its present form fails to account for distinguished names containing either the member name or the string 'CN' in lower case.

extend SimpleMemberName = tostring(split(tostring(split(MemberName, ",")[0]),"CN=")[1])

For instance - event ID 4728 was logged in my lab for adding a user to Domain Admins group. However, the string 'CN' was in lower case in the distinguished name for the member name. As a result, the columns like SimpleMemberName, AccountCustomEntity were empty in the output corresponding to this event.

Fixes #

## Proposed Changes

  -
  -
  -
