### PR TITLE
Update sample data ingest tool to use Monitor Query library

### DIFF
--- a/Tools/Sample-Data-Ingest-Tool/SampleDataIngestTool/Program.cs
+++ b/Tools/Sample-Data-Ingest-Tool/SampleDataIngestTool/Program.cs
@@ -15,7 +15,7 @@ namespace SampleDataIngestTool
         static string logName = "";
         // You can use an optional field to specify the timestamp from the data. If the time field is not specified, Azure Monitor assumes the time is the message ingestion time
         static string timeStampField = "";
-        static void Main()
+        static async Task Main()
         {
             // Get a list of Custom Log file names with their paths
             var files = GetFiles();
@@ -37,8 +37,8 @@ namespace SampleDataIngestTool
                 {
                     var fileName = file.Replace(dirPath, "");
 
-                    // Check if the file has been pushed to the Log Analytics
-                    bool result = laCheck.RunLAQuery(file);
+                    // Check if the file has been pushed to the Log Analytics workspace
+                    bool result = await laCheck.RunLAQuery(fileName);
                     if (result == true)
                     {
                         // Prompt user to choose to repush data

--- a/Tools/Sample-Data-Ingest-Tool/SampleDataIngestTool/SampleDataIngestTool.csproj
+++ b/Tools/Sample-Data-Ingest-Tool/SampleDataIngestTool/SampleDataIngestTool.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.OperationalInsights" Version="0.10.0-preview" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Monitor.Query" Version="1.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/Azure/Azure-Sentinel/issues/3670

Updates the tool to use the Azure Monitor Query client library. A dependency on `Newtonsoft.Json` also had to be added. Previously, this dependency came from the `Microsoft.Azure.OperationalInsights` package. Simplified and refactored the code where possible. Tested using the setup instructions at https://github.com/Azure/Azure-Sentinel/tree/master/Tools/Sample-Data-Ingest-Tool.