### PR TITLE
Discord Risky file download

### DIFF
--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -1,7 +1,7 @@
 id: 010bd98c-a6be-498c-bdcd-502308c0fdae
 name: Discord CDN Risky File Download
 description: |
-  'Identifies  callouts to Discord CDN addresses for risky file extensions. This detection will trigger when a callout for a risky file
+  'Identifies callouts to Discord CDN addresses for risky file extensions. This detection will trigger when a callout for a risky file
   is made to a discord server that has only been seen once in your environment. Unique discord servers are identified using the server ID
   that is included in the request URL (DiscordServerId in query). Discord CDN has been used in multiple campaigns to download additional payloads'
 severity: Medium
@@ -10,7 +10,7 @@ requiredDataConnectors:
     dataTypes:
       - CommonSecurityLog
 queryFrequency: 1d
-queryPeriod: 7d
+queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -24,7 +24,7 @@ query: |
   let riskyExtensions = dynamic([".bin",".exe",".dll",".bin",".msi"]);
   CommonSecurityLog
   | where DeviceVendor =~ "ZScaler"
-  | where RequestURL contains "media.discordapp.net" or RequestURL contains "cdn.discordapp.com"
+  | where RequestURL has_any("media.discordapp.net", "cdn.discordapp.com")
   | where RequestURL has "attachments"
   | where DeviceAction !~ "blocked"
   | extend DiscordServerId = extract(@"\/attachments\/([0-9]+)\/", 1, RequestURL)

--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -1,9 +1,9 @@
 id: 010bd98c-a6be-498c-bdcd-502308c0fdae
 name: Discord CDN Risky File Download
 description: |
-  'Identifies  callouts to Discord CDN addresses  for risky file extensions. This detection will trigger when a callout for a risky file
+  'Identifies  callouts to Discord CDN addresses for risky file extensions. This detection will trigger when a callout for a risky file
   is made to a discord server that has only been seen once in your environment. Unique discord servers are identified using the server ID
-  that is included in the request URL (DiscordServerId in query).'
+  that is included in the request URL (DiscordServerId in query). Discord CDN has been used in multiple campaigns to download additional payloads'
 severity: Medium
 requiredDataConnectors:
   - connectorId: Zscaler

--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -1,7 +1,7 @@
 id: 010bd98c-a6be-498c-bdcd-502308c0fdae
 name: Discord CDN Risky File Download
 description: |
-  'Identifies  callouts to dicord CDN addreses for risky file extensions. This detection will trigger when a callout for a risky file
+  'Identifies  callouts to Discord CDN addresses  for risky file extensions. This detection will trigger when a callout for a risky file
   is made to a discord server that has only been seen once in your environment. Unique discord servers are identified using the server ID
   that is included in the request URL (DiscordServerId in query).'
 severity: Medium

--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -14,7 +14,7 @@ queryPeriod: 7d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - ApplicationLayerProtocol
+  - CommandAndControl
 relevantTechniques:
   - T1071.001
 tags:

--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -23,15 +23,16 @@ query: |
   let connectionThreshold = 1;
   let riskyExtensions = dynamic([".bin",".exe",".dll",".bin",".msi"]);
   CommonSecurityLog
+  | where DeviceVendor =~ "ZScaler"
   | where RequestURL contains "media.discordapp.net" or RequestURL contains "cdn.discordapp.com"
   | where RequestURL has "attachments"
   | where DeviceAction !~ "blocked"
   | extend DiscordServerId = extract(@"\/attachments\/([0-9]+)\/", 1, RequestURL)
-  | summarize dcount(RequestURL), make_list(SourceUserName), make_list(SourceIP), make_list(RequestURL), min(TimeGenerated), max(TimeGenerated), make_list(DeviceAction) by DiscordServerId, DeviceProduct
+  | summarize dcount(RequestURL), make_set(SourceUserName), make_set(SourceIP), make_set(RequestURL), min(TimeGenerated), max(TimeGenerated), make_set(DeviceAction) by DiscordServerId, DeviceProduct
   | where dcount_RequestURL <= connectionThreshold
-  | mv-expand list_SourceUserName to typeof(string), list_RequestURL to typeof(string), list_DeviceAction to typeof(string), list_SourceIP to typeof(string)
-  | summarize by DiscordServerId, DeviceProduct, dcount_RequestURL, list_SourceUserName, min_TimeGenerated, max_TimeGenerated, list_DeviceAction, list_SourceIP, list_RequestURL
-  | project StartTime=min_TimeGenerated, EndTime=max_TimeGenerated, DeviceActionTaken=list_DeviceAction, DeviceProduct, SourceUser=list_SourceUserName, SourceIP=list_SourceIP, RequestURL=list_RequestURL
+  | mv-expand set_SourceUserName to typeof(string), set_RequestURL to typeof(string), set_DeviceAction to typeof(string), set_SourceIP to typeof(string)
+  | summarize by DiscordServerId, DeviceProduct, dcount_RequestURL, set_SourceUserName, min_TimeGenerated, max_TimeGenerated, set_DeviceAction, set_SourceIP, set_RequestURL
+  | project StartTime=min_TimeGenerated, EndTime=max_TimeGenerated, DeviceActionTaken=set_DeviceAction, DeviceProduct, SourceUser=set_SourceUserName, SourceIP=set_SourceIP, RequestURL=set_RequestURL
   | where RequestURL has_any (riskyExtensions)
 entityMappings:
   - entityType: Account

--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -1,0 +1,50 @@
+id: 010bd98c-a6be-498c-bdcd-502308c0fdae
+name: Discord CDN Risky File Download
+description: |
+  'Identifies  callouts to dicord CDN addreses for risky file extensions. This detection will trigger when a callout for a risky file
+  is made to a discord server that has only been seen once in your environment. Unique discord servers are identified using the server ID
+  that is included in the request URL (DiscordServerId in query).'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: Zscaler
+    dataTypes:
+      - CommonSecurityLog
+queryFrequency: 1d
+queryPeriod: 7d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - ApplicationLayerProtocol
+relevantTechniques:
+  - T1071.001
+tags:
+  - AADSecOpsGuide
+query: |
+  let connectionThreshold = 1;
+  let riskyExtensions = dynamic([".bin",".exe",".dll",".bin",".msi"]);
+  CommonSecurityLog
+  | where RequestURL contains "media.discordapp.net" or RequestURL contains "cdn.discordapp.com"
+  | where RequestURL has "attachments"
+  | where DeviceAction !~ "blocked"
+  | extend DiscordServerId = extract(@"\/attachments\/([0-9]+)\/", 1, RequestURL)
+  | summarize dcount(RequestURL), make_list(SourceUserName), make_list(SourceIP), make_list(RequestURL), min(TimeGenerated), max(TimeGenerated), make_list(DeviceAction) by DiscordServerId, DeviceProduct
+  | where dcount_RequestURL <= connectionThreshold
+  | mv-expand list_SourceUserName to typeof(string), list_RequestURL to typeof(string), list_DeviceAction to typeof(string), list_SourceIP to typeof(string)
+  | summarize by DiscordServerId, DeviceProduct, dcount_RequestURL, list_SourceUserName, min_TimeGenerated, max_TimeGenerated, list_DeviceAction, list_SourceIP, list_RequestURL
+  | project StartTime=min_TimeGenerated, EndTime=max_TimeGenerated, DeviceActionTaken=list_DeviceAction, DeviceProduct, SourceUser=list_SourceUserName, SourceIP=list_SourceIP, RequestURL=list_RequestURL
+  | where RequestURL has_any (riskyExtensions)
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: SourceUser
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceIP
+  - entityType: URL
+    fieldMappings:
+      - identifier: Url
+        columnName: RequestURL
+version: 1.0.0
+kind: Scheduled

--- a/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
+++ b/Detections/CommonSecurityLog/DiscordCDNRiskyDownload.yaml
@@ -18,7 +18,7 @@ tactics:
 relevantTechniques:
   - T1071.001
 tags:
-  - AADSecOpsGuide
+  - Discord
 query: |
   let connectionThreshold = 1;
   let riskyExtensions = dynamic([".bin",".exe",".dll",".bin",".msi"]);


### PR DESCRIPTION
   Change(s):
   - Creating DiscordCDNRiskyDownload detection. Raises an alert when a risky file is downloaded from a discord server not seen in the environment commonly.

   Reason for Change(s):
   - na

   Version Updated:
   - na

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes