### PR TITLE
Remove unnecessary condition in UseraddedtoPrivilgedGroups.yaml

### DIFF
--- a/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
+++ b/Detections/AuditLogs/UseraddedtoPrivilgedGroups.yaml
@@ -23,7 +23,7 @@ query: |
   let OperationList = dynamic(["Add member to role","Add member to role in PIM requested (permanent)"]);
   let PrivilegedGroups = dynamic(["UserAccountAdmins","PrivilegedRoleAdmins","TenantAdmins"]);
   AuditLogs
-  | where LoggedByService =~ "Core Directory"
+  //| where LoggedByService =~ "Core Directory"
   | where Category =~ "RoleManagement"
   | where OperationName in~ (OperationList)
   | mv-expand TargetResources
@@ -57,5 +57,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: TargetUserPrincipalName
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
```Add member to role in PIM requested (permanent)``` is ```LoggedByService == "PIM"```, not by ```Core Directory```

Fixes #

I think this rule has never detected the operation ```Add member to role in PIM requested (permanent)```, or at least not nowadays.

## Proposed Changes

  - The rule already filters by OperationName, it should not filter by LoggedByService if you want to detect ```Add member to role in PIM requested (permanent)```
