### PR TITLE
Feature/noamlandress/new installation script for cefama

### DIFF
--- a/DataConnectors/CEF/cef_AMA_installer.py
+++ b/DataConnectors/CEF/cef_AMA_installer.py
@@ -30,7 +30,7 @@ import time
 rsyslog_daemon_name = "rsyslog"
 syslog_ng_daemon_name = "syslog-ng"
 daemon_default_incoming_port = "514"
-syslog_ng_source_content = "source s_src { udp( port({port}})); tcp( port({port}}));};".format(port=daemon_default_incoming_port)
+syslog_ng_source_content = "source s_src { udp( port(%(port)s)); tcp( port(%(port)s));};" % {'port': daemon_default_incoming_port}
 rsyslog_conf_path = "/etc/rsyslog.conf"
 syslog_ng_conf_path = "/etc/syslog-ng/syslog-ng.conf"
 rsyslog_module_udp_content = "# provides UDP syslog reception\nmodule(load=\"imudp\")\ninput(type=\"imudp\" port=\"" + daemon_default_incoming_port + "\")\n"


### PR DESCRIPTION
## Proposed Changes
1. A new CEF installation script meant only for the new AMA.
2. The script is stripped down of anything related to OMS.
3. The script only handles the editing of the syslog daemon (Rsyslog/Syslog-ng)  in order for them to receive events from an inbound listening port.
4. Unlike the other CEF scripts- this one doesn't take any params.