### PR TITLE
Remove unnecessary summarize in SigninPasswordSpray.yaml

### DIFF
--- a/Detections/SigninLogs/SigninPasswordSpray.yaml
+++ b/Detections/SigninLogs/SigninPasswordSpray.yaml
@@ -44,7 +44,6 @@ query: |
     table(tableName)
     | where TimeGenerated > ago(timeRange)
     | where ResultType in(failureCodes)
-    | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), make_set(ClientAppUsed), count() by bin(TimeGenerated, authenticationWindow), IPAddress, AppDisplayName, UserPrincipalName, Type
     | summarize FailedPrincipalCount = dcount(UserPrincipalName) by bin(TimeGenerated, authenticationWindow), IPAddress, AppDisplayName, Type
     | where FailedPrincipalCount >= authenticationThreshold
     | summarize WindowThresholdBreaches = count() by IPAddress, Type
@@ -85,5 +84,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
  Change(s):
   - Remove a summarize immediately followed by another summarize that doesn't use the first aggregation functions.

   Reason for Change(s):
   - It's a step whose results are not used.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
   ____________________________________________
   
   If you want this rule to be updated to aggregate ADFS logs, you can comment lines referring to Location and ClientAppUsed and add:
   
   ```
   ...
let aadADFS = aadFunc("ADFSSignInLogs");
union isfuzzy=true aadSignin, aadNonInt, aadADFS
   ```