### PR TITLE
Join Kind changed from inner to leftouter, IpAddress1 might be preferred

### DIFF
--- a/Detections/SecurityEvent/NonDCActiveDirectoryReplication.yaml
+++ b/Detections/SecurityEvent/NonDCActiveDirectoryReplication.yaml
@@ -28,7 +28,7 @@ query: |
       or Properties has '1131f6ad-9c07-11d1-f79f-00c04fc2dcd2' //DS-Replication-Get-Changes-All
       or Properties has '89e95b76-444d-4c62-991a-0facbeda640c' //DS-Replication-Get-Changes-In-Filtered-Set
   | project TimeGenerated, Account, Activity, Properties, SubjectLogonId, Computer
-  | join kind=inner
+  | join kind=leftouter
   (
       SecurityEvent
       //| where Computer in (DCServersList)
@@ -37,8 +37,8 @@ query: |
       | project TargetLogonId, IpAddress
   )
   on $left.SubjectLogonId == $right.TargetLogonId
-  | project-reorder TimeGenerated, Computer, Account, IpAddress
-  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, SourceAddress = IpAddress 
+  | project-reorder TimeGenerated, Computer, Account, IpAddress1
+  | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, SourceAddress = IpAddress1 
 entityMappings:
   - entityType: Account
     fieldMappings:


### PR DESCRIPTION
If you are missing 4624 events you might not realize replication events are happening. Also we are generating two IpAddresses columns, in my tenant only the IpAddress column from 4624 events (IpAddress1) is populated. Please, could you review this?

Fixes #

Missing replication events in results.
SourceAddress column being empty.
