### PR TITLE
Fixing bug in New Processes Hunt query

### DIFF
--- a/Hunting Queries/SecurityEvent/new_processes.yaml
+++ b/Hunting Queries/SecurityEvent/new_processes.yaml
@@ -19,15 +19,19 @@ query: |
   let processEvents=SecurityEvent
   | where TimeGenerated between(lookback..endtime)
   | where EventID==4688
-  | project TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName, AccountDomain=SubjectDomainName, FileName=tostring(split(NewProcessName, @'')[(-1)]), ProcessCommandLine = CommandLine, InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine='',InitiatingProcessParentFileName='';
+  | project TimeGenerated, Computer, Account, FileName=tostring(split(NewProcessName, @'')[(-1)]), NewProcessName, ProcessCommandLine = CommandLine, InitiatingProcessFileName=ParentProcessName;
   processEvents};
   ProcessCreationEvents
   | where TimeGenerated between(lookback..starttime)
-  | summarize HostCount=dcount(ComputerName) by tostring(FileName)
+  | summarize HostCount=dcount(Computer) by FileName
   | join kind=rightanti (
       ProcessCreationEvents
       | where TimeGenerated between(starttime..endtime)
-      | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), Computers = makeset(ComputerName) , HostCount=dcount(ComputerName) by tostring(FileName)
+      | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Computers = makeset(Computer) , HostCount=dcount(Computer) by Account, NewProcessName, FileName, ProcessCommandLine, InitiatingProcessFileName
   ) on FileName
-  | project StartTimeUtc, Computers, HostCount, FileName
-  | extend timestamp = StartTimeUtc
+  | extend timestamp = StartTime, AccountCustomEntity = Account
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity

--- a/Hunting Queries/SecurityEvent/new_processes.yaml
+++ b/Hunting Queries/SecurityEvent/new_processes.yaml
@@ -17,12 +17,12 @@ query: |
   let lookback = starttime - 14d;
   let ProcessCreationEvents=() {
   let processEvents=SecurityEvent
-  | where TimeGenerated between(lookback..starttime)
+  | where TimeGenerated between(lookback..endtime)
   | where EventID==4688
   | project TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName, AccountDomain=SubjectDomainName, FileName=tostring(split(NewProcessName, @'')[(-1)]), ProcessCommandLine = CommandLine, InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine='',InitiatingProcessParentFileName='';
   processEvents};
   ProcessCreationEvents
-  | where TimeGenerated between(starttime..endtime)
+  | where TimeGenerated between(lookback..starttime)
   | summarize HostCount=dcount(ComputerName) by tostring(FileName)
   | join kind=rightanti (
       ProcessCreationEvents


### PR DESCRIPTION
The query has issues that would prevent it from ever finding the intended results.
-The ProcessCreationEvents function doesn't include the last 24 hours of data so when called it doesn't include the last 24 hours of data to compare
-The joins of the ProcessCreationEvents function both evaluated the same time period, not the historical period against the last 24 hours

This commit fixes both issues

Fixes #

## Proposed Changes

  -
  -
  -
