### PR TITLE
asim/fix-hex-id-user-origid

### DIFF
--- a/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationM365Defender.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/ASimAuthenticationM365Defender.yaml
@@ -70,17 +70,17 @@ ParserQuery: |
     , ActingProcessCommandLine = InitiatingProcessCommandLine
     , ActingProcessCreationTime=InitiatingProcessCreationTime
     , ActingProcessPath=InitiatingProcessFolderPath
-    , ActingProcessId=InitiatingProcessId
-    , ActingProcessMD5=InitiatingProcessMD5
+   , ActingProcessMD5=InitiatingProcessMD5
     , ActingProcessSHA1=InitiatingProcessSHA1
     , ActingProcessSHA256= InitiatingProcessSHA256
     , ActingProcessIntegrityLevel= InitiatingProcessIntegrityLevel
     , ActingProcessTokenElevation=InitiatingProcessTokenElevation
     , ParentProcessName=InitiatingProcessParentFileName
-    , ParentProcessId=InitiatingProcessParentId
     , ParentProcessCreationTime=InitiatingProcessParentCreationTime
       | extend 
-          ActingProcessName=iff(ActingProcessPath hassuffix InitiatingProcessFileName
+      ActingProcessId=tostring(InitiatingProcessId)
+      , ParentProcessId=tostring(InitiatingProcessParentId)
+      , ActingProcessName=iff(ActingProcessPath hassuffix InitiatingProcessFileName
                             , ActingProcessPath
                             , strcat(ActingProcessPath,'\\',InitiatingProcessFileName))
       ,  TargetDvcHostnameType='FQDN'

--- a/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationM365Defender.yaml
+++ b/Parsers/ASimAuthentication/ProductParsers/vimAuthenticationM365Defender.yaml
@@ -89,17 +89,17 @@ ParserQuery: |
     , ActingProcessCommandLine = InitiatingProcessCommandLine
     , ActingProcessCreationTime=InitiatingProcessCreationTime
     , ActingProcessPath=InitiatingProcessFolderPath
-    , ActingProcessId=InitiatingProcessId
     , ActingProcessMD5=InitiatingProcessMD5
     , ActingProcessSHA1=InitiatingProcessSHA1
     , ActingProcessSHA256= InitiatingProcessSHA256
     , ActingProcessIntegrityLevel= InitiatingProcessIntegrityLevel
     , ActingProcessTokenElevation=InitiatingProcessTokenElevation
     , ParentProcessName=InitiatingProcessParentFileName
-    , ParentProcessId=InitiatingProcessParentId
     , ParentProcessCreationTime=InitiatingProcessParentCreationTime
       | extend 
-          ActingProcessName=iff(ActingProcessPath hassuffix InitiatingProcessFileName
+      ActingProcessId=tostring(InitiatingProcessId)
+      , ParentProcessId=tostring(InitiatingProcessParentId)
+      ,   ActingProcessName=iff(ActingProcessPath hassuffix InitiatingProcessFileName
                             , ActingProcessPath
                             , strcat(ActingProcessPath,'\\',InitiatingProcessFileName))
       ,  TargetDvcHostnameType='FQDN'

--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftSecurityEventsCreate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftSecurityEventsCreate.yaml
@@ -29,7 +29,6 @@ ParserQuery: |
               SecurityEvent
               // -- Filter
               | where EventID == 4688
-
               // -- Map
               | extend
                 // Event
@@ -43,12 +42,10 @@ ParserQuery: |
                   EventType = 'ProcessCreated',
                   EventOriginalType = tostring(EventID),
                   EventOriginalUid = EventOriginId, 
-
                 // Device
                   DvcId = SourceComputerId,
                   DvcHostname = Computer,
                   DvcOs = 'Windows',
-
                 // Users
                   ActorUserId = SubjectUserSid,
                   ActorUserIdType = 'SID',
@@ -57,30 +54,24 @@ ParserQuery: |
                   ActorSessionId = SubjectLogonId,
                   ActorType = AccountType, // Add?
                   ActorDomainName = SubjectDomainName,
-
                   TargetUserId =TargetUserSid, 
                   TargetUserIdType = 'SID',
                   TargetUsername = iff (TargetDomainName == '-', TargetUserName, TargetAccount),
                   TargetUsernameType = iff (TargetDomainName == '-', 'Simple', 'Windows'),
                   TargetUserSessionId = TargetLogonId,
-              
                 // Processes 
-                  ActingProcessId = tostring(ProcessId),
+                  ActingProcessId = tostring(toint(ProcessId)),
                   ActingProcessName = ParentProcessName,
-
-                  TargetProcessId = tostring(NewProcessId),
+                  TargetProcessId = tostring(toint(NewProcessId)),
                   TargetProcessName = NewProcessName,
                   TargetProcessCommandLine = CommandLine,
                   TargetProcessTokenElevation = TokenElevationType
-
                 | lookup MandatoryLabelLookup on MandatoryLabel 
-
               // -- Aliases
                 | extend
                   User = TargetUsername,
                   Dvc = DvcHostname,
                   Process = TargetProcessName
-
               // -- Remove potentially confusing
                 | project-away 
                     ParentProcessName, 

--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftSecurityEventsTerminate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftSecurityEventsTerminate.yaml
@@ -19,7 +19,6 @@ ParserQuery: |
               SecurityEvent
               // -- Filter
               | where EventID == 4689
-
               // -- Map
               | extend
                 // Event
@@ -35,12 +34,10 @@ ParserQuery: |
                   EventOriginalUid = EventOriginId,
                   EventResultDetails = Status,
                   EventOriginalResultDetails = Status, 
-
                 // Device
                   DvcId = SourceComputerId,
                   DvcHostname = Computer,
                   DvcOs = "Windows",
- 
                 // Users
                   ActorUserId = SubjectUserSid,
                   ActorUserIdType = "SID",
@@ -48,24 +45,17 @@ ParserQuery: |
                   ActorUsernameType = iff(SubjectDomainName == '-','Simple', 'Windows'),
                   ActorSessionId = SubjectLogonId,
                   ActorDomainName = SubjectDomainName,
-
-
-              
                 // Processes 
-
-                  TargetProcessId = ProcessId,
+                  TargetProcessId = tostring(toint(ProcessId)),
                   TargetProcessName = ProcessName,
                   TargetProcessCommandLine = CommandLine,
                   TargetProcessTokenElevation = TokenElevationType,
-
                   Process = ProcessName
-                
                 // Aliases
                 | extend 
                   User = ActorUsername,
                   Dvc = DvcHostname,
                   Process = TargetProcessName
-
               }; ProcessEvents
 
 

--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftSysmonCreate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftSysmonCreate.yaml
@@ -39,7 +39,7 @@ ParserQuery: |
                                 '</Data><Data Name="IntegrityLevel">'IntegrityLevel
                                 '</Data><Data Name="Hashes">'Hashes
                                 '</Data><Data Name="ParentProcessGuid">{'ParentProcessGuid
-                                '}</Data><Data Name="ParentProcessId">'ParentProcessId
+                                '}</Data><Data Name="ParentProcessId">'ParentProcessId:string
                                 '</Data><Data Name="ParentImage">'ParentImage
                                  '</Data><Data Name="ParentCommandLine">'ParentCommandLine '</Data>'*
             | parse EventData with * '<Data Name="ParentUser">' ActorUsername '</Data>' * // this field exists in new versions of Sysmon

--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventTerminate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventTerminate.yaml
@@ -30,7 +30,7 @@ ParserQuery: |
           EventType = "ProcessTerminated",
           EventResult = 'Success',
           EventOriginalType = tostring(EventID),
-        // EventOriginalUid = EventOriginId, Field will be added later on
+          EventOriginalUid = EventOriginId,
           EventResultDetails = tostring(EventData.Status),
           EventOriginalResultDetails = tostring(EventData.Status), 
         // Device
@@ -44,7 +44,7 @@ ParserQuery: |
           ActorUsernameType = iff(EventData.SubjectDomainName == '-','Simple', 'Windows'),
           ActorSessionId = tostring(toint(EventData.SubjectLogonId)),
         // Processes 
-          TargetProcessId = tostring(toint(tolong(EventData.ProcessId))),
+          TargetProcessId = tostring(toint(tostring(EventData.ProcessId))),
           TargetProcessName = tostring(EventData.ProcessName),
           TargetProcessCommandLine = tostring(EventData.CommandLine),
           TargetProcessTokenElevation = tostring(EventData.TokenElevationType)

--- a/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventTerminate.yaml
+++ b/Parsers/ASimProcessEvent/ProductParsers/ProcessEventMicrosoftWindowsEventTerminate.yaml
@@ -40,8 +40,8 @@ ParserQuery: |
         // Users
           ActorUserId = tostring(EventData.SubjectUserSid),
           ActorUserIdType = "SID",
-          ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))),
-          ActorUsernameType = iff(EventData.SubjectDomainName == '-','Simple', 'Windows'),
+          ActorUsername = tostring(iff (EventData.SubjectDomainName in ('', '-'), EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))),
+          ActorUsernameType = iff(EventData.SubjectDomainName in ('', '-'),'Simple', 'Windows'),
           ActorSessionId = tostring(toint(EventData.SubjectLogonId)),
         // Processes 
           TargetProcessId = tostring(toint(tostring(EventData.ProcessId))),

--- a/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftSecurityEvents.yaml
+++ b/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftSecurityEvents.yaml
@@ -82,10 +82,10 @@ ParserQuery: |
               | extend
                   ActorUserIdType = 'SID',
                   ActorUsername = iff (ActorDomainName == '-', SubjectUserName, SubjectAccount), 
-                  ActorUsernameType = iff(ActorDomainName == '-','Simple', 'Windows') 
+                  ActorUsernameType = iff(ActorDomainName == '-','Simple', 'Windows'),
+                  ActingProcessId = tostring(toint(ProcessId)) 
               // Process 
               | project-rename
-                  ActingProcessId = tostring(toint(ProcessId)), 
                   ActingProcessName = ProcessName
               // -- Aliases
                 | extend

--- a/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftSecurityEvents.yaml
+++ b/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftSecurityEvents.yaml
@@ -36,12 +36,10 @@ ParserQuery: |
                   "MACHINE", "HKEY_LOCAL_MACHINE",
                   "USER", "HKEY_USERS",   
                 ];
-
               let RegistryEvents=(){
               SecurityEvent
               // -- Filter
               | where EventID == 4657          
-
               // Event
               | extend
                   EventCount = int(1), 
@@ -54,16 +52,13 @@ ParserQuery: |
               | project-rename
                   EventOriginalSubType = OperationType,
                   EventOriginalUid = EventOriginId
- 
               | lookup RegistryAction on EventOriginalSubType
- 
               // Registry
               // Normalize key hive
               | parse ObjectName with "\\REGISTRY\\" KeyPrefix "\\" Key
               | lookup Hives on KeyPrefix
               | extend RegistryKey = strcat (Hive, "\\", Key)
               | project-away Hive, Key, KeyPrefix, ObjectName
-
               | project-rename
                 RegistryValue = ObjectValueName
               | extend
@@ -74,13 +69,11 @@ ParserQuery: |
               | lookup RegistryType on $left.NewValueType == $right.TypeCode | project-rename RegistryValueType = TypeName
               | lookup RegistryType on $left.OldValueType == $right.TypeCode | project-rename RegistryValueTypeModified = TypeName
               | project-away OldValue, NewValue, OldValueType, NewValueType
-
               // Device
               | extend
                   DvcId = SourceComputerId,
                   DvcHostname = Computer,
                   DvcOs = 'Windows'
-
               // User
               | project-rename
                   ActorUserId = SubjectUserSid, 
@@ -90,22 +83,18 @@ ParserQuery: |
                   ActorUserIdType = 'SID',
                   ActorUsername = iff (ActorDomainName == '-', SubjectUserName, SubjectAccount), 
                   ActorUsernameType = iff(ActorDomainName == '-','Simple', 'Windows') 
-              
               // Process 
               | project-rename
-                  ActingProcessId = ProcessId, 
+                  ActingProcessId = tostring(toint(ProcessId)), 
                   ActingProcessName = ProcessName
-
               // -- Aliases
                 | extend
                   User = ActorUsername,
                   UserId = ActorUserId,
                   Dvc = DvcHostname,
                   Process = ActingProcessName
-
               // -- Remove potentially confusing
                 | project-away 
                     SubjectUserName,
                     SubjectAccount
-
               }; RegistryEvents

--- a/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftWindowsEvent.yaml
@@ -81,8 +81,8 @@ ParserQuery: |
                           ActorSessionId = tostring( toint(EventData.SubjectLogonId)), 
                           ActorDomainName = tostring(EventData.SubjectDomainName),
                           ActorUserIdType = 'SID',
-                          ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))), 
-                          ActorUsernameType = iff(tostring(EventData.ActorDomainName) == '-','Simple', 'Windows'),              
+                          ActorUsername = tostring(iff (EventData.SubjectDomainName in ('', '-'), EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))), 
+                          ActorUsernameType = iff(tostring(EventData.ActorDomainName) in ('', '-'),'Simple', 'Windows'),              
                       // Process 
                           ActingProcessId = tostring(toint(tostring(EventData.ProcessId))), 
                           ActingProcessName = tostring(EventData.ProcessName)

--- a/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftWindowsEvent.yaml
+++ b/Parsers/ASimRegistry/ProductParsers/RegistryEventMicrosoftWindowsEvent.yaml
@@ -54,8 +54,8 @@ ParserQuery: |
                         NewValueType = tostring(EventData.NewValueType),
                         OldValueType = tostring(EventData.OldValueType)
               | extend
-                          EventOriginalSubType = tostring(EventData.OperationType)
-                          //EventOriginalUid = EventOriginId - No EventOriginId field in WindowsEvent
+                        EventOriginalSubType = tostring(EventData.OperationType),
+                        EventOriginalUid = EventOriginId
               | lookup RegistryAction on EventOriginalSubType
                       // Registry
                       // Normalize key hive
@@ -84,7 +84,7 @@ ParserQuery: |
                           ActorUsername = tostring(iff (EventData.SubjectDomainName == '-', EventData.SubjectUserName, strcat(EventData.SubjectDomainName, @"\" , EventData.SubjectUserName))), 
                           ActorUsernameType = iff(tostring(EventData.ActorDomainName) == '-','Simple', 'Windows'),              
                       // Process 
-                          ActingProcessId = tostring( toint(EventData.ProcessId)), 
+                          ActingProcessId = tostring(toint(tostring(EventData.ProcessId))), 
                           ActingProcessName = tostring(EventData.ProcessName)
                     | extend     
                     // -- Aliases


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Update parsers to correctly convert process IDs to number, and ensure proper type.
   - Ensure both "" and "-" are handled as empty domain.
   - Ensure the new OriginId field is supported
