### PR TITLE
Modified AzureDeploy to remove unnecessary concat

### DIFF
--- a/DataConnectors/O365 Data/azuredeploy.json
+++ b/DataConnectors/O365 Data/azuredeploy.json
@@ -243,7 +243,7 @@
                         "contentTypes": "[parameters('contentTypes')]",
                         "recordTypes": "[parameters('recordTypes')]",
                         "workspaceID": "[parameters('workspaceID')]",
-                        "workspaceKey": "[concat('@Microsoft.KeyVault(SecretUri=https://', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('KeyVaultName'), 'workspaceKey')).SecretUriWithVersion, ')')]",
+                        "workspaceKey": "[concat('@Microsoft.KeyVault(SecretUri=', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('KeyVaultName'), 'workspaceKey')).SecretUriWithVersion, ')')]",
                         "WEBSITE_RUN_FROM_PACKAGE": "https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/O365%20Data/O365APItoAS-Template.zip?raw=true",
                         "customLogName": "O365"
                     }


### PR DESCRIPTION
The concat's on workspaceKey and clientSecret have unnecessary "https://" in the uri which results in a duplication when combined with the SecretUriWithVersion variable.

-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Removed unnecessary "https://" in concat strings for workspaceKey and clientSecret variables

   Reason for Change(s):
   - Value is already supplied by the call to SecretUriWithVersion variable.

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - No


-----------------------------------------------------------------------------------------------------------
