### PR TITLE
Update table name in DomainEntity_DnsEvents.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -1,7 +1,7 @@
 id: 85aca4d1-5d15-4001-abd9-acb86ca1786a
-name: TI map Domain entity to DnsEvent
+name: TI map Domain entity to DnsEvents
 description: |
-  'Identifies a match in DnsEvent table from any Domain IOC from TI'
+  'Identifies a match in DnsEvents from any Domain IOC from TI'
 severity: Medium
 requiredDataConnectors:
   - connectorId: DNS

--- a/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/DomainEntity_DnsEvents.yaml
@@ -67,5 +67,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled


### PR DESCRIPTION
  Change(s):
   - Employ correct name of the Table being compared.

   Reason for Change(s):
   - Coherence with other TI map rules.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes
   
 I think Asim parsers instead of DnsEvents could be used in the next versions of TI map DNS rules.