### PR TITLE
Adding the Az.EventHub module

### DIFF
--- a/Tools/AzureDataExplorer/Migrate-LA-to-ADX.ps1
+++ b/Tools/AzureDataExplorer/Migrate-LA-to-ADX.ps1
@@ -607,6 +607,7 @@ function New-ADXDataConnectionRules {
 
 Get-RequiredModules("Az.Resources")
 Get-RequiredModules("Az.OperationalInsights")
+Get-RequiredModules("Az.EventHub")
 
 # Check Powershell version, needs to be 5 or higher
 if ($host.Version.Major -lt 5) {


### PR DESCRIPTION
This is a dependincy for the New-AzEventHubNamespace cmdLet used in the New-EventHubNamespace function.
This fonction will fail if that module isn't installed.

## Proposed Changes

  - Adding Get-RequiredModules("Az.EventHub") 
