### PR TITLE
Check Unusual logins & Use correct time window in RunCommandUEBABreach.yaml

### DIFF
--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -31,14 +31,14 @@ query: |
   | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
   // Limit to Run Command executions that Succeeded
   | where list_ActivityStatusValue has "Succeeded"
-  // Extract data from the Authorization field, allowing us to later extract the Caller (UPN) and CallerIpAddress
+  // Extract data from the Authorization field
   | extend Authorization_d = parse_json(Authorization)
   | extend Scope = Authorization_d.scope
   | extend Scope_s = split(Scope, "/")
   | extend Subscription = tostring(Scope_s[2])
   | extend VirtualMachineName = tostring(Scope_s[-1])
   | project StartTime, EndTime, Subscription, VirtualMachineName, CorrelationId, Caller, CallerIpAddress=max_CallerIpAddress
-  // Create a join key using  the Caller (UPN) and the Caller IP
+  // Create a join key using  the Caller (UPN)
   | extend joinkey = tolower(Caller)
   // Join the Run Command actions to UEBA data
   | join kind = inner (
@@ -49,7 +49,6 @@ query: |
       | where isnotempty(UserPrincipalName) and isnotempty(UEBASourceIPLocation)
       | extend joinkey = tolower(UserPrincipalName)
   ) on joinkey
-  | project StartTime, EndTime, Subscription, VirtualMachineName, Caller, CallerIpAddress, UEBAEventTime, UEBAActionType, UEBASourceIPLocation, UEBAActivityInsights, UEBAUsersInsights
   // Create a window around the UEBA event times, check to see if the Run Command action was performed within them
   | extend UEBAWindowStart = UEBAEventTime - 1h | extend UEBAWindowEnd = UEBAEventTime + 6h
   | where StartTime between (UEBAWindowStart .. UEBAWindowEnd)

--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -43,15 +43,15 @@ query: |
   // Join the Run Command actions to UEBA data
   | join kind = inner (
       BehaviorAnalytics
-      // We are specifically interested in unsual logins
-      | where EventSource == "Azure AD"
+      // We are specifically interested in unusual logins
+      | where EventSource == "Azure AD" and ActivityInsights.ActionUncommonlyPerformedByUser == "True"
       | project UEBAEventTime=TimeGenerated, UEBAActionType=ActionType, UserPrincipalName, UEBASourceIPLocation=SourceIPLocation, UEBAActivityInsights=ActivityInsights, UEBAUsersInsights=UsersInsights
       | where isnotempty(UserPrincipalName) and isnotempty(UEBASourceIPLocation)
       | extend joinkey = tolower(UserPrincipalName)
   ) on joinkey
   | project StartTime, EndTime, Subscription, VirtualMachineName, Caller, CallerIpAddress, UEBAEventTime, UEBAActionType, UEBASourceIPLocation, UEBAActivityInsights, UEBAUsersInsights
   // Create a window around the UEBA event times, check to see if the Run Command action was performed within them
-  | extend UEBAWindowStart = UEBAEventTime - 1h | extend UEBAWindowEnd = UEBAEventTime - 6h
+  | extend UEBAWindowStart = UEBAEventTime - 6h | extend UEBAWindowEnd = UEBAEventTime + 6h
   | where StartTime between (UEBAWindowStart .. UEBAWindowEnd)
   | project StartTime, EndTime, Subscription, VirtualMachineName, Caller, CallerIpAddress, UEBAEventTime, UEBAActionType, UEBASourceIPLocation, UEBAActivityInsights, UEBAUsersInsights
   | extend timestamp = StartTime, AccountCustomEntity=Caller, IPCustomEntity=CallerIpAddress
@@ -64,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: scheduled

--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -50,7 +50,7 @@ query: |
       | extend joinkey = tolower(UserPrincipalName)
   ) on joinkey
   // Create a window around the UEBA event times, check to see if the Run Command action was performed within them
-  | extend UEBAWindowStart = UEBAEventTime - 1h | extend UEBAWindowEnd = UEBAEventTime + 6h
+  | extend UEBAWindowStart = UEBAEventTime - 1h, UEBAWindowEnd = UEBAEventTime + 6h
   | where StartTime between (UEBAWindowStart .. UEBAWindowEnd)
   | project StartTime, EndTime, Subscription, VirtualMachineName, Caller, CallerIpAddress, UEBAEventTime, UEBAActionType, UEBASourceIPLocation, UEBAActivityInsights, UEBAUsersInsights
   | extend timestamp = StartTime, AccountCustomEntity=Caller, IPCustomEntity=CallerIpAddress

--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -51,7 +51,7 @@ query: |
   ) on joinkey
   | project StartTime, EndTime, Subscription, VirtualMachineName, Caller, CallerIpAddress, UEBAEventTime, UEBAActionType, UEBASourceIPLocation, UEBAActivityInsights, UEBAUsersInsights
   // Create a window around the UEBA event times, check to see if the Run Command action was performed within them
-  | extend UEBAWindowStart = UEBAEventTime - 6h | extend UEBAWindowEnd = UEBAEventTime + 6h
+  | extend UEBAWindowStart = UEBAEventTime - 1h | extend UEBAWindowEnd = UEBAEventTime + 6h
   | where StartTime between (UEBAWindowStart .. UEBAWindowEnd)
   | project StartTime, EndTime, Subscription, VirtualMachineName, Caller, CallerIpAddress, UEBAEventTime, UEBAActionType, UEBASourceIPLocation, UEBAActivityInsights, UEBAUsersInsights
   | extend timestamp = StartTime, AccountCustomEntity=Caller, IPCustomEntity=CallerIpAddress

--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
     dataTypes:
       - BehaviorAnalytics
 queryFrequency: 1d
-queryPeriod: 7d
+queryPeriod: 2d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:


### PR DESCRIPTION
UEBAWindowStart has to be lower than UEBAWindowEnd, or there will be **nothing in between.**

I think the author wanted to write "UEBAWindowEnd = UEBAEventTime _+_ **6h**" instead of "UEBAEventTime _-_ **6h**"

Also, it does not check **unusual** activity in Behaviour Analytics table.

## Proposed Changes

  - Use "ActivityInsights.ActionUncommonlyPerformedByUser == "True"" as condition
  - Extend window of  UEBAevent
  - Reduce Query Period from 7 days to 2 days, could be further reduced.
  
  
 I think a thorough review of Sentinel Detections would be worth it.
