### PR TITLE
Add conditions in OfficeMailForwarding_hunting.yaml

### DIFF
--- a/Hunting Queries/OfficeActivity/OfficeMailForwarding_hunting.yaml
+++ b/Hunting Queries/OfficeActivity/OfficeMailForwarding_hunting.yaml
@@ -18,7 +18,7 @@ query: |
 
   OfficeActivity
   | where (Operation =~ "Set-Mailbox" and Parameters contains 'ForwardingSmtpAddress') 
-  or (Operation =~ 'New-InboxRule' and Parameters contains 'ForwardTo')
+  or (Operation in~ ('New-InboxRule','Set-InboxRule') and (Parameters contains 'ForwardTo' or Parameters contains 'RedirectTo'))
   | extend parsed=parse_json(Parameters)
   | extend fwdingDestination_initial = (iif(Operation=~"Set-Mailbox", tostring(parsed[1].Value), tostring(parsed[2].Value)))
   | where isnotempty(fwdingDestination_initial)


### PR DESCRIPTION
   Change(s):
   - Add conditions in OfficeMailForwarding_hunting.yaml

   Reason for Change(s):
   - The added operations might be of interest for the query.

 **Description for the PR:**
  I would like to add some conditions where emails can be forwarded to external domain addresses.
  
  ***This rule has another problem***, but I would not like to address it here. Parameters do not have always the same number of items, or in the same order, so this:
  
  ```| extend fwdingDestination_initial = (iif(Operation=~"Set-Mailbox", tostring(parsed[1].Value), tostring(parsed[2].Value)))```
  
  might not work for most tenants, the forwarding destination address is not always in the second or third element.
  
  Something like this can address this problem:
  
  ```yaml
| extend Properties = extract_all(@'Name\":\"(?P<key>\w+)\",\"Value\":\"(?P<value>[^\"]*)', dynamic(["key", "value"]), Parameters)
| mv-apply Properties on (summarize make_bag(pack(tostring(Properties[0]), Properties[1])))
| evaluate bag_unpack(bag_, columnsConflict='replace_source')
... column_ifexists("ForwardTo", "") ...
... column_ifexists("RedirectTo", "") ... 
... column_ifexists("DeliverToMailboxAndForward", "") ...
 
```
Please, feel free to change the query appropriately with this code if you consider it an improvement, in this PR, or another.

**Testing Completed:**
  Yes/ No : Yes


-----------------------------------------------------------------------------------------------------------