### PR TITLE
Tokesr patch 1

### DIFF
--- a/Playbooks/Spur-Enrichment/AlertTrigger/azuredeploy.json
+++ b/Playbooks/Spur-Enrichment/AlertTrigger/azuredeploy.json
@@ -65,7 +65,7 @@
             "type": "Microsoft.Logic/workflows",
             "apiVersion": "2017-07-01",
             "name": "[parameters('PlaybookName')]",
-            "location": "northeurope",
+            "location": "[resourceGroup().location]",
             "identity": {
                 "type": "SystemAssigned"
             },

--- a/Playbooks/Spur-Enrichment/IncidentTrigger/azuredeploy.json
+++ b/Playbooks/Spur-Enrichment/IncidentTrigger/azuredeploy.json
@@ -65,7 +65,7 @@
             "type": "Microsoft.Logic/workflows",
             "apiVersion": "2017-07-01",
             "name": "[parameters('PlaybookName')]",
-            "location": "northeurope",
+            "location": "[resourceGroup().location]",
             "identity": {
                 "type": "SystemAssigned"
             },

--- a/Playbooks/Spur-Enrichment/README.md
+++ b/Playbooks/Spur-Enrichment/README.md
@@ -30,12 +30,6 @@ The Playbook modifies an Incident in two ways:
 1. A tag (label) is added to the incident in the following format per entity (IP): Spur:{IP}=[Clean|Anonymizer]. This format mimics the taxonomies in TheHive. At this point in Azure Sentinel it is not possible to tag individual entities, all of the tags are related to the incident itself, so I decided to use the following tagging format in my Playbooks (until a better option): {PlaybookName}:{Entity}={Conclusion}. See an example below:
 
 
-**Comment**:<br/>
-![comment](../static/comment.PNG)
-
-**Tagging**:<br/>
-![tagging](../static/tagging.PNG)
-
 ## Installation and Configuration
 
 **Deployment**:


### PR DESCRIPTION
Fixes #
Hardcoded location changed to [resourceGroup().location] in the json codes.
The hardcoded value prevented to Playbook to be successfully deployed any location other than 'northeurope'. After the changes the deployment tests were successful at other locations too.

The correction was needed because of the issues in: #2768 detected by @sarah-yo 
If there is any other issue please let me know

## Proposed Changes

  -
  -
  -
