### PR TITLE
Adding Azure Firewall Support to the NetworkConnectiontoOMIPorts Hunting Query

### DIFF
--- a/Hunting Queries/MultipleDataSources/NetworkConnectiontoOMIPorts.yaml
+++ b/Hunting Queries/MultipleDataSources/NetworkConnectiontoOMIPorts.yaml
@@ -14,6 +14,9 @@ requiredDataConnectors:
   - connectorId: AzureMonitor(VMInsights)
     dataTypes:
       - VMConnection
+  - connectorId: AzureFirewall
+    dataTypes: 
+      - AzureDiagnostics
 tactics:
   - Reconnaissance
   - Initial Access
@@ -51,5 +54,12 @@ query: |
   | parse VM_s with * '/' VM 
   | project TimeGenerated, SourceIp = SrcIP_s, DestinationIp = DestIP_s, DestinationPort = DestPort_d, Protocol = L7Protocol_s, NSGRule_s, VM, Type
   | extend Timestamp = TimeGenerated, HostCustomEntity = VM, IPCustomEntity = SourceIp
+  ),
+  AzureDiagnostics
+  | where Category == "AzureFirewallNetworkRule" and OperationName == "AzureFirewallNatRuleLog"
+  | parse msg_s with Protocol ' request from ' SourceIp ':' SourcePort ' to ' DestinationIp ':' DestinationPort " was " Action " to " InternalIP ':' InternalPort
+  | where DestinationPort in (Port)
+  | project TimeGenerated, SourceIP, DestinationIP, DestinationPort, Protocol, Action, Resource
+  | extend Timestamp = TimeGenerated, HostCustomEntity = Resource, IPCustomEntity = SourceIp
   )
   )

--- a/Hunting Queries/MultipleDataSources/NetworkConnectiontoOMIPorts.yaml
+++ b/Hunting Queries/MultipleDataSources/NetworkConnectiontoOMIPorts.yaml
@@ -60,6 +60,6 @@ query: |
   | parse msg_s with Protocol ' request from ' SourceIp ':' SourcePort ' to ' DestinationIp ':' DestinationPort " was " Action " to " InternalIP ':' InternalPort
   | where DestinationPort in (Port)
   | project TimeGenerated, SourceIp, DestinationIp, DestinationPort, Protocol, Action, Resource
-  | extend Timestamp = TimeGenerated, HostCustomEntity = Resource, IPCustomEntity = SourceIp
+  | extend Timestamp = TimeGenerated, IPCustomEntity = SourceIp
   )
   )

--- a/Hunting Queries/MultipleDataSources/NetworkConnectiontoOMIPorts.yaml
+++ b/Hunting Queries/MultipleDataSources/NetworkConnectiontoOMIPorts.yaml
@@ -59,7 +59,7 @@ query: |
   | where Category == "AzureFirewallNetworkRule" and OperationName == "AzureFirewallNatRuleLog"
   | parse msg_s with Protocol ' request from ' SourceIp ':' SourcePort ' to ' DestinationIp ':' DestinationPort " was " Action " to " InternalIP ':' InternalPort
   | where DestinationPort in (Port)
-  | project TimeGenerated, SourceIP, DestinationIP, DestinationPort, Protocol, Action, Resource
+  | project TimeGenerated, SourceIp, DestinationIp, DestinationPort, Protocol, Action, Resource
   | extend Timestamp = TimeGenerated, HostCustomEntity = Resource, IPCustomEntity = SourceIp
   )
   )


### PR DESCRIPTION
Fixes # Added Azure Firewall query to find attacks targeting OMI vulnerability (CVE-2021-38647) in DNAT traffic.

## Proposed Changes

  - Adding Azure Diagnostics query to detect connection attempts from the external IP addresses to the management ports(5985,5986,1270) related to Open Management Infrastructure(OMI) through DNAT rules in Azure Firewall.
