### PR TITLE
Use correct time columns to check Expiration and to summarize in TI Map Detections.

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
@@ -17,6 +17,7 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
+
     let dt_lookBack = 1h;
     let ioc_lookBack = 14d;
     //Create a list of TLDs in our threat feed for later validation of extracted domains
@@ -71,5 +72,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
@@ -55,8 +55,9 @@ query: |
             //Validate parsed domain by checking TLD against TLDs from threat feed and drop domains where there is no chance of a match
             | where tld in~ (list_tlds)
             | extend CommonSecurityLog_TimeGenerated = TimeGenerated
-        ) on $left.DomainName==$right.Domain
-        | where CommonSecurityLog_TimeGenerated >= TimeGenerated and CommonSecurityLog_TimeGenerated < ExpirationDateTime
+        )
+        on $left.DomainName==$right.Domain
+        | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
         | project LatestIndicatorTime, Description, ActivityGroupNames, PA_Url, Domain, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, CommonSecurityLog_TimeGenerated, DeviceAction, DestinationIP, DestinationPort, DeviceName, SourceIP, SourcePort, ApplicationProtocol, RequestMethod
         | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, URLCustomEntity = PA_Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_CommonSecurityLog.yaml
@@ -54,7 +54,7 @@ query: |
             | extend tld = parts[(array_length(parts)-1)]
             //Validate parsed domain by checking TLD against TLDs from threat feed and drop domains where there is no chance of a match
             | where tld in~ (list_tlds)
-            | extend CommonSecurityLog_TimeGenerated = TimeGenerated
+            | project-rename CommonSecurityLog_TimeGenerated = TimeGenerated
         )
         on $left.DomainName==$right.Domain
         | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -47,7 +47,7 @@ query: |
         | extend tld = parts[(array_length(parts)-1)]
         //Validate parsed domain by checking if the TLD is in the list of TLDs in our threat feed
         | where tld in~ (list_tlds)
-        | extend DNS_TimeGenerated = TimeGenerated
+        | project-rename DNS_TimeGenerated = TimeGenerated
     )
     on $left.DomainName==$right.Name
     | summarize DNS_TimeGenerated = arg_max(DNS_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -66,5 +66,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -48,9 +48,9 @@ query: |
         //Validate parsed domain by checking if the TLD is in the list of TLDs in our threat feed
         | where tld in~ (list_tlds)
         | extend DNS_TimeGenerated = TimeGenerated
-    ) on $left.DomainName==$right.Name
-    | where DNS_TimeGenerated >= TimeGenerated and DNS_TimeGenerated < ExpirationDateTime
-    | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+    )
+    on $left.DomainName==$right.Name
+    | summarize DNS_TimeGenerated = arg_max(DNS_TimeGenerated, *) by IndicatorId
     | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Url, DNS_TimeGenerated, Computer, ClientIP, Name, QueryType
     | extend timestamp = DNS_TimeGenerated, HostCustomEntity = Computer, IPCustomEntity = ClientIP, URLCustomEntity = Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
@@ -76,5 +76,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
@@ -60,7 +60,7 @@ query: |
             | where tld in~ (list_tlds)
             | extend CommonSecurityLog_TimeGenerated = TimeGenerated
         ) on $left.DomainName==$right.Domain
-        | where CommonSecurityLog_TimeGenerated >= TimeGenerated and CommonSecurityLog_TimeGenerated < ExpirationDateTime
+        | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
         | project LatestIndicatorTime, Description, ActivityGroupNames, PA_Url, Domain, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, CommonSecurityLog_TimeGenerated, DeviceAction, DestinationIP, DestinationPort, DeviceName, SourceIP, SourcePort, ApplicationProtocol, RequestMethod
         | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, URLCustomEntity = PA_Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_PaloAlto.yaml
@@ -58,7 +58,7 @@ query: |
             | extend tld = parts[(array_length(parts)-1)]
             //Validate parsed domain by checking TLD against TLDs from threat feed and drop domains where there is no chance of a match
             | where tld in~ (list_tlds)
-            | extend CommonSecurityLog_TimeGenerated = TimeGenerated
+            | project-rename CommonSecurityLog_TimeGenerated = TimeGenerated
         ) on $left.DomainName==$right.Domain
         | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
         | project LatestIndicatorTime, Description, ActivityGroupNames, PA_Url, Domain, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, CommonSecurityLog_TimeGenerated, DeviceAction, DestinationIP, DestinationPort, DeviceName, SourceIP, SourcePort, ApplicationProtocol, RequestMethod

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -61,9 +61,8 @@ query: |
         | extend IP_addr = iif(EntityType == 'ip', EntityAddress, '')
         | extend Alert_TimeGenerated = TimeGenerated
         | extend Alert_Description = Description
-    ) on $left.DomainName==$right.domain
-    | where Alert_TimeGenerated >= TimeGenerated and Alert_TimeGenerated < ExpirationDateTime
-    | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+    )on $left.DomainName==$right.domain
+    | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId
     | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated, AlertName, Alert_Description, ProviderName, AlertSeverity, ConfidenceLevel, HostName, IP_addr, Url
     | extend timestamp = Alert_TimeGenerated, HostCustomEntity = HostName, IPCustomEntity = IP_addr, URLCustomEntity = Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -61,7 +61,8 @@ query: |
         | extend IP_addr = iif(EntityType == 'ip', EntityAddress, '')
         | extend Alert_TimeGenerated = TimeGenerated
         | extend Alert_Description = Description
-    )on $left.DomainName==$right.domain
+    )
+    on $left.DomainName==$right.domain
     | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId
     | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated, AlertName, Alert_Description, ProviderName, AlertSeverity, ConfidenceLevel, HostName, IP_addr, Url
     | extend timestamp = Alert_TimeGenerated, HostCustomEntity = HostName, IPCustomEntity = IP_addr, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -59,8 +59,7 @@ query: |
         | extend EntityType = tostring(parse_json(EntitiesDynamicArray).Type), EntityAddress = tostring(EntitiesDynamicArray.Address), EntityHostName = tostring(EntitiesDynamicArray.HostName)
         | extend HostName = iif(EntityType == 'host', EntityHostName, '')
         | extend IP_addr = iif(EntityType == 'ip', EntityAddress, '')
-        | extend Alert_TimeGenerated = TimeGenerated
-        | extend Alert_Description = Description
+        | project-rename Alert_TimeGenerated = TimeGenerated, Alert_Description = Description
     )
     on $left.DomainName==$right.domain
     | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -79,5 +79,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
@@ -49,9 +49,9 @@ query: |
         //Validate parsed domain by checking if the TLD is in the list of TLDs in our threat feed
         | where tld in~ (list_tlds)
         | extend Syslog_TimeGenerated = TimeGenerated
-    ) on $left.DomainName==$right.domain
-    | where Syslog_TimeGenerated >= TimeGenerated and Syslog_TimeGenerated < ExpirationDateTime
-    | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+    )
+    on $left.DomainName==$right.domain
+    | summarize Syslog_TimeGenerated = arg_max(Syslog_TimeGenerated, *) by IndicatorId
     | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Syslog_TimeGenerated, SyslogMessage, Computer, ProcessName, domain, HostIP, Url
     | extend timestamp = Syslog_TimeGenerated, HostCustomEntity = Computer, IPCustomEntity = HostIP, URLCustomEntity = Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
@@ -67,5 +67,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_Syslog.yaml
@@ -48,7 +48,7 @@ query: |
         | extend tld = parts[(array_length(parts)-1)]
         //Validate parsed domain by checking if the TLD is in the list of TLDs in our threat feed
         | where tld in~ (list_tlds)
-        | extend Syslog_TimeGenerated = TimeGenerated
+        | project-rename Syslog_TimeGenerated = TimeGenerated
     )
     on $left.DomainName==$right.domain
     | summarize Syslog_TimeGenerated = arg_max(Syslog_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
@@ -34,7 +34,7 @@ query: |
       AzureActivity | where TimeGenerated >= ago(dt_lookBack) and isnotempty(Caller)
       | extend Caller = tolower(Caller)
       | where Caller matches regex emailregex
-      | extend AzureActivity_TimeGenerated = TimeGenerated
+      | project-rename AzureActivity_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.Caller
   | summarize AzureActivity_TimeGenerated = arg_max(AzureActivity_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
@@ -37,8 +37,7 @@ query: |
       | extend AzureActivity_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.Caller
-  | where AzureActivity_TimeGenerated >= TimeGenerated and AzureActivity_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize AzureActivity_TimeGenerated = arg_max(AzureActivity_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Url, AzureActivity_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Caller, Level, CallerIpAddress, CategoryValue,
   OperationNameValue, ActivityStatusValue, ResourceGroup, SubscriptionId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_AzureActivity.yaml
@@ -56,5 +56,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
@@ -54,5 +54,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
@@ -36,8 +36,7 @@ query: |
       | extend OfficeActivity_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.UserId
-  | where OfficeActivity_TimeGenerated >= TimeGenerated and OfficeActivity_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, OfficeActivity_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, UserId, ClientIP, Operation, UserType, RecordType, OfficeWorkload, Parameters
   | extend timestamp = OfficeActivity_TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_OfficeActivity.yaml
@@ -33,7 +33,7 @@ query: |
   | join (
       OfficeActivity | where TimeGenerated >= ago(dt_lookBack) and isnotempty(UserId)
       | where UserId matches regex emailregex
-      | extend OfficeActivity_TimeGenerated = TimeGenerated
+      | project-rename OfficeActivity_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.UserId
   | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
@@ -36,7 +36,7 @@ query: |
       | where DeviceVendor == "Palo Alto Networks" and  DeviceEventClassID == "wildfire" and ApplicationProtocol in ("smtp","pop3")
       | extend DestinationUserID = tolower(DestinationUserID)
       | where DestinationUserID matches regex emailregex
-      | extend CommonSecurityLog_TimeGenerated = TimeGenerated
+      | project-rename CommonSecurityLog_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.DestinationUserID
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
@@ -39,8 +39,7 @@ query: |
       | extend CommonSecurityLog_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.DestinationUserID
-  | where CommonSecurityLog_TimeGenerated >= TimeGenerated and CommonSecurityLog_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, CommonSecurityLog_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, DestinationUserID, DeviceEventClassID, LogSeverity, DeviceAction,
   SourceIP, SourcePort, DestinationIP, DestinationPort, Protocol, ApplicationProtocol

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_PaloAlto.yaml
@@ -58,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
@@ -46,8 +46,7 @@ query: |
       | extend Alert_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.EntityEmail
-  | where Alert_TimeGenerated >= TimeGenerated and Alert_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, EntityEmail, AlertName, AlertType,
   AlertSeverity, Entities, ProviderName, VendorName

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
@@ -43,7 +43,7 @@ query: |
       | where Entitytype =~ "account"
       | extend EntityEmail = tolower(strcat(EntityName, "@", EntityUPNSuffix))
       | where EntityEmail matches regex emailregex
-      | extend Alert_TimeGenerated = TimeGenerated
+      | project-rename Alert_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.EntityEmail
   | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml
@@ -61,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
@@ -61,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
@@ -35,7 +35,7 @@ query: |
       //Normalizing the column to lower case for exact match with EmailSenderAddress column
       | extend TargetUserName = tolower(TargetUserName)
       // renaming timestamp column so it is clear the log this came from SecurityEvent table
-      | extend SecurityEvent_TimeGenerated = TimeGenerated
+      | project-rename SecurityEvent_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.TargetUserName
   | summarize SecurityEvent_TimeGenerated = arg_max(SecurityEvent_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityEvent.yaml
@@ -38,8 +38,7 @@ query: |
       | extend SecurityEvent_TimeGenerated = TimeGenerated
   )
   on $left.EmailSenderAddress == $right.TargetUserName
-  | where SecurityEvent_TimeGenerated >= TimeGenerated and SecurityEvent_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize SecurityEvent_TimeGenerated = arg_max(SecurityEvent_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SecurityEvent_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Computer, EventID, TargetUserName, Activity, IpAddress, AccountType,
   LogonTypeName, LogonProcessName, Status, SubStatus

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
@@ -69,5 +69,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
@@ -43,7 +43,7 @@ query: |
       | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
       | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion)
       // renaming timestamp column so it is clear the log this came from SigninLogs table
-      | extend SigninLogs_TimeGenerated = TimeGenerated, SigninLogs_Type = Type
+      | project-rename SigninLogs_TimeGenerated = TimeGenerated, SigninLogs_Type = Type
   )
   on $left.EmailSenderAddress == $right.UserPrincipalName
   | summarize SigninLogs_TimeGenerated = arg_max(SigninLogs_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
@@ -43,13 +43,13 @@ query: |
       | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
       | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion)
       // renaming timestamp column so it is clear the log this came from SigninLogs table
-      | extend SigninLogs_TimeGenerated = TimeGenerated, Type = Type
+      | extend SigninLogs_TimeGenerated = TimeGenerated, SigninLogs_Type = Type
   )
   on $left.EmailSenderAddress == $right.UserPrincipalName
   | summarize SigninLogs_TimeGenerated = arg_max(SigninLogs_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SigninLogs_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, IPAddress, UserPrincipalName, AppDisplayName,
-  StatusCode, StatusDetails, NetworkIP, NetworkDestinationIP, NetworkSourceIP, Type
+  StatusCode, StatusDetails, NetworkIP, NetworkDestinationIP, NetworkSourceIP, Type = SigninLogs_Type
   | extend timestamp = SigninLogs_TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, URLCustomEntity = Url
   };
   let aadSignin = aadFunc("SigninLogs");

--- a/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/EmailEntity_SigninLogs.yaml
@@ -46,8 +46,7 @@ query: |
       | extend SigninLogs_TimeGenerated = TimeGenerated, Type = Type
   )
   on $left.EmailSenderAddress == $right.UserPrincipalName
-  | where SigninLogs_TimeGenerated >= TimeGenerated and SigninLogs_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize SigninLogs_TimeGenerated = arg_max(SigninLogs_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, SigninLogs_TimeGenerated,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, IPAddress, UserPrincipalName, AppDisplayName,
   StatusCode, StatusDetails, NetworkIP, NetworkDestinationIP, NetworkSourceIP, Type

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
@@ -34,7 +34,7 @@ query: |
   |  join (
      CommonSecurityLog | where TimeGenerated >= ago(dt_lookBack)
      | where isnotempty(FileHash)
-     | extend CommonSecurityLog_TimeGenerated = TimeGenerated
+     | project-rename CommonSecurityLog_TimeGenerated = TimeGenerated
   )
   on $left.FileHashValue == $right.FileHash
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
@@ -60,5 +60,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
@@ -37,8 +37,7 @@ query: |
      | extend CommonSecurityLog_TimeGenerated = TimeGenerated
   )
   on $left.FileHashValue == $right.FileHash
-  | where CommonSecurityLog_TimeGenerated >= TimeGenerated and CommonSecurityLog_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   CommonSecurityLog_TimeGenerated, SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction,
   RequestURL, DestinationUserName, DestinationUserID, ApplicationProtocol, Activity

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
@@ -29,8 +29,8 @@ query: |
      | extend CommonSecurityLog_TimeGenerated = TimeGenerated
   )
   on $left.FileHashValue == $right.FileHash
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by FileHashValue
-  | project LatestIndicatorTime, FileHashValue, FileHashType, Description, ThreatType,  
+  | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by FileHashValue
+  | project LatestIndicatorTime = TimeGenerated, FileHashValue, FileHashType, Description, ThreatType,  
   CommonSecurityLog_TimeGenerated, SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction, 
   RequestURL, DestinationUserName, DestinationUserID, ApplicationProtocol, Activity
   | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, AccountCustomEntity = SourceUserName

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
@@ -26,7 +26,7 @@ query: |
   |  join (
      CommonSecurityLog | where TimeGenerated >= ago(dt_lookBack) 
      | where isnotempty(FileHash)
-     | extend CommonSecurityLog_TimeGenerated = TimeGenerated
+     | project-rename CommonSecurityLog_TimeGenerated = TimeGenerated
   )
   on $left.FileHashValue == $right.FileHash
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by FileHashValue

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
@@ -47,5 +47,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
@@ -53,5 +53,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
@@ -32,7 +32,7 @@ query: |
     SecurityEvent | where TimeGenerated >= ago(dt_lookBack)
         | where EventID in ("8003","8002","8005")
         | where isnotempty(FileHash)
-        | extend SecurityEvent_TimeGenerated = TimeGenerated, Event = EventID
+        | project-rename SecurityEvent_TimeGenerated = TimeGenerated, Event = EventID
   )
   on $left.FileHashValue == $right.FileHash
   | summarize SecurityEvent_TimeGenerated = arg_max(SecurityEvent_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
@@ -35,8 +35,7 @@ query: |
         | extend SecurityEvent_TimeGenerated = TimeGenerated, Event = EventID
   )
   on $left.FileHashValue == $right.FileHash
-  | where SecurityEvent_TimeGenerated >= TimeGenerated and SecurityEvent_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize SecurityEvent_TimeGenerated = arg_max(SecurityEvent_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   SecurityEvent_TimeGenerated, Process, FileHash, Computer, Account, Event
   | extend timestamp = SecurityEvent_TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
@@ -37,7 +37,7 @@ query: |
   | join (
       AWSCloudTrail | where TimeGenerated >= ago(dt_lookBack)
       // renaming time column so it is clear the log this came from
-      | extend AWSCloudTrail_TimeGenerated = TimeGenerated
+      | project-rename AWSCloudTrail_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.SourceIpAddress
   | summarize AWSCloudTrail_TimeGenerated = arg_max(AWSCloudTrail_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
@@ -40,8 +40,7 @@ query: |
       | extend AWSCloudTrail_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.SourceIpAddress
-  | where AWSCloudTrail_TimeGenerated >= TimeGenerated and AWSCloudTrail_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize AWSCloudTrail_TimeGenerated = arg_max(AWSCloudTrail_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AWSCloudTrail_TimeGenerated,
   TI_ipEntity, EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserIdentityUserName, SourceIpAddress,
   NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AWSCloudTrail.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AppServiceHTTPLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AppServiceHTTPLogs.yaml
@@ -32,14 +32,14 @@ query: |
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
   | join (
-      AppServiceHTTPLogs | where TimeGenerated >= ago(dt_lookBack)
+    AppServiceHTTPLogs | where TimeGenerated >= ago(dt_lookBack)
     | where isnotempty(CIp)
     | extend WebApp = split(_ResourceId, '/')[8]
     // renaming time column so it is clear the log this came from
     | extend AppService_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.CIp
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize AppService_TimeGenerated = arg_max(AppService_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AppService_TimeGenerated, TI_ipEntity, CsUsername, WebApp = split(_ResourceId, '/')[8], CIp, CsHost, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AppService_TimeGenerated, AccountCustomEntity = CsUsername, IPCustomEntity = CIp, URLCustomEntity = CsHost
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AppServiceHTTPLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AppServiceHTTPLogs.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AppServiceHTTPLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AppServiceHTTPLogs.yaml
@@ -36,7 +36,7 @@ query: |
     | where isnotempty(CIp)
     | extend WebApp = split(_ResourceId, '/')[8]
     // renaming time column so it is clear the log this came from
-    | extend AppService_TimeGenerated = TimeGenerated
+    | project-rename AppService_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.CIp
   | summarize AppService_TimeGenerated = arg_max(AppService_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
@@ -37,7 +37,7 @@ query: |
   | join (
       AzureActivity | where TimeGenerated >= ago(dt_lookBack)
       // renaming time column so it is clear the log this came from
-      | extend AzureActivity_TimeGenerated = TimeGenerated
+      | project-rename AzureActivity_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.CallerIpAddress
   | summarize AzureActivity_TimeGenerated = arg_max(AzureActivity_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
@@ -58,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureActivity.yaml
@@ -40,8 +40,7 @@ query: |
       | extend AzureActivity_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.CallerIpAddress
-  | where AzureActivity_TimeGenerated >= TimeGenerated and AzureActivity_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize AzureActivity_TimeGenerated = arg_max(AzureActivity_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AzureActivity_TimeGenerated,
   TI_ipEntity, CallerIpAddress, Caller, OperationNameValue, ActivityStatusValue, CategoryValue, ResourceId, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureActivity_TimeGenerated, IPCustomEntity = CallerIpAddress, AccountCustomEntity = Caller, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -45,7 +45,6 @@ query: |
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.DestinationAddress
-  | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, SourceAddress
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated,
   TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
@@ -34,7 +34,7 @@ query: |
       AzureDiagnostics
       | where ResourceType =~ "VAULTS"
       | where TimeGenerated >= ago(dt_lookBack)
-      | extend KeyVaultEvents_TimeGenerated = TimeGenerated, ClientIP = CallerIPAddress
+      | project-rename KeyVaultEvents_TimeGenerated = TimeGenerated, ClientIP = CallerIPAddress
   )
   on $left.TI_ipEntity == $right.ClientIP
   | summarize KeyVaultEvents_TimeGenerated = arg_max(KeyVaultEvents_TimeGenerated, *) by IndicatorId, ClientIP

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
@@ -51,5 +51,5 @@ entityMappings:
     fieldMappings:
       - identifier: ResourceId
         columnName: ResourceId
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
@@ -31,13 +31,12 @@ query: |
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
-          AzureDiagnostics
-         | where ResourceType =~ "VAULTS"
-         | where TimeGenerated >= ago(dt_lookBack)
-         | extend KeyVaultEvents_TimeGenerated = TimeGenerated, ClientIP = CallerIPAddress
+      AzureDiagnostics
+      | where ResourceType =~ "VAULTS"
+      | where TimeGenerated >= ago(dt_lookBack)
+      | extend KeyVaultEvents_TimeGenerated = TimeGenerated, ClientIP = CallerIPAddress
   )
   on $left.TI_ipEntity == $right.ClientIP
-  | where KeyVaultEvents_TimeGenerated < ExpirationDateTime
   | summarize KeyVaultEvents_TimeGenerated = arg_max(KeyVaultEvents_TimeGenerated, *) by IndicatorId, ClientIP
   | project KeyVaultEvents_TimeGenerated , Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, ClientIP, ResourceId, SubscriptionId, OperationName, ResultType, CorrelationId, id_s, clientInfo_s, httpStatusCode_d, identity_claim_appid_g, identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureNetworkAnalytics.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureNetworkAnalytics.yaml
@@ -41,8 +41,7 @@ query: |
       | extend PIP = tostring(PIPs[0])
   )
   on $left.TI_ipEntity == $right.PIP
-  | where AzureNetworkAnalytics_CL_TimeGenerated >= TimeGenerated and AzureNetworkAnalytics_CL_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize AzureNetworkAnalytics_CL_TimeGenerated = arg_max(AzureNetworkAnalytics_CL_TimeGenerated, *) by IndicatorId
   // Set to alert on Allowed NSG Flows from TI Public IP IOC
   | where FlowStatus_s == "A"
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, AzureNetworkAnalytics_CL_TimeGenerated,

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureNetworkAnalytics.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureNetworkAnalytics.yaml
@@ -61,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureNetworkAnalytics.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureNetworkAnalytics.yaml
@@ -34,11 +34,11 @@ query: |
   | join (
       AzureNetworkAnalytics_CL
       | where TimeGenerated >= ago(dt_lookBack)
-      // renaming time column so it is clear the log this came from
-      | extend AzureNetworkAnalytics_CL_TimeGenerated = TimeGenerated
       // NSG Flow Logs have additional information concat with Public IP, removing onlp Public IP
       | extend PIPs = split(PublicIPs_s, '|', 0)
       | extend PIP = tostring(PIPs[0])
+      // renaming time column so it is clear the log this came from
+      | project-rename AzureNetworkAnalytics_CL_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.PIP
   | summarize AzureNetworkAnalytics_CL_TimeGenerated = arg_max(AzureNetworkAnalytics_CL_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
@@ -48,5 +48,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: ClientIP
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
@@ -38,7 +38,6 @@ query: |
         Application = column_ifexists("application_name_s", "Not Available"), HostName = column_ifexists("host_name_s", "Not Available")
   )
   on $left.TI_ipEntity == $right.ClientIP
-  | where SQLSecurityAuditEvents_TimeGenerated < ExpirationDateTime
   | summarize SQLSecurityAuditEvents_TimeGenerated = arg_max(SQLSecurityAuditEvents_TimeGenerated, *) by IndicatorId, ClientIP
   | project SQLSecurityAuditEvents_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, ResourceId, ClientIP, Action, Application, HostName, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
@@ -32,7 +32,7 @@ query: |
         | where TimeGenerated >= ago(dt_lookBack)
         | where ResourceProvider == 'MICROSOFT.SQL'
         | where Category == 'SQLSecurityAuditEvents'
-        | extend SQLSecurityAuditEvents_TimeGenerated = TimeGenerated
+        | project-rename SQLSecurityAuditEvents_TimeGenerated = TimeGenerated
         // projecting fields with column if exists as this is in AzureDiag and if the event is not in the table, then queries will fail due to event specific schemas
         | extend ClientIP = column_ifexists("client_ip_s", "Not Available"), Action = column_ifexists("action_name_s", "Not Available"), 
         Application = column_ifexists("application_name_s", "Not Available"), HostName = column_ifexists("host_name_s", "Not Available")

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
@@ -44,8 +44,7 @@ query: |
       | extend DNS_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.SingleIP
-  | where DNS_TimeGenerated >= TimeGenerated and DNS_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize DNS_TimeGenerated = arg_max(DNS_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, DNS_TimeGenerated,
   TI_ipEntity, Computer, EventId, SubType, ClientIP, Name, IPAddresses, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = DNS_TimeGenerated, IPCustomEntity = ClientIP, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
@@ -41,7 +41,7 @@ query: |
       | mvexpand SingleIP
       | extend SingleIP = tostring(SingleIP)
       // renaming time column so it is clear the log this came from
-      | extend DNS_TimeGenerated = TimeGenerated
+      | project-rename DNS_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.SingleIP
   | summarize DNS_TimeGenerated = arg_max(DNS_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
@@ -62,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
@@ -37,7 +37,7 @@ query: |
   | join (
       OfficeActivity | where TimeGenerated >= ago(dt_lookBack)
       // renaming time column so it is clear the log this came from
-      | extend OfficeActivity_TimeGenerated = TimeGenerated
+      | project-rename OfficeActivity_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.ClientIP
   | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
@@ -40,8 +40,7 @@ query: |
       | extend OfficeActivity_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.ClientIP
-  | where OfficeActivity_TimeGenerated >= TimeGenerated and OfficeActivity_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, OfficeActivity_TimeGenerated,
   TI_ipEntity, ClientIP, UserId, Operation, ResultStatus, RecordType, OfficeObjectId, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = OfficeActivity_TimeGenerated, IPCustomEntity = ClientIP, AccountCustomEntity = UserId, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_OfficeActivity.yaml
@@ -58,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
@@ -41,8 +41,7 @@ query: |
       | extend VMConnection_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIp
-  | where VMConnection_TimeGenerated >= TimeGenerated and VMConnection_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize VMConnection_TimeGenerated = arg_max(VMConnection_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, VMConnection_TimeGenerated,
   TI_ipEntity, Computer, Direction, ProcessName, SourceIp, DestinationIp, RemoteIp, Protocol, DestinationPort, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = VMConnection_TimeGenerated, IPCustomEntity = RemoteIp, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_VMConnection.yaml
@@ -38,7 +38,7 @@ query: |
       VMConnection
       | where TimeGenerated >= ago(dt_lookBack)
       // renaming time column so it is clear the log this came from
-      | extend VMConnection_TimeGenerated = TimeGenerated
+      | project-rename VMConnection_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIp
   | summarize VMConnection_TimeGenerated = arg_max(VMConnection_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
@@ -39,7 +39,7 @@ query: |
       | where TimeGenerated >= ago(dt_lookBack)
       | where isnotempty(cIP)
       // renaming time column so it is clear the log this came from
-      | extend W3CIISLog_TimeGenerated = TimeGenerated
+      | project-rename W3CIISLog_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.cIP
   | summarize W3CIISLog_TimeGenerated = arg_max(W3CIISLog_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
@@ -42,8 +42,7 @@ query: |
       | extend W3CIISLog_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.cIP
-  | where W3CIISLog_TimeGenerated >= TimeGenerated and W3CIISLog_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize W3CIISLog_TimeGenerated = arg_max(W3CIISLog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   W3CIISLog_TimeGenerated, TI_ipEntity, Computer, sSiteName, cIP, sIP, sPort, csMethod, csUserName, scStatus, scSubStatus, scWin32Status,
   NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_W3CIISLog.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
@@ -38,7 +38,7 @@ query: |
       WireData | where TimeGenerated >= ago(dt_lookBack)
       | where isnotempty(RemoteIP)
       // renaming time column so it is clear the log this came from
-      | extend WireData_TimeGenerated = TimeGenerated
+      | project-rename WireData_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIP
   | summarize WireData_TimeGenerated = arg_max(WireData_TimeGenerated, *) by IndicatorId

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_WireData.yaml
@@ -41,8 +41,7 @@ query: |
       | extend WireData_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIP
-  | where WireData_TimeGenerated >= TimeGenerated and WireData_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize WireData_TimeGenerated = arg_max(WireData_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, WireData_TimeGenerated,
   TI_ipEntity, Computer, LocalIP, RemoteIP, ProcessName, ApplicationProtocol, LocalPortNumber, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = WireData_TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = Computer, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
@@ -47,7 +47,6 @@ query: |
       | extend SigninLogs_TimeGenerated = TimeGenerated, Type = Type
   )
   on $left.TI_ipEntity == $right.IPAddress
-  | where SigninLogs_TimeGenerated < ExpirationDateTime
   | summarize SigninLogs_TimeGenerated = arg_max(SigninLogs_TimeGenerated, *) by IndicatorId, IPAddress
   | project SigninLogs_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   TI_ipEntity, IPAddress, UserPrincipalName, AppDisplayName, StatusCode, StatusDetails, StatusReason, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress, Type

--- a/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
@@ -69,5 +69,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPentity_SigninLogs.yaml
@@ -44,12 +44,12 @@ query: |
       | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails), StatusReason = tostring(Status.failureReason)
       | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion)
       // renaming time column so it is clear the log this came from
-      | extend SigninLogs_TimeGenerated = TimeGenerated, Type = Type
+      | project-rename SigninLogs_TimeGenerated = TimeGenerated, SigninLogs_Type = Type
   )
   on $left.TI_ipEntity == $right.IPAddress
   | summarize SigninLogs_TimeGenerated = arg_max(SigninLogs_TimeGenerated, *) by IndicatorId, IPAddress
   | project SigninLogs_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
-  TI_ipEntity, IPAddress, UserPrincipalName, AppDisplayName, StatusCode, StatusDetails, StatusReason, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress, Type
+  TI_ipEntity, IPAddress, UserPrincipalName, AppDisplayName, StatusCode, StatusDetails, StatusReason, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress, Type = SigninLogs_Type
   | extend timestamp = SigninLogs_TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, URLCustomEntity = Url
   };
   let aadSignin = aadFunc("SigninLogs");

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
@@ -39,8 +39,7 @@ query: |
     | extend TargetResourceDisplayName = tostring(TargetResources[0].displayName)
     | extend Audit_TimeGenerated = TimeGenerated
   ) on Url
-  | where Audit_TimeGenerated >= TimeGenerated and Audit_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize Audit_TimeGenerated = arg_max(Audit_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
   Audit_TimeGenerated, OperationName, Identity, userPrincipalName, TargetResourceDisplayName, Url
   | extend timestamp = Audit_TimeGenerated, AccountCustomEntity = userPrincipalName, HostCustomEntity = TargetResourceDisplayName, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
@@ -37,7 +37,7 @@ query: |
     | where isnotempty(Url)
     | extend userPrincipalName = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
     | extend TargetResourceDisplayName = tostring(TargetResources[0].displayName)
-    | extend Audit_TimeGenerated = TimeGenerated
+    | project-rename Audit_TimeGenerated = TimeGenerated
   ) on Url
   | summarize Audit_TimeGenerated = arg_max(Audit_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_AuditLogs.yaml
@@ -57,5 +57,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
@@ -33,10 +33,10 @@ query: |
     | extend Url = iif(OfficeWorkload == "AzureActiveDirectory",extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+);", 1,ModifiedProperties),tostring(parse_json(ModifiedProperties)[12].NewValue))
     | where isnotempty(Url)
     // Ensure we get a clean URL
-    | extend Url = tostring(split(Url, ';')[0])
-    | extend OfficeActivity_TimeGenerated = TimeGenerated
+    | extend Url = tostring(split(Url, ';')[0])    
     // Project a single user identity that we can use for entity mapping
     | extend User = iif(isnotempty(UserId), UserId, iif(isnotempty(Actor), tostring(parse_json(Actor)[0].ID), tostring(parse_json(Parameters)[0].Vlaue))) 
+    | project-rename OfficeActivity_TimeGenerated = TimeGenerated
   ) on Url
   | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Operation, 

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
@@ -38,8 +38,7 @@ query: |
     // Project a single user identity that we can use for entity mapping
     | extend User = iif(isnotempty(UserId), UserId, iif(isnotempty(Actor), tostring(parse_json(Actor)[0].ID), tostring(parse_json(Parameters)[0].Vlaue))) 
   ) on Url
-  | where OfficeActivity_TimeGenerated >= TimeGenerated and OfficeActivity_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Operation, 
   UserType, OfficeWorkload, Parameters, OfficeActivity_TimeGenerated, Url, User
   | extend timestamp = OfficeActivity_TimeGenerated, AccountCustomEntity = User, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
@@ -52,5 +52,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
@@ -61,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
@@ -45,7 +45,7 @@ query: |
     | where isnotempty(PA_Url)
     | extend CommonSecurityLog_TimeGenerated = TimeGenerated
   ) on $left.Url == $right.PA_Url
-  | where CommonSecurityLog_TimeGenerated >= TimeGenerated and CommonSecurityLog_TimeGenerated < ExpirationDateTime
+  | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, DeviceAction, SourceIP, CommonSecurityLog_TimeGenerated, PA_Url, DeviceName
   | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, URLCustomEntity = PA_Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_PaloAlto.yaml
@@ -43,7 +43,7 @@ query: |
     | extend PA_Url = iif(isempty(PA_Url), extract("([^\"]+)", 1, tolower(AdditionalExtensions)), trim('"', PA_Url))
     | extend PA_Url = iif(PA_Url !startswith "http://" and ApplicationProtocol !~ "ssl", strcat('http://', PA_Url), iif(PA_Url !startswith "https://" and ApplicationProtocol =~ "ssl", strcat('https://', PA_Url), PA_Url))
     | where isnotempty(PA_Url)
-    | extend CommonSecurityLog_TimeGenerated = TimeGenerated
+    | project-rename CommonSecurityLog_TimeGenerated = TimeGenerated
   ) on $left.Url == $right.PA_Url
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, DeviceAction, SourceIP, CommonSecurityLog_TimeGenerated, PA_Url, DeviceName

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
@@ -45,8 +45,7 @@ query: |
     | extend Compromised_Host = tostring(parse_json(ExtendedProperties).["Compromised Host"])
     | extend Alert_TimeGenerated = TimeGenerated
   ) on Url
-  | where Alert_TimeGenerated >= TimeGenerated and Alert_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated,
   AlertName, AlertSeverity, Description, Url, Compromised_Host
   | extend timestamp = Alert_TimeGenerated, HostCustomEntity = Compromised_Host, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
@@ -59,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml
@@ -43,7 +43,7 @@ query: |
     | where isnotempty(Url)
     // Extract hostname from JSON data for entity mapping
     | extend Compromised_Host = tostring(parse_json(ExtendedProperties).["Compromised Host"])
-    | extend Alert_TimeGenerated = TimeGenerated
+    | project-rename Alert_TimeGenerated = TimeGenerated
   ) on Url
   | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Alert_TimeGenerated,

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
@@ -37,8 +37,7 @@ query: |
     | where isnotempty(Url)
     | extend Syslog_TimeGenerated = TimeGenerated
   ) on Url
-  | where Syslog_TimeGenerated >= TimeGenerated and Syslog_TimeGenerated < ExpirationDateTime
-  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | summarize Syslog_TimeGenerated = arg_max(Syslog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Syslog_TimeGenerated, SyslogMessage, Computer, ProcessName, Url, HostIP
   | extend timestamp = Syslog_TimeGenerated, HostCustomEntity = Computer, IPCustomEntity = HostIP, URLCustomEntity = Url
 entityMappings:

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
@@ -54,5 +54,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_Syslog.yaml
@@ -35,7 +35,7 @@ query: |
     // Extract URL from the Syslog message but only take messages that include URLs
     | extend Url = extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)", 1,SyslogMessage)
     | where isnotempty(Url)
-    | extend Syslog_TimeGenerated = TimeGenerated
+    | project-rename Syslog_TimeGenerated = TimeGenerated
   ) on Url
   | summarize Syslog_TimeGenerated = arg_max(Syslog_TimeGenerated, *) by IndicatorId
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Syslog_TimeGenerated, SyslogMessage, Computer, ProcessName, Url, HostIP


### PR DESCRIPTION
This Pull Request comes from a closed unmerged pull request that got messy (https://github.com/Azure/Azure-Sentinel/pull/3477)

Fixes #

Saving some unnecessary conditions.

Expiration Date is already getting compared at
```yaml
ThreatIntelligenceIndicator
| where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
```

2nd summarize was getting its TimeGenerated from the event table, not from the Indicator Table.

## Proposed Changes

  - Remove conditions about the time of the indicator, as they are already fulfilled.
  - Use correct column in 2nd summarize.
  - Use project-rename for Event columns that conflict with Indicator columns.