### PR TITLE
Update AuthenticationMethodsChangesforPriviledgedAccount to correctly lowercase string before matching

### DIFF
--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -33,7 +33,7 @@ query: |
   | where Category =~ "UserManagement"
   | where ActivityDisplayName =~ "User registered security info"
   | where LoggedByService =~ "Authentication Methods"
-  | extend AccountCustomEntity = tostring(TargetResources[0].userPrincipalName), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
+  | extend AccountCustomEntity = tolower(tostring(TargetResources[0].userPrincipalName)), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
   | where AccountCustomEntity in (VIPUsers)
 entityMappings:
   - entityType: Account

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -44,5 +44,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Updated to ensure the Account entity is correctly lowercase to match previous tolower() operation on AccountUPN.

   Reason for Change(s):
   - In cases identified by a partner this can cause mismatch issues.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes