### PR TITLE
fix: Awake Security Workbook unset parameter value

### DIFF
--- a/Solutions/AristaAwakeSecurity/Workbooks/AristaAwakeSecurityWorkbook.json
+++ b/Solutions/AristaAwakeSecurity/Workbooks/AristaAwakeSecurityWorkbook.json
@@ -66,7 +66,7 @@
             "label": "Host Name",
             "type": 1,
             "isRequired": true,
-            "value": "dogfood-rc.mv.awakenetworks.net"
+            "value": ""
           }
         ],
         "style": "pills",


### PR DESCRIPTION
Fixes

- unsets hostname parameter value for Awake Security Workbook
