### PR TITLE
Fixes for ASimAuthenticationMicrosoftWindowsEvent

### DIFF
--- a/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
@@ -107,8 +107,8 @@ ParserQuery: |
           | project-rename 
               TargetDvcHostname = Computer
           // , TargetUserType=AccountType - no AccountType in windowsEvents
-              , EventOriginalUid = EventOriginId          
-          | extend EventOriginId=EventID | project-away EventID
+              , EventOriginalUid=EventOriginId          
+              , EventOriginId=EventID
           | extend  EventCount=int(1)
                   , EventSchemaVersion='0.1.0'
                   , ActorUserIdType='SID'
@@ -147,7 +147,7 @@ ParserQuery: |
        , EventOriginalUid = EventOriginId
        , LogonProtocol=AuthenticationPackageName
        , SrcDvcIpAddr=IpAddress
-    | extend EventOriginId=EventID | project-away EventID 
+       , EventOriginId=EventID
     | extend EventResult = iff(EventOriginId == 4625, 'Failure', 'Success')
       , EventCount=int(1)
       , EventSchemaVersion='0.1.0'

--- a/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
@@ -119,8 +119,8 @@ ParserQuery: |
                   , EventStartTime =TimeGenerated
                   , EventEndTime=TimeGenerated
                   , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')                  
-                  , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )                  
-                  , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
+                  , ActorUsernameType= iff(EventData.SubjectDomainName in ('-',''),'Simple', 'Windows' )                  
+                  , TargetUsernameType=iff(TargetDomainName in ('-',''), 'Simple', 'Windows')
                   , SrcDvcOs = 'Windows'
                   , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
           | lookup LogonStatus on EventStatus
@@ -158,8 +158,8 @@ ParserQuery: |
       , EventStartTime =TimeGenerated
       , EventEndTime=TimeGenerated
       , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
-      , ActorUsername = iff (SubjectDomainName == '-', SubjectUserName, SubjectAccount)
-      , ActorUsernameType= iff(SubjectDomainName == '-','Simple', 'Windows' )
+      , ActorUsername = iff (SubjectDomainName in ('-',''), SubjectUserName, SubjectAccount)
+      , ActorUsernameType= iff(SubjectDomainName in ('-',''), 'Simple', 'Windows' )
       , TargetUsername = iff (TargetDomainName in ('-',''), trim(@'\\',TargetUserName), trim(@'\\',TargetAccount))
       , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
       , SrcDvcOs = 'Windows'

--- a/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
@@ -110,7 +110,7 @@ ParserQuery: |
               TargetDvcHostname = Computer
           // , TargetUserType=AccountType - no AccountType in windowsEvents
               , EventOriginalUid=EventOriginId          
-              , EventOriginId=EventID
+              , EventOriginalType=EventID
           | extend  EventCount=int(1)
                   , EventSchemaVersion='0.1.0'
                   , ActorUserIdType='SID'
@@ -147,7 +147,7 @@ ParserQuery: |
        , EventOriginalUid = EventOriginId
        , LogonProtocol=AuthenticationPackageName
        , SrcDvcIpAddr=IpAddress
-       , EventOriginId=EventID
+       , EventOriginalType=EventID
     | extend EventResult = iff(EventOriginId == 4625, 'Failure', 'Success')
       , EventCount=int(1)
       , EventSchemaVersion='0.1.0'

--- a/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
@@ -89,14 +89,12 @@ ParserQuery: |
                       ActingProcessId = tostring(toint(EventData.ProcessId)),
                       ActingProcessName = tostring(EventData.ProcessName),
                       Status = tostring(EventData.Status),
-                      ActorSessionId = tostring(EventData.SubjectLogonId),
-                      ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))),
+                      ActorSessionId = tostring(EventData.SubjectLogonId),                      
                       ActorUserId = tostring(EventData.SubjectUserSid),
                       SubStatus = tostring(EventData.SubStatus),
                       TargetDomainName = tostring(EventData.TargetDomainName),
                       TargetSessionId = tostring(EventData.TargetLogonId),
-                      TargetUserId = tostring(EventData.TargetUserSid),
-                      TargetUsername = tostring(iff (EventData.TargetDomainName == '-', EventData.TargetUserName, strcat(EventData.TargetDomainName, @"\" , EventData.TargetUserName))),
+                      TargetUserId = tostring(EventData.TargetUserSid),                      
                       SrcDvcHostname = tostring(EventData.WorkstationName),
                       EventProduct = "Security Events"
           | extend EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
@@ -109,8 +107,8 @@ ParserQuery: |
           | project-rename 
               TargetDvcHostname = Computer
           // , TargetUserType=AccountType - no AccountType in windowsEvents
-          // , EventOriginalUid = EventOriginId - no EventOriginalId in WindowsEvents
-          , EventOriginId=EventID
+              , EventOriginalUid = EventOriginId          
+          | extend EventOriginId=EventID | project-away EventID
           | extend  EventCount=int(1)
                   , EventSchemaVersion='0.1.0'
                   , ActorUserIdType='SID'
@@ -119,10 +117,10 @@ ParserQuery: |
                   , EventStartTime =TimeGenerated
                   , EventEndTime=TimeGenerated
                   , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
-                  , ActorUsername = tostring(EventData.SubjectUserName)
+                  , ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName)))
                   , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )
-                  , TargetUsername = tostring(EventData.TargetUsername)
-                  , TargetUsernameType=iff (TargetDomainName == '-', 'Simple', 'Windows')
+                  , TargetUsername = tostring(iff (EventData.TargetDomainName in ('-',''), EventData.TargetUserName, strcat(EventData.TargetDomainName, @"\" , EventData.TargetUserName)))
+                  , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
                   , SrcDvcOs = 'Windows'
                   , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
           | lookup LogonStatus on EventStatus

--- a/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationMicrosoftWindowsEvent.yaml
@@ -89,12 +89,14 @@ ParserQuery: |
                       ActingProcessId = tostring(toint(EventData.ProcessId)),
                       ActingProcessName = tostring(EventData.ProcessName),
                       Status = tostring(EventData.Status),
-                      ActorSessionId = tostring(EventData.SubjectLogonId),                      
+                      ActorSessionId = tostring(EventData.SubjectLogonId),
+                      ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))),
                       ActorUserId = tostring(EventData.SubjectUserSid),
                       SubStatus = tostring(EventData.SubStatus),
                       TargetDomainName = tostring(EventData.TargetDomainName),
                       TargetSessionId = tostring(EventData.TargetLogonId),
-                      TargetUserId = tostring(EventData.TargetUserSid),                      
+                      TargetUserId = tostring(EventData.TargetUserSid),
+                      TargetUsername = tostring(iff (EventData.TargetDomainName in ('-',''), EventData.TargetUserName, strcat(EventData.TargetDomainName, @"\" , EventData.TargetUserName))),
                       SrcDvcHostname = tostring(EventData.WorkstationName),
                       EventProduct = "Security Events"
           | extend EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
@@ -116,10 +118,8 @@ ParserQuery: |
                   , EventVendor='Microsoft'  
                   , EventStartTime =TimeGenerated
                   , EventEndTime=TimeGenerated
-                  , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
-                  , ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName)))
-                  , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )
-                  , TargetUsername = tostring(iff (EventData.TargetDomainName in ('-',''), EventData.TargetUserName, strcat(EventData.TargetDomainName, @"\" , EventData.TargetUserName)))
+                  , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')                  
+                  , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )                  
                   , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
                   , SrcDvcOs = 'Windows'
                   , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
@@ -160,8 +160,8 @@ ParserQuery: |
       , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
       , ActorUsername = iff (SubjectDomainName == '-', SubjectUserName, SubjectAccount)
       , ActorUsernameType= iff(SubjectDomainName == '-','Simple', 'Windows' )
-      , TargetUsername = iff (TargetDomainName == '-', trim(@'\\',TargetUserName), trim(@'\\',TargetAccount))
-      , TargetUsernameType=iff (TargetDomainName == '-', 'Simple', 'Windows')
+      , TargetUsername = iff (TargetDomainName in ('-',''), trim(@'\\',TargetUserName), trim(@'\\',TargetAccount))
+      , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
       , SrcDvcOs = 'Windows'
       , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
     | lookup LogonStatus on EventStatus

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
@@ -115,7 +115,7 @@ ParserQuery: |
                       TargetDomainName = tostring(EventData.TargetDomainName),
                       TargetSessionId = tostring(EventData.TargetLogonId),
                       TargetUserId = tostring(EventData.TargetUserSid),
-                      TargetUsername = tostring(iff (EventData.TargetDomainName == '-', EventData.TargetUserName, strcat(EventData.TargetDomainName, @"\" , EventData.TargetUserName)))
+                      TargetUsername = tostring(iff (EventData.TargetDomainName in ('-',''), EventData.TargetUserName, strcat(EventData.TargetDomainName, @"\" , EventData.TargetUserName)))
           // ***************      <Postfilterring>  **********************************
           | where (targetusername_has=='*' or TargetUsername has targetusername_has)
           // ***************      <Postfilterring>  ********************************** 
@@ -141,11 +141,9 @@ ParserQuery: |
                   , EventVendor='Microsoft'  
                   , EventStartTime =TimeGenerated
                   , EventEndTime=TimeGenerated
-                  , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
-                  , ActorUsername = tostring(EventData.SubjectUserName)
-                  , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )
-                  , TargetUsername = tostring(EventData.TargetUsername)
-                  , TargetUsernameType=iff (TargetDomainName == '-', 'Simple', 'Windows')
+                  , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')                  
+                  , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )                  
+                  , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
                   , SrcDvcOs = 'Windows'
                   , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
           | lookup LogonStatus on EventStatus
@@ -195,8 +193,8 @@ ParserQuery: |
       , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
       , ActorUsername = iff (SubjectDomainName == '-', SubjectUserName, SubjectAccount)
       , ActorUsernameType= iff(SubjectDomainName == '-','Simple', 'Windows' )
-      , TargetUsername = iff (TargetDomainName == '-', trim(@'\\',TargetUserName), trim(@'\\',TargetAccount))
-      , TargetUsernameType=iff (TargetDomainName == '-', 'Simple', 'Windows')
+      , TargetUsername = iff (TargetDomainName in ('-',''), trim(@'\\',TargetUserName), trim(@'\\',TargetAccount))
+      , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
       , SrcDvcOs = 'Windows'
       , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
     | lookup LogonStatus on EventStatus

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
@@ -132,8 +132,8 @@ ParserQuery: |
           | project-rename 
               TargetDvcHostname = Computer
           // , TargetUserType=AccountType - no AccountType in windowsEvents
-          // , EventOriginalUid = EventOriginId - no EventOriginalId in WindowsEvents
-          , EventOriginId=EventID
+             , EventOriginalUid = EventOriginId
+             , EventOriginId=EventID
           | extend  EventCount=int(1)
                   , EventSchemaVersion='0.1.0'
                   , ActorUserIdType='SID'
@@ -182,7 +182,7 @@ ParserQuery: |
        , EventOriginalUid = EventOriginId
        , LogonProtocol=AuthenticationPackageName
        , SrcDvcIpAddr=IpAddress
-    | extend EventOriginId=EventID | project-away EventID 
+       , EventOriginId=EventID
     | extend EventResult = iff(EventOriginId == 4625, 'Failure', 'Success')
       , EventCount=int(1)
       , EventSchemaVersion='0.1.0'

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
@@ -109,7 +109,7 @@ ParserQuery: |
                       ActingProcessName = tostring(EventData.ProcessName),
                       Status = tostring(EventData.Status),
                       ActorSessionId = tostring(EventData.SubjectLogonId),
-                      ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))),
+                      ActorUsername = tostring(iff (EventData.SubjectDomainName in ('-',''), EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))),
                       ActorUserId = tostring(EventData.SubjectUserSid),
                       SubStatus = tostring(EventData.SubStatus),
                       TargetDomainName = tostring(EventData.TargetDomainName),
@@ -142,7 +142,7 @@ ParserQuery: |
                   , EventStartTime =TimeGenerated
                   , EventEndTime=TimeGenerated
                   , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')                  
-                  , ActorUsernameType= iff(EventData.SubjectDomainName == '-','Simple', 'Windows' )                  
+                  , ActorUsernameType= iff(EventData.SubjectDomainName in ('-',''),'Simple', 'Windows' )                  
                   , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
                   , SrcDvcOs = 'Windows'
                   , EventStatus= iff(SubStatus=='0x0',Status,SubStatus)
@@ -191,8 +191,8 @@ ParserQuery: |
       , EventStartTime =TimeGenerated
       , EventEndTime=TimeGenerated
       , EventType=iff(EventOriginId in (LogoffEvents), 'Logoff', 'Logon')
-      , ActorUsername = iff (SubjectDomainName == '-', SubjectUserName, SubjectAccount)
-      , ActorUsernameType= iff(SubjectDomainName == '-','Simple', 'Windows' )
+      , ActorUsername = iff (SubjectDomainName in ('-',''), SubjectUserName, SubjectAccount)
+      , ActorUsernameType= iff(SubjectDomainName in ('-',''),'Simple', 'Windows' )
       , TargetUsername = iff (TargetDomainName in ('-',''), trim(@'\\',TargetUserName), trim(@'\\',TargetAccount))
       , TargetUsernameType=iff (TargetDomainName in ('-',''), 'Simple', 'Windows')
       , SrcDvcOs = 'Windows'

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationMicrosoftWindowsEvent.yaml
@@ -133,7 +133,7 @@ ParserQuery: |
               TargetDvcHostname = Computer
           // , TargetUserType=AccountType - no AccountType in windowsEvents
              , EventOriginalUid = EventOriginId
-             , EventOriginId=EventID
+             , EventOriginalType=EventID
           | extend  EventCount=int(1)
                   , EventSchemaVersion='0.1.0'
                   , ActorUserIdType='SID'
@@ -180,7 +180,7 @@ ParserQuery: |
        , EventOriginalUid = EventOriginId
        , LogonProtocol=AuthenticationPackageName
        , SrcDvcIpAddr=IpAddress
-       , EventOriginId=EventID
+       , EventOriginalType=EventID
     | extend EventResult = iff(EventOriginId == 4625, 'Failure', 'Success')
       , EventCount=int(1)
       , EventSchemaVersion='0.1.0'


### PR DESCRIPTION
    Change(s):

Fixed ASimAuthenticationMicrosoftWindowsEvent function (forwarded events part of the function)

   Reason for Change(s):

- **WindowsEvent** contains **EventOriginId** as a field, hence the project-rename for EventID to EventOriginId was failing, resulting in no records being found at all. Fixed by removing this from project-rename and uncommented rename for EventOriginId to EventOriginalUid which seemed to be in the kusto query already.  Also put EventID in EventOriginID + dropped EventID as per consistency for how SecurityEvents are handled.

- **ActorUsername** and **TargetUsername** were "extended" twice. Moreover, 2nd extend of TargetUsername was relying on EventData.TargetUsername which is faulty as it's EventData.TargetUserName (upper N) resulting in empty Targetusername. Fixed by removing the first 2 extends for these fields and correctly implementing lower in the query.

- **TargetDomainName** was blank in my forwarded events, resulting in Windows to be used for TargetUsernameType rather than Simple. Fixed this by not only looking for a "-" but also "" (blank string)

   Version Updated:
   - No

   Testing Completed:
   - Yes, in my own environment
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes