### PR TITLE
Detect Access attempts to AAD Joined or Registered Devices Info and Transport Keys Registry Keys

### DIFF
--- a/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
+++ b/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
@@ -1,0 +1,93 @@
+id: a356c8bd-c81d-428b-aa36-83be706be034
+name: AAD Local Device Join Information and Transport Key Registry Keys Access 
+description: |
+  'This detection uses Windows security events to detect suspicious access attempts by the same process
+   to registry keys that provide information about an AAD joined or registered devices and Transport keys (tkpub / tkpriv).
+   This information can be used to export the Device Certificate (dkpub / dkpriv) and Transport key (tkpub/tkpriv).
+   These set of keys can be used to impersonate existing Azure AD joined devices.
+   This detection requires an access control entry (ACE) on the system access control list (SACL) of the following securable objects:
+   HKLM:\SYSTEM\CurrentControlSet\Control\CloudDomainJoin (AAD joined devices)
+   HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WorkplaceJoin (AAD registered devices)
+   HKLM:\SYSTEM\CurrentControlSet\Control\Cryptography\Ngc\KeyTransportKey (Transport Key)
+  Make sure you set the SACL to propagate to its sub-keys. You can find more information in here https://github.com/OTRF/Set-AuditRule/blob/master/rules/registry/aad_connect_health_service_agent.yml
+  '
+severity: Medium
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvent
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Discovery
+relevantTechniques:
+  - T1012
+tags:
+  - SimuLand
+  - ATR
+query: |
+  // AADJoined or Register Device Registry Keys
+  let aadJoinRoot = "\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet001\\Control\\CloudDomainJoin\\JoinInfo\\";
+  let aadRegisteredRoot = "\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\WorkplaceJoin";
+  // Transport Key Registry Key
+  let keyTransportKey = "\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet001\\Control\\Cryptography\\Ngc\\KeyTransportKey\\";
+  (union isfuzzy=true
+  (
+  // Access to Object Requested
+  SecurityEvent
+  | where EventID == '4656'
+  | where EventData contains aadJoinRoot or EventData contains aadRegisteredRoot
+  | extend EventData = parse_xml(EventData).EventData.Data
+  | mv-expand bagexpansion=array EventData
+  | evaluate bag_unpack(EventData)
+  | extend Key = tostring(column_ifexists('@Name', "")), Value = column_ifexists('#text', "")
+  | evaluate pivot(Key, any(Value), TimeGenerated, Computer, EventID)
+  | where ObjectType == 'Key'
+  | where ObjectName startswith aadJoinRoot and SubjectLogonId != '0x3e7' //Local System
+  | extend ProcessId = column_ifexists("ProcessId", ""), Process = split(ProcessName, '\\', -1)[-1],Account = strcat(SubjectDomainName, "\\", SubjectUserName)
+  | join kind=innerunique (
+      SecurityEvent
+      | where EventID == '4656'
+      | where EventData contains keyTransportKey
+      | extend EventData = parse_xml(EventData).EventData.Data
+      | mv-expand bagexpansion=array EventData
+      | evaluate bag_unpack(EventData)
+      | extend Key = tostring(column_ifexists('@Name', "")), Value = column_ifexists('#text', "")
+      | evaluate pivot(Key, any(Value), TimeGenerated, Computer, EventID)
+      | extend ObjectName = column_ifexists("ObjectName", ""),ObjectType = column_ifexists("ObjectType", "")
+      | where ObjectType == 'Key'
+      | where ObjectName startswith keyTransportKey and SubjectLogonId != '0x3e7' //Local System
+      | extend ProcessId = column_ifexists("ProcessId", ""), Process = split(ProcessName, '\\', -1)[-1],Account = strcat(SubjectDomainName, "\\", SubjectUserName)
+  ) on $left.Computer == $right.Computer and $left.SubjectLogonId == $right.SubjectLogonId and $left.ProcessId == $right.ProcessId
+  | project TimeGenerated, Computer, Account, SubjectDomainName, SubjectUserName, SubjectLogonId, ObjectName, tostring(Process), ProcessName, ProcessId, EventID
+  ),
+  // Accessing Object
+  (
+  SecurityEvent
+  | where EventID == '4663'
+  | where ObjectType == 'Key'
+  | where (ObjectName startswith aadJoinRoot or ObjectName contains aadRegisteredRoot) and SubjectLogonId != '0x3e7' //Local System
+  | extend Account = SubjectAccount
+  | join kind=innerunique (
+      SecurityEvent
+      | where EventID == '4663'
+      | where ObjectType == 'Key'
+      | where ObjectName contains keyTransportKey and SubjectLogonId != '0x3e7' //Local System
+      | extend Account = SubjectAccount
+  ) on $left.Computer == $right.Computer and $left.SubjectLogonId == $right.SubjectLogonId and $left.ProcessId == $right.ProcessId
+  | project TimeGenerated, Computer, Account, SubjectDomainName, SubjectUserName, SubjectLogonId, ObjectName, Process, ProcessName, ProcessId, EventID
+  )
+  )
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ServicePrincipal
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer
+version: 1.0.0
+kind: scheduled

--- a/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
+++ b/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
@@ -9,8 +9,8 @@ description: |
    HKLM:\SYSTEM\CurrentControlSet\Control\CloudDomainJoin (AAD joined devices)
    HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WorkplaceJoin (AAD registered devices)
    HKLM:\SYSTEM\CurrentControlSet\Control\Cryptography\Ngc\KeyTransportKey (Transport Key)
-  Make sure you set the SACL to propagate to its sub-keys. You can find more information in here https://github.com/OTRF/Set-AuditRule/blob/master/rules/registry/aad_connect_health_service_agent.yml
-  '
+   Make sure you set the SACL to propagate to its sub-keys. You can find more information in here https://github.com/OTRF/Set-AuditRule/blob/master/rules/registry/aad_connect_health_service_agent.yml
+   Reference: https://o365blog.com/post/deviceidentity/'
 severity: Medium
 requiredDataConnectors:
   - connectorId: SecurityEvents

--- a/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
+++ b/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
@@ -27,6 +27,7 @@ relevantTechniques:
 tags:
   - SimuLand
   - ATR
+  - AADInternals
 query: |
   // AADJoined or Register Device Registry Keys
   let aadJoinRoot = "\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet001\\Control\\CloudDomainJoin\\JoinInfo\\";

--- a/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
+++ b/Detections/SecurityEvent/LocalDeviceJoinInfoAndTransportKeyRegKeysAccess.yaml
@@ -84,7 +84,7 @@ entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: ServicePrincipal
+        columnName: Account
   - entityType: Host
     fieldMappings:
       - identifier: FullName


### PR DESCRIPTION
This detection uses Windows security events to detect suspicious access attempts by the same process to registry keys that provide information about an AAD joined or registered devices and Transport keys (tkpub / tkpriv).

This information can be used to export the Device Certificate (dkpub / dkpriv) and Transport key (tkpub/tkpriv). These set of keys can be used to impersonate existing Azure AD joined devices.

Reference: https://o365blog.com/post/deviceidentity/

This detection requires an access control entry (ACE) on the system access control list (SACL) of the following securable objects:

1.    HKLM:\SYSTEM\CurrentControlSet\Control\CloudDomainJoin (AAD joined devices)
2.    HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WorkplaceJoin (AAD registered devices)
3.    HKLM:\SYSTEM\CurrentControlSet\Control\Cryptography\Ngc\KeyTransportKey (Transport Key)

Process that usually queries (1 or 2) and 3 is Lsass.exe.