### PR TITLE
Update ChiaCryptoMining.yaml

### DIFF
--- a/Detections/MultipleDataSources/ChiaCryptoMining.yaml
+++ b/Detections/MultipleDataSources/ChiaCryptoMining.yaml
@@ -62,6 +62,7 @@ query:  |
   let IPList = (iocs | where Type =~ "ip"| project IoC);
   let domains = (iocs | where Type =~ "domainname"| project IoC);
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
+  //This query uses sysmon data, sections that have - | where Source == "Microsoft-Windows-Sysmon" - may need to be updated with latest
   (union isfuzzy=true
   (CommonSecurityLog
   | where SourceIP in (IPList) or DestinationIP in (IPList) or DestinationHostName has_any (domains) or RequestURL has_any (domains) or Message has_any (IPList)
@@ -69,48 +70,48 @@ query:  |
   | project TimeGenerated, SourceIP, DestinationIP, Message, SourceUserID, RequestURL, DNSName, Type
   | extend MessageIP = extract(IPRegex, 0, Message), RequestIP = extract(IPRegex, 0, RequestURL)
   | extend IPMatch = case(SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", MessageIP in (IPList), "Message", RequestURL has_any (domains), "RequestUrl", "NoMatch"),  AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, IPMatch == "Message", MessageIP, "NoMatch"), AccountCustomEntity = SourceUserID, UrlCustomEntity = RequestURL 
+  | extend timestamp = TimeGenerated, IPEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, IPMatch == "Message", MessageIP, "NoMatch"), Account = SourceUserID
   ),
   (DnsEvents
   | where IPAddresses in (IPList) or Name in~ (domains)  
   | project TimeGenerated, Computer, IPAddresses, Name, ClientIP, Type
-  | extend DestinationIPAddress = IPAddresses, DNSName = Name, Host = Computer , AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host
+  | extend DestinationIPAddress = IPAddresses, DNSName = Name, Computer , AlertDetail = 'Chia crypto IOC detected'
+  | extend timestamp = TimeGenerated, IPEntity = DestinationIPAddress
   ),
   (VMConnection
   | where SourceIp in (IPList) or DestinationIp in (IPList) or RemoteDnsCanonicalNames has_any (domains)
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | project TimeGenerated, Computer, Direction, ProcessName, SourceIp, DestinationIp, DestinationPort, RemoteDnsQuestions, DNSName,BytesSent, BytesReceived, RemoteCountry, Type
   | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None") , AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, IPCustomEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "NoMatch"), HostCustomEntity = Computer, ProcessCustomEntity = ProcessName
+  | extend timestamp = TimeGenerated, IPEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "NoMatch"), File = ProcessName
   ),
   (Event
-  //This query uses sysmon data depending on table name used this may need updating
   | where Source == "Microsoft-Windows-Sysmon"
   | where EventID == 3
   | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
   | extend SourceIP = EventDetail.[9].["#text"], DestinationIP = EventDetail.[14].["#text"], Image = EventDetail.[4].["#text"]
   | where SourceIP in (IPList) or DestinationIP in (IPList) or Image has_any (process)
-  | project TimeGenerated, SourceIP, DestinationIP, Image, UserName, Computer, Type
+  | project TimeGenerated, SourceIP, DestinationIP, Image, Account = UserName, Computer, Type
   | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None") , AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserName, ProcessCustomEntity = split(Image, '\\', -1)[-1], HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
+  | extend timestamp = TimeGenerated, File = tostring(split(Image, '\\', -1)[-1]), IPEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
+  | extend FilePath = replace_string(Image, File, '')
   ),  
   (OfficeActivity
   | where ClientIP in (IPList) 
   | project TimeGenerated, UserAgent, Operation, RecordType, UserId, ClientIP, AlertDetail = 'Chia crypto IOC detected', Type
-  | extend timestamp = TimeGenerated, IPCustomEntity = ClientIP, AccountCustomEntity = UserId
+  | extend timestamp = TimeGenerated, IPEntity = ClientIP, Account = UserId
   ),
   (DeviceNetworkEvents
   | where RemoteUrl has_any (domains) or RemoteIP in (IPList) or InitiatingProcessSHA256 in (sha256Hashes) or InitiatingProcessFileName has_any (process)
-  | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RemoteIP, RemoteUrl, RemotePort, LocalIP, Type
-  | extend timestamp = TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName,  AlertDetail = 'Chia crypto IOC detected', UrlCustomEntity =RemoteUrl
+  | project TimeGenerated, ActionType, DeviceId, Computer = DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RemoteIP, RemoteUrl, RemotePort, LocalIP, Type
+  | extend timestamp = TimeGenerated, IPEntity = RemoteIP,  AlertDetail = 'Chia crypto IOC detected'
   ),
   (WindowsFirewall
   | where SourceIP in (IPList) or DestinationIP in (IPList) 
   | project TimeGenerated, Computer, CommunicationDirection, SourceIP, DestinationIP, SourcePort, DestinationPort, Type
   | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None"), AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
+  | extend timestamp = TimeGenerated, Computer, IPEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "None")
   ),
   (AzureDiagnostics
   | where ResourceType == "AZUREFIREWALLS"
@@ -118,19 +119,18 @@ query:  |
   | project TimeGenerated,Resource, msg_s, Type
   | parse msg_s with "DNS Request: " ClientIP ":" ClientPort " - " QueryID " " Request_Type " " Request_Class " " Request_Name ". " Request_Protocol " " Request_Size " " EDNSO_DO " " EDNS0_Buffersize " " Responce_Code " " Responce_Flags " " Responce_Size " " Response_Duration
   | where Request_Name has_any (domains)  or ClientIP in (IPList)
-  | extend timestamp = TimeGenerated, DNSName = Request_Name, IPCustomEntity = ClientIP, AlertDetail = 'Chia crypto IOC detected'
+  | extend timestamp = TimeGenerated, DNSName = Request_Name, IPEntity = ClientIP, AlertDetail = 'Chia crypto IOC detected'
   ),
   (AzureDiagnostics 
   | where ResourceType == "AZUREFIREWALLS"
   | where Category == "AzureFirewallApplicationRule"
-  | project TimeGenerated,Resource, msg_s
+  | project TimeGenerated,Resource, msg_s, Type
   | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
   | where isnotempty(DestinationHost)
   | where DestinationHost has_any (domains)  
-  | extend timestamp = TimeGenerated, DNSName = DestinationHost, IPCustomEntity = SourceHost, AlertDetail = 'Chia crypto IOC detected'
+  | extend timestamp = TimeGenerated, DNSName = DestinationHost, IPEntity = SourceHost, AlertDetail = 'Chia crypto IOC detected'
   ),
   (Event
-  //This query uses sysmon data depending on table name used this may need updating
   | where Source == "Microsoft-Windows-Sysmon"
   | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
@@ -138,43 +138,48 @@ query:  |
   | parse EventDetail with * 'SHA256=' SHA256 '",' *
   | project TimeGenerated, EventDetail, UserName, Computer, Type, Source, SHA256
   | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256, Image = EventDetail.[4].["#text"] , AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
+  | extend timestamp = TimeGenerated, Computer, Account, File = tostring(split(Image, '\\', -1)[-1]), FileHashAlgo = 'SHA256'
+  | extend FilePath = replace_string(Image, File, '')
   ),
   (DeviceFileEvents
   | where  InitiatingProcessFolderPath has_any (process)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, RequestAccountName, RequestSourceIP, InitiatingProcessSHA256, Type
   | extend Account = RequestAccountName, Computer = DeviceName, IPAddress = RequestSourceIP, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash
+  | extend timestamp = TimeGenerated, Computer, Account, File = InitiatingProcessFileName, FileHashAlgo = 'SHA256'
+  | extend FilePath = replace_string(InitiatingProcessFolderPath, File, '')
   ),
   (CommonSecurityLog
   | where FileHash in (sha256Hashes)
   | project TimeGenerated,  Message, SourceUserID, FileHash, Type
-  | extend timestamp = TimeGenerated, FileHashCustomEntity = FileHash, AlertDetail = 'Chia crypto IOC detected'
+  | extend timestamp = TimeGenerated, AlertDetail = 'Chia crypto IOC detected'
   ),
   (Event
-  //This query uses sysmon data depending on table name used this may need updating
   | where Source == "Microsoft-Windows-Sysmon"
   | where EventID == 1
   | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
   | project TimeGenerated, EventDetail, UserName, Computer, Type
-  | extend Image = EventDetail.[4].["#text"] , CommandLine =  EventDetail.[10].["#text"], Account = UserName, FileHash = EventDetail.[17].["#text"] , AlertDetail = 'Chia crypto IOC detected'
+  | extend Image = EventDetail.[4].["#text"], CommandLine =  EventDetail.[10].["#text"], Account = UserName, FileHash = EventDetail.[17].["#text"], AlertDetail = 'Chia crypto IOC detected'
   | where Image has_any (process)
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = split(Image, '\\', -1)[-1], FileHashCustomEntity = FileHash
+  | extend timestamp = TimeGenerated, Computer, Account, File = tostring(split(Image, '\\', -1)[-1]), FileHashAlgo = 'SHA256'
+  | extend FilePath= replace_string(Image, File, '')
   ),
   (DeviceEvents
   | where  InitiatingProcessFileName has_any (process) or InitiatingProcessSHA256 in~ (sha256Hashes)
   | project TimeGenerated, ActionType, DeviceId, DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessCommandLine, InitiatingProcessFolderPath, InitiatingProcessId, InitiatingProcessParentFileName, InitiatingProcessFileName, InitiatingProcessSHA256, Type
   | extend Account = InitiatingProcessAccountName, Computer = DeviceName, CommandLine = InitiatingProcessCommandLine, FileHash = InitiatingProcessSHA256, Image = InitiatingProcessFolderPath, AlertDetail = 'Chia crypto IOC detected'
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = InitiatingProcessFileName, FileHashCustomEntity = FileHash
+  | extend timestamp = TimeGenerated, Computer, Account, File = InitiatingProcessFileName, FileHashAlgo = 'SHA256'
+  | extend FilePath = replace_string(InitiatingProcessFolderPath, File, '')
   ),
-  (  SecurityEvent
+  (SecurityEvent
   | where EventID == '4688'
   | where NewProcessName  has_any (process)
   | project TimeGenerated, Computer, NewProcessName, ParentProcessName, Account, NewProcessId, Type
-  | extend timestamp = TimeGenerated, HostCustomEntity = Computer , AccountCustomEntity = Account, ProcessCustomEntity = NewProcessName, AlertDetail = 'Chia crypto IOC detected'
+  | extend timestamp = TimeGenerated, Computer, Account, File = tostring(split(NewProcessName, '\\', -1)[-1]), AlertDetail = 'Chia crypto IOC detected'
+  | extend FilePath = replace_string(NewProcessName, File, '')
   )
   )
+  | extend AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IPEntity, FileCustomEntity = File, FilePathCustomEntity = FilePath, FileHashCustomEntity = FileHash
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -187,15 +192,17 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity 
-  - entityType: Process
+        columnName: IPCustomEntity
+  - entityType: File
     fieldMappings:
-      - identifier: ProcessId
-        columnName: ProcessCustomEntity
+      - identifier: Name
+        columnName: FileCustomEntity
+      - identifier: Directory
+        columnName: FilePathCustomEntity
   - entityType: FileHash
     fieldMappings:
       - identifier: Algorithm
-        columnName: SHA256
+        columnName: FileHashAlgo
       - identifier: Value
         columnName: FileHashCustomEntity
 version: 1.0.0

--- a/Detections/MultipleDataSources/ChiaCryptoMining.yaml
+++ b/Detections/MultipleDataSources/ChiaCryptoMining.yaml
@@ -90,7 +90,7 @@ query:  |
   | where EventID == 3
   | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
-  | extend SourceIP = EventDetail.[9].["#text"], DestinationIP = EventDetail.[14].["#text"], Image = EventDetail.[4].["#text"]
+  | extend SourceIP = tostring(EventDetail.[9].["#text"]), DestinationIP = tostring(EventDetail.[14].["#text"]), Image = tostring(EventDetail.[4].["#text"])
   | where SourceIP in (IPList) or DestinationIP in (IPList) or Image has_any (process)
   | project TimeGenerated, SourceIP, DestinationIP, Image, Account = UserName, Computer, Type
   | extend IPMatch = case( SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", "None") , AlertDetail = 'Chia crypto IOC detected'
@@ -137,7 +137,7 @@ query:  |
   | where EventDetail has_any (sha256Hashes) 
   | parse EventDetail with * 'SHA256=' SHA256 '",' *
   | project TimeGenerated, EventDetail, UserName, Computer, Type, Source, SHA256
-  | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256, Image = EventDetail.[4].["#text"] , AlertDetail = 'Chia crypto IOC detected'
+  | extend Type = strcat(Type, ": ", Source), Account = UserName, FileHash = SHA256, Image = tostring(EventDetail.[4].["#text"]), AlertDetail = 'Chia crypto IOC detected'
   | extend timestamp = TimeGenerated, Computer, Account, File = tostring(split(Image, '\\', -1)[-1]), FileHashAlgo = 'SHA256'
   | extend FilePath = replace_string(Image, File, '')
   ),
@@ -150,8 +150,8 @@ query:  |
   ),
   (CommonSecurityLog
   | where FileHash in (sha256Hashes)
-  | project TimeGenerated,  Message, SourceUserID, FileHash, Type
-  | extend timestamp = TimeGenerated, AlertDetail = 'Chia crypto IOC detected'
+  | project TimeGenerated, Message, SourceUserID, FileHash, Type
+  | extend timestamp = TimeGenerated, AlertDetail = 'Chia crypto IOC detected', FileHashAlgo = 'SHA256', Account = SourceUserID
   ),
   (Event
   | where Source == "Microsoft-Windows-Sysmon"
@@ -159,7 +159,7 @@ query:  |
   | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
   | project TimeGenerated, EventDetail, UserName, Computer, Type
-  | extend Image = EventDetail.[4].["#text"], CommandLine =  EventDetail.[10].["#text"], Account = UserName, FileHash = EventDetail.[17].["#text"], AlertDetail = 'Chia crypto IOC detected'
+  | extend Image = tostring(EventDetail.[4].["#text"]), CommandLine = tostring(EventDetail.[10].["#text"]), Account = UserName, FileHash = tostring(EventDetail.[17].["#text"]), AlertDetail = 'Chia crypto IOC detected'
   | where Image has_any (process)
   | extend timestamp = TimeGenerated, Computer, Account, File = tostring(split(Image, '\\', -1)[-1]), FileHashAlgo = 'SHA256'
   | extend FilePath= replace_string(Image, File, '')
@@ -205,5 +205,5 @@ entityMappings:
         columnName: FileHashAlgo
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.1.0
 kind: Scheduled


### PR DESCRIPTION
Based on issue #3455: Chia rule entity mapping issues - 

Fixes #
 - Fixing entity mappings in general
 - Changing process to file as we do not have a process name or process path entity mapping, it is done thru file.
 - Adding in FilePath and we are missing a column value to indicate the hash algorithm so added that in.  
 - UX will look for xxxCustomEntity to auto map some values as part of the entity mapping feature so making sure those are available still. 
 - Reducing extending names so it is done once outside of the join, this also reduces characters below 10000 which the rule creator errors on if more than.
 - Moving sysmon comment to top and only having one instance
 - Added tostring() for items in this format - EventDetail.[4].["#text"]
