### PR TITLE
Increase Queryperiod in AuthenticationMethodsChangedforPrivilegedAccount.yaml

### DIFF
--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
     dataTypes:
       - BehaviorAnalytics
 queryFrequency: 2h
-queryPeriod: 2h
+queryPeriod: 14d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -22,14 +22,21 @@ relevantTechniques:
 tags:
   - AADSecOpsGuide
 query: |
-  let VIPUsers = (IdentityInfo
-  | where AssignedRoles contains "Admin"
-  | summarize by tolower(AccountUPN));
+  let lookback = 14d;
+  let queryfrequency = 2h;
+  let VIPUsers = (
+      IdentityInfo
+      | where TimeGenerated > ago(lookback)
+      | summarize arg_max(TimeGenerated, *) by AccountUPN
+      | mv-expand AssignedRoles
+      | where AssignedRoles matches regex 'Admin'
+      | summarize by tolower(AccountUPN));
   AuditLogs
+  | where TimeGenerated > ago(queryfrequency)
   | where Category =~ "UserManagement"
   | where ActivityDisplayName =~ "User registered security info"
   | where LoggedByService =~ "Authentication Methods"
-  | extend AccountCustomEntity = tostring(TargetResources[0].userPrincipalName), IPCustomEntity = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend AccountCustomEntity = tostring(TargetResources[0].userPrincipalName), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
   | where AccountCustomEntity in (VIPUsers)
 entityMappings:
   - entityType: Account
@@ -40,5 +47,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
-kind: scheduled
+version: 1.0.2
+kind: Scheduled

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -22,11 +22,11 @@ relevantTechniques:
 tags:
   - AADSecOpsGuide
 query: |
-  let lookback = 14d;
+  let queryperiod = 14d;
   let queryfrequency = 2h;
   let VIPUsers = (
       IdentityInfo
-      | where TimeGenerated > ago(lookback)
+      | where TimeGenerated > ago(queryperiod)
       | summarize arg_max(TimeGenerated, *) by AccountUPN
       | mv-expand AssignedRoles
       | where AssignedRoles matches regex 'Admin'


### PR DESCRIPTION
IdentityInfo does not have all records every 2 hours.

Fixes #

Not getting wanted results.

## Proposed Changes

  - Use greater query period, ideally should be 21 days as I think IdentityInfo is resynced every 21 days.
