### PR TITLE
Git lab hunting queries

### DIFF
--- a/Hunting Queries/GitLab/Brute Force on Local Accounts
+++ b/Hunting Queries/GitLab/Brute Force on Local Accounts
@@ -1,0 +1,59 @@
+id: 2238d13a-cf05-4973-a83f-d12a25dbb153
+name: GitLab - Brute-force Attempts
+description: |
+  'This query relies on GitLab Application Logs to get failed logins to highlight brute-force attempts from different IP addresses in a short space of time.'
+severity: Medium
+requiredDataConnectors:
+   - connectorId: Syslog
+    dataTypes:
+      - Syslog
+queryFrequency: 1h
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Credential Access
+relevantTechniques:
+  - T1110
+query: |
+
+let LearningPeriod = 7d; 
+let BinTime = 1h; 
+let RunTime = 1h; 
+let StartTime = 1h; 
+let NumberOfStds = 3; 
+let MinThreshold = 10.0; 
+let EndRunTime = StartTime - RunTime; 
+let EndLearningTime = StartTime + LearningPeriod;
+let GitLabFailedLogins = 
+Syslog
+// Using syslog Facility and ProcessName for pre-filtering could help performances. 
+// Example: using a specific facility for GitLab and a process name for Syslog ingestion.
+// | where Facility == 'local7'
+// | where ProcessName contains 'GitLab-Application-Logs'
+| where SyslogMessage contains "Failed Login"
+| parse kind=regex SyslogMessage with EventTime ": Failed Login: username=" Username "ip=" IpAddress 
+| project TimeGenerated, EventTime, Username, IpAddress;
+GitLabFailedLogins 
+  | where todatetime(EventTime) between (ago(EndLearningTime) .. ago(StartTime)) 
+  | summarize FailedLoginsCountInBinTime = count() by User = Username, bin(todatetime(EventTime), BinTime) 
+  | summarize AvgOfFailedLoginsInLearning = avg(FailedLoginsCountInBinTime), StdOfFailedLoginsInLearning = stdev(FailedLoginsCountInBinTime) by User 
+  | extend LearningThreshold = max_of(AvgOfFailedLoginsInLearning + StdOfFailedLoginsInLearning * NumberOfStds, MinThreshold) 
+  | join kind=innerunique ( 
+    GitLabFailedLogins 
+    | where todatetime(EventTime) between (ago(StartTime) .. ago(EndRunTime)) 
+    | summarize FailedLoginsCountInRunTime = count() by User = Username, IpAddress 
+  ) on User 
+  | where FailedLoginsCountInRunTime > LearningThreshold
+  | extend User, IpAddress
+
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPAddress
+   - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: User
+version: 1.0.0

--- a/Hunting Queries/GitLab/External User added to GitLab
+++ b/Hunting Queries/GitLab/External User added to GitLab
@@ -1,0 +1,48 @@
+id: c1544d8f-cbbd-4e35-8d32-5b9312279833
+name: GitLab - External User Added to GitLab
+description: |
+  'This queries GitLab Application logs to list external user accounts (i.e.: account not in allow-listed domains) which have been added to GitLab users.'
+severity: Medium
+requiredDataConnectors:
+   - connectorId: Syslog
+    dataTypes:
+      - Syslog
+queryFrequency: 1h
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Credential Access
+  - Persistence
+query: |
+
+let allowedDomain = pack_array("mydomain.com");
+Syslog
+// Using syslog Facility and ProcessName for pre-filtering could help performances. 
+// Example: using a specific facility for GitLab and a process name for Syslog ingestion.
+// | where Facility == 'local7'
+// | where ProcessName contains 'GitLab-Application-Logs'
+| where SyslogMessage contains "\"add\":\"user\""
+| extend parsedMessage = parse_json(SyslogMessage)
+| project Author = parsedMessage.author_name, AuthorIPAddress = parsedMessage.ip_address, UserAdded = tostring(parsedMessage.entity_path), SyslogMessage
+| join (Syslog 
+| where SyslogMessage contains "User" and SyslogMessage contains " was created" 
+| parse kind=regex SyslogMessage with EventTime ": User \"" Username "\"" EmailAddress " was created"
+| project UserAdded = tostring(Username), EmailAddress = substring(EmailAddress,2,strlen(EmailAddress)-3)) on UserAdded
+| project  Author, AuthorIPAddress, UserAdded, EmailAddress, SyslogMessage, DomainName = tostring(extract("@(.*)$", 1, EmailAddress))
+| where allowedDomain !contains DomainName
+
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: AuthorIPAddress
+   - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserAdded
+   - entityType: DNS
+    fieldMappings:
+      - identifier: DomainName
+        columnName: DomainName        
+version: 1.0.0

--- a/Hunting Queries/GitLab/Local Authentication without MFA
+++ b/Hunting Queries/GitLab/Local Authentication without MFA
@@ -1,0 +1,42 @@
+id: e0b45487-5c79-482d-8ac0-695de8c031af
+name: GitLab - Local Auth - No MFA 
+description: |
+  'This query checks GitLab Audit Logs to see if a user authenticated without MFA. Ot might mean that MFA was disabled for the GitLab server or that an external authentication provider was bypassed.
+ This rule focuses on 'admin' privileges but the parameter can be adapted to also include all users.'
+severity: Medium
+requiredDataConnectors:
+   - connectorId: Syslog
+    dataTypes:
+      - Syslog
+queryFrequency: 1h
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Credential Access
+relevantTechniques:
+  - T1110
+query: |
+
+let isAdmin = true;
+let SyslogResults = Syslog
+// Using syslog Facility and ProcessName for pre-filtering could help performances. 
+// Example: using a specific facility for GitLab and a process name for Syslog ingestion.
+// | where Facility == 'local7'
+// | where ProcessName contains 'GitLab-Audit-Logs'
+| where TimeGenerated > TimeRange
+| where SyslogMessage contains "\"with\":\"standard\"" and ((isAdmin and SyslogMessage contains "Administrator") or (isAdmin==false));
+SyslogResults
+| parse kind=regex SyslogMessage with "\"severity\":\"" Severity "\",\"time\":\"" EventTime "\",\"correlation_id\":\"" CorrelationID "\",\"author_id\":" AuthorID ",\"author_name\":\"" AuthorName "\",\"entity_id\":" EntityID ",\"entity_type\":\"" EntityType "\",\"ip_address\":\"" IPAddress "\",\"with\":\"" AuthenticationType "\",\"target_id\":" TargetID ",\"target_type\":\"" TargetType "\",\"target_details\":\"" TargetDetails "\",\"entity_path\":\"" EntityPath
+| project Severity, EventTime, IPAddress, AuthorName, AuthenticationType, TargetType, TargetDetails, EntityPath
+
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPAddress
+   - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AuthorName
+version: 1.0.0

--- a/Hunting Queries/GitLab/Personal Access Tokens creation
+++ b/Hunting Queries/GitLab/Personal Access Tokens creation
@@ -1,0 +1,43 @@
+id: 4d6d8b0e-6d9a-4857-a141-f5d89393cddb
+name: GitLab - Personal Access Tokens creation over time
+description: |
+  'This queries GitLab Audit Logs for access tokens. Attacker can exfiltrate data from you GitLab repository after gaining access to it by generating or hijacking access tokens. 
+  This hunting queries allows you to track the personal access tokens creation or each of your repositories. 
+  The visualization allow you to quickly identify anomalies/excessive creation, to further investigate repo access & permissions.'
+severity: Medium
+requiredDataConnectors:
+   - connectorId: Syslog
+    dataTypes:
+      - Syslog
+queryFrequency: 1h
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Collection
+relevantTechniques:
+  - T1213
+query: |
+
+// l_min_tokens_created - minimum tokens created per repository per day to consider
+let l_min_tokens_created = 0;
+let auditMessagesPAT = Syslog
+// Using syslog Facility and ProcessName for pre-filtering could help performances. 
+// Example: using a specific facility for GitLab and a process name for Syslog ingestion.
+// | where Facility == 'local7'
+// | where ProcessName contains 'GitLab-Audit-Logs'
+| where SyslogMessage contains "PersonalAccessToken";
+let min_t = toscalar(auditMessagesPAT
+| summarize min(TimeGenerated));
+let max_t = toscalar(auditMessagesPAT
+| summarize max(TimeGenerated));
+auditMessagesPAT
+| parse kind=regex SyslogMessage with "\"severity:\"" Severity "\",\"time\":\"" EventTime "\",\"correlation_id\":\"" CorrelationID "\",\"author_id\":" AuthorID ",\"author_name\":\"" AuthorName "\",\"entity_id\":" EntityID ",\"entity_type\":\"" EntityType "\",\"ip_address\":\"" IPAddress "\",\"target_id\":" TargetID ",\"target_type\":\"" TargetType "\",\"target_details\":\"" TargetDetails "\",\"action\":\"" Action "\",\"custom_message\":\"" CustomMessage "\",\"entity_path\":\"" EntityPath "\""
+| project Severity, EventDay = bin(todatetime(EventTime),1d), AuthorName, IPAddress, Repository = EntityPath, Action, SyslogMessage
+| summarize sumTokens = count() by Repository, EventDay
+| where sumTokens > l_min_tokens_created
+| make-series num=sum(sumTokens) default=0 on EventDay in range(ago(2d), now(), 1d) by Repository
+| extend (anomalies, score, baseline) = series_decompose_anomalies(num, 1.5, -1, 'linefit')
+| render timechart
+
+version: 1.0.0

--- a/Hunting Queries/GitLab/Sign-in Bursts SSO
+++ b/Hunting Queries/GitLab/Sign-in Bursts SSO
@@ -1,0 +1,34 @@
+id: 57b1634b-531d-4eab-a456-8b855887428f
+name: GitLab - SSO - Sign-Ins Burst 
+description: |
+  'This query relies on Azure Active Directory sign-in activity when Azure AD is used for SSO with GitLab to highlights GitLab accounts associated with multiple authentications from different geographical locations in a short space of time.'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+queryFrequency: 1h
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Credential Access
+relevantTechniques:
+  - T1110
+query: |
+
+let locationCountMin = 1;
+let appRegistrationName = "GitLab";
+SigninLogs
+| where AppDisplayName == appRegistrationName
+| where ResultType == 0
+| where Location != ""
+| summarize CountOfLocations = dcount(Location), Locations = make_set(Location) by User = Identity
+| where CountOfLocations > locationCountMin
+
+entityMappings:
+   - entityType: Account
+     fieldMappings:
+      - identifier: FullName
+        columnName: User
+version: 1.0.0

--- a/Hunting Queries/GitLab/Visibility of a Repository Changed to Public
+++ b/Hunting Queries/GitLab/Visibility of a Repository Changed to Public
@@ -1,0 +1,43 @@
+id: 8b291c3d-90ba-4ebf-af2c-0283192d430e
+name: GitLab - Repository visibility to Public
+description: |
+  'This query leverages GitLab Audit Logs. A repository in GitLab changed visibility from Private or Internal to Public which could indicate compromise, error or misconfiguration leading to exposing the repository to the public.'
+severity: Medium
+requiredDataConnectors:
+   - connectorId: Syslog
+    dataTypes:
+      - Syslog
+queryFrequency: 1h
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Persistence
+  - Defense Evasion
+  - Execution
+query: |
+
+let SyslogResults = Syslog
+// Using syslog Facility and ProcessName for pre-filtering could help performances. 
+// Example: using a specific facility for GitLab and a process name for Syslog ingestion.
+// | where Facility == 'local7'
+// | where ProcessName contains 'GitLab-Audit-Logs'
+| where SyslogMessage contains 'visibility' and SyslogMessage contains '"from":"Public"';
+SyslogResults
+| parse kind=regex SyslogMessage with "\"severity\":\"" Severity "\",\"time\":\"" EventTime "\",\"correlation_id\":\"" CorrelationID "\",\"author_id\":" AuthorID ",\"author_name\":\"" AuthorName "\",\"entity_id\":" EntityID ",\"entity_type\":\"" EntityType "\",\"ip_address\":\"" IPAddress "\",\"change\":\"" ChangeType "\",\"from\":\"" From "\",\"to\":\"" To "\",\"target_id\":" TargetID ",\"target_type\":\"" TargetType "\",\"target_details\":\"" TargetDetails "\",\"entity_path\":\"" EntityPath
+| project EventTime, IPAddress, AuthorName, ChangeType, TargetType, From, To, TargetDetails, EntityPath
+
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPAddress
+   - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AuthorName
+   - entityType: URL
+    fieldMappings:
+      - identifier: Url
+        columnName: EntityPath        
+version: 1.0.0


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Sentinel analytics rules for GitLab standalone edition
  - Created 6 analytics rules leveraging GitLab logs using syslog as a datasource
  - Analytics rules are about:
  
1. Brute-force on GitLab account
2. External users added in GitLab
3. Local Authentication without MFA
4. PAT Tokens creation over time
5. Sign-in Bursts GitLab SSO using Azure AD
6. Repo visibility changed

More analytics rules will be created in coming weeks once these are accepted/validated.
This is requested by some of my customers (I am a Security CSA at Microsoft BeLux).
