### PR TITLE
Update Nobelium_FoggyWeb.yaml

### DIFF
--- a/Detections/MultipleDataSources/Nobelium_FoggyWeb.yaml
+++ b/Detections/MultipleDataSources/Nobelium_FoggyWeb.yaml
@@ -111,7 +111,7 @@ query: |
   | where ImageLoaded has_any (FilePaths) or SHA256 has_any (sha256Hashes) 
   | project TimeGenerated, EventDetail, UserName, Computer, Type, Source, SHA256, ImageLoaded, EventID
   | extend Type = strcat(Type,":",EventID, ": ", Source), Account = UserName, FileHash = SHA256, Image = EventDetail.[4].["#text"] 
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
+  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = tostring(split(Image, '\\', -1)[-1]), FileHashCustomEntity = FileHash
   ),
   (CommonSecurityLog
   | where FileHash in (sha256Hashes)
@@ -149,7 +149,7 @@ query: |
   | where EventDetail has_any (sha256Hashes) 
   | project TimeGenerated, EventDetail, UserName, Computer, Type, Source, SHA256
   | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256, Image = EventDetail.[4].["#text"] 
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
+  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = tostring(split(Image, '\\', -1)[-1]), FileHashCustomEntity = FileHash
   ),
   (W3CIISLog 
   | where ( csMethod == 'GET' and csUriStem has_any (GET_URI)) or (csMethod == 'POST' and csUriStem has_any (POST_URI))

--- a/Detections/MultipleDataSources/Nobelium_FoggyWeb.yaml
+++ b/Detections/MultipleDataSources/Nobelium_FoggyWeb.yaml
@@ -188,5 +188,5 @@ entityMappings:
     fieldMappings:
       - identifier: ProcessId
         columnName: ProcessCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
Fixing ProcessCustomEntity mapping to make sure type is string so we don't get 2 types.

Fixes #
Line 58 - output split (dynamic) to string - ProcessCustomEntity = tostring(split(Image, '\\', -1)[-1])
Line 96 - output split (dynamic) to string - ProcessCustomEntity = tostring(split(Image, '\\', -1)[-1])

Fix for issue #3401 

