### PR TITLE
Updated custom table name to fix PR  KQL validation

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/SecurityRegulatoryCompliance.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SecurityRegulatoryCompliance.json
@@ -1,5 +1,5 @@
 {
-  "Name": "SecurityRecommendation",
+  "Name": "SecurityRegulatoryCompliance",
   "Properties": [
     {
       "Name": "TenantId",


### PR DESCRIPTION
Fixes #
Error : The name 'SecurityRecommendation' refers to more than one column or variable.
Fix : Updated proper table name to fix PR KQL validation error 

## Proposed Changes

  -
  -
  -
