### PR TITLE
Update powershell_newencodedscipts.yaml

### DIFF
--- a/Hunting Queries/SecurityEvent/powershell_newencodedscipts.yaml
+++ b/Hunting Queries/SecurityEvent/powershell_newencodedscipts.yaml
@@ -19,27 +19,33 @@ query: |
   let processEvents=SecurityEvent
   | where TimeGenerated between(ago(lookback)..endtime)
   | where EventID==4688
-  | project  TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName,AccountDomain=SubjectDomainName,
-    FileName=tostring(split(NewProcessName, '\\')[-1]),
-  ProcessCommandLine = CommandLine,
-  InitiatingProcessFileName=ParentProcessName,InitiatingProcessCommandLine="",InitiatingProcessParentFileName="";
+  | where NewProcessName has_any ("powershell.exe","pwsh.exe")
+  | project TimeGenerated, Computer, Account, NewProcessName, FileName=tostring(split(NewProcessName, '\\')[-1]), ProcessCommandLine = CommandLine, ParentProcessName;
   processEvents};
   let encodedPSScripts =
   ProcessCreationEvents
   | where TimeGenerated between(ago(midlookback)..starttime)
-  | where FileName =~ "powershell.exe"
-  | where ProcessCommandLine contains "-encodedCommand";
+  | where FileName in~ ("powershell.exe","pwsh.exe")
+  | where ProcessCommandLine has "-encodedCommand";
   encodedPSScripts
   | where TimeGenerated between(starttime..endtime)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count() by ProcessCommandLine
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), count() by Computer, Account, NewProcessName, FileName, ProcessCommandLine, ParentProcessName
   | parse ProcessCommandLine with * "-EncodedCommand " encodedCommand
-  | project StartTimeUtc, EndTimeUtc, decodedCommand=base64_decodestring(substring(encodedCommand, 0,
-   strlen(encodedCommand) - (strlen(encodedCommand) %8))), encodedCommand
-  | join kind=anti (encodedPSScripts
+  | extend decodedCommand = base64_decode_tostring(substring(encodedCommand, 0, strlen(encodedCommand) - (strlen(encodedCommand) %8)))
+  | join kind=leftanti (
+    encodedPSScripts
     | where TimeGenerated between(ago(lookback)..starttime)
     | summarize count() by ProcessCommandLine
     | parse ProcessCommandLine with * "-EncodedCommand " encodedCommand
-    | project decodedCommand=base64_decodestring(substring(encodedCommand, 0,
-     strlen(encodedCommand) - (strlen(encodedCommand) %8))), encodedCommand
+    | extend decodedCommand = base64_decode_tostring(substring(encodedCommand, 0, strlen(encodedCommand) - (strlen(encodedCommand) %8)))
   ) on encodedCommand, decodedCommand
-  | extend timestamp = StartTimeUtc
+  | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = Computer
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity


### PR DESCRIPTION
Modifying to get included changes from #2705 as this was older than what was in master

## Proposed Changes

  - adding in perf improvements to initial functions to only include newprocessname with powershell
  - Simplifying account and computer mapping, no need to be renaming them
  - Removing project filtering in 2nd function as we lose needed fields for context
  - Updated to base64_decode_tostring and removing limiting project so we get more output parameters such as process name, computer and account
  - Changing to explicit leftanti
  - Adding in entity mappings to support future features