### PR TITLE
Change the location used to create the data connection

### DIFF
--- a/Tools/AzureDataExplorer/Migrate-LA-to-ADX.ps1
+++ b/Tools/AzureDataExplorer/Migrate-LA-to-ADX.ps1
@@ -529,6 +529,7 @@ function New-ADXDataConnectionRules {
         Register-AzResourceProvider -ProviderNamespace Microsoft.Kusto        
         Write-Log -Message "Creating Azure Data Explorer data connection" -LogFileName $LogFileName -Severity Information
         $ADXClusterName = $ADXClusterURL.split('.')[0].replace("https://", "").Trim()
+	$ADXClusterLocation = $ADXClusterURL.split('.')[1]
         foreach ($AdxEH in $AdxEventHubs) {            
             Write-Verbose "Executing: Get-AzEventHub -ResourceGroup $LogAnalyticsResourceGroup -NamespaceName $AdxEH"            
             try {
@@ -557,7 +558,7 @@ function New-ADXDataConnectionRules {
                                                                         
                         $DataConnBody = @"
                         {
-                            "location": "$LogAnalyticsLocation",
+                            "location": "$ADXClusterLocation",
                             "kind": "EventHub",
                             "properties": {
                               "eventHubResourceId": "$EventHubResourceId",                              


### PR DESCRIPTION
The current version is using the location of the log analytic workspace. That works only if the ADX cluster is also in the same location.
For this to work in cases where the ADX cluster is in a different location as the log analytic workspace we need to provide the ADX's location.
I suggest to extract the location from $ADXClusterURL and provide it in the location parameter when swending the PUT to create the data connection.

Fixes #
Current version is returning a 400 when attemping to create a data connection on an ADX cluster is the ADX cluster location is different than the log analytic workspace location

## Proposed Changes

  - Extract the location of the ADX cluster this way: $ADXClusterURL.Split(".")[1] and save it as $ADXClusterName
  - Use $ADXClusterName in the location parameter sent in the PUT request
 
