### PR TITLE
Corrects Algorithm Entity values for Solarwinds scheduled alert rules.

### DIFF
--- a/Detections/ASimProcess/imProcess_SolarWinds_SUNBURST_Process-IOCs.yaml
+++ b/Detections/ASimProcess/imProcess_SolarWinds_SUNBURST_Process-IOCs.yaml
@@ -32,6 +32,7 @@ query:  |
       timestamp = TimeGenerated,
       AccountCustomEntity = ActorUsername,
       HostCustomEntity = User,
+      AlgorithmCustomEntity = "MD5",
       FileHashCustomEntity = TargetProcessMD5 // Change to *hash* once implemented
 entityMappings:
   - entityType: Account
@@ -45,8 +46,8 @@ entityMappings:
   - entityType: FileHash
     fieldMappings:
       - identifier: Algorithm
-        columnName: MD5
+        columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/DeviceFileEvents/SolarWinds_SUNBURST_&_SUPERNOVA_File-IOCs.yaml
+++ b/Detections/DeviceFileEvents/SolarWinds_SUNBURST_&_SUPERNOVA_File-IOCs.yaml
@@ -27,6 +27,7 @@ query:  |
       timestamp = TimeGenerated,
       AccountCustomEntity = iff(isnotempty(InitiatingProcessAccountUpn), InitiatingProcessAccountUpn, InitiatingProcessAccountName),
       HostCustomEntity = DeviceName,
+      AlgorithmCustomEntity = "MD5",
       FileHashCustomEntity = MD5
 entityMappings:
   - entityType: Account
@@ -40,8 +41,8 @@ entityMappings:
   - entityType: FileHash
     fieldMappings:
       - identifier: Algorithm
-        columnName: MD5
+        columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/DeviceProcessEvents/SolarWinds_SUNBURST_Process-IOCs.yaml
+++ b/Detections/DeviceProcessEvents/SolarWinds_SUNBURST_Process-IOCs.yaml
@@ -30,6 +30,7 @@ query:  |
       timestamp = TimeGenerated,
       AccountCustomEntity = iff(isnotempty(InitiatingProcessAccountUpn), InitiatingProcessAccountUpn, InitiatingProcessAccountName),
       HostCustomEntity = DeviceName,
+      AlgorithmCustomEntity = "MD5",
       FileHashCustomEntity = MD5
 entityMappings:
   - entityType: Account
@@ -43,8 +44,8 @@ entityMappings:
   - entityType: FileHash
     fieldMappings:
       - identifier: Algorithm
-        columnName: MD5
+        columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
  
   Change(s):
   - Updated syntax for:
     - Detections/ASimProcess/imProcess_SolarWinds_SUNBURST_Process-IOCs.yaml
     - Detections/DeviceFileEvents/SolarWinds_SUNBURST_&_SUPERNOVA_File-IOCs.yaml
     - Detections/DeviceProcessEvents/SolarWinds_SUNBURST_Process-IOCs.yaml

   Reason for Change(s):
   - Entity mappings were pointing to a field instead of one of allowed string.
     See also: https://docs.microsoft.com/en-us/azure/sentinel/entities-reference#file-hash

   Testing Completed:
   - Need Help
