### PR TITLE
Ensured ProcssedID's are in dec format

### DIFF
--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventCreate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventCreate.yaml
@@ -58,9 +58,9 @@ ParserQuery: |
                                 TargetUsernameType = iff (EventData.TargetDomainName == '-', 'Simple', 'Windows'),
                                 TargetUserSessionId = tostring(toint(EventData.TargetLogonId)),    
                               // Processes 
-                                ActingProcessId = tostring(toint(EventData.ProcessId)),
+                                ActingProcessId = tostring(toint(tolong(EventData.ProcessId))),
                                 ActingProcessName = tostring(EventData.ParentProcessName),
-                                TargetProcessId = tostring(EventData.NewProcessId),
+                                TargetProcessId = tostring(toint(tolong(EventData.NewProcessId))),
                                 TargetProcessName = tostring(EventData.NewProcessName),
                                 TargetProcessCommandLine = tostring(EventData.CommandLine),
                                 TargetProcessTokenElevation = tostring(EventData.TokenElevationType),

--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventTerminate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventTerminate.yaml
@@ -44,7 +44,7 @@ ParserQuery: |
           ActorUsernameType = iff(EventData.SubjectDomainName == '-','Simple', 'Windows'),
           ActorSessionId = tostring(toint(EventData.SubjectLogonId)),
         // Processes 
-          TargetProcessId = tostring(toint(EventData.ProcessId)),
+          TargetProcessId = tostring(toint(tolong(EventData.ProcessId))),
           TargetProcessName = tostring(EventData.ProcessName),
           TargetProcessCommandLine = tostring(EventData.CommandLine),
           TargetProcessTokenElevation = tostring(EventData.TokenElevationType)


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Changed vimProcessCreateMicrosoftWindowsEvents so that ActingProcessId and TargetProcessId are in decimal format rather than hex.
   - Changed vimProcessTerminateMicrosoftWindowsEvents so that TargetProcessId is in decimal format rather than hex.

   Reason for Change(s):
   - Other parsers use decimal format for process identifiers, hence when querying over several sources results were inconsistent.

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
