### PR TITLE
Fix some Domain Entities not being checked in DomainEntity_SecurityAlert.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_SecurityAlert.yaml
@@ -47,25 +47,27 @@ query: |
         | extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
         | where MSTI == false
         //Extract domain patterns from message
-        | extend domain = extract("(([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,})", 1, tolower(Entities))
-        | where isnotempty(domain)
+        | extend domain = todynamic(dynamic_to_json(extract_all(@"(((xn--)?[a-z0-9\-]+\.)+([a-z]+|(xn--[a-z0-9]+)))", dynamic([1]), tolower(Entities))))
+        | mv-expand domain
+        | extend domain = tostring(domain[0])
         | extend parts = split(domain, '.')
         //Split out the TLD
         | extend tld = parts[(array_length(parts)-1)]
         //Validate parsed domain by checking if the TLD is in the list of TLDs in our threat feed
         | where tld in~ (list_tlds)
         // Converting Entities into dynamic data type and use mv-expand to unpack the array
-        | extend EntitiesDynamicArray = parse_json(Entities) | mv-expand EntitiesDynamicArray
-        // Parsing relevant entity column extract hostname and IP address
-        | extend EntityType = tostring(parse_json(EntitiesDynamicArray).Type), EntityAddress = tostring(EntitiesDynamicArray.Address), EntityHostName = tostring(EntitiesDynamicArray.HostName)
-        | extend HostName = iif(EntityType == 'host', EntityHostName, '')
-        | extend IP_addr = iif(EntityType == 'ip', EntityAddress, '')
+        | extend EntitiesDynamicArray = parse_json(Entities)
+        | mv-apply EntitiesDynamicArray on
+            (summarize
+                HostName = take_anyif(tostring(EntitiesDynamicArray.HostName), EntitiesDynamicArray.Type == "host"),
+                IP_addr = take_anyif(tostring(EntitiesDynamicArray.Address), EntitiesDynamicArray.Type == "ip")
+        )
         | extend Alert_TimeGenerated = TimeGenerated
         | extend Alert_Description = Description
     ) on $left.DomainName==$right.domain
     | where Alert_TimeGenerated < ExpirationDateTime
     | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId, AlertName
-    | project Alert_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, AlertName, Alert_Description, ProviderName, AlertSeverity, ConfidenceLevel, HostName, IP_addr, Url
+    | project Alert_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, DomainName, AlertName, Alert_Description, ProviderName, AlertSeverity, ConfidenceLevel, HostName, IP_addr, Url, Entities
     | extend timestamp = Alert_TimeGenerated, HostCustomEntity = HostName, IPCustomEntity = IP_addr, URLCustomEntity = Url
 entityMappings:
   - entityType: Host
@@ -80,5 +82,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   1. Check all possible domains in Entities, instead of just one per SecurityAlert, I have lost alerts because of this.
   2. Take just one hostname and one address from each alert, instead of expanding their entities (useless with innerunique kind).
   3. Extend the domain name regex to accept punycode.
   4. Add the domain name and entities in the projected columns.

   Reason for Change(s):
   1. An alert can have multiple Url Entities. Some analytic rules integrate all events in one alert, or create an alert for each event.
   2. The join kind is innerunique, so which Hostname or Address end up in the results cannot be controlled.
   3. There are punycode top level domains, which were not being considered in the query.
   4. Without them you don't know what are you looking for.

   Testing Completed: Yes but Need Help

  I don't have a good dataset to check this query against, please, could you check it?

  I have a problem with ```extract_all```. If I don't ```todynamic(dynamic_to_json(``` the results, expanding them sometimes returns a dynamic and other times a string.
_________________________________
**The same thing happens with https://github.com/Azure/Azure-Sentinel/blob/master/Detections/ThreatIntelligenceIndicator/URLEntity_SecurityAlerts.yaml**

Does not happen with **https://github.com/Azure/Azure-Sentinel/blob/master/Detections/ThreatIntelligenceIndicator/EmailEntity_SecurityAlert.yaml**

I think these 3 queries should try to be more common or be normalized to a more similar pattern.

Also, there could be a "IPEntity_SecurityAlert.yaml"