### PR TITLE
Update Log4J_IPIOC_Dec112021.yaml

### DIFF
--- a/Detections/MultipleDataSources/Log4J_IPIOC_Dec112021.yaml
+++ b/Detections/MultipleDataSources/Log4J_IPIOC_Dec112021.yaml
@@ -165,6 +165,7 @@ query:  |
   ( 
   DeviceNetworkEvents
   | where RemoteIP in (ipMatch)
+  | where ActionType == "InboundConnectionAccepted"
   | project TimeGenerated, RemoteIP, DeviceName, Type
   | extend timestamp = TimeGenerated, IPCustomEntity = RemoteIP, HostCustomEntity = DeviceName
   ),
@@ -203,5 +204,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled


### PR DESCRIPTION
This change reduces false positives in the DeviceNetworkEvents table by checking only for inbound connections, not outbound.

-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Check for ActionType of InboundConnectionAccepted to reduce false positives from outbound connections from clients
   - Increment version

   Reason for Change(s):
   - Many false positives

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes

_Note: If updating a detection, you must update the version field._

> After the submission has been made, please look at the Validation Checks.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
