### PR TITLE
Remove Duplicate Query in Filter for Known Domains Using Long DNS

### DIFF
--- a/Hunting Queries/DnsEvents/DNS_LongURILookup.yaml
+++ b/Hunting Queries/DnsEvents/DNS_LongURILookup.yaml
@@ -40,7 +40,7 @@ query: |
   and Name !has "_ldap" and Name !has "_kerberos" and Name !has "modsecurity.org" and Name !has "fdmarc.net" and Name !has "ipass.com" and Name !has "wpad"
   and Name !has "cnr.io" and Name !has "trendmicro.com" and Name !has "sophosxl.net" and Name !has "spotify.com" and Name !has "e5.sk" and Name !has "mcafee.com" 
   and Name !has "opendns.com"  and Name !has "spameatingmonkey.net" and Name !has "_ldap" and Name !has "_kerberos" and Name !has "modsecurity.org" and Name !has "fdmarc.net" 
-  and Name !has "ipass.com" and Name !has "wpad"
+  and Name !has "ipass.com"
   | extend Name = tolower(Name), Urilength = strlen(Name) 
   | where Urilength >= uriThreshold
   | extend SubDomain = case(


### PR DESCRIPTION
Extra Name !has "wpad"

   Required items, please complete
   
   Change(s):
   - Updated filter for DNS_LongURILookup.yaml
  
   Reason for Change(s):
   - Duplicate domain name with known long DNS lookup

   Version Updated:
   - No as no change in logic
 
   Testing Completed:
   - Need Help

   Checked that the validations are passing and have addressed any issues that are present:
   - Need Help