### PR TITLE
Fix Action not being parsed & Compare Allowed Public Source Address in IPEntity_AzureFirewall.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -48,6 +48,7 @@ query: |
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
       )
       on $left.TI_ipEntity == $right.RemoteIP
+  | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated, TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureFirewall_TimeGenerated, IPCustomEntity = TI_ipEntity, URLCustomEntity = Url

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -38,18 +38,18 @@ query: |
   | join kind=innerunique (
       AzureDiagnostics
       | where TimeGenerated >= ago(dt_lookBack)
-      | where OperationName in ("AzureFirewallApplicationRuleLog","AzureFirewallNetworkRuleLog")
-      | parse kind=regex flags=U msg_s with Protocol 'request from ' SourceHost 'to ' DestinationHost @'\.? Action:' Action
-      | extend SourceAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?',1,SourceHost)
-      | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?',1,DestinationHost)
-      | where not(ipv4_is_private(DestinationAddress))
+      | where OperationName in ("AzureFirewallApplicationRuleLog", "AzureFirewallNetworkRuleLog")
+      | parse kind=regex flags=U msg_s with Protocol 'request from ' SourceHost 'to ' DestinationHost @'\.? Action: ' Action @'\.' Rest_msg
+      | extend SourceAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, SourceHost)
+      | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, DestinationHost)
+      | extend RemoteIP = case(not(ipv4_is_private(DestinationAddress)), DestinationAddress, not(ipv4_is_private(SourceAddress)), SourceAddress, "")
+      // Traffic where there is a public destination address, or the public source address was allowed
+      | where isnotempty(RemoteIP) and not(RemoteIP == SourceAddress and Action == "Deny")
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
-  )
-  on $left.TI_ipEntity == $right.DestinationAddress
-  | where AzureFirewall_TimeGenerated < ExpirationDateTime
-  | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, DestinationAddress
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated,
-  TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
+      )
+      on $left.TI_ipEntity == $right.RemoteIP
+  | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated, TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureFirewall_TimeGenerated, IPCustomEntity = TI_ipEntity, URLCustomEntity = Url
 entityMappings:
   - entityType: IP
@@ -60,5 +60,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -44,7 +44,7 @@ query: |
       | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, DestinationHost)
       | extend RemoteIP = case(not(ipv4_is_private(DestinationAddress)), DestinationAddress, not(ipv4_is_private(SourceAddress)), SourceAddress, "")
       // Traffic that involves a public address, and in case this is the source address then the traffic was not denied
-      | where isnotempty(RemoteIP) and not(RemoteIP == SourceAddress and Action == "Deny")
+      | where isnotempty(RemoteIP)
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIP

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -50,7 +50,8 @@ query: |
       on $left.TI_ipEntity == $right.RemoteIP
   | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated, TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
+  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated,
+  TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureFirewall_TimeGenerated, IPCustomEntity = TI_ipEntity, URLCustomEntity = Url
 entityMappings:
   - entityType: IP

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -46,8 +46,8 @@ query: |
       // Traffic that involves a public address, and in case this is the source address then the traffic was not denied
       | where isnotempty(RemoteIP) and not(RemoteIP == SourceAddress and Action == "Deny")
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
-      )
-      on $left.TI_ipEntity == $right.RemoteIP
+  )
+  on $left.TI_ipEntity == $right.RemoteIP
   | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated,

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -43,7 +43,7 @@ query: |
       | extend SourceAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, SourceHost)
       | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, DestinationHost)
       | extend RemoteIP = case(not(ipv4_is_private(DestinationAddress)), DestinationAddress, not(ipv4_is_private(SourceAddress)), SourceAddress, "")
-      // Traffic where there is a public destination address, or the public source address was allowed
+      // Traffic that involves there a public address, and in case this is the source address then the traffic was not denied
       | where isnotempty(RemoteIP) and not(RemoteIP == SourceAddress and Action == "Deny")
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
       )

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -43,7 +43,7 @@ query: |
       | extend SourceAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, SourceHost)
       | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, DestinationHost)
       | extend RemoteIP = case(not(ipv4_is_private(DestinationAddress)), DestinationAddress, not(ipv4_is_private(SourceAddress)), SourceAddress, "")
-      // Traffic that involves there a public address, and in case this is the source address then the traffic was not denied
+      // Traffic that involves a public address, and in case this is the source address then the traffic was not denied
       | where isnotempty(RemoteIP) and not(RemoteIP == SourceAddress and Action == "Deny")
       | project-rename AzureFirewall_TimeGenerated = TimeGenerated
       )


### PR DESCRIPTION
Fixes #

Action column was not being parsed due to Ungreedy regex flag.

Source Address may be a public address, and it could also be compared to TI Indicators, specially when the traffic was not denied (publicly exposed machines).
____
Maybe you prefer the Source Address to not be compared. In my case it did not add much noise except for a machine that serves as a WAF.