### PR TITLE
Feature/noamlandress/update os list for cef

### DIFF
--- a/DataConnectors/CEF/cef_AMA_installer.py
+++ b/DataConnectors/CEF/cef_AMA_installer.py
@@ -7,8 +7,8 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09 and 2
-#       Oracle Linux 7, 8
+#       Amazon Linux 2017.09
+#       Oracle Linux 7
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9
 #       Ubuntu Linux 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS

--- a/DataConnectors/CEF/cef_AMA_installer.py
+++ b/DataConnectors/CEF/cef_AMA_installer.py
@@ -7,8 +7,8 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09
-#       Oracle Linux 7
+#       Amazon Linux 2017.09 and 2
+#       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9
 #       Ubuntu Linux 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS

--- a/DataConnectors/CEF/cef_gather_info.py
+++ b/DataConnectors/CEF/cef_gather_info.py
@@ -7,8 +7,8 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09
-#       Oracle Linux 7
+#       Amazon Linux 2017.09 and 2
+#       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9
 #       Ubuntu Linux 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS

--- a/DataConnectors/CEF/cef_gather_info.py
+++ b/DataConnectors/CEF/cef_gather_info.py
@@ -7,7 +7,7 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09 and 2
+#       Amazon Linux 2017.09 and Amazon Linux 2
 #       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9

--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -7,8 +7,8 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09
-#       Oracle Linux 7
+#       Amazon Linux 2017.09 and 2
+#       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9
 #       Ubuntu Linux 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS

--- a/DataConnectors/CEF/cef_installer.py
+++ b/DataConnectors/CEF/cef_installer.py
@@ -7,7 +7,7 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09 and 2
+#       Amazon Linux 2017.09 and Amazon Linux 2
 #       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9

--- a/DataConnectors/CEF/cef_troubleshoot.py
+++ b/DataConnectors/CEF/cef_troubleshoot.py
@@ -9,7 +9,7 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09 and 2
+#       Amazon Linux 2017.09 and Amazon Linux 2
 #       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9

--- a/DataConnectors/CEF/cef_troubleshoot.py
+++ b/DataConnectors/CEF/cef_troubleshoot.py
@@ -9,8 +9,8 @@
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8
-#       Amazon Linux 2017.09
-#       Oracle Linux 7
+#       Amazon Linux 2017.09 and 2
+#       Oracle Linux 7, 8
 #       Red Hat Enterprise Linux Server 7 and 8
 #       Debian GNU/Linux 8 and 9
 #       Ubuntu Linux 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Adding support of Oracle 8, Amazon Linux 2 to CEF scripts docs

   Reason for Change(s):
   - OMS agent supports 2 new VM's

   Testing Completed:
   - Running all CEF scripts successfully on the new OS.


-----------------------------------------------------------------------------------------------------------
