### PR TITLE
Create ServicePrincipalNameAssignedToUserAccount.yaml

### DIFF
--- a/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
+++ b/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
@@ -3,7 +3,7 @@ name: UserPrincipalNameAssignedToUserAccount
 description: |
   'This query identifies whether a Active Directory user object was assigned a user principal name which could indicate that an adversary is preparing for performing Kerberoasting. 
   This query checks for event id 5136 that the Object Class field is "user" and the LDAP Display Name is "servicePrincipalName".'
-severity: High
+severity: Medium
 requiredDataConnectors:
   - connectorId: SecurityEvents
     dataTypes:

--- a/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
+++ b/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
@@ -25,7 +25,7 @@ query: |
     | where AttributeLDAPDisplayName == "servicePrincipalName" and  ObjectClass == "user"
     | parse EventData with * 'ObjectDN">' ObjectDN "<" *
     | parse EventData with * 'AttributeValue">' AttributeValue "<" *
-    | project TimeGenerated, Computer, SubjectAccount, ObjectDN, AttributeValue
+    | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by Computer, SubjectAccount, ObjectDN, AttributeValue
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
+++ b/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
@@ -1,0 +1,38 @@
+id: 875d0eb1-883a-4191-bd0e-dbfdeb95a464
+name: UserPrincipalNameAssignedToUserAccount
+description: |
+  'This query identifies whether a Active Directory user object was assigned a user principal name which could indicate that an adversary is preparing for performing Kerberoasting. 
+  This query checks for event id 5136 that the Object Class field is "user" and the LDAP Display Name is "servicePrincipalName".'
+severity: High
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvent
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1134
+query: |
+SecurityEvent
+	| where EventID == 5136 
+    | parse EventData with * 'AttributeLDAPDisplayName">' AttributeLDAPDisplayName "<" *
+    | parse EventData with * 'ObjectClass">' ObjectClass "<" *
+    | parse EventData with * 'ObjectDN">' ObjectDN "<" *
+    | parse EventData with * 'AttributeValue">' AttributeValue "<" *
+    | where AttributeLDAPDisplayName == "servicePrincipalName" and  ObjectClass == "user"
+    | project TimeGenerated, Computer, SubjectAccount, ObjectDN, AttributeValue
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: SubjectAccount
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer
+version: 1.0.0
+kind: Scheduled

--- a/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
+++ b/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
@@ -1,7 +1,7 @@
 id: 875d0eb1-883a-4191-bd0e-dbfdeb95a464
-name: UserPrincipalNameAssignedToUserAccount
+name: ServicePrincipalNameAssignedToUserAccount
 description: |
-  'This query identifies whether a Active Directory user object was assigned a user principal name which could indicate that an adversary is preparing for performing Kerberoasting. 
+  'This query identifies whether a Active Directory user object was assigned a service principal name which could indicate that an adversary is preparing for performing Kerberoasting. 
   This query checks for event id 5136 that the Object Class field is "user" and the LDAP Display Name is "servicePrincipalName".
   Ref: https://thevivi.net/assets/docs/2019/theVIVI-AD-Security-Workshop_AfricaHackon2019.pdf'
 severity: Medium

--- a/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
+++ b/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
@@ -2,7 +2,8 @@ id: 875d0eb1-883a-4191-bd0e-dbfdeb95a464
 name: UserPrincipalNameAssignedToUserAccount
 description: |
   'This query identifies whether a Active Directory user object was assigned a user principal name which could indicate that an adversary is preparing for performing Kerberoasting. 
-  This query checks for event id 5136 that the Object Class field is "user" and the LDAP Display Name is "servicePrincipalName".'
+  This query checks for event id 5136 that the Object Class field is "user" and the LDAP Display Name is "servicePrincipalName".
+  Ref: https://thevivi.net/assets/docs/2019/theVIVI-AD-Security-Workshop_AfricaHackon2019.pdf'
 severity: Medium
 requiredDataConnectors:
   - connectorId: SecurityEvents
@@ -21,9 +22,9 @@ query: |
     | where EventID == 5136 
     | parse EventData with * 'AttributeLDAPDisplayName">' AttributeLDAPDisplayName "<" *
     | parse EventData with * 'ObjectClass">' ObjectClass "<" *
+    | where AttributeLDAPDisplayName == "servicePrincipalName" and  ObjectClass == "user"
     | parse EventData with * 'ObjectDN">' ObjectDN "<" *
     | parse EventData with * 'AttributeValue">' AttributeValue "<" *
-    | where AttributeLDAPDisplayName == "servicePrincipalName" and  ObjectClass == "user"
     | project TimeGenerated, Computer, SubjectAccount, ObjectDN, AttributeValue
 entityMappings:
   - entityType: Account

--- a/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
+++ b/Detections/SecurityEvent/UserPrincipalNameAssignedToUserAccount.yaml
@@ -17,8 +17,8 @@ tactics:
 relevantTechniques:
   - T1134
 query: |
-SecurityEvent
-	| where EventID == 5136 
+    SecurityEvent
+    | where EventID == 5136 
     | parse EventData with * 'AttributeLDAPDisplayName">' AttributeLDAPDisplayName "<" *
     | parse EventData with * 'ObjectClass">' ObjectClass "<" *
     | parse EventData with * 'ObjectDN">' ObjectDN "<" *


### PR DESCRIPTION
This query identifies whether a Active Directory user object was assigned a user principal name which could indicate that an adversary is preparing for performing Kerberoasting.

## Before submitting this PR please ensure that you have read the following sections and then completed the template below:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures, there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for UserPrincipalNameAssignedToUserAccount.yaml

   Reason for Change(s):
   - New schema used for UserPrincipalNameAssignedToUserAccount.yaml
   - Resolves ISSUE #1234

## After the submission has been made, please look at the Validation Checks:

> Check that the validations are passing and address any issues that are present. Let us know if you have tried fixing and need help.

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)

## PR Template

-----------------------------------------------------------------------------------------------------------
 **Description for the PR:**
  (Enter the description below)
This is a new detection that identifies whether a Active Directory user object was assigned a userprincipalname which could indicate that an adversary is preparing for performing Kerberoasting.

**Testing Completed:**
  Yes/ No : Yes

-----------------------------------------------------------------------------------------------------------