### PR TITLE
Project column "Prevalence" in RareRunCommandPowerShellScript.yaml

### DIFF
--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -79,7 +79,7 @@ query: |
   | join kind=leftouter (
   hashTotals
   ) on ScriptFingerprintHash
-  // Calculate prevalance, while we don't need this, it may be useful for responders to know how rare this script is in relation to normal activity
+  // Calculate prevalence, while we don't need this, it may be useful for responders to know how rare this script is in relation to normal activity
   | extend Prevalence = toreal(HashCount) / toreal(totals) * 100
   // Where the hash was only ever seen once.
   | where HashCount == 1

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -15,7 +15,7 @@ requiredDataConnectors:
       - DeviceFileEvents
       - DeviceEvents
 queryFrequency: 1d
-queryPeriod: 7d
+queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -79,7 +79,7 @@ query: |
   | join kind=leftouter (
   hashTotals
   ) on ScriptFingerprintHash
-  // Calculate prevelance, while we don't need this, it may be useful for responders to know how rare this script is in relation to normal activity
+  // Calculate prevalance, while we don't need this, it may be useful for responders to know how rare this script is in relation to normal activity
   | extend Prevalence = toreal(HashCount) / toreal(totals) * 100
   // Where the hash was only ever seen once.
   | where HashCount == 1

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -98,5 +98,5 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
-version: 1.0.0
-kind: scheduled
+version: 1.0.1
+kind: Scheduled

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -80,11 +80,11 @@ query: |
   hashTotals
   ) on ScriptFingerprintHash
   // Calculate prevelance, while we don't need this, it may be useful for responders to know how rare this script is in relation to normal activity
-  | extend Prevelance = toreal(HashCount) / toreal(totals) * 100
+  | extend Prevalence = toreal(HashCount) / toreal(totals) * 100
   // Where the hash was only ever seen once.
   | where HashCount == 1
   | extend timestamp = StartTime, IPCustomEntity=CallerIpAddress, AccountCustomEntity=Caller, HostCustomEntity=VirtualMachineName
-  | project timestamp, StartTime, EndTime, PowershellFileName, VirtualMachineName, Caller, CallerIpAddress, PowershellScriptCommands, PowershellFileSize, ScriptFingerprintHash, IPCustomEntity, AccountCustomEntity, HostCustomEntity
+  | project timestamp, StartTime, EndTime, PowershellFileName, VirtualMachineName, Caller, CallerIpAddress, PowershellScriptCommands, PowershellFileSize, ScriptFingerprintHash, Prevalence, IPCustomEntity, AccountCustomEntity, HostCustomEntity
 entityMappings:
   - entityType: Account
     fieldMappings:


### PR DESCRIPTION
I think Prevelance is not a correct word, and the column was not used in results. Maybe you want to skip the column, and you can comment it.

Fixes #

Prevalence does not appear in results.

## Proposed Changes

  - Project prevalence
 
ALSO, this alert could trigger 7 days in a row from only one event, maybe it should only check events from the last day.