### PR TITLE
Update AuthenticationAADSigninLogs Parser

### DIFF
--- a/Parsers/ASimAuthentication/ProductParsers/AuthenticationAADSigninLogs.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/AuthenticationAADSigninLogs.yaml
@@ -35,6 +35,7 @@ ParserQuery: |
     , Location = todynamic(LocationDetails)
     , TargetUsernameType='Upn'
     , TargetUserIdType='AADID'
+    , SrcDvcIpAddr=IPAddress
   | extend
         SrcGeoCity=tostring(Location.city)
         , SrcGeoCountry=tostring(Location.countryOrRegion)
@@ -71,6 +72,7 @@ ParserQuery: |
        , SrcGeoCountry
        , TargetAppId
        , TargetAppName
+       , SrcDvcIpAddr
        // ** Aliases
         | extend 
           User=TargetUsername


### PR DESCRIPTION
Fixes #

## Proposed Changes
-Adding SrcDvcIpAddr field in AuthenticationAADSigninLogs Parser as SrcDvcIpAddr is required for the password spray (imAuthPasswordSpray.yaml) detection rule to work.

