### PR TITLE
Update AWS-S3 scripts

### DIFF
--- a/DataConnectors/AWS-S3/ConfigCloudTrailDataConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigCloudTrailDataConnector.ps1
@@ -345,7 +345,7 @@ if($kmsCofirmation -eq 'y')
 		$currentKmsPolicyObject = $currentKmsPolicy | ConvertFrom-Json 	
 		$currentKmsPolicies = ($currentKmsPolicyObject.Policy) | ConvertFrom-Json
 		
-		$kmsRequiredPoliciesThatNotExistInCurrentPolicy =  $kmsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json) -notin ($currentKmsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+		$kmsRequiredPoliciesThatNotExistInCurrentPolicy =  $kmsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentKmsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 		if($kmsRequiredPoliciesThatNotExistInCurrentPolicy -ne $null)
 		{
 			$currentKmsPolicies.Statement += $kmsRequiredPoliciesThatNotExistInCurrentPolicy
@@ -373,7 +373,7 @@ if($currentSqsPolicy -ne $null)
 	$currentSqsPolicyObject = $currentSqsPolicy | ConvertFrom-Json 	
 	$currentSqsPolicies = ($currentSqsPolicyObject.Attributes.Policy) | ConvertFrom-Json 
 	
-	$sqsRequiredPoliciesThatNotExistInCurrentPolicy =  $sqsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json) -notin ($currentSqsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+	$sqsRequiredPoliciesThatNotExistInCurrentPolicy =  $sqsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentSqsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 	if($sqsRequiredPoliciesThatNotExistInCurrentPolicy -ne $null)
 	{
 		$currentSqsPolicies.Statement += $sqsRequiredPoliciesThatNotExistInCurrentPolicy
@@ -413,7 +413,7 @@ if($isBucketPolicyExist)
 	$currentBucketPolicyObject = $currentBucketPolicy | ConvertFrom-Json 	
 	$currentBucketPolicies = ($currentBucketPolicyObject.Policy) | ConvertFrom-Json 
 	 
-    $sqsRequiredPolicyThatNotExistInCurrentPolicy = $s3RequiredPolicyObject.Statement | Where-Object { ($_ | ConvertTo-Json) -notin ($currentBucketPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+    $sqsRequiredPolicyThatNotExistInCurrentPolicy = $s3RequiredPolicyObject.Statement | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentBucketPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 	if($sqsRequiredPolicyThatNotExistInCurrentPolicy -ne $null)
 	{
 		$currentBucketPolicies.Statement += $sqsRequiredPolicyThatNotExistInCurrentPolicy

--- a/DataConnectors/AWS-S3/ConfigGuardDutyDataConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigGuardDutyDataConnector.ps1
@@ -280,13 +280,13 @@ $callerAccount = (aws sts get-caller-identity | ConvertFrom-Json).Account
 
 Write-Output `n`n'Kms Definition.'
 Retry-Action({
-	$kmaAliasName = Read-Host 'Please insert KMS alias Name'
-	$kmsKeyDescription = aws kms describe-key --key-id alias/$kmaAliasName 2>&1
+	$script:kmaAliasName = Read-Host 'Please insert KMS alias Name'
+	$script:kmsKeyDescription = aws kms describe-key --key-id alias/$kmaAliasName 2>&1
 	$isKmsNotExist = $lastexitcode -ne 0
 	if($isKmsNotExist)
 	{
-		$kmsKeyDescription = aws kms create-key
-		$kmsKeyId = ($kmsKeyDescription | ConvertFrom-Json).KeyMetadata.KeyId
+		$script:kmsKeyDescription = aws kms create-key
+		$kmsKeyId = ($script:kmsKeyDescription | ConvertFrom-Json).KeyMetadata.KeyId
 		$tempForOutput = aws kms create-alias --alias-name alias/$kmaAliasName --target-key-id $kmsKeyId 2>&1
 		if($lastexitcode -eq 0)
 		{
@@ -318,7 +318,7 @@ if($currentKmsPolicy -ne $null)
 	$currentKmsPolicyObject = $currentKmsPolicy | ConvertFrom-Json 	
 	$currentKmsPolicies = ($currentKmsPolicyObject.Policy) | ConvertFrom-Json
 	
-	$kmsRequiredPoliciesThatNotExistInCurrentPolicy =  $kmsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json) -notin ($currentKmsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+	$kmsRequiredPoliciesThatNotExistInCurrentPolicy =  $kmsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentKmsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 	if($kmsRequiredPoliciesThatNotExistInCurrentPolicy -ne $null)
 	{
 		$currentKmsPolicies.Statement += $kmsRequiredPoliciesThatNotExistInCurrentPolicy
@@ -346,7 +346,7 @@ if($currentSqsPolicy -ne $null)
 	$currentSqsPolicyObject = $currentSqsPolicy | ConvertFrom-Json 	
 	$currentSqsPolicies = ($currentSqsPolicyObject.Attributes.Policy) | ConvertFrom-Json 
 	
-	$sqsRequiredPoliciesThatNotExistInCurrentPolicy =  $sqsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json) -notin ($currentSqsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+	$sqsRequiredPoliciesThatNotExistInCurrentPolicy =  $sqsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentSqsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 	if($sqsRequiredPoliciesThatNotExistInCurrentPolicy -ne $null)
 	{
 		$currentSqsPolicies.Statement += $sqsRequiredPoliciesThatNotExistInCurrentPolicy
@@ -433,9 +433,9 @@ Write-Output `n'Enabling GuardDuty'
 	}
 	else
 	{
-		$detectorId = ($newGuarduty | ConvertFrom-Json).DetectorId
+		$script:detectorId = ($newGuarduty | ConvertFrom-Json).DetectorId
 	}
-	$currentDestinations = aws guardduty list-publishing-destinations --detector-id $detectorId 2>&1
+	$script:currentDestinations = aws guardduty list-publishing-destinations --detector-id $detectorId 2>&1
  })
  
 $currentDestinationsObject = $currentDestinations | ConvertFrom-Json

--- a/DataConnectors/AWS-S3/ConfigVpcFlowDataConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigVpcFlowDataConnector.ps1
@@ -221,7 +221,7 @@ if($currentSqsPolicy -ne $null)
 	$currentSqsPolicyObject = $currentSqsPolicy | ConvertFrom-Json 	
 	$currentSqsPolicies = ($currentSqsPolicyObject.Attributes.Policy) | ConvertFrom-Json 
 	
-	$sqsRequiredPoliciesThatNotExistInCurrentPolicy =  $sqsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json) -notin ($currentSqsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+	$sqsRequiredPoliciesThatNotExistInCurrentPolicy =  $sqsRequiredPoliciesObject.Statement | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentSqsPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 	if($sqsRequiredPoliciesThatNotExistInCurrentPolicy -ne $null)
 	{
 		$currentSqsPolicies.Statement += $sqsRequiredPoliciesThatNotExistInCurrentPolicy
@@ -250,7 +250,7 @@ if($isBucketPolicyExist)
 	$currentBucketPolicyObject = $currentBucketPolicy | ConvertFrom-Json 	
 	$currentBucketPolicies = ($currentBucketPolicyObject.Policy) | ConvertFrom-Json 
 	 
-	$s3RequiredPolicyThatNotExistInCurrentPolicy =  $s3RequiredPolicyObject | Where-Object { ($_ | ConvertTo-Json) -notin ($currentBucketPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json}  )}
+	$s3RequiredPolicyThatNotExistInCurrentPolicy =  $s3RequiredPolicyObject | Where-Object { ($_ | ConvertTo-Json -Depth 5) -notin ($currentBucketPolicies.Statement | ForEach-Object { $_ | ConvertTo-Json -Depth 5}  )}
 	if($s3RequiredPolicyThatNotExistInCurrentPolicy -ne $null)
 	{
 		$currentBucketPolicies.Statement += $s3RequiredPolicyThatNotExistInCurrentPolicy


### PR DESCRIPTION
Fixes #

## Update AWS-S3 scripts

  -` ConvertTo-Json`, support by default 2 depth. Add `-Depth 5` to compare between full objects
  - add `$script` in GurdDuty script, inside retry script. to have the ability to use these values outside the script
