### PR TITLE
New detections for renamed sdelete usage &

### DIFF
--- a/Detections/ASimProcess/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPoliciesASIM.yaml
+++ b/Detections/ASimProcess/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPoliciesASIM.yaml
@@ -31,7 +31,7 @@ query: |
     | where TimeGenerated > ago(1d)
     | where Process has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
     | where Process !in (known_processes)
-    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated), AffectedComputers=makeset(Computer) by Process, CommandLine
+    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated), AffectedComputers=makeset(DvcHostname) by Process, CommandLine
 entityMappings: []
 version: 1.0.0
 kind: scheduled

--- a/Detections/ASimProcess/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPoliciesASIM.yaml
+++ b/Detections/ASimProcess/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPoliciesASIM.yaml
@@ -1,0 +1,37 @@
+id: 0dd2a343-4bf9-4c93-a547-adf3658ddaec
+name: New EXE deployed via Default Domain or Default Domain Controller Policies ASIM
+description: |
+  'This detection highlights executables deployed to hosts via either the Default Domain or Default Domain Controller Policies. These policies apply to all hosts or Domain Controllers and best practice is that these policies should not be used for deployment of files.
+    A threat actor may use these policies to deploy files or scripts to all hosts in a domain.
+    This query uses the ASIM parsers and will need them deployed before usage - https://docs.microsoft.com/azure/sentinel/normalization'
+severity: High
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+queryFrequency: 1d
+queryPeriod: 14d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Execution
+  - LateralMovement
+relevantTechniques:
+  - T1072
+  - T1570
+query: |
+  let known_processes = (
+    imProcess
+    // Change these values if adjusting Query Frequency or Query Period
+    | where TimeGenerated between(ago(14d)..ago(1d))
+    | where Process has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
+    | summarize by Process);
+    imProcess
+    // Change these values if adjusting Query Frequency or Query Period
+    | where TimeGenerated > ago(1d)
+    | where Process has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
+    | where Process !in (known_processes)
+    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated), AffectedComputers=makeset(Computer) by Process, CommandLine
+entityMappings: []
+version: 1.0.0
+kind: scheduled

--- a/Detections/ASimProcess/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPoliciesASIM.yaml
+++ b/Detections/ASimProcess/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPoliciesASIM.yaml
@@ -31,7 +31,11 @@ query: |
     | where TimeGenerated > ago(1d)
     | where Process has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
     | where Process !in (known_processes)
-    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated), AffectedComputers=makeset(DvcHostname) by Process, CommandLine
-entityMappings: []
+    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated) by Process, CommandLine, DvcHostname
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: DvcHostname
 version: 1.0.0
 kind: scheduled

--- a/Detections/ASimProcess/Potentialre-namedsdeleteusageASIM.yaml
+++ b/Detections/ASimProcess/Potentialre-namedsdeleteusageASIM.yaml
@@ -11,7 +11,7 @@ queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - PrivilegeEscalation
+  - DefenseEvasion
   - Impact
 relevantTechniques:
   - T1485

--- a/Detections/ASimProcess/Potentialre-namedsdeleteusageASIM.yaml
+++ b/Detections/ASimProcess/Potentialre-namedsdeleteusageASIM.yaml
@@ -1,0 +1,38 @@
+id: 5b6ae038-f66e-4f74-9315-df52fd492be4
+name: Potential re-named sdelete usage ASIM
+description: |
+  'This detection looks for command line parameters associated with the use of Sysinternals sdelete (https://docs.microsoft.com/sysinternals/downloads/sdelete) to delete multiple files on a host's C drive.
+  A threat actor may re-name the tool to avoid detection and then use it for destructive attacks on a host.
+  This detection uses the ASIM imProcess parser, this will need to be deployed before use - https://docs.microsoft.com/azure/sentinel/normalization'
+severity: Low
+requiredDataConnectors: []
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - PrivilegeEscalation
+  - Impact
+relevantTechniques:
+  - T1485
+  - T1036
+query: |
+  imProcess
+    | where CommandLine has_all ("-accepteula", "-s", "-r", "-q")
+    | where Process !endswith "sdelete.exe"
+    | where CommandLine !has "sdelete"
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: DvcHostname
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DvcIpAddr
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ActorUsername
+version: 1.0.0
+kind: scheduled

--- a/Detections/SecurityEvent/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPolicies.yaml
+++ b/Detections/SecurityEvent/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPolicies.yaml
@@ -33,7 +33,11 @@ query: |
     | where NewProcessName has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
     | where Process !in (known_processes)
     // This will likely apply to multiple hosts so summarize these data
-    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated), AffectedComputers=makeset(Computer) by Process, NewProcessName, CommandLine
-entityMappings: []
+    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated) by Process, NewProcessName, CommandLine, Computer
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer
 version: 1.0.0
 kind: scheduled

--- a/Detections/SecurityEvent/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPolicies.yaml
+++ b/Detections/SecurityEvent/NewEXEdeployedviaDefaultDomainorDefaultDomainControllerPolicies.yaml
@@ -1,0 +1,39 @@
+id: 05b4bccd-dd12-423d-8de4-5a6fb526bb4f
+name: New EXE deployed via Default Domain or Default Domain Controller Policies
+description: |
+  'This detection highlights executables deployed to hosts via either the Default Domain or Default Domain Controller Policies. These policies apply to all hosts or Domain Controllers and best practice is that these policies should not be used for deployment of files.
+  A threat actor may use these policies to deploy files or scripts to all hosts in a domain.'
+severity: High
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+queryFrequency: 1d
+queryPeriod: 14d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Execution
+  - LateralMovement
+relevantTechniques:
+  - T1072
+  - T1570
+query: |
+  let known_processes = (
+    SecurityEvent
+    // If adjusting Query Period or Frequency update these
+    | where TimeGenerated between(ago(14d)..ago(1d))
+    | where EventID == 4688
+    | where NewProcessName has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
+    | summarize by Process);
+    SecurityEvent
+    // If adjusting Query Period or Frequency update these
+    | where TimeGenerated > ago(1d)
+    | where EventID == 4688
+    | where NewProcessName has_any ("Policies\\{6AC1786C-016F-11D2-945F-00C04fB984F9}", "Policies\\{31B2F340-016D-11D2-945F-00C04FB984F9}")
+    | where Process !in (known_processes)
+    // This will likely apply to multiple hosts so summarize these data
+    | summarize FirstSeen=min(TimeGenerated), LastSeen=max(TimeGenerated), AffectedComputers=makeset(Computer) by Process, NewProcessName, CommandLine
+entityMappings: []
+version: 1.0.0
+kind: scheduled

--- a/Detections/SecurityEvent/Potentialre-namedsdeleteusage.yaml
+++ b/Detections/SecurityEvent/Potentialre-namedsdeleteusage.yaml
@@ -1,0 +1,37 @@
+id: 720d12c6-a08c-44c4-b18f-2236412d59b0
+name: Potential re-named sdelete usage
+description: |
+  'This detection looks for command line parameters associated with the use of Sysinternals sdelete (https://docs.microsoft.com/sysinternals/downloads/sdelete) to delete multiple files on a host's C drive.
+  A threat actor may re-name the tool to avoid detection and then use it for destructive attacks on a host.'
+severity: Low
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - PrivilegeEscalation
+  - Impact
+relevantTechniques:
+  - T1485
+  - T1036
+query: |
+  SecurityEvent
+    | where EventID == 4688
+    | where Process !~ "sdelete.exe"
+    | where CommandLine has_all ("-accepteula", "-r", "-s", "-q", "c:/")
+    | where CommandLine !has ("sdelete")
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Account
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer
+version: 1.0.0
+kind: scheduled

--- a/Detections/SecurityEvent/Potentialre-namedsdeleteusage.yaml
+++ b/Detections/SecurityEvent/Potentialre-namedsdeleteusage.yaml
@@ -13,7 +13,7 @@ queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - PrivilegeEscalation
+  - DefenseEvasion
   - Impact
 relevantTechniques:
   - T1485


### PR DESCRIPTION
deployment of exe's via default domain policies

   Required items, please complete
   
   Change(s):
   - Added new detections for renamed sdelete usage and deployment via Default Domain GPOs
   - Both include ASIM and non-ASIM versions

   Reason for Change(s):
   - New Detections

   Version Updated:
   - N/A

   Testing Completed:
   - Y
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Y

