### PR TITLE
Corrects parameter misspelling in ASIM parsers.

### DIFF
--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADManagedIdentity.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADManagedIdentity.yaml
@@ -29,7 +29,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let AADMIAuthentication=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let AADMIAuthentication=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
     AADManagedIdentitySignInLogs | where not(disabled)
     // ************************************************************************* 
     //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADNonInteractive.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADNonInteractive.yaml
@@ -29,7 +29,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let AADNIAuthentication=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let AADNIAuthentication=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
     AADNonInteractiveUserSignInLogs | where not(disabled)
     // ************************************************************************* 
     //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADServicePrincipalSignInLogs.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADServicePrincipalSignInLogs.yaml
@@ -29,7 +29,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let AADSvcPrincipal=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let AADSvcPrincipal=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
     AADServicePrincipalSignInLogs | where not(disabled)
     // ************************************************************************* 
     //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADSigninLogs.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAADSigninLogs.yaml
@@ -29,7 +29,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let AADSigninLogs=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let AADSigninLogs=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
   SigninLogs | where not(disabled)
   // ************************************************************************* 
   //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAWSCloudTrail.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationAWSCloudTrail.yaml
@@ -29,7 +29,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let AWSLogon=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let AWSLogon=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
   AWSCloudTrail | where not(disabled)
   // ************************************************************************* 
   //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationM365Defender.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationM365Defender.yaml
@@ -32,7 +32,7 @@ ParserQuery: |
   let FaliureReason=datatable(EventOriginalResultDetails:string, EventResultDetails:string)[
     'InvalidUserNameOrPassword','No such user or password'
     ];
-  let AuthM365D=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let AuthM365D=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
     DeviceLogonEvents  | where not(disabled)
   // ************************************************************************* 
   //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftMD4IoT.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftMD4IoT.yaml
@@ -28,7 +28,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let Authentication_MD4IoT=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false)
+  let Authentication_MD4IoT=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false)
     {
       SecurityIoTRawEvent  | where not(disabled)
       | where RawEventName == "Login"

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
@@ -156,7 +156,7 @@ ParserQuery: |
                   , LogonTarget=TargetDvcHostname
                   , Dvc=SrcDvcHostname
               };
-  let SecEventLogon =(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let SecEventLogon =(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
     SecurityEvent | where not(disabled)
     // ************************************************************************* 
     //       <Prefilterring>

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationOktaOSS.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationOktaOSS.yaml
@@ -29,7 +29,7 @@ ParserParams:
     Type: bool
     Default: false
 ParserQuery: |
-  let OktaSignin=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disable:bool=false){
+  let OktaSignin=(starttime:datetime=datetime(null), endtime:datetime=datetime(null), targetusername_has:string="*", disabled:bool=false){
     let OktaSuccessfulOutcome = dynamic(['SUCCESS', 'ALLOW']);
     let OktaFailedOutcome = dynamic(['FAILURE', 'SKIPPED','DENY']);
     let OktaSigninEvents=dynamic(['user.session.start', 'user.session.end']);


### PR DESCRIPTION
Functions as part of ASimAuthentication Parsers are using one parameter name in in the signature (`disable`) and another in the body (`disabled`). This PR corrects it to `disabled` which is how it is defined in the `ParserParams`-section as well as what other such functions are using. 

This does not yet correct the [ARM templates](https://github.com/Azure/Azure-Sentinel/tree/master/Parsers/ASimAuthentication/ARM) which have the same issue embedded.