### PR TITLE
Update MultiplePasswordresetsbyUser.yaml

### DIFF
--- a/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
+++ b/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
@@ -71,7 +71,7 @@ query: |
   | where Total > PerUserThreshold
   | extend ResetPivot = "PerUserReset"),  
   (pwrmd
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ComputerList = make_set(Computer, 25), AccountList = make_set(Account, 25), AccountType = make_set(AccountType, 25), Account = arg_max(Account, TimeGenerated), Computer = arg_max(Computer , TimeGenerated), TargetUserList = make_set(TargetUserName, 25), TargetUserName = arg_max(TargetUserName, TimeGenerated), Total=count() by Type
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ComputerList = make_set(Computer, 25), AccountList = make_set(Account, 25), AccountType = make_set(AccountType, 25), Computer = arg_max(Computer , TimeGenerated), TargetUserList = make_set(TargetUserName, 25), TargetUserName = arg_max(TargetUserName, TimeGenerated), Total=count() by Type
   | where Total > TotalThreshold
   | extend ResetPivot = "TotalUserReset")
   )


### PR DESCRIPTION
In PerUserReset pivot Account field shows Actor account.
In TotalUserReset it just takes random one using arg_max which is very confusing, makes you think that this Account was responsible for all these aggregated resets. I propose just leaving this field blank for TotalUserReset, not to introduce confusion.

Fixes #

## Proposed Changes

  -
  -
  -
