### PR TITLE
Reduce Query Time Range in UserAccountEnabledDisabled_10m.yaml

### DIFF
--- a/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
 queryFrequency: 1d
-queryPeriod: 2d
+queryPeriod: 25h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -25,8 +25,8 @@ query: |
   let timeframe = 1d;
   let spanoftime = 10m;
   let threshold = 0;
-  SecurityEvent 
-  | where TimeGenerated > ago(2*timeframe) 
+  SecurityEvent
+  | where TimeGenerated > ago(timeframe+spanoftime)
   // A user account was enabled
   | where EventID == 4722
   | where AccountType =~ "User"
@@ -35,8 +35,8 @@ query: |
   AccountUsedToEnable = SubjectAccount, SIDofAccountUsedToEnable = SubjectUserSid, TargetAccount = tolower(TargetAccount), TargetSid
   | join kind= inner (
     SecurityEvent
-    | where TimeGenerated > ago(timeframe) 
-    // A user account was disabled 
+    | where TimeGenerated > ago(timeframe)
+    // A user account was disabled
     | where EventID == 4725
   | where AccountType =~ "User"
   | project DisableTime = TimeGenerated, DisableEventID = EventID, DisableActivity = Activity, Computer, UserPrincipalName, 

--- a/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
If you join (2*timeframe) with (timeframe), when the timeframe is 1d, and the spanoftime is 10m, you will have queried 23h50m worth of data that will never be used, wasting computing resources.

Fixes #

Wasting computing resources not used.

## Proposed Changes

Reduce Query Time Range.
