### PR TITLE
Update description in ssh_NewlyInternetExposed.yaml

### DIFF
--- a/Detections/Syslog/ssh_NewlyInternetExposed.yaml
+++ b/Detections/Syslog/ssh_NewlyInternetExposed.yaml
@@ -1,7 +1,7 @@
 id: 4915c713-ab38-432e-800b-8e2d46933de6
 name: New internet-exposed SSH endpoints
 description: |
-  'Looks for SSH endpoints with a history of sign-ins only from private IP addresses are accessed from a public IP address.'
+  'Looks for SSH endpoints that rarely are accessed from a public IP address, in comparison with their history of sign-ins from private IP addresses.'
 severity: Medium
 requiredDataConnectors:
   - connectorId: Syslog
@@ -63,5 +63,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
I think the description can be misleading

```Looks for SSH endpoints with a history of sign-ins only from private IP addresses are accessed from a public IP address.```

when this example can happen:

Each of the last 7 days an endpoint has been accessed privately, in such a way that the **average private accesses** per day are **14 or less**. If this endpoint is accessed publicly only once in the last day, this detection rule **will not trigger**.
