### PR TITLE
Create MissingDCHearbeat.yaml

### DIFF
--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -17,12 +17,13 @@ query: |
   let missing_period = 1h;
   //Enter a reference list of hostnames for your DC servers
   let DCServersList = dynamic (["DC01.simulandlabs.com","DC02.simulandlabs.com"]);
-  //let DCServersList = _GetWatchlist('HostName-DomainControllers');
+  //Alternatively, a Watchlist can be used
+  //let DCServersList = _GetWatchlist('HostName-DomainControllers') | project HostName;
   Heartbeat
   | summarize arg_max(TimeGenerated, *) by Computer
   | where Computer in (DCServersList)
   //You may specify the OS type of your Domain Controllers
-  //where OSType == 'Windows'
+  //| where OSType == 'Windows'
   | where TimeGenerated between (ago(query_frequency + missing_period) .. ago(missing_period))
   | project TimeGenerated, Computer, OSType, Version, ComputerEnvironment, Type, Solutions
   | sort by TimeGenerated asc

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -11,7 +11,6 @@ triggerThreshold: 0
 tactics:
   - Impact
   - DefenseEvasion
-  - ImpairProcessControl
 query: |
 
   let query_frequency = 15m;

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -20,7 +20,7 @@ query: |
   //let DCServersList = _GetWatchlist('HostName-DomainControllers');
   Heartbeat
   | summarize arg_max(TimeGenerated, *) by Computer
-  | where Computer in (DCServersList) 
+  | where Computer in (DCServersList)
   //You may specify the OS type of your Domain Controllers
   //where OSType == 'Windows'
   | where TimeGenerated between (ago(query_frequency + missing_period) .. ago(missing_period))

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -1,7 +1,7 @@
 id: b8b8ba09-1e89-45a1-8bd7-691cd23bfa32
 name: Missing Domain Controller Heartbeat
 description: |
-  'This detection will go over the heartbeats received from the agents of Domain Controllers over the last hour, and will create alerts if the heartbeats have not been received.'
+  'This detection will go over the heartbeats received from the agents of Domain Controllers over the last hour, and will create alerts if the last heartbeats were received an hour ago.'
 severity: High
 requiredDataConnectors: []
 queryFrequency: 15m

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -1,0 +1,35 @@
+id: b8b8ba09-1e89-45a1-8bd7-691cd23bfa32
+name: Missing Domain Controller Heartbeat
+description: |
+  'This detection will go over the heartbeats received from the agents of Domain Controllers over the last hour, and will create alerts if the heartbeats have not been received.'
+severity: High
+requiredDataConnectors: []
+queryFrequency: 15m
+queryPeriod: 2h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Impact
+  - DefenseEvation
+query: |
+
+  let query_frequency = 15m;
+  let missing_period = 1h;
+  //Enter a reference list of hostnames for your DC servers
+  let DCServersList = dynamic (["DC01.simulandlabs.com","DC02.simulandlabs.com"]);
+  //let DCServersList = _GetWatchlist('HostName-DomainControllers');
+  Heartbeat
+  | summarize arg_max(TimeGenerated, *) by Computer
+  | where Computer in DCServersList 
+  //You may specify the OS type of your Domain Controllers
+  //where OSType == 'Windows'
+  | where TimeGenerated between (ago(query_frequency + missing_period) .. ago(missing_period))
+  | project TimeGenerated, Computer, OSType, Version, ComputerEnvironment, Type, Solutions
+  | sort by TimeGenerated asc
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: Computer
+version: 1.0.0
+kind: Scheduled

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -20,7 +20,7 @@ query: |
   //let DCServersList = _GetWatchlist('HostName-DomainControllers');
   Heartbeat
   | summarize arg_max(TimeGenerated, *) by Computer
-  | where Computer in DCServersList 
+  | where Computer in (DCServersList) 
   //You may specify the OS type of your Domain Controllers
   //where OSType == 'Windows'
   | where TimeGenerated between (ago(query_frequency + missing_period) .. ago(missing_period))

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -10,7 +10,7 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - Impact
-  - DefenseEvation
+  - DefenseEvasion
 query: |
 
   let query_frequency = 15m;

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -11,6 +11,7 @@ triggerThreshold: 0
 tactics:
   - Impact
   - DefenseEvasion
+  - ImpairProcessControl
 query: |
 
   let query_frequency = 15m;


### PR DESCRIPTION
This rule should detect when the most recent Heartbeat of a specified DomainController happened more than 1 hour ago (or the time specified).

**It only triggers once**, while the Heartbeat has not been reestablished.

Please, could you check if this is useful? At least it has been in my tenant, with legacy Log Analytics (Microsoft Monitoring Agent).