### PR TITLE
Fix QueryFrequency in AnomalousIPUsageFollowedByTeamsAction.yaml

### DIFF
--- a/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
+++ b/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
@@ -56,12 +56,12 @@ query: |
           | extend TotalSignin = toscalar(signinData | summarize count())
           | extend CountryPrevalence = toreal(CountCountrySignin) / toreal(TotalSignin) * 100;
       // Count signins by user and IP address
-      let userIPSignin =
+      let userIpSignin =
           signinData
           | summarize CountIPSignin = count(), Country = any(Country), ListSigninTimeGenerated = make_list(TimeGenerated) by IPAddress, UserPrincipalName;
       // Calculate delta between the IP addresses with the most and minimum activity by user
       let userIpDelta =
-          userIPSignin
+          userIpSignin
           | summarize MaxIPSignin = max(CountIPSignin), MinIPSignin = min(CountIPSignin), DistinctCountries = dcount(Country), make_set(Country) by UserPrincipalName
           | extend UserIPDelta = toreal(MaxIPSignin - MinIPSignin) / toreal(MaxIPSignin) * 100;
       // Collect Team operations the user account has performed within a time range of the suspicious signins
@@ -76,7 +76,7 @@ query: |
           // Check users with high IP delta
           | where UserIPDelta >= deltaThreshold
           // Add information about signins and countries
-          | join kind = leftouter userIPSignin on UserPrincipalName
+          | join kind = leftouter userIpSignin on UserPrincipalName
           | join kind = leftouter countryPrevalence on Country
           // Check activity that comes from nonprevalent countries
           | where CountryPrevalence < countryPrevalenceThreshold

--- a/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
+++ b/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
@@ -33,89 +33,77 @@ query: |
   //The bigger the window the better the data sample size, as we use IP prevalence, more sample data is better.
   //The minimum number of countries that the account has been accessed from [default: 2]
   let minimumCountries = 2;
-  //The delta (%) between the largest in-use IP and the smallest [default: 90]
+  //The delta (%) between the largest in-use IP and the smallest [default: 95]
   let deltaThreshold = 95;
   //The maximum (%) threshold that the country appears in login data [default: 10]
   let countryPrevalenceThreshold = 10;
   //The time to project forward after the last login activity [default: 60min]
-  let projectedEndTime = 60min; 
-  //Get Teams successful signins globally
-  let aadFunc = (tableName:string){
-  let signinData =
-    table(tableName)
-    | where AppDisplayName has "Teams"
-    | where ConditionalAccessStatus =~ "success"
-    | extend country = tostring(todynamic(LocationDetails)['countryOrRegion'])
-    | where isnotempty(country) and isnotempty(IPAddress);
-  // Collect successful signins to teams
-  let loginEvents = 
-    signinData
-    | summarize count(), country=any(country), make_list(TimeGenerated) by IPAddress, UserPrincipalName;
-  //Calcualte delta between logins
-  let loginDelta =
-    loginEvents
-    | summarize max(count_), min(count_) by UserPrincipalName
-    | extend delta = toreal(max_count_ - min_count_) / max_count_ * 100
-    | where delta >= deltaThreshold;
-  //Count number of countries used to sign in
-  let countryCount =
-    loginEvents
-    | summarize Countries = dcount(country) by UserPrincipalName;
-  //Join delta and sign in counts to successful logins
-  loginDelta
-  | join kind=rightouter  (
-    loginEvents
-  ) on UserPrincipalName
-  | join kind=rightouter (
-    countryCount
-  ) on UserPrincipalName
-  //Check where the record meets the minimum required countries
-  | where Countries >= minimumCountries
-  | join kind=leftouter (
-        signinData
-        | summarize count() by country
-        | join (
-            //Now get the total number of logins from any country and join it to the previous count in a single table
-            signinData
-            | summarize count() by country
-            | summarize sum(count_), make_list(country)
-            | mv-expand list_country
-            | extend country = tostring(list_country)
-        ) on country
-        | summarize by country, count_, sum_count_
-        //Now calculate each countries prevalence within login events
-        | extend prevalence = toreal(count_) / toreal(sum_count_) * 100
-        | project-away sum_count_
-        | order by prevalence
-  ) on country
-  //The % that suspicious country is prevalent in data, this can be configured, less than 10% is uncommon
-  | where prevalence < countryPrevalenceThreshold
-  | where min_count_ == count_
-  //Login start and end times from the JSON object, this is the activity window the suspicious IP was active within
-  | extend EventTimes = list_TimeGenerated
-  | extend SuspiciousIP = IPAddress
-  | project UserPrincipalName, SuspiciousIP, UserIPDelta = delta, SuspiciousLoginCountry = country, SuspiciousCountryPrevalence = prevalence, EventTimes
-  //Teams join to collect operations the user account has performed within the given time range
-  | join kind=inner( 
-    OfficeActivity
-    | where Operation in~ ("TeamsAdminAction", "MemberAdded", "MemberRemoved", "MemberRoleChanged", "AppInstalled", "BotAddedToTeam")
-    | project Operation, UserId=tolower(UserId), OperationTime=TimeGenerated
-  ) on $left.UserPrincipalName == $right.UserId
-  | mv-expand StartTime = EventTimes
-  | extend StartTime = make_datetime(StartTime)
-  //The end time is projected 60 minutes forward, in case actions took place within the last hour of the final login for the suspicious IP
-  | extend ProjectedEndTime = make_datetime(StartTime + projectedEndTime)
-  //Limit to operations carried out by the user account in the timeframe the IP was active
-  | where OperationTime between (StartTime .. ProjectedEndTime)
-  | project UserPrincipalName, SuspiciousIP, StartTime, ProjectedEndTime, OperationTime, Operation, SuspiciousLoginCountry, SuspiciousCountryPrevalence
-  //Filter on suspicious actions
-  | extend activitySummary = pack(tostring(StartTime), pack("Operation",tostring(Operation), "OperationTime", OperationTime))
-  | summarize make_bag(activitySummary) by UserPrincipalName, SuspiciousIP, SuspiciousLoginCountry, SuspiciousCountryPrevalence
-  | extend IPCustomEntity = SuspiciousIP, AccountCustomEntity = UserPrincipalName
+  let projectedEndTime = 60m;
+  let queryfrequency = 1d;
+  let queryperiod = 14d;
+  let aadFunc = (tableName: string) {
+      // Get successful signins to Teams
+      let signinData =
+          table(tableName)
+          | where TimeGenerated > ago(queryperiod)
+          | where AppDisplayName has "Teams" and ConditionalAccessStatus =~ "success"
+          | extend Country = tostring(todynamic(LocationDetails)['countryOrRegion'])
+          | where isnotempty(Country) and isnotempty(IPAddress);
+      // Calculate prevalence of countries
+      let countryPrevalence =
+          signinData
+          | summarize CountCountrySignin = count() by Country
+          | extend TotalSignin = toscalar(signinData | summarize count())
+          | extend CountryPrevalence = toreal(CountCountrySignin) / toreal(TotalSignin) * 100;
+      // Count signins by user and IP address
+      let userIPSignin =
+          signinData
+          | summarize CountIPSignin = count(), Country = any(Country), ListSigninTimeGenerated = make_list(TimeGenerated) by IPAddress, UserPrincipalName;
+      // Calculate delta between the IP addresses with the most and minimum activity by user
+      let userIpDelta =
+          userIPSignin
+          | summarize MaxIPSignin = max(CountIPSignin), MinIPSignin = min(CountIPSignin), DistinctCountries = dcount(Country), make_set(Country) by UserPrincipalName
+          | extend UserIPDelta = toreal(MaxIPSignin - MinIPSignin) / toreal(MaxIPSignin) * 100;
+      // Collect Team operations the user account has performed within a time range of the suspicious signins
+      OfficeActivity
+      | where TimeGenerated > ago(queryfrequency)
+      | where Operation in~ ("TeamsAdminAction", "MemberAdded", "MemberRemoved", "MemberRoleChanged", "AppInstalled", "BotAddedToTeam")
+      | project OperationTimeGenerated = TimeGenerated, UserId = tolower(UserId), Operation
+      | join kind = inner(
+          userIpDelta
+          // Check users with activity from distinct countries
+          | where DistinctCountries >= minimumCountries
+          // Check users with high IP delta
+          | where UserIPDelta >= deltaThreshold
+          // Add information about signins and countries
+          | join kind = leftouter userIPSignin on UserPrincipalName
+          | join kind = leftouter countryPrevalence on Country
+          // Check activity that comes from nonprevalent countries
+          | where CountryPrevalence < countryPrevalenceThreshold
+          | project
+              UserPrincipalName,
+              SuspiciousIP = IPAddress,
+              UserIPDelta,
+              SuspiciousSigninCountry = Country,
+              SuspiciousCountryPrevalence = CountryPrevalence,
+              EventTimes = ListSigninTimeGenerated
+      ) on $left.UserId == $right.UserPrincipalName
+      // Check the signins occured 60 min before the Teams operations
+      | mv-expand SigninTimeGenerated = EventTimes
+      | extend SigninTimeGenerated = todatetime(SigninTimeGenerated)
+      | where OperationTimeGenerated between (SigninTimeGenerated .. (SigninTimeGenerated + projectedEndTime))
   };
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
   union isfuzzy=true aadSignin, aadNonInt
+  | summarize arg_max(SigninTimeGenerated, *) by UserPrincipalName, SuspiciousIP, OperationTimeGenerated
+  | summarize ActivitySummary = make_bag(pack(tostring(SigninTimeGenerated), pack("Operation", tostring(Operation), "OperationTime", OperationTimeGenerated)))
+      by
+      UserPrincipalName,
+      SuspiciousIP,
+      SuspiciousSigninCountry,
+      SuspiciousCountryPrevalence
+  | extend IPCustomEntity = SuspiciousIP, AccountCustomEntity = UserPrincipalName
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -125,5 +113,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
+++ b/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
@@ -97,12 +97,9 @@ query: |
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
   union isfuzzy=true aadSignin, aadNonInt
   | summarize arg_max(SigninTimeGenerated, *) by UserPrincipalName, SuspiciousIP, OperationTimeGenerated
-  | summarize ActivitySummary = make_bag(pack(tostring(SigninTimeGenerated), pack("Operation", tostring(Operation), "OperationTime", OperationTimeGenerated)))
-      by
-      UserPrincipalName,
-      SuspiciousIP,
-      SuspiciousSigninCountry,
-      SuspiciousCountryPrevalence
+  | summarize
+      ActivitySummary = make_bag(pack(tostring(SigninTimeGenerated), pack("Operation", tostring(Operation), "OperationTime", OperationTimeGenerated)))
+      by UserPrincipalName, SuspiciousIP, SuspiciousSigninCountry, SuspiciousCountryPrevalence
   | extend IPCustomEntity = SuspiciousIP, AccountCustomEntity = UserPrincipalName
 entityMappings:
   - entityType: Account


### PR DESCRIPTION
   Change(s):
   1. Establish a queryfrequency parameter for OfficeActivity.
   2. Check activities from non-prevalent countries even if that activity is not the "lightest" activity.
   3. Remove other unneeded code.

   Reason for Change(s):
   1. If not, the same event will trigger an alert every day for 14 days.
   2. This line ```| where min_count_ == count_``` is leaving out rare activity that could possibly match OfficeActivity events.
   3. The query is a bit chaotic to understand, there are some oversteps, and it checks signinlogs even if there are not Office activities...

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

-----------------------------------------------------------------------------------------------------------

If you want to keep it just as it is, just remove completely my commit and add:

```
let projectedEndTime = 60min;
let queryfrequency = 1d;
...
OfficeActivity
| where TimeGenerated > ago(queryfrequency)
```
So an event only triggers an alert once.