### PR TITLE
Add option for parsing UPN in AccountCreatedandDeletedinShortTimeframe.yaml

### DIFF
--- a/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
+++ b/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
@@ -42,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: scheduled

--- a/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
+++ b/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
@@ -22,20 +22,26 @@ query: |
   let queryfrequency = 1h;
   let queryperiod = 1d;
   AuditLogs
-  | where OperationName =~ "Add user"
-  | extend UPN = tostring(TargetResources[0].userPrincipalName)
+  | where TimeGenerated > ago(queryfrequency)
+  | where OperationName =~ "Delete user"
+  //extend UserPrincipalName = tostring(TargetResources[0].userPrincipalName)
+  | extend UserPrincipalName = extract(@'([a-f0-9]{32})?(.*)', 2, tostring(TargetResources[0].userPrincipalName))
+  | extend DeletedByUser = tostring(InitiatedBy.user.userPrincipalName), DeletedByIPAddress = tostring(InitiatedBy.user.ipAddress)
+  | extend DeletedByApp = tostring(InitiatedBy.app.displayName)
+  | project Deletion_TimeGenerated = TimeGenerated, UserPrincipalName, DeletedByUser, DeletedByIPAddress, DeletedByApp, Deletion_AdditionalDetails = AdditionalDetails, Deletion_InitiatedBy = InitiatedBy, Deletion_TargetResources = TargetResources
   | join kind=inner (
-    AuditLogs
-    | where TimeGenerated > ago(queryfrequency)
-    | where OperationName =~ "Delete user"
-    | extend UPN = extract(@'([a-f0-9]{32})?(.*)', 2, tostring(TargetResources[0].userPrincipalName))
-    //extend UPN = tostring(TargetResources[0].userPrincipalName)
-    | extend IPAddress = tostring(InitiatedBy.user.ipAddress)
-  ) on UPN
-  | extend timedelta = TimeGenerated1 - TimeGenerated
-  | project-reorder TimeGenerated, TimeGenerated1, timedelta
-  | where timedelta < timespan(queryperiod) and timedelta > timespan(0h)
-  | extend CustomAccountEntity = UPN, IPCustomEntity = IPAddress
+      AuditLogs
+      | where TimeGenerated > ago(queryperiod)
+      | where OperationName =~ "Add user"
+      | extend UserPrincipalName = tostring(TargetResources[0].userPrincipalName)
+      | project-rename Creation_TimeGenerated = TimeGenerated
+  ) on UserPrincipalName
+  | extend TimeDelta = Deletion_TimeGenerated - Creation_TimeGenerated
+  | where  TimeDelta between (time(0s) .. queryperiod)
+  | extend CreatedByUser = tostring(InitiatedBy.user.userPrincipalName), CreatedByIPAddress = tostring(InitiatedBy.user.ipAddress)
+  | extend CreatedByApp = tostring(InitiatedBy.app.displayName)
+  | project Creation_TimeGenerated, Deletion_TimeGenerated, TimeDelta, UserPrincipalName, DeletedByUser, DeletedByIPAddress, DeletedByApp, CreatedByUser, CreatedByIPAddress, CreatedByApp, Creation_AdditionalDetails = AdditionalDetails, Creation_InitiatedBy = InitiatedBy, Creation_TargetResources = TargetResources, Deletion_AdditionalDetails, Deletion_InitiatedBy, Deletion_TargetResources
+  | extend timestamp = Deletion_TimeGenerated, CustomAccountEntity = UserPrincipalName, IPCustomEntity = DeletedByIPAddress
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
+++ b/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
@@ -27,7 +27,7 @@ query: |
     | where OperationName =~ "Delete user"
     | extend UPN = tostring(TargetResources[0].userPrincipalName)
     //extend UPN = extract(@'([a-f0-9]{32})?(.*)', 2, UPN)
-    | extend IPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+    | extend IPAddress = tostring(InitiatedBy.user.ipAddress)
   ) on UPN
   | extend timedelta = TimeGenerated1 - TimeGenerated
   | project-reorder TimeGenerated, TimeGenerated1, timedelta

--- a/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
+++ b/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
@@ -8,7 +8,7 @@ requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
       - SigninLogs
-queryFrequency: 1d
+queryFrequency: 1h
 queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 0
@@ -19,19 +19,22 @@ relevantTechniques:
 tags:
   - AADSecOpsGuide
 query: |
+  let queryfrequency = 1h;
+  let queryperiod = 1d;
   AuditLogs
   | where OperationName =~ "Add user"
   | extend UPN = tostring(TargetResources[0].userPrincipalName)
   | join kind=inner (
     AuditLogs
+    | where TimeGenerated > ago(queryfrequency)
     | where OperationName =~ "Delete user"
-    | extend UPN = tostring(TargetResources[0].userPrincipalName)
-    //extend UPN = extract(@'([a-f0-9]{32})?(.*)', 2, UPN)
+    | extend UPN = extract(@'([a-f0-9]{32})?(.*)', 2, tostring(TargetResources[0].userPrincipalName))
+    //extend UPN = tostring(TargetResources[0].userPrincipalName)
     | extend IPAddress = tostring(InitiatedBy.user.ipAddress)
   ) on UPN
   | extend timedelta = TimeGenerated1 - TimeGenerated
   | project-reorder TimeGenerated, TimeGenerated1, timedelta
-  | where timedelta < timespan(24h) and timedelta > timespan(0h)
+  | where timedelta < timespan(queryperiod) and timedelta > timespan(0h)
   | extend CustomAccountEntity = UPN, IPCustomEntity = IPAddress
 entityMappings:
   - entityType: Account
@@ -43,4 +46,4 @@ entityMappings:
       - identifier: Address
         columnName: IPCustomEntity
 version: 1.0.2
-kind: scheduled
+kind: Scheduled

--- a/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
+++ b/Detections/AuditLogs/AccountCreatedandDeletedinShortTimeframe.yaml
@@ -22,10 +22,13 @@ query: |
   AuditLogs
   | where OperationName =~ "Add user"
   | extend UPN = tostring(TargetResources[0].userPrincipalName)
-  | join kind=inner (AuditLogs
-  | where OperationName =~ "Delete user"
-  | extend UPN = tostring(TargetResources[0].userPrincipalName)
-  | extend IPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)) on UPN
+  | join kind=inner (
+    AuditLogs
+    | where OperationName =~ "Delete user"
+    | extend UPN = tostring(TargetResources[0].userPrincipalName)
+    //extend UPN = extract(@'([a-f0-9]{32})?(.*)', 2, UPN)
+    | extend IPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  ) on UPN
   | extend timedelta = TimeGenerated1 - TimeGenerated
   | project-reorder TimeGenerated, TimeGenerated1, timedelta
   | where timedelta < timespan(24h) and timedelta > timespan(0h)


### PR DESCRIPTION
In my tenant the "user principal name" of deleted users gets prepended a 32 character hexadecimal string.

Please, could you check if this is common between tenants? In that case the query will not get the desired results.