### PR TITLE
Create print-pooler-service-suspicious-file-creation.yaml

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
@@ -16,5 +16,6 @@ query: |
   DeviceFileEvents
   | where Timestamp > ago(7d)
   | where ActionType == "FileCreated"
+  | where FileName endswith ".dll"
   | where FolderPath startswith "C:\\WINDOWS\\SYSTEM32\\SPOOL\\drivers\\x64\\\3\\"
      or FolderPath startswith "C:\\WINDOWS\\SYSTEM32\\SPOOL\\drivers\\x64\\\4\\"

--- a/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
@@ -1,0 +1,20 @@
+id: 67309406-12ad-4591-84db-0cc331634d0c
+name: Windows Spooler Service Suspicious File Creation
+description: |
+  The query digs in Windows print spooler drivers folder for any file creations,
+  MANY OF THE FILES THAT SHOULD COME UP HERE MAY BE LEGIT. Suspicious DLL is load from Spooler Service backup folder. 
+  This behavior is used from PoC Exploit of CVE-2021-34527, CVE-2021-1675 or CVE-2022-21999.
+requiredDataConnectors:
+- connectorId: Microsoft365Defender
+  dataTypes:
+  - DeviceFileEvents
+tactics:
+- Privilege escalation
+- Lateral movement
+- Exploit
+query: |
+  DeviceFileEvents
+  | where Timestamp > ago(7d)
+  | where ActionType == "FileCreated"
+  | where FolderPath startswith "C:\\WINDOWS\\SYSTEM32\\SPOOL\\drivers\\x64\\\3\\"
+     or FolderPath startswith "C:\\WINDOWS\\SYSTEM32\\SPOOL\\drivers\\x64\\\4\\"

--- a/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
@@ -12,6 +12,8 @@ tactics:
 - Privilege escalation
 - Lateral movement
 - Exploit
+relevantTechniques:
+- t1574
 query: |
   DeviceFileEvents
   | where Timestamp > ago(7d)

--- a/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Exploits/print-pooler-service-suspicious-file-creation.yaml
@@ -5,7 +5,7 @@ description: |
   MANY OF THE FILES THAT SHOULD COME UP HERE MAY BE LEGIT. Suspicious DLL is load from Spooler Service backup folder. 
   This behavior is used from PoC Exploit of CVE-2021-34527, CVE-2021-1675 or CVE-2022-21999.
 requiredDataConnectors:
-- connectorId: Microsoft365Defender
+- connectorId: MicrosoftThreatProtection
   dataTypes:
   - DeviceFileEvents
 tactics:


### PR DESCRIPTION
 Required items, please complete
   
   Change(s):
   - Create New rule to detect DLL Load via PrintNightmare Vulnerability

   Reason for Change(s):
   - New rule for DLL Load detection on Spooler Service backup folder

   Version Updated:
   - Required only for Detections/Analytic Rule templates

   Testing Completed:
   - Tested on event with sigma rule

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

References: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/image_load/image_load_spoolsv_dll_load.yml
