### PR TITLE
Corrects EntityMapping in ASim detection rule for Solarwinds

### DIFF
--- a/Detections/ASimFileEvent/imFileESolarWindsSunburstSupernova.yaml
+++ b/Detections/ASimFileEvent/imFileESolarWindsSunburstSupernova.yaml
@@ -29,7 +29,8 @@ query:  |
       timestamp = TimeGenerated,
       AccountCustomEntity = User, 
       HostCustomEntity = DvcHostname,
-      FileHashCustomEntity = TargetFileMD5
+      FileHashCustomEntity = TargetFileMD5,
+      AlgorithmCustomEntity = "MD5"
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -42,7 +43,7 @@ entityMappings:
   - entityType: FileHash
     fieldMappings:
       - identifier: Algorithm
-        columnName: TargetFileMD5
+        columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
 version: 1.0.1

--- a/Detections/ASimFileEvent/imFileESolarWindsSunburstSupernova.yaml
+++ b/Detections/ASimFileEvent/imFileESolarWindsSunburstSupernova.yaml
@@ -42,8 +42,8 @@ entityMappings:
   - entityType: FileHash
     fieldMappings:
       - identifier: Algorithm
-        columnName: MD5
+        columnName: TargetFileMD5
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
Detection rule `SUNBURST and SUPERNOVA backdoor hashes (Normalized File Events)` uses non-normalized field (MD5) in entity mappings breaking rule deployment.
   
   Change(s):
   - This PR makes the rule use the correct field as used in the imFileEvent parser (TargetFileMD5).

   Reason for Change(s):
   - Incorrect entity field breaks deployment

   Testing Completed:
   - Yes
