### PR TITLE
removing fusion rule

### DIFF
--- a/Solutions/Training/Azure-Sentinel-Training-Lab/Artifacts/LinkedTemplates/alertRules.json
+++ b/Solutions/Training/Azure-Sentinel-Training-Lab/Artifacts/LinkedTemplates/alertRules.json
@@ -5,13 +5,6 @@
         "workspaceName": {
             "type": "string"
         },
-        "fusionRuleGuid": {
-            "type": "string",
-            "defaultValue": "[newGuid()]",
-            "metadata": {
-                "description": "The unique guid for this scheduled alert rule"
-            }
-        },
         "solarigateRuleGuid": {
             "type": "string",
             "defaultValue": "[newGuid()]"
@@ -30,24 +23,10 @@
     "resources": [
         {
             "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
-            "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/',parameters('fusionRuleGuid'))]",
-            "apiVersion": "2020-01-01",
-            "kind": "Fusion",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "enabled": true,
-                "alertRuleTemplateName": "f71aba3d-28fb-450b-b192-4e76a83015c8"
-            }
-        },
-        {
-            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
             "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/',parameters('solarigateRuleGuid'))]",
             "kind": "Scheduled",
             "apiVersion":"2021-03-01-preview",
             "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces/providers/alertRules', parameters('workspaceName'), 'Microsoft.SecurityInsights', parameters('fusionRuleGuid'))]"
-            ],
             "properties": {
                 "displayName": "Solorigate Network Beacon",
                 "description": "Identifies a match across various data feeds for domains IOCs related to the Solorigate incident.\n References: https://blogs.microsoft.com/on-the-issues/2020/12/13/customers-protect-nation-state-cyberattacks/, \n https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html?1",


### PR DESCRIPTION
Solution deployment was failing because Fusion rule was being created as part of the deployment template. If the workspace is already create, it will have the Fusion rule already and will fail due to conflict.

FIx: removed fusion rule from alertRules.json
