### PR TITLE
Update array indexes in CorrelateIPC_Unfamiliar-Atypical.yaml

### DIFF
--- a/Detections/SecurityAlert/CorrelateIPC_Unfamiliar-Atypical.yaml
+++ b/Detections/SecurityAlert/CorrelateIPC_Unfamiliar-Atypical.yaml
@@ -31,10 +31,10 @@ query: |
   | extend Alert2Time = TimeGenerated
   | extend Alert2 = AlertName
   | extend Alert2Severity = AlertSeverity
-  | extend CurrentLocation = strcat(tostring(parse_json(tostring(parse_json(Entities)[1].Location)).CountryCode), "|", tostring(parse_json(tostring(parse_json(Entities)[1].Location)).State), "|", tostring(parse_json(tostring(parse_json(Entities)[1].Location)).City))
-  | extend PreviousLocation = strcat(tostring(parse_json(tostring(parse_json(Entities)[2].Location)).CountryCode), "|", tostring(parse_json(tostring(parse_json(Entities)[2].Location)).State), "|", tostring(parse_json(tostring(parse_json(Entities)[2].Location)).City))
-  | extend CurrentIPAddress = tostring(parse_json(Entities)[1].Address)
-  | extend PreviousIPAddress = tostring(parse_json(Entities)[2].Address)
+  | extend CurrentLocation = strcat(tostring(parse_json(tostring(parse_json(Entities)[2].Location)).CountryCode), "|", tostring(parse_json(tostring(parse_json(Entities)[2].Location)).State), "|", tostring(parse_json(tostring(parse_json(Entities)[2].Location)).City))
+  | extend PreviousLocation = strcat(tostring(parse_json(tostring(parse_json(Entities)[3].Location)).CountryCode), "|", tostring(parse_json(tostring(parse_json(Entities)[3].Location)).State), "|", tostring(parse_json(tostring(parse_json(Entities)[3].Location)).City))
+  | extend CurrentIPAddress = tostring(parse_json(Entities)[2].Address)
+  | extend PreviousIPAddress = tostring(parse_json(Entities)[3].Address)
   ;
   Alert1
   | join kind=inner Alert2 on UserPrincipalName
@@ -52,5 +52,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
In my tenant Entities array has 4 elements. I think some changes may have been introduced since this query was created. My tenant did not have Atypical travel alerts until 2 days ago.

Fixes #

Half of the IP values missing.

## Proposed Changes

  - Update array indexes.

Please, could you review this?