### PR TITLE
updated query frequency - timeseries

### DIFF
--- a/Detections/SecurityEvent/TimeSeriesAnomaly-ProcessExecutions.yaml
+++ b/Detections/SecurityEvent/TimeSeriesAnomaly-ProcessExecutions.yaml
@@ -13,7 +13,7 @@ requiredDataConnectors:
   - connectorId: WindowsSecurityEvents
     dataTypes:
       - SecurityEvent
-queryFrequency: 1h
+queryFrequency: 1d
 queryPeriod: 14d
 triggerOperator: gt
 triggerThreshold: 0
@@ -64,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - changing query freq to 1 d from 1 h 

   Reason for Change(s):
   - customer reported bugfix to avoid duplicate rules

   Version Updated:
   - yes


   Testing Completed:
   - See guidance below


