### PR TITLE
Exclude TI map Alerts from TI Map Security Alert

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -79,5 +79,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -43,6 +43,8 @@ query: |
     | join (
         SecurityAlert
         | where TimeGenerated > ago(dt_lookBack)
+        | extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
+        | where MSTI == false
         //Extract domain patterns from message
         | extend domain = extract("(([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,})", 1, tolower(Entities))
         | where isnotempty(domain)

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
@@ -61,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
@@ -31,7 +31,10 @@ query: |
   //Filtering the table for Email related IOCs
   | where isnotempty(EmailSenderAddress)
   | join (
-      SecurityAlert | where TimeGenerated >= ago(dt_lookBack)
+      SecurityAlert 
+      | where TimeGenerated >= ago(dt_lookBack)
+      | extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
+      | where MSTI == false
       // Converting Entities into dynamic data type and use mv-expand to unpack the array
       | extend EntitiesDynamicArray = parse_json(Entities) | mv-expand EntitiesDynamicArray
       // Parsing relevant entity column to filter type account and creating new column by combining account and UPNSuffix

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
@@ -35,6 +35,8 @@ query: |
   | join (
     SecurityAlert
     | where TimeGenerated >= ago(dt_lookBack)
+    | extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
+    | where MSTI == false
     // Extract URL from JSON data
     | extend Url = extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)", 1,Entities)
     // We only want alerts that actually contain URL data

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled


### PR DESCRIPTION
Fixes #
TI mapping based on entities showing up in Security Alerts was causing 2 rules to fire over and over because their own Alert was retriggering.

## Proposed Changes
  - Exclude Alerts based on rules from MS that have names with TI Map in them
 ```yaml
| extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
| where MSTI == false
```
