### PR TITLE
SCX RunAsProvider ExecuteShellCommand

### DIFF
--- a/Hunting Queries/Syslog/SCXRunAsProviderExecuteShellCommand.yml
+++ b/Hunting Queries/Syslog/SCXRunAsProviderExecuteShellCommand.yml
@@ -1,7 +1,7 @@
 id: 0d298a1d-1a08-4f4b-8b28-687bfe0012e8
 name: SCX RunAsProvider ExecuteShellCommand
 description: |
-  'This detection uses the Syslog connector to ingest Auditd security events to detect the use of the SCX RunAsProvider Invoke_ExecuteShellCommand to execute any UNIX/Linux command using the /bin/sh shell.
+  'This hunting query uses Auditd security events collected via the Syslog data connector to explore the use of the SCX RunAsProvider Invoke_ExecuteShellCommand to execute any UNIX/Linux command using the /bin/sh shell.
   SCXcore, started as the Microsoft Operations Manager UNIX/Linux Agent, is now used in a host of products including Microsoft Operations Manager. Microsoft Azure, and Microsoft Operations Management Suite. 
   '
 severity: High

--- a/Hunting Queries/Syslog/SCXRunAsProviderExecuteShellCommand.yml
+++ b/Hunting Queries/Syslog/SCXRunAsProviderExecuteShellCommand.yml
@@ -24,18 +24,20 @@ tags:
 query: |
   Syslog
   | parse SyslogMessage with "type=" EventType " audit(" * "): " EventData
-  | project TimeGenerated, EventType, Computer, EventData 
-  // Extract AUOMS_EXECVE details from EventData
-  | where EventType =~ "AUOMS_EXECVE"
+  | where EventType =~ "AUOMS_EXECVE" and EventData has '/var/opt/microsoft/scx/tmp'
+  | project TimeGenerated, EventType, Computer, EventData
   | parse EventData with * "syscall=" syscall " syscall_r=" * " success=" success " exit=" exit " a0" * " ppid=" ppid " pid=" pid " audit_user=" audit_user " auid=" auid " user=" user " uid=" uid " group=" group " gid=" gid "effective_user=" effective_user " euid=" euid " set_user=" set_user " suid=" suid " filesystem_user=" filesystem_user " fsuid=" fsuid " effective_group=" effective_group " egid=" egid " set_group=" set_group " sgid=" sgid " filesystem_group=" filesystem_group " fsgid=" fsgid " tty=" tty " ses=" ses " comm=\"" comm "\" exe=\"" exe "\"" * "cwd=\"" cwd "\"" * "name=\"" name "\"" * "cmdline=\"" cmdline "\" containerid=" containerid
-  // Find wget and curl commands
   | where uid == '0'
   | where cwd == '/var/opt/microsoft/scx/tmp'
   | where comm == 'sh'
-  | extend Timestamp = TimeGenerated, HostCustomEntity = Computer
+  | extend Timestamp = TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = user
 entityMappings: 
   - entityType: Host
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
 version: 1.0.0

--- a/Hunting Queries/Syslog/SCXRunAsProviderExecuteShellCommand.yml
+++ b/Hunting Queries/Syslog/SCXRunAsProviderExecuteShellCommand.yml
@@ -1,0 +1,41 @@
+id: 0d298a1d-1a08-4f4b-8b28-687bfe0012e8
+name: SCX RunAsProvider ExecuteShellCommand
+description: |
+  'This detection uses the Syslog connector to ingest Auditd security events to detect the use of the SCX RunAsProvider Invoke_ExecuteShellCommand to execute any UNIX/Linux command using the /bin/sh shell.
+  SCXcore, started as the Microsoft Operations Manager UNIX/Linux Agent, is now used in a host of products including Microsoft Operations Manager. Microsoft Azure, and Microsoft Operations Management Suite. 
+  '
+severity: High
+requiredDataConnectors:
+  - connectorId: Syslog
+    dataTypes: 
+      - Syslog
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+  - Execution
+relevantTechniques:
+  - T1190
+  - T1203
+tags:
+  - SimuLand
+query: |
+  Syslog
+  | parse SyslogMessage with "type=" EventType " audit(" * "): " EventData
+  | project TimeGenerated, EventType, Computer, EventData 
+  // Extract AUOMS_EXECVE details from EventData
+  | where EventType =~ "AUOMS_EXECVE"
+  | parse EventData with * "syscall=" syscall " syscall_r=" * " success=" success " exit=" exit " a0" * " ppid=" ppid " pid=" pid " audit_user=" audit_user " auid=" auid " user=" user " uid=" uid " group=" group " gid=" gid "effective_user=" effective_user " euid=" euid " set_user=" set_user " suid=" suid " filesystem_user=" filesystem_user " fsuid=" fsuid " effective_group=" effective_group " egid=" egid " set_group=" set_group " sgid=" sgid " filesystem_group=" filesystem_group " fsgid=" fsgid " tty=" tty " ses=" ses " comm=\"" comm "\" exe=\"" exe "\"" * "cwd=\"" cwd "\"" * "name=\"" name "\"" * "cmdline=\"" cmdline "\" containerid=" containerid
+  // Find wget and curl commands
+  | where uid == '0'
+  | where cwd == '/var/opt/microsoft/scx/tmp'
+  | where comm == 'sh'
+  | extend Timestamp = TimeGenerated, HostCustomEntity = Computer
+entityMappings: 
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity
+version: 1.0.0


### PR DESCRIPTION
This hunting query uses Auditd security events collected via the Syslog data connector to explore the use of the [SCX RunAsProvider Invoke_ExecuteShellCommand](https://github.com/microsoft/SCXcore/blob/master/source/code/providers/support/runasprovider.cpp#L137) to execute any UNIX/Linux command using the /bin/sh shell.

SCXcore, started as the Microsoft Operations Manager UNIX/Linux Agent, is now used in a host of products including Microsoft Operations Manager. Microsoft Azure, and Microsoft Operations Management Suite.

SCX has a support provider named [RunAsProvider](https://github.com/microsoft/SCXcore/blob/master/source/code/providers/support/runasprovider.cpp). This provider has a few classes:
* [ExecuteCommand](https://github.com/microsoft/SCXcore#runas-provider-executecommand)
* [ExecuteShellCommand](https://github.com/microsoft/SCXcore#runas-provider-executeshellcommand)
* [ExecuteScript](https://github.com/microsoft/SCXcore#runas-provider-executescript)

Based on [OMIGOD: Critical Vulnerabilities in OMI Affecting Countless Azure Customers](https://www.wiz.io/blog/omigod-critical-vulnerabilities-in-omi-azure) by [Wiz](https://twitter.com/wiz_io) , `ExecuteShellCommand` was used in the HTTP request to test  `CVE-2021-38647`. 

```
<s:Body>
      <p:ExecuteShellCommand_INPUT xmlns:p="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
         <p:command>id</p:command>
         <p:timeout>0</p:timeout>
      </p:ExecuteShellCommand_INPUT>
   </s:Body>
```  

This was derived from initial testing while executing commands via `/opt/omi/bin/omicli` and exploring responses.

```
/opt/omi/bin/omicli --hostname 192.168.1.1 -u azureuser -p Password1 iv root/scx { SCX_OperatingSystem } ExecuteShellCommand { command 'id' timeout 0 }
```

Using the same template provided in the blog post by Wiz, we prepared a quick test:

```
<s:Body>
      <p:ExecuteShellCommand_INPUT xmlns:p="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
         <p:command>echo 'Hola MSTIC'</p:command>
         <p:timeout>0</p:timeout>
      </p:ExecuteShellCommand_INPUT>
   </s:Body>
```  

We set the SCX logging to  `verbose`  

```
/opt/microsoft/scx/bin/tools/scxadmin -log-set all verbose
```

and we were able to capture the activity on the OMI server side in the `scx.log`:

```
tail -f /var/opt/microsoft/scx/log/scx.log
```

![image](https://user-images.githubusercontent.com/9653181/133753733-b14886cf-e601-490f-9488-4bf152de1719.png)

![image](https://user-images.githubusercontent.com/9653181/133755011-c4860e94-abc2-4753-a306-2eb118928cb9.png)


Next, we checked our `Sysmon for Linux` and `auditd` logs in our lab environment and identified where the commands were being executed from:

 
![image](https://user-images.githubusercontent.com/9653181/133755415-ffdbd036-70c2-4c00-9f74-ff4490a0332d.png)

![image](https://user-images.githubusercontent.com/9653181/133756156-4fb9c2b1-aa65-4380-957b-72170de36fc4.png)


We then put together the following query to validate our testing. The query is part of this PR.

![image](https://user-images.githubusercontent.com/9653181/133753139-64b29613-f4c2-4903-b268-dc330758e826.png)


# References:
* https://www.wiz.io/blog/omigod-critical-vulnerabilities-in-omi-azure
* https://docs.microsoft.com/en-us/system-center/scom/manage-security-administer-crossplat-agent?view=sc-om-2019
* https://github.com/microsoft/SCXcore
* https://github.com/microsoft/SCXcore/blob/master/source/code/providers/support/runasprovider.cpp#L137
