### PR TITLE
Removing duplicate ConnectorId entries from Query

### DIFF
--- a/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
@@ -94,5 +94,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
@@ -10,10 +10,7 @@ requiredDataConnectors:
       - SecurityEvent
   - connectorId: WindowsSecurityEvents
     dataTypes:
-      - SecurityEvent
-  - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents   
+      - SecurityEvent 
 queryFrequency: 1d
 queryPeriod: 25h
 triggerOperator: gt

--- a/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.yaml
+++ b/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.yaml
@@ -83,5 +83,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.yaml
+++ b/Detections/SecurityEvent/UserCreatedAddedToBuiltinAdmins_1d.yaml
@@ -10,10 +10,7 @@ requiredDataConnectors:
      - SecurityEvent
   - connectorId: WindowsSecurityEvents
     dataTypes:
-      - SecurityEvent
-  - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents  
+      - SecurityEvent 
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Removing duplicate ConnectorId entries from Query

   Reason for Change(s):
   - Duplicate connectorId not needed and is a bug in the query

   Version Updated:
   - Yes

   Testing Completed:
   -Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below
