### PR TITLE
Update link in AzurePortalSigninfromanotherAzureTenant.yaml

### DIFF
--- a/Detections/SigninLogs/AzurePortalSigninfromanotherAzureTenant.yaml
+++ b/Detections/SigninLogs/AzurePortalSigninfromanotherAzureTenant.yaml
@@ -21,7 +21,7 @@ query: |
   // Get details of current Azure Ranges (note this URL updates regularly so will need to be manually updated over time)
   // You may find the name of the new JSON here: https://www.microsoft.com/download/details.aspx?id=56519
   let azure_ranges = externaldata(changeNumber: string, cloud: string, values: dynamic)
-  ["https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20211108.json"]
+  ["https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20211129.json"]
   with(format='multijson')
   | mv-expand values
   | mv-expand values.properties.addressPrefixes
@@ -47,5 +47,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
-kind: scheduled
+version: 1.0.2
+kind: Scheduled


### PR DESCRIPTION
Fixes #

Outdated link.

## Proposed Changes

  - There should be another way for this to be updated. last time it was only 21 days ago.

I know there is an Azure Function in the repository, to update regularly a Watchlist with Cloud Ranges.

Maybe you could provide a Watchlist with Azure Ranges in all Sentinel workspaces, and this rule would use that hypotetical Watchlist.

Or create a permanent link that updates its content by itself.