### PR TITLE
[TrendMicro] Roll back deploy script name for aka.ms url.

### DIFF
--- a/DataConnectors/Trend Micro/azuredeploy_TrendMicroVisionOne_API_FunctionApp.json
+++ b/DataConnectors/Trend Micro/azuredeploy_TrendMicroVisionOne_API_FunctionApp.json
@@ -222,7 +222,7 @@
                         "workspaceKey": "[parameters('workspaceKey')]",
                         "apiTokens": "[parameters('apiTokens')]",
                         "regionCode": "[parameters('regionCode')]",
-                        "WEBSITE_RUN_FROM_PACKAGE": "https://storageyx4ebkako5tma.blob.core.windows.net/connector-file/AzureFunctionTrendMicroXDR.zip"
+                        "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinel-trendmicroxdr-functionapp"
                     }
                 }
             ]


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated azuredeploy_TrendMicroVisionOne_API_FunctionApp.json file name.

   Reason for Change(s):
   - Since aka.me point to old naming. Roll back to old file name.

   Version Updated:
   - No
  
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes