### PR TITLE
Adding build validation bypass for - HighlySensitivePasswordAccessed.yaml

### DIFF
--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -121,7 +121,12 @@
   },
   {
     "id": "6e575295-a7e6-464c-8192-3e1d8fd6a990",
-    "templateName": "Log4J_IPIOC_Dec112021",
+    "templateName": "Log4J_IPIOC_Dec112021.yaml",
     "validationFailReason": "The name 'imDns' does not refer to any known function."
+  },
+  {
+    "id": "b39e6482-ab7e-4817-813d-ec910b64b26e",
+    "templateName": "HighlySensitivePasswordAccessed.yaml",
+    "validationFailReason": "The name '_GetWatchlist' does not refer to any known function."
   }
 ]


### PR DESCRIPTION
Fixes #
 HighlySensitivePasswordAccessed is failing validations because of watchlist usage - "The name '_GetWatchlist' does not refer to any known function."
