### PR TITLE
remove id duplicate

### DIFF
--- a/Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaHighCountsOfTheSameBytesInSize.yaml
+++ b/Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaHighCountsOfTheSameBytesInSize.yaml
@@ -1,4 +1,4 @@
-id: 173f8699-6af5-484a-8b06-8c47ba89b380
+id: 55393e5b-3f7e-4d40-85e5-38ef9ecd8484
 name: Cisco Umbrella - Higher values of count of the Same BytesIn size
 description: |
   'Calculate the count of BytesIn per Source-Destination pair over 24 hours. Higher values may indicate beaconing.'


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - changed out id for a newly generated one

   Reason for Change(s):
   - id was a duplicate from "Multiple Teams deleted by a single user"

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes