### PR TITLE
[Proofpoint detection] - Fixes on TI match and lookback time.

### DIFF
--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -15,31 +15,37 @@ tactics:
   - Exfiltration
   - InitialAccess
 query: |
+  let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
-  let timeframe = 1h;
-  let TI_IP_List =
-  (ThreatIntelligenceIndicator
-  | where TimeGenerated > ago(ioc_lookBack) and ExpirationDateTime > now()
+  ThreatIntelligenceIndicator
+  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now() 
   | where Active == true
   | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
-  | extend TI_ipEntity = coalesce(NetworkIP, NetworkDestinationIP, NetworkSourceIP,EmailSourceIpAddress,"")
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | summarize make_set(TI_ipEntity));
-  ProofpointPOD 
-  | where TimeGenerated > ago(timeframe)
-  | where isnotempty(SrcIpAddr)
-  | where SrcIpAddr in~ (TI_IP_List)
-  | extend Message = "Email sender IP in TI list"
-  | project Message, SrcUserUpn, DstUserUpn, SrcIpAddr
-  | extend AccountCustomEntity = SrcUserUpn, IpCustomEntity = SrcIpAddr
+  | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
+  | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
+  | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
+  // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
+  | join kind=innerunique (
+            ProofpointPOD 
+            | where TimeGenerated >= ago(dt_lookBack)
+            | where isnotempty(SrcIpAddr)
+            | extend Message = "Email sender IP in TI list"
+            | extend ProofpointPOD_TimeGenerated = TimeGenerated, ClientIP = SrcIpAddr
+    )
+  on $left.TI_ipEntity == $right.ClientIP
+  | where KeyVaultEvents_TimeGenerated < ExpirationDateTime
+  | summarize ProofpointPOD_TimeGenerated = arg_max(KeyVaultEvents_TimeGenerated, *) by IndicatorId, ClientIP
+  | project ProofpointPOD_TimeGenerated, Message, SrcUserUpn, DstUserUpn, SrcIpAddr, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
+  TI_ipEntity, ClientIP
+  | extend timestamp = KeyVaultEvents_TimeGenerated
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: SrcUserUpn
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
 version: 1.1.0
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -41,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.1.0
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -30,6 +30,8 @@ query: |
   | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | where Active == true
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
             ProofpointPOD 

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -24,8 +24,7 @@ query: |
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
-  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now() 
-  | where Active == true
+  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
   | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
   | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -34,10 +34,10 @@ query: |
     )
   on $left.TI_ipEntity == $right.ClientIP
   | where KeyVaultEvents_TimeGenerated < ExpirationDateTime
-  | summarize ProofpointPOD_TimeGenerated = arg_max(KeyVaultEvents_TimeGenerated, *) by IndicatorId, ClientIP
+  | summarize ProofpointPOD_TimeGenerated = arg_max(ProofpointPOD_TimeGenerated, *) by IndicatorId, ClientIP
   | project ProofpointPOD_TimeGenerated, Message, SrcUserUpn, DstUserUpn, SrcIpAddr, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, ClientIP
-  | extend timestamp = KeyVaultEvents_TimeGenerated
+  | extend timestamp = ProofpointPOD_TimeGenerated
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -34,7 +34,7 @@ query: |
   on $left.TI_ipEntity == $right.ClientIP
   | where ProofpointPOD_TimeGenerated < ExpirationDateTime
   | summarize ProofpointPOD_TimeGenerated = arg_max(ProofpointPOD_TimeGenerated, *) by IndicatorId, ClientIP
-  | project ProofpointPOD_TimeGenerated, Message, SrcUserUpn, DstUserUpn, SrcIpAddr, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
+  | project ProofpointPOD_TimeGenerated, SrcUserUpn, DstUserUpn, SrcIpAddr, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, ClientIP
   | extend timestamp = ProofpointPOD_TimeGenerated
 entityMappings:

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -4,6 +4,12 @@ description: |
   'Email sender IP in TI list.'
 severity: Medium
 requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: ProofpointPOD
     dataTypes:
       - ProofpointPOD_maillog_CL

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -29,11 +29,10 @@ query: |
             ProofpointPOD 
             | where TimeGenerated >= ago(dt_lookBack)
             | where isnotempty(SrcIpAddr)
-            | extend Message = "Email sender IP in TI list"
             | extend ProofpointPOD_TimeGenerated = TimeGenerated, ClientIP = SrcIpAddr
     )
   on $left.TI_ipEntity == $right.ClientIP
-  | where KeyVaultEvents_TimeGenerated < ExpirationDateTime
+  | where ProofpointPOD_TimeGenerated < ExpirationDateTime
   | summarize ProofpointPOD_TimeGenerated = arg_max(ProofpointPOD_TimeGenerated, *) by IndicatorId, ClientIP
   | project ProofpointPOD_TimeGenerated, Message, SrcUserUpn, DstUserUpn, SrcIpAddr, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, ClientIP

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -15,13 +15,15 @@ tactics:
   - Exfiltration
   - InitialAccess
 query: |
-  let ioc_lookBack = 30d;
+  let ioc_lookBack = 14d;
   let timeframe = 1h;
   let TI_IP_List =
-  ThreatIntelligenceIndicator
-  | where TimeGenerated > ago(ioc_lookBack)
-  | where isnotempty(NetworkIP)
-  | summarize make_list(NetworkIP);
+  (ThreatIntelligenceIndicator
+  | where TimeGenerated > ago(ioc_lookBack) and ExpirationDateTime > now()
+  | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
+  | extend TI_ipEntity = coalesce(NetworkIP, NetworkDestinationIP, NetworkSourceIP,EmailSourceIpAddress,"")
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize make_set(TI_ipEntity));
   ProofpointPOD 
   | where TimeGenerated > ago(timeframe)
   | where isnotempty(SrcIpAddr)

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -41,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderIPinTIList.yaml
@@ -20,6 +20,7 @@ query: |
   let TI_IP_List =
   (ThreatIntelligenceIndicator
   | where TimeGenerated > ago(ioc_lookBack) and ExpirationDateTime > now()
+  | where Active == true
   | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
   | extend TI_ipEntity = coalesce(NetworkIP, NetworkDestinationIP, NetworkSourceIP,EmailSourceIpAddress,"")
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -36,5 +36,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.1.0
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -27,7 +27,7 @@ query: |
   | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now() 
   | where Active == true
   | where isnotempty(EmailSenderAddress)
-  | extend TI_emailEntity = EmailSenderAddress)
+  | extend TI_emailEntity = EmailSenderAddress
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
          ProofpointPOD 

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -39,8 +39,7 @@ query: |
   on $left.TI_emailEntity == $right.ClientEmail
   | where ProofpointPOD_TimeGenerated < ExpirationDateTime
   | summarize ProofpointPOD_TimeGenerated = arg_max(ProofpointPOD_TimeGenerated, *) by IndicatorId, ClientEmail
-  | project ProofpointPOD_TimeGenerated, Description, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
-  TI_ipEntity, ClientEmail
+  | project ProofpointPOD_TimeGenerated, Description, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, ClientEmail
   | extend timestamp = ProofpointPOD_TimeGenerated
 entityMappings:
   - entityType: Account

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -15,26 +15,33 @@ tactics:
   - Exfiltration
   - InitialAccess
 query: |
+  let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
-  let timeframe = 1h;
-  let TI_email_List =
-  (ThreatIntelligenceIndicator
-  | where TimeGenerated > ago(ioc_lookBack) and ExpirationDateTime > now()
+  ThreatIntelligenceIndicator
+  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now() 
   | where Active == true
   | where isnotempty(EmailSenderAddress)
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
-  | summarize make_set(EmailSenderAddress));
-  ProofpointPOD 
-  | where TimeGenerated > ago(timeframe)
-  | where isnotempty(SrcUserUpn)
-  | where SrcUserUpn in~ (TI_email_List)
-  | extend Message = "Email sender in TI list"
-  | project Message, SrcUserUpn, DstUserUpn
-  | extend AccountCustomEntity = SrcUserUpn
+  | extend TI_emailEntity = EmailSenderAddress)
+  // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
+  | join kind=innerunique (
+         ProofpointPOD 
+         | where TimeGenerated >= ago(dt_lookBack)
+         | where isnotempty(SrcUserUpn)
+         | extend ProofpointPOD_TimeGenerated = TimeGenerated, ClientEmail = SrcUserUpn
+            
+  )
+  on $left.TI_emailEntity == $right.ClientEmail
+  | where ProofpointPOD_TimeGenerated < ExpirationDateTime
+            | project Message, SrcUserUpn, DstUserUpn
+            | extend AccountCustomEntity = SrcUserUpn
+  | summarize ProofpointPOD_TimeGenerated = arg_max(ProofpointPOD_TimeGenerated, *) by IndicatorId, ClientEmail
+  | project ProofpointPOD_TimeGenerated, Description, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
+  TI_ipEntity, ClientEmail
+  | extend timestamp = ProofpointPOD_TimeGenerated
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: ClientEmail
 version: 1.1.0
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -32,8 +32,6 @@ query: |
   )
   on $left.TI_emailEntity == $right.ClientEmail
   | where ProofpointPOD_TimeGenerated < ExpirationDateTime
-            | project Message, SrcUserUpn, DstUserUpn
-            | extend AccountCustomEntity = SrcUserUpn
   | summarize ProofpointPOD_TimeGenerated = arg_max(ProofpointPOD_TimeGenerated, *) by IndicatorId, ClientEmail
   | project ProofpointPOD_TimeGenerated, Description, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, ClientEmail

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -4,6 +4,12 @@ description: |
   'Email sender in TI list.'
 severity: Medium
 requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
   - connectorId: ProofpointPOD
     dataTypes:
       - ProofpointPOD_maillog_CL

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -15,13 +15,14 @@ tactics:
   - Exfiltration
   - InitialAccess
 query: |
-  let ioc_lookBack = 30d;
+  let ioc_lookBack = 14d;
   let timeframe = 1h;
   let TI_email_List =
-  ThreatIntelligenceIndicator
-  | where TimeGenerated > ago(ioc_lookBack)
+  (ThreatIntelligenceIndicator
+  | where TimeGenerated > ago(ioc_lookBack) and ExpirationDateTime > now()
   | where isnotempty(EmailSenderAddress)
-  | summarize make_list(EmailSenderAddress);
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize make_set(EmailSenderAddress));
   ProofpointPOD 
   | where TimeGenerated > ago(timeframe)
   | where isnotempty(SrcUserUpn)

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -20,6 +20,7 @@ query: |
   let TI_email_List =
   (ThreatIntelligenceIndicator
   | where TimeGenerated > ago(ioc_lookBack) and ExpirationDateTime > now()
+  | where Active == true
   | where isnotempty(EmailSenderAddress)
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
   | summarize make_set(EmailSenderAddress));

--- a/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODEmailSenderInTIList.yaml
@@ -36,5 +36,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODMultipleProtectedEmailsToUnknownRecipient.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODMultipleProtectedEmailsToUnknownRecipient.yaml
@@ -42,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.1.0
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODMultipleProtectedEmailsToUnknownRecipient.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODMultipleProtectedEmailsToUnknownRecipient.yaml
@@ -42,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ProofpointPOD/ProofpointPODMultipleProtectedEmailsToUnknownRecipient.yaml
+++ b/Detections/ProofpointPOD/ProofpointPODMultipleProtectedEmailsToUnknownRecipient.yaml
@@ -15,7 +15,7 @@ tactics:
   - Exfiltration
 query: |
   let lbtime = 30m;
-  let lbperiod = 30d;
+  let lbperiod = 14d;
   let knownrecipients = ProofpointPOD
   | where TimeGenerated > ago(lbperiod)
   | where EventType == 'message'


### PR DESCRIPTION
Fixes #3137 

## Proposed Changes

  - Filtered Inactive IoCs.
  - Checked possible IP address fields.
  - Taken only the last copy of the IoC from TI table
  - Updated the time frame for IOC look back from 30days to 14days as per Analytics Rule design.
  
@oshezaf , @Amitbergman, @ShaniFelig - Do we need to update the version number as well for these fixes !
