### PR TITLE
Update FirstAppOrServicePrincipalCredential.yaml

### DIFF
--- a/Detections/AuditLogs/FirstAppOrServicePrincipalCredential.yaml
+++ b/Detections/AuditLogs/FirstAppOrServicePrincipalCredential.yaml
@@ -35,6 +35,7 @@ query: |
   | extend new_value_set = parse_json(tostring(keyEvents.newValue))
   | extend old_value_set = parse_json(tostring(keyEvents.oldValue))
   | where old_value_set == "[]"
+  | mv-expand new_value_set
   | parse new_value_set with * "KeyIdentifier=" keyIdentifier:string ",KeyType=" keyType:string ",KeyUsage=" keyUsage:string ",DisplayName=" keyDisplayName:string "]" *
   | where keyUsage == "Verify"  or keyUsage == ""
   | extend UserAgent = iff(AdditionalDetails[0].key == "User-Agent",tostring(AdditionalDetails[0].value),"")
@@ -54,5 +55,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled


### PR DESCRIPTION
new_value_set contains multiple values, therefore i used mv-expand. 
bumped version to 1.1.1

   Required items, please complete
   
   Change(s):
   - Splitted new_value_set with mv-expand

   Reason for Change(s):
   - new_value_set had 2 records KeyUsage: Sign and Verify, the parse only returned Sign and the query did not gave the expected result

   Version Updated:
   - Yes (1.1.1)

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes