### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,13 +9,13 @@
 
 /.script/ @oshvartz
 /ASIM/ @oshezaf @YaronFruchtmann
-/DataConnectors/ @NoamLandress @shschwar @ashishsyal
+/DataConnectors/ @NoamLandress @shschwar @ashishsyal @preetikr
 /Detections/ @timbMSFT @juliango2100 @oshezaf @aprakash13 @ashwin-patil @petebryan @shainw @thmcelro
 /Hunting%20Queries/ @timbMSFT @aprakash13 @ashwin-patil @petebryan @shainw @thmcelro
 /Notebooks/ @ianhelle @petebryan @ashwin-patil
-/Parsers/ @oshezaf @ashishsyal @YaronFruchtmann @aprakash13 @ashwin-patil @petebryan @shainw
+/Parsers/ @oshezaf @ashishsyal @YaronFruchtmann @aprakash13 @ashwin-patil @petebryan @shainw @preetikr
 /Playbooks/ @dicolanl @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir
 /Workbooks/ @nazang @alexkarabas @aprakash13 @ashwin-patil @petebryan @shainw @thmcelro
-/Solutions/ @ashishsyal
-/Solutions/HoneyTokens @haneuvir
-/Solutions/SAP @udidekel @tamirkopitz
+/Solutions/ @ashishsyal @preetikr
+/Solutions/HoneyTokens @haneuvir @ashishsyal @preetikr
+/Solutions/SAP @udidekel @tamirkopitz @ashishsyal @preetikr


### PR DESCRIPTION
Change(s):
   - Adding Preeti to proper folders

Reason for Change(s):
   - Due to how codeowners works, global code owners must be part of defined folders to show up as reviewer in PR

Testing Completed:
   - Yes

Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
