### PR TITLE
Fixing null comparison

### DIFF
--- a/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionPaloAltoCEF.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionPaloAltoCEF.yaml
@@ -61,15 +61,15 @@ ParserQuery: |
     CommonSecurityLog | where not(disabled)
       | where DeviceVendor=="Palo Alto Networks" and (Activity=="TRAFFIC")
       /// Prefilterring:
-      | where (starttime==datetime(null) or TimeGenerated>=starttime)
-      and (endtime==datetime(null) or TimeGenerated<=endtime)
+      | where (isnull(starttime) or TimeGenerated>=starttime)
+      and     (isnull(endtime) or TimeGenerated<=endtime)
       and (array_length(srcipaddr_has_any_prefix)==0 
                 or has_any_ipv4_prefix(SourceIP,srcipaddr_has_any_prefix)
                 )
       and (array_length(dstipaddr_has_any_prefix)==0 
                 or has_any_ipv4_prefix(DestinationIP,dstipaddr_has_any_prefix)
                 )
-      and (dstportnumber==int(null) or DestinationPort==dstportnumber)
+      and (isnull(dstportnumber) or DestinationPort==dstportnumber)
       and (array_length(hostname_has_any)==0)
         // dvcaction - post filterring
         and (eventresult=="*" or (DeviceAction=="allow" and eventresult=="Success") or (eventresult=="Failure"))


### PR DESCRIPTION
   
   Change(s):
   - Updated syntax for null comparison on PAN parser.

   Reason for Change(s):
   - in kusto one datetime(null) DOES NOT EQ another datetime(null). one must use isnull(parameter)
