### PR TITLE
Fixes broken parser due to missing commas.

### DIFF
--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftMD4IoT.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftMD4IoT.yaml
@@ -20,7 +20,7 @@ ParserQuery: |
                 SecurityIoTRawEvent 
                 | where RawEventName == "Process" 
                 | extend
-                  EventDetails = todynamic(EventDetails)
+                  EventDetails = todynamic(EventDetails),
                   EventOriginalUid = tostring(EventDetails.OriginalEventId), 
                   EventCount = toint(EventDetails.HitCount), 
                   EventProduct = 'Azure Defender for IoT', 
@@ -33,8 +33,8 @@ ParserQuery: |
                   EventResult = 'Success', 
                   TargetProcessId = tostring(EventDetails.ProcessId), 
                   TargetProcessCommandLine = coalesce (tostring(EventDetails.Commandline), tostring(EventDetails.Executable)), 
-                  TargetProcessName = coalesce (tostring(EventDetails.Executable), split(EventDetails.Commandline," ")[0])
-                  DvcOs = iif (EventDetails.MessageSource == "Linux", "Linux", "Windows") // Intermediate fix
+                  TargetProcessName = coalesce (tostring(EventDetails.Executable), split(EventDetails.Commandline," ")[0]),
+                  DvcOs = iif (EventDetails.MessageSource == "Linux", "Linux", "Windows"), // Intermediate fix
                   TargetUsernameType = iif (DvcOs == "Windows", "Windows", "Simple"), 
                   TargetUsername = iff (DvcOs == "Windows", tostring(EventDetails.UserName), ""), 
                   ActingProcessId = iff (DvcOs == "Windows", tostring(EventDetails.ParentProcessId), "") 


### PR DESCRIPTION
The vimProcessEventMD4IoT parser was missing some commas, breaking the parser.
This PR adds those missing commas to fix the issue.