### PR TITLE
Fix playbook 'Watchlist-InformSubowner-IncidentTrigger' prerequisites

### DIFF
--- a/Playbooks/Watchlist-InformSubowner-IncidentTrigger/azuredeploy.json
+++ b/Playbooks/Watchlist-InformSubowner-IncidentTrigger/azuredeploy.json
@@ -4,7 +4,7 @@
 	"metadata": {
         "title": "Watchlists - Inform Subscription Owner", 
         "description": "Use Microsoft Sentinel watchlists and a playbook to contact the subscription owner of the affected resource automatically. This template uses the subscription owner level, but you can implement this solution for any specified resource owner.<br>[Learn more](https://docs.microsoft.com/azure/sentinel/automate-playbook-watchlist)",
-        "prerequisites": ["Create a Watchlists that this playbook will query","1.Create an input comma-separated value (CSV) file with the following columns: SubscriptionId, SubscriptionName, OwnerName, OwnerEmail, where each row represents a subscription in an Azure tenant.", "2. Upload the table to the Microsoft Sentinel Watchlist area. Make a note of the value you use as the Watchlist Alias, as you'll use it to query this watchlist from the playbook."],
+        "prerequisites": ["Create a Watchlist that this playbook will query: <br /> 1.Create an input comma-separated value (CSV) file with the following columns: SubscriptionId, SubscriptionName, OwnerName, OwnerEmail, where each row represents a subscription in an Azure tenant. <br /> 2. Upload the table to the Microsoft Sentinel Watchlist area. Make a note of the value you use as the Watchlist Alias, as you'll use it to query this watchlist from the playbook."],
         "lastUpdateTime": "2021-11-26T00:00:00.000Z", 
         "entities": ["AzureResource"], 
         "tags": ["Notification"], 


### PR DESCRIPTION
Change prerequisites to be a single item with custom formatting and line breaks, since having multiple items in prerequisites automatically adds line numbers in the portal