### PR TITLE
Reduce Query Time Range in UserAccountCreatedDeleted_10m.yaml

### DIFF
--- a/Detections/SecurityEvent/UserAccountCreatedDeleted_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountCreatedDeleted_10m.yaml
@@ -58,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/SecurityEvent/UserAccountCreatedDeleted_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountCreatedDeleted_10m.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
 queryFrequency: 1d
-queryPeriod: 2d
+queryPeriod: 25h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -25,8 +25,8 @@ query: |
   let timeframe = 1d;
   let spanoftime = 10m;
   let threshold = 0;
-  SecurityEvent 
-  | where TimeGenerated > ago(2*timeframe) 
+  SecurityEvent
+  | where TimeGenerated > ago(timeframe+spanoftime)
   // A user account was created
   | where EventID == 4720
   | where AccountType =~ "User"
@@ -34,11 +34,11 @@ query: |
   AccountUsedToCreate = SubjectAccount, SIDofAccountUsedToCreate = SubjectUserSid, TargetAccount = tolower(TargetAccount), TargetSid
   | join kind= inner (
     SecurityEvent
-    | where TimeGenerated > ago(timeframe) 
-    // A user account was deleted 
+    | where TimeGenerated > ago(timeframe)
+    // A user account was deleted
     | where EventID == 4726
   | where AccountType == "User"
-  | project deletionTime = TimeGenerated, DeleteEventID = EventID, DeleteActivity = Activity, Computer, TargetUserName, UserPrincipalName, 
+  | project deletionTime = TimeGenerated, DeleteEventID = EventID, DeleteActivity = Activity, Computer, TargetUserName, UserPrincipalName,
   AccountUsedToDelete = SubjectAccount, SIDofAccountUsedToDelete = SubjectUserSid, TargetAccount = tolower(TargetAccount), TargetSid
   ) on Computer, TargetAccount
   | where deletionTime - creationTime < spanoftime

--- a/Detections/SecurityEvent/UserAccountCreatedDeleted_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountCreatedDeleted_10m.yaml
@@ -38,7 +38,7 @@ query: |
     // A user account was deleted
     | where EventID == 4726
   | where AccountType == "User"
-  | project deletionTime = TimeGenerated, DeleteEventID = EventID, DeleteActivity = Activity, Computer, TargetUserName, UserPrincipalName,
+  | project deletionTime = TimeGenerated, DeleteEventID = EventID, DeleteActivity = Activity, Computer, TargetUserName, UserPrincipalName, 
   AccountUsedToDelete = SubjectAccount, SIDofAccountUsedToDelete = SubjectUserSid, TargetAccount = tolower(TargetAccount), TargetSid
   ) on Computer, TargetAccount
   | where deletionTime - creationTime < spanoftime


### PR DESCRIPTION
If you join (2*timeframe) with (timeframe), when the timeframe is 1d, and the spanoftime is 10m, you will have queried 23h50m worth of data that will never be used, wasting computing resources.

Fixes #

Wasting computing resources not used.

## Proposed Changes

Reduce Query Time Range
