### PR TITLE
Handle lettercase mismatch in FileHashEntity_SecurityEvent.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
@@ -28,12 +28,13 @@ query: |
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
   | where Active == true
   | where isnotempty(FileHashValue)
+  | extend FileHashValue = toupper(FileHashValue)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
     SecurityEvent | where TimeGenerated >= ago(dt_lookBack)
         | where EventID in ("8003","8002","8005")
         | where isnotempty(FileHash)
-        | extend SecurityEvent_TimeGenerated = TimeGenerated, Event = EventID
+        | extend SecurityEvent_TimeGenerated = TimeGenerated, Event = EventID, FileHash = toupper(FileHash)
   )
   on $left.FileHashValue == $right.FileHash
   | where SecurityEvent_TimeGenerated < ExpirationDateTime
@@ -54,5 +55,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled


### PR DESCRIPTION
Threat Intelligence Indicator hashes might be in lowercase or uppercase.

I have seen SecurityEvent hashes to be uppercase in my tenant, I don't know other tenants.

Other detections like:

https://github.com/Azure/Azure-Sentinel/blob/master/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
https://github.com/Azure/Azure-Sentinel/blob/master/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml

approach this problem in another way. 

I think **forcing both tables to be uppercase** might be more efficient than **forcing the case and doubling the number of Indicators** that have to be compared. I may be wrong.

Fixes #

Mismatch in hash comparison due to letter case.

## Proposed Changes

  - Force uppercase value in both tables.
