### PR TITLE
Update RDP_MultipleConnectionsFromSingleSystem.yaml

### DIFF
--- a/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
+++ b/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
@@ -29,12 +29,12 @@ query: |
   | where TimeGenerated >= ago(endtime) 
   | where EventID == 4624 and LogonType == 10
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ComputerCountToday = dcount(Computer), ComputerSet = makeset(Computer), ProcessSet = makeset(ProcessName)  
-  by Account, IpAddress, AccountType, Activity, LogonTypeName
+  by Account = tolower(Account), IpAddress, AccountType, Activity, LogonTypeName
   | join kind=leftouter (
   SecurityEvent
   | where TimeGenerated >= ago(starttime) and TimeGenerated < ago(endtime) 
   | where EventID == 4624 and LogonType == 10
-  | summarize ComputerCountPrev7Days = dcount(Computer) by Account, IpAddress
+  | summarize ComputerCountPrev7Days = dcount(Computer) by Account = tolower(Account), IpAddress
   ) on Account, IpAddress
   | extend Ratio = iff(isempty(ComputerCountPrev7Days), toreal(ComputerCountToday), ComputerCountToday / (ComputerCountPrev7Days * 1.0))
   // Where the ratio of today to previous 7 days is more than double.

--- a/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
+++ b/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
@@ -50,5 +50,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.1.0
 kind: Scheduled

--- a/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
+++ b/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
@@ -30,13 +30,13 @@ query: |
   | where EventID == 4624 and LogonType == 10
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ComputerCountToday = dcount(Computer), ComputerSet = makeset(Computer), ProcessSet = makeset(ProcessName)  
   by Account, IpAddress, AccountType, Activity, LogonTypeName
-  | join kind=inner (
+  | join kind=leftouter (
   SecurityEvent
   | where TimeGenerated >= ago(starttime) and TimeGenerated < ago(endtime) 
   | where EventID == 4624 and LogonType == 10
   | summarize ComputerCountPrev7Days = dcount(Computer) by Account, IpAddress
   ) on Account, IpAddress
-  | extend Ratio = ComputerCountToday/(ComputerCountPrev7Days*1.0)
+  | extend Ratio = iff(isempty(ComputerCountPrev7Days), toreal(ComputerCountToday), ComputerCountToday / (ComputerCountPrev7Days * 1.0))
   // Where the ratio of today to previous 7 days is more than double.
   | where Ratio > threshold
   | project StartTimeUtc, EndTimeUtc, Account, IpAddress, ComputerSet, ComputerCountToday, ComputerCountPrev7Days, Ratio, AccountType, Activity, LogonTypeName, ProcessSet


### PR DESCRIPTION
The original query misses out on scenarios where there were 0 RDP connections in the previous 7 days from the same account and IP address. This change takes that into account and behaves as if there had been 1 such RDP connection in the previous 7 days. This fits with the original query because the original query would produce a result if there are 2 (or more) RDP connections today with only 1 RDP connection in the previous 7 days.

Fixes #

## Proposed Changes

  -
  -
  -
