### PR TITLE
Add modified StrongAuthenticationMethod events to AuthenticationMethodsChangedforPrivilegedAccount.yaml

### DIFF
--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -28,10 +28,10 @@ query: |
       | mv-expand AssignedRoles
       | where AssignedRoles matches regex 'Admin'
       | summarize by tolower(AccountUPN));
-  let UserRegisteredSecurityInfo =
+  let RegisteredSecurityInfo =
       AuditLogs
       | where TimeGenerated > ago(queryfrequency)
-      | where OperationName == "User registered security info";
+      | where OperationName in ("User registered security info", "Admin registered security info");
   let UpdateUserStrongAuthenticationMethod =
       AuditLogs
       | where TimeGenerated > ago(queryfrequency)

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -28,9 +28,17 @@ query: |
       | mv-expand AssignedRoles
       | where AssignedRoles matches regex 'Admin'
       | summarize by tolower(AccountUPN));
-  AuditLogs
-  | where TimeGenerated > ago(queryfrequency)
-  | where OperationName == "User registered security info" or (OperationName == "Update user" and TargetResources[0].modifiedProperties[0].displayName == "StrongAuthenticationMethod")
+  let UserRegisteredSecurityInfo =
+      AuditLogs
+      | where TimeGenerated > ago(queryfrequency)
+      | where OperationName == "User registered security info";
+  let UpdateUserStrongAuthenticationMethod =
+      AuditLogs
+      | where TimeGenerated > ago(queryfrequency)
+      | where OperationName == "Update user"
+      | mv-expand modifiedProperty = TargetResources[0].modifiedProperties
+      | where modifiedProperty.displayName == "StrongAuthenticationMethod";
+  union isfuzzy=true UserRegisteredSecurityInfo, UpdateUserStrongAuthenticationMethod
   | extend AccountCustomEntity = tolower(tostring(TargetResources[0].userPrincipalName)), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
   | where AccountCustomEntity in (VIPUsers)
 entityMappings:

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -38,7 +38,7 @@ query: |
       | where OperationName == "Update user"
       | mv-expand modifiedProperty = TargetResources[0].modifiedProperties
       | where modifiedProperty.displayName == "StrongAuthenticationMethod";
-  union isfuzzy=true UserRegisteredSecurityInfo, UpdateUserStrongAuthenticationMethod
+  union isfuzzy=true RegisteredSecurityInfo, UpdateUserStrongAuthenticationMethod
   | extend AccountCustomEntity = tolower(tostring(TargetResources[0].userPrincipalName)), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
   | where AccountCustomEntity in (VIPUsers)
 entityMappings:

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -30,9 +30,7 @@ query: |
       | summarize by tolower(AccountUPN));
   AuditLogs
   | where TimeGenerated > ago(queryfrequency)
-  | where Category =~ "UserManagement"
-  | where ActivityDisplayName =~ "User registered security info"
-  | where LoggedByService =~ "Authentication Methods"
+  | where OperationName == "User registered security info" or (OperationName == "Update user" and TargetResources[0].modifiedProperties[0].displayName == "StrongAuthenticationMethod")
   | extend AccountCustomEntity = tolower(tostring(TargetResources[0].userPrincipalName)), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
   | where AccountCustomEntity in (VIPUsers)
 entityMappings:
@@ -44,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -1,7 +1,7 @@
 id: 694c91ee-d606-4ba9-928e-405a2dd0ff0f
 name: Authentication Methods Changed for Privileged Account
 description: |
-  'Identifies authentication methods being changed for a privileged account. This could be an indicated of an attacker adding an auth method to the account so they can have continued access.
+  'Identifies authentication methods being changed for a privileged account. This could be an indication of an attacker adding an auth method to the account so they can have continued access.
   Ref : https://docs.microsoft.com/azure/active-directory/fundamentals/security-operations-privileged-accounts#things-to-monitor-1'
 severity: High
 requiredDataConnectors:

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -28,17 +28,17 @@ query: |
       | mv-expand AssignedRoles
       | where AssignedRoles matches regex 'Admin'
       | summarize by tolower(AccountUPN));
-  let RegisteredSecurityInfo =
+  let ChangedSecurityInfo =
       AuditLogs
       | where TimeGenerated > ago(queryfrequency)
-      | where OperationName in ("User registered security info", "Admin registered security info");
+      | where OperationName has "security info" and OperationName has_any ("User", "Admin") and OperationName has_any ("registered","updated");
   let UpdateUserStrongAuthenticationMethod =
       AuditLogs
       | where TimeGenerated > ago(queryfrequency)
       | where OperationName == "Update user"
       | mv-expand modifiedProperty = TargetResources[0].modifiedProperties
       | where modifiedProperty.displayName == "StrongAuthenticationMethod";
-  union isfuzzy=true RegisteredSecurityInfo, UpdateUserStrongAuthenticationMethod
+  union isfuzzy=true ChangedSecurityInfo, UpdateUserStrongAuthenticationMethod
   | extend AccountCustomEntity = tolower(tostring(TargetResources[0].userPrincipalName)), IPCustomEntity = tostring(InitiatedBy.user.ipAddress)
   | where AccountCustomEntity in (VIPUsers)
 entityMappings:

--- a/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
+++ b/Detections/MultipleDataSources/AuthenticationMethodsChangedforPrivilegedAccount.yaml
@@ -31,11 +31,14 @@ query: |
   let ChangedSecurityInfo =
       AuditLogs
       | where TimeGenerated > ago(queryfrequency)
-      | where OperationName has "security info" and OperationName has_any ("User", "Admin") and OperationName has_any ("registered","updated");
+      | where OperationName has "security info" and OperationName has_any ("User", "Admin") and OperationName has_any ("registered","updated")
+      //| where Result == "success"
+      ;
   let UpdateUserStrongAuthenticationMethod =
       AuditLogs
       | where TimeGenerated > ago(queryfrequency)
       | where OperationName == "Update user"
+      //| where Result == "success"
       | mv-expand modifiedProperty = TargetResources[0].modifiedProperties
       | where modifiedProperty.displayName == "StrongAuthenticationMethod";
   union isfuzzy=true ChangedSecurityInfo, UpdateUserStrongAuthenticationMethod


### PR DESCRIPTION
  Change(s):
   - Add events where Strong Authentication Methods of users are modified.

   Reason for Change(s):
   - Not every change in Authentication Methods is registered through ```OperationName == "User registered security info"```

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

Please, modify the operator to ```=~``` if you want.

I have observed this activity in an environment where a PhoneNumber is allowed for StrongAuthentication. For this specific activity I have not observed any event where OperationName contained "security info", only "Update user" and StrongAuthenticationDetails was modified too.