### PR TITLE
Differentiate Action column from Indicators and from Azure Firewall in IPEntity_AzureFirewall.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -39,7 +39,7 @@ query: |
       AzureDiagnostics
       | where TimeGenerated >= ago(dt_lookBack)
       | where OperationName in ("AzureFirewallApplicationRuleLog", "AzureFirewallNetworkRuleLog")
-      | parse kind=regex flags=U msg_s with Protocol 'request from ' SourceHost 'to ' DestinationHost @'\.? Action: ' Action @'\.' Rest_msg
+      | parse kind=regex flags=U msg_s with Protocol 'request from ' SourceHost 'to ' DestinationHost @'\.? Action: ' Firewall_Action @'\.' Rest_msg
       | extend SourceAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, SourceHost)
       | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, DestinationHost)
       | extend RemoteIP = case(not(ipv4_is_private(DestinationAddress)), DestinationAddress, not(ipv4_is_private(SourceAddress)), SourceAddress, "")
@@ -51,7 +51,7 @@ query: |
   | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
   | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated,
-  TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
+  TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Firewall_Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureFirewall_TimeGenerated, IPCustomEntity = TI_ipEntity, URLCustomEntity = Url
 entityMappings:
   - entityType: IP
@@ -62,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled


### PR DESCRIPTION
Fixes #

Sorry for not catching up this yesterday.

Some Indicators may have an "Action" column that collides with the Action column I specified for the Azure Firewall action.
