### PR TITLE
Use of param domain_has_any

### DIFF
--- a/Detections/MultipleDataSources/ExchangeServerVulnerabilitiesMarch2021IoCs.yaml
+++ b/Detections/MultipleDataSources/ExchangeServerVulnerabilitiesMarch2021IoCs.yaml
@@ -165,5 +165,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.5.0
+version: 1.6.0
 kind: Scheduled

--- a/Detections/MultipleDataSources/ExchangeServerVulnerabilitiesMarch2021IoCs.yaml
+++ b/Detections/MultipleDataSources/ExchangeServerVulnerabilitiesMarch2021IoCs.yaml
@@ -58,6 +58,7 @@ query: |
   let sha256s = (iocs | where Type =~ "sha256" | project IoC);
   let ips = (iocs | where Type =~ "ip" | project IoC);
   let domains = (iocs | where Type =~ "domainname" | project IoC);
+  let dyndomains = todynamic(toscalar((domains | summarize make_set(IoC))));
   union isfuzzy=true
   (SecurityEvent
   | where EventID == 4663
@@ -144,7 +145,7 @@ query: |
   | extend timestamp = TimeGenerated, IPCustomEntity = ClientIP, HostCustomEntity = Computer
   ),
   (
-  _Im_Dns(domain_has_any=domains)
+  _Im_Dns(domain_has_any=dyndomains)
   | extend timestamp = TimeGenerated, IPCustomEntity = SrcIpAddr, HostCustomEntity = Dvc
   )
 entityMappings:


### PR DESCRIPTION
  
   Change(s):
   - Modified the parameter passed to dynamic parameter domain_has_any

   Reason for Change(s):
   - Syntax error

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

