### PR TITLE
[Data connectors] Aws-S3 script update

### DIFF
--- a/DataConnectors/AWS-S3/ConfigAwsConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigAwsConnector.ps1
@@ -24,7 +24,7 @@
 param (
     [Parameter()]
     [string]
-    $LogPath=(Get-Location).Path,
+    $LogPath=(Join-Path (Get-Location).Path Logs),
     [Parameter()]
     [ValidateSet("VPC","CloudTrail","GuardDuty")][string]$AwsLogType
 )
@@ -45,6 +45,7 @@ if ($null -eq (Get-Command "aws" -ErrorAction SilentlyContinue))
 }
 
 # Setup basic logging
+New-Item -ItemType Directory -Force -Path $LogPath | Out-Null
 $TimeStamp = Get-Date -Format MMddHHmm 
 $LogFileName = '{0}-{1}.csv' -f "AwsS3", $TimeStamp
 $LogFileName = Join-Path $LogPath $LogFileName

--- a/DataConnectors/AWS-S3/ConfigCloudTrailDataConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigCloudTrailDataConnector.ps1
@@ -233,11 +233,13 @@ function Set-OrganizationTrailConfig
 }
 
 # ***********       Main Flow       ***********
+
+# Validate AWS configuration
+Test-AwsConfiguration
+
 Write-Log -Message "Starting CloudTrail data connector configuration script" -LogFileName $LogFileName -Severity Verbose
 Write-Log -Message "This script creates an Assume Role with minimal permissions to grant Azure Sentinel access to your logs in a designated S3 bucket & SQS of your choice, enable CloudTrail Logs, S3 bucket, SQS Queue, and S3 notifications." -LogFileName $LogFileName -Severity Information -LinePadding 2
-
-# Connect using the AWS CLI
-Get-AwsConfig
+Write-ScriptNotes
 
 New-ArnRole
 
@@ -361,4 +363,4 @@ Write-Log -Message "Executing: aws cloudtrail start-logging  --name $cloudTrailN
 aws cloudtrail start-logging  --name $cloudTrailName
 
 # Output information needed to configure Sentinel data connector
-Write-RequiredConnectorDefinitionInfo
+Write-RequiredConnectorDefinitionInfo -DestinationTable AWSCloudTrail

--- a/DataConnectors/AWS-S3/ConfigGuardDutyDataConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigGuardDutyDataConnector.ps1
@@ -164,7 +164,7 @@ function Enable-GuardDuty
             Write-Log -Message "Executing: aws guardduty list-detectors" -LogFileName $LogFileName -Severity Verbose
             aws guardduty list-detectors
             
-            $script:detectorId = Read-ValidatedHost 'Please enter detector Id'
+            $script:detectorId = Read-ValidatedHost 'Please enter detector Id from the above list'
             Write-Log -Message "Detector Id: $detectorId" -LogFileName $LogFileName
         }
         else
@@ -214,11 +214,12 @@ function Set-GuardDutyPublishDestinationBucket
 
 # ***********       Main Flow       ***********
 
+# Validate AWS configuration
+Test-AwsConfiguration
+
 Write-Log -Message "Starting GuardDuty data connector configuration script" -LogFileName $LogFileName -Severity Verbose
 Write-Log -Message "This script creates an Assume Role with minimal permissions to grant Azure Sentinel access to your logs in a designated S3 bucket & SQS of your choice, enable GuardDuty Logs, S3 bucket, SQS Queue, and S3 notifications." -LogFileName $LogFileName -LinePadding 2
-
-# Connect using the AWS CLI
-Get-AwsConfig
+Write-ScriptNotes
 
 New-ArnRole
 Write-Log -Message "Executing: aws iam get-role --role-name $roleName" -LogFileName $LogFileName -Severity Verbose
@@ -261,4 +262,4 @@ Enable-GuardDuty
 Set-GuardDutyPublishDestinationBucket
  
 # Output information needed to configure Sentinel data connector
-Write-RequiredConnectorDefinitionInfo
+Write-RequiredConnectorDefinitionInfo -DestinationTable AWSGuardDuty

--- a/DataConnectors/AWS-S3/ConfigVpcFlowDataConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigVpcFlowDataConnector.ps1
@@ -1,8 +1,9 @@
+# Validate AWS configuration
+Test-AwsConfiguration
+
 Write-Log -Message "Starting Vpc flow data connector configuration script" -LogFileName $LogFileName -Severity Verbose
 Write-Log -Message "This script creates an Assume Role with minimal permissions to grant Azure Sentinel access to your logs in a designated S3 bucket & SQS of your choice, enable VPCFlow Logs, S3 bucket, SQS Queue, and S3 notifications." -LogFileName $LogFileName
-
-# Connect using the AWS CLI
-Get-AwsConfig
+Write-ScriptNotes
 
 # Create new Arn Role
 New-ArnRole
@@ -17,7 +18,7 @@ Write-Log -Message "Executing: (aws sts get-caller-identity | ConvertFrom-Json).
 $callerAccount = (aws sts get-caller-identity | ConvertFrom-Json).Account
 Write-Log -Message $callerAccount -LogFileName $LogFileName -Severity Verbose
 
-Write-Log -Message "Listing your available VPCs" -LogFileName $LogFileName -Severity Information -LinePadding 1
+Write-Log -Message "Listing your available VPC IDs" -LogFileName $LogFileName -Severity Information -LinePadding 1
 Write-Log -Message "Executing: aws ec2 --output text --query 'Vpcs[*].{VpcId:VpcId}' describe-vpcs" -LogFileName $LogFileName -Severity Verbose
 aws ec2 --output text --query 'Vpcs[*].{VpcId:VpcId}' describe-vpcs
 
@@ -25,7 +26,7 @@ Write-Log 'Enabling VPC flow Logs (default format)' -LogFileName $LogFileName -S
 
 Set-RetryAction({
 	
-	$vpcResourceIds = Read-ValidatedHost 'Please enter Vpc Resource Id[s] (space separated)'
+	$vpcResourceIds = Read-ValidatedHost 'Please enter VPC Resource Id[s] from the above list (space separated)'
 	Write-Log -Message "Using Vpc Resource Ids: $vpcResourceIds" -LogFileName $LogFileName -Severity Information -Indent 2
 	
 	do
@@ -38,14 +39,14 @@ Set-RetryAction({
 
 	} until ($?)
 
-	$vpcName = Read-ValidatedHost 'Please enter Vpc name'
+	$vpcName = Read-ValidatedHost 'Please enter Vpc flow logs name'
 	Write-Log "Using Vpc name: $vpcName" -LogFileName $LogFileName -Indent 2
 
 	$vpcTagSpecifications = "ResourceType=vpc-flow-log,Tags=[{Key=Name,Value=${vpcName}}]"
 	Write-Log -Message "Vpc tag specification: $vpcTagSpecifications" -LogFileName $LogFileName
 
 	Write-Log -Message "Executing: aws ec2 create-flow-logs --resource-type VPC --resource-ids $vpcResourceIds.Split(' ') --traffic-type $vpcTrafficType --log-destination-type s3 --log-destination arn:aws:s3:::$bucketName --tag-specifications $vpcTagSpecifications 2>&1" -LogFileName $LogFileName -Severity Verbose
-	$tempForOutput = aws ec2 create-flow-logs --resource-type VPC --resource-ids $vpcResourceIds.Split(' ') --traffic-type $vpcTrafficType --log-destination-type s3 --log-destination arn:aws:s3:::$bucketName --tag-specifications $vpcTagSpecifications 2>&1
+	$tempForOutput = aws ec2 create-flow-logs --resource-type VPC --resource-ids $vpcResourceIds.Split(' ') --traffic-type $vpcTrafficType.ToUpper() --log-destination-type s3 --log-destination arn:aws:s3:::$bucketName --tag-specifications $vpcTagSpecifications 2>&1
 	Write-Log $tempForOutput -LogFileName $LogFileName -Severity Verbose
 
 })
@@ -71,4 +72,4 @@ Update-S3Policy -RequiredPolicy $s3RequiredPolicy
 Enable-S3EventNotification -DefaultEventNotificationPrefix "AWSLogs/${callerAccount}/vpcflowlogs/"
 
 # Output information needed to configure Sentinel data connector
-Write-RequiredConnectorDefinitionInfo
+Write-RequiredConnectorDefinitionInfo -DestinationTable AWSVPCFlow

--- a/DataConnectors/AWS-S3/ConfigVpcFlowLogs.ps1
+++ b/DataConnectors/AWS-S3/ConfigVpcFlowLogs.ps1
@@ -1,10 +1,11 @@
 # Include helper scripts
 . ".\Utils\HelperFunctions.ps1"
 
+# Validate AWS configuration
+Test-AwsConfiguration
+
 Write-Output `n`n'Setting up your AWS environment'
 Write-Output `n'This script enables additional VPC Flow Logs if you have already set up the required resources Bucket S3, SQS etc.'
-
-Get-AwsConfig
 
 Write-Output `n`n'S3 Bucket definition'
 
@@ -32,4 +33,4 @@ Write-Output " Using Vpc name: $vpcname"
 $vpcTagSpecifications = "ResourceType=vpc-flow-log,Tags=[{Key=Name,Value=${vpcName}}]"
 
 # creating the VPC Flow logs with specified info
-aws ec2 create-flow-logs --resource-type VPC --resource-ids $vpcResourceId.Split(' ') --traffic-type $vpcTrafficType --log-destination-type s3 --log-destination arn:aws:s3:::$bucketName --tag-specifications $vpcTagSpecifications | Out-Null
+aws ec2 create-flow-logs --resource-type VPC --resource-ids $vpcResourceId.Split(' ') --traffic-type $vpcTrafficType.ToUpper() --log-destination-type s3 --log-destination arn:aws:s3:::$bucketName --tag-specifications $vpcTagSpecifications | Out-Null

--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -26,7 +26,7 @@ You must have PowerShell and the AWS CLI installed before using these scripts.
 
 - PowerShell [Installation instructions](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.1)
 - AWS CLI [Installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-  - Run from PowerShell `aws configure`, For more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+  - Run from PowerShell `aws configure`, for more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
 
 ## Using the scripts
 

--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -41,6 +41,7 @@ Then run the following from PowerShell and follow the prompts to complete the co
 
 ```powershell
 
+aws configure
 .\ConfigAwsConnector.ps1
 
 ```

--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -26,7 +26,7 @@ You must have PowerShell and the AWS CLI installed before using these scripts.
 
 - PowerShell [Installation instructions](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.1)
 - AWS CLI [Installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-- AWS configure. Run from Powershell `aws configure`, For more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+  - Run from PowerShell `aws configure`, For more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
 
 ## Using the scripts
 
@@ -38,7 +38,7 @@ Make sure that you have PowerShell and the AWS CLI installed.
 > To mark the scripts safe, use the `Unblock-File` cmdlet or  
 > right-click on the script file(s), then click **Properties** and then click **Unblock**.
 
-Then run the following from run and follow the prompts to complete the configuration.
+Then run the following from PowerShell and follow the prompts to complete the configuration.
 
 ```powershell
 

--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -41,7 +41,7 @@ Then run the following from PowerShell and follow the prompts to complete the co
 
 ```powershell
 
-aws configure
+aws configure (For more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html))
 .\ConfigAwsConnector.ps1
 
 ```

--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -26,6 +26,7 @@ You must have PowerShell and the AWS CLI installed before using these scripts.
 
 - PowerShell [Installation instructions](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.1)
 - AWS CLI [Installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+- AWS configure. Run from Powershell `aws configure`, For more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 
 ## Using the scripts
 
@@ -37,11 +38,10 @@ Make sure that you have PowerShell and the AWS CLI installed.
 > To mark the scripts safe, use the `Unblock-File` cmdlet or  
 > right-click on the script file(s), then click **Properties** and then click **Unblock**.
 
-Then run the following from PowerShell and follow the prompts to complete the configuration.
+Then run the following from run and follow the prompts to complete the configuration.
 
 ```powershell
 
-aws configure (For more information see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html))
 .\ConfigAwsConnector.ps1
 
 ```

--- a/DataConnectors/AWS-S3/Utils/AwsResourceCreator.ps1
+++ b/DataConnectors/AWS-S3/Utils/AwsResourceCreator.ps1
@@ -23,7 +23,7 @@ function New-ArnRole
             Write-Output "`n`n"
             Write-Log "You must specify the the Azure Sentinel Workspace ID. This is found in the Azure Sentinel portal." -LogFileName $LogFileName -Severity Information -LinePadding 1
             
-            $workspaceId = Read-ValidatedHost -Prompt "Please enter your Azure Sentinel Workspace ID (External Id)"
+            $workspaceId = Read-ValidatedHost -Prompt "Please enter your Azure Sentinel External ID (Workspace ID)"
             Write-Log "Using Azure Sentinel Workspace ID: $workspaceId" -LogFileName $LogFileName -Severity Information -Indent 2
 
             $rolePolicy = Get-RoleArnPolicy -WorkspaceId $workspaceId
@@ -54,21 +54,20 @@ function New-S3Bucket
         
         # Get s3 bucket name from user and clean up based on naming rules see https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
         
-        $script:bucketName = (Read-ValidatedHost -Prompt "Please enter S3 bucket name" -MaxLength 64 -MinLength 3)
+        $script:bucketName = (Read-ValidatedHost -Prompt "Please enter S3 bucket name (between 3 and 63 characters long)" -MaxLength 64 -MinLength 3)
 
         Write-Log -Message "Using S3 Bucket name: $bucketname" -LogFileName $LogFileName -Indent 2
-            
+        
+        $regionConfiguration = aws configure get region
+        Write-Log -Message "current region configuration: $regionConfiguration" -LogFileName $LogFileName -Severity Verbose
+
         Write-Log -Message "Executing: aws s3api head-bucket --bucket $bucketName 2>&1" -LogFileName $LogFileName -Severity Verbose
         $headBucketOutput = aws s3api head-bucket --bucket $bucketName 2>&1
             
         $isBucketNotExist = $null -ne $headBucketOutput
         if ($isBucketNotExist)
-        {
-
-            $bucketRegion = Read-ValidatedHost -Prompt "Please enter the AWS region in which to create S3 bucket"
-            Write-Log -Message "Using S3 bucket region: $bucketRegion" -LogFileName $LogFileName -Indent 2
-            
-            if ($bucketRegion -eq "us-east-1") # see aws doc https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html
+        {      
+            if ($regionConfiguration -eq "us-east-1") # see aws doc https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html
             {
                 Write-Log -Message "Executing: aws s3api create-bucket --bucket $bucketName 2>&1" -LogFileName $LogFileName -Severity Verbose
                 $tempForOutput = aws s3api create-bucket --bucket $bucketName 2>&1
@@ -76,14 +75,18 @@ function New-S3Bucket
             }
             else
             {
-                Write-Log "Executing: aws s3api create-bucket --bucket $bucketName --create-bucket-configuration LocationConstraint=$bucketRegion 2>&1" -LogFileName $LogFileName -Severity Verbose
-                $tempForOutput = aws s3api create-bucket --bucket $bucketName --create-bucket-configuration LocationConstraint=$bucketRegion 2>&1
+                Write-Log "Executing: aws s3api create-bucket --bucket $bucketName --create-bucket-configuration LocationConstraint=$regionConfiguration 2>&1" -LogFileName $LogFileName -Severity Verbose
+                $tempForOutput = aws s3api create-bucket --bucket $bucketName --create-bucket-configuration LocationConstraint=$regionConfiguration 2>&1
                 Write-Log -Message $tempForOutput -LogFileName $LogFileName -Severity Verbose
             }
                 
             if ($lastexitcode -eq 0)
             {
                 Write-Log "S3 Bucket $bucketName created successfully" -LogFileName $LogFileName -Indent 2
+            }
+            elseif($error[0] -Match "InvalidBucketName")
+            {
+                 Write-Log -Message "Please see AWS valid name documentation https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html" -LogFileName $LogFileName -Severity Error
             }
         }
     })
@@ -134,7 +137,8 @@ function Enable-S3EventNotification
         }
 
         $eventNotificationPrefix = $DefaultEventNotificationPrefix
-      
+
+        Write-Log -Message "Event notificaion prefix definition, to Limit the notifications to objects with key starting with specified characters." -LogFileName $LogFileName     
         $prefixOverrideConfirm = Read-ValidatedHost -Prompt "The default prefix is '$eventNotificationPrefix'. `n  Do you want to override the event notification prefix? [y/n]" -ValidationType Confirm
         if ($prefixOverrideConfirm -eq 'y')
         {

--- a/DataConnectors/AWS-S3/Utils/HelperFunctions.ps1
+++ b/DataConnectors/AWS-S3/Utils/HelperFunctions.ps1
@@ -8,12 +8,13 @@ function Test-AwsConfiguration
     Write-Log -Message "Checking AWS CLI configuration..." -LogFileName $LogFileName -Severity Information -LinePadding 1
 
     # validate aws configuration. in case of invalid region\credentials the following command will trow exception
-     aws ec2 describe-regions | Out-Null
+     aws ec2 describe-regions 2>&1 | Out-Null
 
      if ($lastExitCode -ne 0 )
      {
-         Write-Log -Message $error[0] -LogFileName $LogFileName -Severity Error
-         Write-Log -Message "Please execute again 'aws configure' and verify that AWS configuration is correct." -LogFileName $LogFileName -Severity Error               
+        Write-Log -Message $error[0] -LogFileName $LogFileName -Severity Error
+        Write-Log -Message "Please execute again 'aws configure' and verify that AWS configuration is correct." -LogFileName $LogFileName -Severity Error
+        Write-Log -Message "For more information see AWS doc https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html" -LogFileName $LogFileName -Severity Error               
         exit
      }
 }
@@ -39,7 +40,7 @@ function Write-ScriptNotes
 {
     Write-Log -Message "Notes:" -LogFileName $LogFileName -Severity Information -LinePadding 1 -Indent 2 -Color DarkYellow
     Write-Log -Message "* You can find more information about the script in https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/AWS-S3/README.md" -LogFileName $LogFileName -Severity Information -Indent 2 -Color DarkYellow
-    Write-Log -Message "* If a resource name(like: S3, Sqs, Kms) already exist, the script will use the available one and not create a new resource" -LogFileName $LogFileName -Severity Information -Indent 2 -Color DarkYellow
+    Write-Log -Message "* If a resource name(like: S3, Sqs, Kms) already exists, the script will use the available one and not create a new resource" -LogFileName $LogFileName -Severity Information -Indent 2 -Color DarkYellow
 }
 
 function Set-RetryAction

--- a/DataConnectors/AWS-S3/Utils/HelperFunctions.ps1
+++ b/DataConnectors/AWS-S3/Utils/HelperFunctions.ps1
@@ -14,7 +14,7 @@ function Test-AwsConfiguration
      {
         Write-Log -Message $error[0] -LogFileName $LogFileName -Severity Error
         Write-Log -Message "Please execute again 'aws configure' and verify that AWS configuration is correct." -LogFileName $LogFileName -Severity Error
-        Write-Log -Message "For more information see AWS doc https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html" -LogFileName $LogFileName -Severity Error               
+        Write-Log -Message "For more information see AWS doc https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html" -LogFileName $LogFileName -Severity Error               
         exit
      }
 }

--- a/DataConnectors/AWS-S3/Utils/HelperFunctions.ps1
+++ b/DataConnectors/AWS-S3/Utils/HelperFunctions.ps1
@@ -1,15 +1,21 @@
-function Get-AwsConfig
+function Test-AwsConfiguration
 {
     <#
     .SYNOPSIS
         This function executes "aws configure" to ensure it is connected for subsequent commands.
     #>
 
-    Write-Log -Message "Setting up your AWS CLI environment..." -LogFileName $LogFileName -Severity Information -LinePadding 1
-    Write-Log -Message "Please ensure that the AWS CLI is connected:" -LogFileName $LogFileName -Severity Information -LinePadding 1
-    Write-Log -Message "Executing: aws configure" -LogFileName $LogFileName -Severity Verbose
+    Write-Log -Message "Checking AWS CLI configuration..." -LogFileName $LogFileName -Severity Information -LinePadding 1
 
-    aws configure
+    # validate aws configuration. in case of invalid region\credentials the following command will trow exception
+     aws ec2 describe-regions | Out-Null
+
+     if ($lastExitCode -ne 0 )
+     {
+         Write-Log -Message $error[0] -LogFileName $LogFileName -Severity Error
+         Write-Log -Message "Please execute again 'aws configure' and verify that AWS configuration is correct." -LogFileName $LogFileName -Severity Error               
+        exit
+     }
 }
 
 function Write-RequiredConnectorDefinitionInfo
@@ -17,10 +23,23 @@ function Write-RequiredConnectorDefinitionInfo
     <#
     .SYNOPSIS
         Write data needed to configure the Azure Sentinel Data Connector for user.
+    .PARAMETER DestinationTable
+        Specifies the connector destination table
     #>
+    param(
+        [Parameter(Mandatory=$true,Position=0)][string]$DestinationTable
+    )
     Write-Log -Message "Use the values below to configure the Amazon Web Service S3 data connector in the Azure Sentinel portal." -LogFileName $LogFileName -Severity Information -LinePadding 3
-    Write-Log -Message "Role arn: $roleArn" -LogFileName $LogFileName -Severity Information -LinePadding 1
+    Write-Log -Message "Role Arn: $roleArn" -LogFileName $LogFileName -Severity Information -LinePadding 1
     Write-Log -Message "Sqs Url: $sqsUrl" -LogFileName $LogFileName -Severity Information
+    Write-Log -Message "Destination Table: $DestinationTable" -LogFileName $LogFileName -Severity Information
+}
+
+function Write-ScriptNotes
+{
+    Write-Log -Message "Notes:" -LogFileName $LogFileName -Severity Information -LinePadding 1 -Indent 2 -Color DarkYellow
+    Write-Log -Message "* You can find more information about the script in https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/AWS-S3/README.md" -LogFileName $LogFileName -Severity Information -Indent 2 -Color DarkYellow
+    Write-Log -Message "* If a resource name(like: S3, Sqs, Kms) already exist, the script will use the available one and not create a new resource" -LogFileName $LogFileName -Severity Information -Indent 2 -Color DarkYellow
 }
 
 function Set-RetryAction
@@ -51,7 +70,7 @@ function Set-RetryAction
                 Write-Log -Message $error[0] -LogFileName $LogFileName -Severity Error
 				if ($retryCount -lt $maxRetries)
 				{
-					Start-Sleep 10
+					Start-Sleep 5
                     Write-Log -Message "Retrying..." -LogFileName $LogFileName -Severity Information
 				}
             }
@@ -150,6 +169,8 @@ function Write-Log
         Specifies the number of empty rows to add before message in the console. This does not apply to the log on disk.
     .PARAMETER Indent
         Specified the number of characters to indent the message in the console. This does not apply to the log on disk.
+    .PARAMETER Color
+        Specified the color of the text for information severity.
 
     .EXAMPLE
         Write-Log -Message "Starting script" -LogFileName C:\temp\TestLog1.csv -Severity Information
@@ -166,7 +187,7 @@ function Write-Log
     .EXAMPLE
         Write-Log -Message "Detailed debugging text that most people do not want to see in the console" -LogFileName C:\temp\TestLog1.csv -Severity Verbose -Indent 2
         Write the message to the verbose channel and to the log. Users would only see this in the console if they have enabled Verbose messaging.
-        .EXAMPLE
+    .EXAMPLE
         Write-Log -Message "Text to only send to the log" -LogFileName C:\temp\TestLog1.csv -Severity Verbose -Indent 2
         Write the text only to the log and not to the console.    
     #>
@@ -184,7 +205,9 @@ function Write-Log
         [parameter(Mandatory=$false)]
         [int]$LinePadding = 0,
         [parameter(Mandatory=$false)]
-        [int]$Indent = 0
+        [int]$Indent = 0,
+        [parameter(Mandatory=$false)]
+        [ConsoleColor]$Color = "White"
     )
 
     # If data is passed in that is not a string, instead of generating an error, just convert it to string.
@@ -222,7 +245,7 @@ function Write-Log
 
     # Write the message to the correct output channel											  
     switch ($Severity) {
-        "Information" { Write-Host $Message }
+        "Information" { Write-Host $Message -ForegroundColor $Color }
         "Warning" { Write-Warning $Message }
         "Error" { Write-Host $Message -ForegroundColor Red }
         "Verbose" {Write-Verbose $Message }


### PR DESCRIPTION
[Data connectors] Aws-S3 script update according to bugbash inputs:

- add "destination table" to the final output
- update logs default path to put the logs in a dedicated folder ( Logs)
- Update "Write-Log" function to have a Color parameter for info output. (we use it to highlight a new text)
- Remove S3 bucket input. this value is available in aws config, so we don't need to ask the customer for this input
- update vpcTrafficType  value to "Upper case". the validation is insensitive case, but AWS excepted this value to be in upper case 
- Remove `aws config` out of sentinel script according to security team request. 
     -  Update the readme file 
     -  Add aws configuration validation at the benign of the script (this validation was missing also before this change)

