### PR TITLE
Fixing extra spaces after and before curly braces.

### DIFF
--- a/Detections/AWSGuardDuty/AWS_GuardDuty_template.yaml
+++ b/Detections/AWSGuardDuty/AWS_GuardDuty_template.yaml
@@ -23,7 +23,7 @@ query:
   | project-away TimeGenerated, TenantId, SchemaVersion, Region, Partition
   | extend Severity= iff(Severity between (7.0..8.9),"High",iff(Severity between
   (4.0..6.9), "Medium", iff(Severity between (1.0..3.9),"Low","Unknown")))
-version: 1.0.0
+version: 1.0.1
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/AWSGuardDuty/AWS_GuardDuty_template.yaml
+++ b/Detections/AWSGuardDuty/AWS_GuardDuty_template.yaml
@@ -36,8 +36,8 @@ customDetails:
   ResourceTypeAffected: ResourceTypeAffected
   UniqueFindingId: UniqueFindingId
 alertDetailsOverride:
-  alertDisplayNameFormat: '{{Title}}'
-  alertDescriptionFormat: '{{Description}}'
+  alertDisplayNameFormat: {{Title}}
+  alertDescriptionFormat: {{Description}}
   alertTacticsColumnName: ThreatPurpose
   alertSeverityColumnName: Severity
 kind: Scheduled

--- a/Detections/AWSGuardDuty/AWS_GuardDuty_template.yaml
+++ b/Detections/AWSGuardDuty/AWS_GuardDuty_template.yaml
@@ -23,7 +23,7 @@ query:
   | project-away TimeGenerated, TenantId, SchemaVersion, Region, Partition
   | extend Severity= iff(Severity between (7.0..8.9),"High",iff(Severity between
   (4.0..6.9), "Medium", iff(Severity between (1.0..3.9),"Low","Unknown")))
-version: 1.0.1
+version: 1.0.0
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -36,8 +36,8 @@ customDetails:
   ResourceTypeAffected: ResourceTypeAffected
   UniqueFindingId: UniqueFindingId
 alertDetailsOverride:
-  alertDisplayNameFormat: {{Title}}
-  alertDescriptionFormat: {{Description}}
+  alertDisplayNameFormat: '{{Title}}'
+  alertDescriptionFormat: '{{Description}}'
   alertTacticsColumnName: ThreatPurpose
   alertSeverityColumnName: Severity
 kind: Scheduled

--- a/Detections/VectraAI/VectraDetect-Account-by-Severity.yaml
+++ b/Detections/VectraAI/VectraDetect-Account-by-Severity.yaml
@@ -63,8 +63,8 @@ entityMappings:
       - identifier: Url
         columnName: URLCustomEntity
 alertDetailsOverride:
-  alertDisplayNameFormat: Vectra AI Detect - Account {{ sacccount }} reaches {{ level }} severity
-  alertDescriptionFormat: The account {{ saccount }} is in the {{ level }} quadrant. Pivot to Detect UI with {{ vectra_URL }}
+  alertDisplayNameFormat: Vectra AI Detect - Account {{sacccount}} reaches {{level}} severity
+  alertDescriptionFormat: The account {{saccount}} is in the {{level}} quadrant. Pivot to Detect UI with {{vectra_URL}}
   alertTacticsColumnName: null
   alertSeverityColumnName: Severity
 version: 1.0.0

--- a/Detections/VectraAI/VectraDetect-Account-by-Severity.yaml
+++ b/Detections/VectraAI/VectraDetect-Account-by-Severity.yaml
@@ -67,5 +67,5 @@ alertDetailsOverride:
   alertDescriptionFormat: The account {{saccount}} is in the {{level}} quadrant. Pivot to Detect UI with {{vectra_URL}}
   alertTacticsColumnName: null
   alertSeverityColumnName: Severity
-version: 1.0.0
+version: 1.0.1
 kind: scheduled

--- a/Detections/VectraAI/VectraDetect-HighSeverityDetection-by-Tactics.yaml
+++ b/Detections/VectraAI/VectraDetect-HighSeverityDetection-by-Tactics.yaml
@@ -77,5 +77,5 @@ alertDetailsOverride:
   alertDescriptionFormat: Malicious behavior {{Activity}} has been detected for entity {{source_entity}}. Pivot to Detect UI with {{vectra_URL}}
   alertTacticsColumnName: Tactic
   alertSeverityColumnName: Severity
-version: 1.0.0
+version: 1.0.1
 kind: scheduled

--- a/Detections/VectraAI/VectraDetect-HighSeverityDetection-by-Tactics.yaml
+++ b/Detections/VectraAI/VectraDetect-HighSeverityDetection-by-Tactics.yaml
@@ -73,8 +73,8 @@ entityMappings:
       - identifier: Url
         columnName: URLCustomEntity
 alertDetailsOverride:
-  alertDisplayNameFormat: Vectra AI Detect - High Severity behavior for {{ source_entity }}
-  alertDescriptionFormat: Malicious behavior {{ Activity }} has been detected for entity {{ source_entity }}. Pivot to Detect UI with {{ vectra_URL }}
+  alertDisplayNameFormat: Vectra AI Detect - High Severity behavior for {{source_entity}}
+  alertDescriptionFormat: Malicious behavior {{Activity}} has been detected for entity {{source_entity}}. Pivot to Detect UI with {{vectra_URL}}
   alertTacticsColumnName: Tactic
   alertSeverityColumnName: Severity
 version: 1.0.0

--- a/Detections/VectraAI/VectraDetect-Host-by-Severity.yaml
+++ b/Detections/VectraAI/VectraDetect-Host-by-Severity.yaml
@@ -67,5 +67,5 @@ alertDetailsOverride:
   alertDescriptionFormat: The host {{SourceHostName}} is in the {{level}} quadrant. Pivot to Detect UI with {{vectra_URL}}
   alertTacticsColumnName: null
   alertSeverityColumnName: Severity
-version: 1.0.0
+version: 1.0.1
 kind: scheduled

--- a/Detections/VectraAI/VectraDetect-Host-by-Severity.yaml
+++ b/Detections/VectraAI/VectraDetect-Host-by-Severity.yaml
@@ -63,8 +63,8 @@ entityMappings:
       - identifier: Url
         columnName: URLCustomEntity
 alertDetailsOverride:
-  alertDisplayNameFormat: Vectra AI Detect - Host {{ SourceHostName }} reaches {{ level }} severity
-  alertDescriptionFormat: The host {{ SourceHostName }} is in the {{ level }} quadrant. Pivot to Detect UI with {{ vectra_URL }}
+  alertDisplayNameFormat: Vectra AI Detect - Host {{SourceHostName}} reaches {{level}} severity
+  alertDescriptionFormat: The host {{SourceHostName}} is in the {{level}} quadrant. Pivot to Detect UI with {{vectra_URL}}
   alertTacticsColumnName: null
   alertSeverityColumnName: Severity
 version: 1.0.0

--- a/Solutions/ARGOSCloudSecurity/Analytic Rules/ExploitableSecurityIssues.yaml
+++ b/Solutions/ARGOSCloudSecurity/Analytic Rules/ExploitableSecurityIssues.yaml
@@ -6,7 +6,7 @@ requiredDataConnectors:
     dataTypes:
       - ARGOS_CL
 kind: Scheduled
-version: 1.0.0
+version: 1.0.1
 severity: High
 query: |
   ARGOS_CL | where exploitable_b

--- a/Solutions/ARGOSCloudSecurity/Analytic Rules/ExploitableSecurityIssues.yaml
+++ b/Solutions/ARGOSCloudSecurity/Analytic Rules/ExploitableSecurityIssues.yaml
@@ -33,7 +33,7 @@ incidentConfiguration:
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 alertDetailsOverride:
-  alertDisplayNameFormat: New exploitable cloud resource - {{ name_s }} - {{ ruleId_s }}
+  alertDisplayNameFormat: New exploitable cloud resource - {{name_s}} - {{ruleId_s}}
 customDetails:
 entityMappings:
 - entityType: AzureResource


### PR DESCRIPTION
-----------------------------------------------------------------------------------------------------------
   
   Change(s):
   - Updated detections that were using alert details overrides with added spaces inside of curly braces and single quotes

   Reason for Change(s):
   - Extra spaces break the variable mapping
   - single quotes come thru in the alertname/alertdetails

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
 
-----------------------------------------------------------------------------------------------------------
