### PR TITLE
Change the string "IPList" by dynamic named IPList in WSLMalwareCorrelation.yaml

### DIFF
--- a/Detections/MultipleDataSources/WSLMalwareCorrelation.yaml
+++ b/Detections/MultipleDataSources/WSLMalwareCorrelation.yaml
@@ -141,5 +141,5 @@ entityMappings:
         columnName: SHA256
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/WSLMalwareCorrelation.yaml
+++ b/Detections/MultipleDataSources/WSLMalwareCorrelation.yaml
@@ -91,7 +91,7 @@ query:  |
     | project TimeGenerated,Resource, msg_s
     | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
     | where isnotempty(DestinationHost) 
-    | where SourceHost has "IPList"
+    | where SourceHost in (IPList) or DestinationHost in (IPList)
     | extend timestamp = TimeGenerated, DNSName = DestinationHost, IPCustomEntity = SourceHost
     ),
     (DeviceFileEvents


### PR DESCRIPTION
Fixes #

The query of "AzureFirewallApplicationRule" did not check the IP address properly.

It was comparing the IP address string against the literal string "IPList".

## Proposed Changes

  - use **in (IPList)** both for Source and Destination address
