### PR TITLE
Use different time periods in PrivilegedAccountsSigninFailureSpikes.yaml

### DIFF
--- a/Detections/MultipleDataSources/PrivilegedAccountsSigninFailureSpikes.yaml
+++ b/Detections/MultipleDataSources/PrivilegedAccountsSigninFailureSpikes.yaml
@@ -13,7 +13,7 @@ requiredDataConnectors:
     dataTypes:
       - AADNonInteractiveUserSignInLogs
 queryFrequency: 1d
-queryPeriod: 1d
+queryPeriod: 14d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -28,46 +28,43 @@ query: |
   let scorethreshold = 3;
   let baselinethreshold = 5;
   let aadFunc = (tableName:string){
-  IdentityInfo
-  | where AssignedRoles contains "Admin"
-  | mv-expand AssignedRoles
-  | extend Roles = tostring(AssignedRoles), AccountUPN = tolower(AccountUPN)
-  | where Roles contains "Admin"
-  | distinct Roles, AccountUPN
-  | join kind=inner (
-    // Failed Signins attempts with reasoning related to MFA.
-    table(tableName)
-    | where TimeGenerated between (startofday(ago(starttime))..startofday(ago(timeframe)))
-    | where ResultType != 0
-    | extend UserPrincipalName = tolower(UserPrincipalName)
-  ) on $left.AccountUPN == $right.UserPrincipalName
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName
+      IdentityInfo
+      | where TimeGenerated > ago(starttime)
+      | summarize arg_max(TimeGenerated, *) by AccountUPN
+      | mv-expand AssignedRoles
+      | where AssignedRoles matches regex 'Admin'
+      | summarize Roles = make_list(AssignedRoles) by AccountUPN = tolower(AccountUPN)
+      | join kind=inner (
+          table(tableName)
+          | where TimeGenerated between (startofday(ago(starttime))..startofday(now()))
+          | where ResultType != 0
+          | extend UserPrincipalName = tolower(UserPrincipalName)
+      ) on $left.AccountUPN == $right.UserPrincipalName
+      | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, Roles = tostring(Roles)
   };
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
-  let allSignins = union isfuzzy=true aadSignin, aadNonInt ;
-  let TimeSeriesData = union isfuzzy=true aadSignin, aadNonInt 
-  | project TimeGenerated, Roles, UserPrincipalName
-  | make-series HourlyCount=count() on TimeGenerated from startofday(ago(starttime)) to startofday(now()) step timeframe by UserPrincipalName, Roles
-  | project TimeGenerated, Roles, UserPrincipalName, HourlyCount;
-  let TimeSeriesAlerts = TimeSeriesData
-  | extend (anomalies, score, baseline) = series_decompose_anomalies(HourlyCount, scorethreshold, -1, 'linefit')
-  | mv-expand HourlyCount to typeof(double), TimeGenerated to typeof(datetime), anomalies to typeof(double),score to typeof(double), baseline to typeof(long)
-  | where anomalies > 0 | extend AnomalyHour = TimeGenerated
-  | where baseline > baselinethreshold // Filtering low count events per baselinethreshold
-  | project Roles, UserPrincipalName, AnomalyHour, TimeGenerated, HourlyCount, baseline, anomalies, score;
-  let AnomalyHours = TimeSeriesAlerts | where TimeGenerated > ago(2d) | project TimeGenerated;
+  let allSignins = union isfuzzy=true aadSignin, aadNonInt;
+  let TimeSeriesAlerts = 
+      allSignins
+      | make-series HourlyCount=count() on TimeGenerated from startofday(ago(starttime)) to startofday(now()) step 1h by UserPrincipalName, Roles
+      | extend (anomalies, score, baseline) = series_decompose_anomalies(HourlyCount, scorethreshold, -1, 'linefit')
+      | mv-expand HourlyCount to typeof(double), TimeGenerated to typeof(datetime), anomalies to typeof(double), score to typeof(double), baseline to typeof(long)
+      // Filtering low count events per baselinethreshold
+      | where anomalies > 0 and baseline > baselinethreshold
+      | extend AnomalyHour = TimeGenerated
+      | project UserPrincipalName, Roles, AnomalyHour, TimeGenerated, HourlyCount, baseline, anomalies, score;
   // Filter the alerts for specified timeframe
   TimeSeriesAlerts
-  | where TimeGenerated > ago(2d)
+  | where TimeGenerated > startofday(ago(timeframe))
   | join kind=inner ( 
-  union isfuzzy=true aadSignin, aadNonInt
-  | where TimeGenerated > ago(2d)
-  | extend DateHour = bin(TimeGenerated, 1h) // create a new column and round to hour
-  | where DateHour in ((AnomalyHours)) //filter the dataset to only selected anomaly hours
-   | summarize HourlyCount=count(), LatestAnomalyTime = arg_max(timestamp,*) by bin(TimeGenerated,1h), OperationName, Category, ResultType, ResultDescription, UserPrincipalName, UserDisplayName, AppDisplayName, ClientAppUsed, IPAddress, ResourceDisplayName
-  ) on UserPrincipalName
-  | project LatestAnomalyTime, OperationName, Category, UserPrincipalName, UserDisplayName, ResultType, ResultDescription, AppDisplayName, ClientAppUsed, UserAgent, IPAddress, Location, AuthenticationRequirement, ConditionalAccessStatus, ResourceDisplayName, HourlyCount, baseline, anomalies, score
+      allSignins
+      | where TimeGenerated > startofday(ago(timeframe))
+      // create a new column and round to hour
+      | extend DateHour = bin(TimeGenerated, 1h)
+      | summarize PartialFailedSignins = count(), LatestAnomalyTime = arg_max(TimeGenerated, *) by bin(TimeGenerated, 1h), OperationName, Category, ResultType, ResultDescription, UserPrincipalName, Roles, UserDisplayName, AppDisplayName, ClientAppUsed, IPAddress, ResourceDisplayName
+  ) on UserPrincipalName, $left.AnomalyHour == $right.DateHour
+  | project LatestAnomalyTime, OperationName, Category, UserPrincipalName, Roles = todynamic(Roles), UserDisplayName, ResultType, ResultDescription, AppDisplayName, ClientAppUsed, UserAgent, IPAddress, Location, AuthenticationRequirement, ConditionalAccessStatus, ResourceDisplayName, PartialFailedSignins, TotalFailedSignins = HourlyCount, baseline, anomalies, score
   | extend timestamp = LatestAnomalyTime, IPCustomEntity = IPAddress, AccountCustomEntity = UserPrincipalName
 entityMappings:
   - entityType: Account
@@ -78,5 +75,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
**SIMILAR PULL REQUEST AS https://github.com/Azure/Azure-Sentinel/pull/3508**

If the query period is 1d, you won't get results from 14 days ago that you try to query.

Fixes #

Not getting any meaningful results due to several time periods.

HourlyCount was computed in timeframes of 1 day, maybe this was intended, but then it shouldn't be called HourlyCount or compared to DateHour (which was computed in timeframes of 1 hour).

## Proposed Changes

  - Use query period of 14 days, as other Detection Rules have it when they search events from 14 days ago.
  - Reuse ```let allSignins = union isfuzzy=true aadSignin, aadNonInt ;``` or remove it.
  - Use ```TimeSeriesAlerts
  | where TimeGenerated > startofday(ago(timeframe)) ``` or is it intended to be 2d when the queryfrequency is 1d?
  - Compute HourlyCount with timeframe of 1h, instead of 1d
  - several other changes to make it work
  
  The anomalies were intented to be computed by hour or by day? This alert could be noisy.