### PR TITLE
New hunting and detection queries for suspicious host activity

### DIFF
--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -23,5 +23,15 @@
     "id": "09c49590-4e9d-4da9-a34d-17222d0c9e7e",
     "templateName": "PotentiallyHarmfulFileTypes.yaml",
     "validationFailReason": "The name '_GetWatchList' does not refer to any known function"
+  },
+  {
+    "id": "6cb193f3-7c6d-4b53-9153-49a09be830d7",
+    "templateName": "CrashdumpdisabledonhostASIM.yaml",
+    "validationFailReason": "Valid imTable"
+  },
+  {
+    "id": "ac9e233e-44d4-45eb-b522-6e47445f6582",
+    "templateName": "CrashdumpdisabledonhostASIM.yaml",
+    "validationFailReason": "Valid imTable"
   }
 ]

--- a/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
+++ b/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
@@ -4,7 +4,7 @@ description: |
   'This detection looks for the steps required to conduct a UAC bypass using Fodhelper.exe. By default this detection looks for the setting of the required registry keys and the invoking of the process within 1 hour - this can be tweaked as required.'
 severity: Medium
 requiredDataConnectors: []
-queryFrequency: 1h
+queryFrequency: 2h
 queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0

--- a/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
+++ b/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
@@ -1,0 +1,39 @@
+id: ac9e233e-44d4-45eb-b522-6e47445f6582
+name: Potential Fodhelper UAC Bypass ASIM
+description: |
+  'This detection looks for the steps required to conduct a UAC bypass using Fodhelper.exe. By default this detection looks for the setting of the required registry keys and the invoking of the process within 1 hour - this can be tweaked as required.'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: []
+queryFrequency: 2h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1548.002
+query: |
+  imRegistry
+    | where EventType in ("RegistryValueSet", "RegistryKeyCreated")
+    | where RegistryKey has "Software\\Classes\\ms-settings\\shell\\open\\command"
+    | extend timekey = bin(TimeGenerated, 1h)
+    | join (imProcess
+    | where Process endswith "fodhelper.exe"
+    | where ParentProcessName endswith "cmd.exe" or ParentProcessName endswith "powershell.exe" or ParentProcessName endswith "powershell_ise.exe"
+    | extend timekey = bin(TimeGenerated, 1h)) on TimeKey, DvcId
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: DvcHostname
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DvcIpAddr
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ActorUsername
+version: 1.0.0
+kind: scheduled

--- a/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
+++ b/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
@@ -3,8 +3,7 @@ name: Potential Fodhelper UAC Bypass ASIM
 description: |
   'This detection looks for the steps required to conduct a UAC bypass using Fodhelper.exe. By default this detection looks for the setting of the required registry keys and the invoking of the process within 1 hour - this can be tweaked as required.'
 severity: Medium
-requiredDataConnectors:
-  - connectorId: []
+requiredDataConnectors: []
 queryFrequency: 2h
 queryPeriod: 1h
 triggerOperator: gt

--- a/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
+++ b/Detections/MultipleDataSources/PotentialFodhelperUACBypassASIM.yaml
@@ -4,8 +4,8 @@ description: |
   'This detection looks for the steps required to conduct a UAC bypass using Fodhelper.exe. By default this detection looks for the setting of the required registry keys and the invoking of the process within 1 hour - this can be tweaked as required.'
 severity: Medium
 requiredDataConnectors: []
-queryFrequency: 2h
-queryPeriod: 1h
+queryFrequency: 1h
+queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:

--- a/Detections/SecurityEvent/PotentialFodhelperUACBypass.yaml
+++ b/Detections/SecurityEvent/PotentialFodhelperUACBypass.yaml
@@ -1,0 +1,41 @@
+id: 56f3f35c-3aca-4437-a1fb-b7a84dc4af00
+name: Potential Fodhelper UAC Bypass
+description: |
+  'This detection looks for the steps required to conduct a UAC bypass using Fodhelper.exe. By default this detection looks for the setting of the required registry keys and the invoking of the process within 1 hour - this can be tweaked as required.'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+queryFrequency: 2h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1548.002
+query: |
+  SecurityEvent
+    | where EventID == 4657
+    | parse ObjectName with "\\REGISTRY\\" KeyPrefix "\\" RegistryKey
+    | project-reorder RegistryKey
+    | where RegistryKey has "Software\\Classes\\ms-settings\\shell\\open\\command"
+    | extend TimeKey = bin(TimeGenerated, 1h)
+    | join (
+    SecurityEvent
+    | where EventID == 4688
+    | where Process =~ "fodhelper.exe"
+    | where ParentProcessName endswith "cmd.exe" or ParentProcessName endswith "powershell.exe" or ParentProcessName endswith "powershell_ise.exe"
+    | extend TimeKey = bin(TimeGenerated, 1h)) on TimeKey, Computer
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Account
+version: 1.0.0
+kind: scheduled

--- a/Detections/SecurityEvent/PotentialFodhelperUACBypass.yaml
+++ b/Detections/SecurityEvent/PotentialFodhelperUACBypass.yaml
@@ -7,7 +7,7 @@ requiredDataConnectors:
   - connectorId: SecurityEvents
     dataTypes:
       - SecurityEvents
-queryFrequency: 1h
+queryFrequency: 2h
 queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0

--- a/Detections/SecurityEvent/PotentialFodhelperUACBypass.yaml
+++ b/Detections/SecurityEvent/PotentialFodhelperUACBypass.yaml
@@ -7,8 +7,8 @@ requiredDataConnectors:
   - connectorId: SecurityEvents
     dataTypes:
       - SecurityEvents
-queryFrequency: 2h
-queryPeriod: 1h
+queryFrequency: 1h
+queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:

--- a/Hunting Queries/ASimProcess/Discorddownloadinvokedfromcmdline(ASIM).yaml
+++ b/Hunting Queries/ASimProcess/Discorddownloadinvokedfromcmdline(ASIM).yaml
@@ -2,8 +2,7 @@ id: 3169dc83-9e97-452c-afcc-baebdb0ddf7c
 name: Discord download invoked from cmd line (ASIM)
 description: |
   'This hunting query looks for hosts that have attempted to interact with the Discord CDN. This activity is not normally invoked from the command line and could indicate C2, exfiltration, or malware delivery activity.'
-requiredDataConnectors:
-  - connectorId: {}
+requiredDataConnectors: []
 tactics:
   - Execution
   - CommandAndControl

--- a/Hunting Queries/ASimProcess/Discorddownloadinvokedfromcmdline(ASIM).yaml
+++ b/Hunting Queries/ASimProcess/Discorddownloadinvokedfromcmdline(ASIM).yaml
@@ -1,0 +1,28 @@
+id: 3169dc83-9e97-452c-afcc-baebdb0ddf7c
+name: Discord download invoked from cmd line (ASIM)
+description: |
+  'This hunting query looks for hosts that have attempted to interact with the Discord CDN. This activity is not normally invoked from the command line and could indicate C2, exfiltration, or malware delivery activity.'
+requiredDataConnectors:
+  - connectorId: {}
+tactics:
+  - Execution
+  - CommandAndControl
+  - Exfiltration
+relevantTechniques:
+  - T1204
+  - T1102
+  - T1567
+query: |
+  imProcess
+    | where Process has_any ("powershell.exe", "powershell_ise.exe", "cmd.exe") or CommandLine has "powershell"
+    | where CommandLine has_any ("cdn.discordapp.com", "moc.ppadrocsid.ndc")
+    | project-reorder TimeGenerated, Computer, Account, Process, CommandLine
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Account
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer

--- a/Hunting Queries/ASimRegistry/CrashdumpdisabledonhostASIM.yaml
+++ b/Hunting Queries/ASimRegistry/CrashdumpdisabledonhostASIM.yaml
@@ -1,0 +1,26 @@
+id: 6cb193f3-7c6d-4b53-9153-49a09be830d7
+name: Crash dump disabled on host ASIM
+description: |
+  'This detection looks the prevention of crash dumps being created. This can be used to limit reporting by malware, look for suspicious processes setting this registry key.'
+requiredDataConnectors:
+  - connectorId: []
+tactics:
+  - DefenseEvasion
+relevantTechniques:
+  - T1070
+query: |
+    imRegistry
+    | where RegistryKey == "SYSTEM\\CurrentControlSet\\Control\\CrashControl"
+    | where RegistryValue == "CrashDumpEnabled"
+    | where RegistryValueData == 0
+    | project-reorder TimeGenerated, RegistryKey, RegistryValue, RegistryValueData, Process, User, ParentProcessName
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: User
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: DvcHostname
+

--- a/Hunting Queries/ASimRegistry/CrashdumpdisabledonhostASIM.yaml
+++ b/Hunting Queries/ASimRegistry/CrashdumpdisabledonhostASIM.yaml
@@ -2,8 +2,7 @@ id: 6cb193f3-7c6d-4b53-9153-49a09be830d7
 name: Crash dump disabled on host ASIM
 description: |
   'This detection looks the prevention of crash dumps being created. This can be used to limit reporting by malware, look for suspicious processes setting this registry key.'
-requiredDataConnectors:
-  - connectorId: []
+requiredDataConnectors: []
 tactics:
   - DefenseEvasion
 relevantTechniques:

--- a/Hunting Queries/SecurityEvent/Crashdumpdisabledonhost.yaml
+++ b/Hunting Queries/SecurityEvent/Crashdumpdisabledonhost.yaml
@@ -1,0 +1,30 @@
+id: 5a3615af-21c9-427e-8bf1-ed2350992bb4
+name: Crash dump disabled on host
+description: |
+  'This detection looks the prevention of crash dumps being created. This can be used to limit reporting by malware, look for suspicious processes setting this registry key.'
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+tactics:
+  - DefenseEvasion
+relevantTechniques:
+  - T1070
+query: |
+  SecurityEvent
+    | where EventID == 4657
+    | parse ObjectName with "\\REGISTRY\\" KeyPrefix "\\" RegistryKey
+    | project-reorder RegistryKey
+    | where RegistryKey has "SYSTEM\\CurrentControlSet\\Control\\CrashControl"
+    | where ObjectValueName =~ "CrashDumpEnabled"
+    | extend  RegistryValueData = iff (OperationType == "%%1906", OldValue, NewValue)
+    | where RegistryValueData == 0
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Account
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer

--- a/Hunting Queries/SecurityEvent/Discorddownloadinvokedfromcmdline.yaml
+++ b/Hunting Queries/SecurityEvent/Discorddownloadinvokedfromcmdline.yaml
@@ -1,0 +1,31 @@
+id: e7dd442a-0af8-48eb-8358-9e91f4911849
+name: Discord download invoked from cmd line
+description: |
+  'This hunting query looks for hosts that have attempted to interact with the Discord CDN. This activity is not normally invoked from the command line and could indicate C2, exfiltration, or malware delivery activity.'
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+tactics:
+  - Execution
+  - CommandAndControl
+  - Exfiltration
+relevantTechniques:
+  - T1204
+  - T1102
+  - T1567
+query: |
+    SecurityEvent
+    | where EventID == 4688
+    | where Process has_any ("powershell.exe", "powershell_ise.exe", "cmd.exe") or CommandLine has "powershell"
+    | where CommandLine has_any ("cdn.discordapp.com", "moc.ppadrocsid.ndc")
+    | project-reorder TimeGenerated, Computer, Account, Process, CommandLine
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Account
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer


### PR DESCRIPTION


   Required items, please complete
   
   Change(s):
   - See guidance below

   Reason for Change(s):
   - New content:
    Fodhelper UAC Bypass
    Discord Downloads from command line
    Crash Dump disablement
    All queries include an ASIM version

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


