### PR TITLE
Create Detection for Password Spray against ADFSSignInLogs

### DIFF
--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -19,10 +19,11 @@ relevantTechniques:
 query: |
 
   let queryfrequency = 15m;
+  let querywait = 15m;
   let accountthreshold = 5;
   let successCodes = dynamic([0, 50144]);
   ADFSSignInLogs
-  | where TimeGenerated > ago(queryfrequency)
+  | where TimeGenerated between (ago(queryfrequency + querywait)..ago(querywait))
   | where not(todynamic(AuthenticationDetails)[0].authenticationMethod == "Integrated Windows Authentication")
   | summarize
       DistinctFailureCount = dcountif(UserPrincipalName, ResultType !in (successCodes)),

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -1,0 +1,44 @@
+id: 5170c3c4-b8c9-485c-910d-a21d965ee181
+name: Password spray attack against ADFSSignInLogs
+description: |
+  'Identifies evidence of password spray activity against Connect Health for AD FS sign-in events by looking for failures from multiple accounts from the same IP address within a time window.
+  Reference: https://adfshelp.microsoft.com/References/ConnectHealthErrorCodeReference'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - ADFSSignInLogs
+queryFrequency: 15m
+queryPeriod: 15m
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1110
+query: |
+
+  let queryfrequency = 15m;
+  let accountthreshold = 5;
+  let successCodes = dynamic([0, 50144]);
+  ADFSSignInLogs
+  | where TimeGenerated > ago(queryfrequency)
+  | where not(todynamic(AuthenticationDetails)[0].authenticationMethod == "Integrated Windows Authentication")
+  | summarize
+      DistinctFailureCount = dcountif(UserPrincipalName, ResultType !in (successCodes)),
+      DistinctSuccessCount = dcountif(UserPrincipalName, ResultType in (successCodes)),
+      SuccessAccounts = make_set_if(UserPrincipalName, ResultType in (successCodes)),
+      arg_min(TimeGenerated, Category, OperationName, AuthenticationRequirement, ConditionalAccessStatus, IsInteractive, UserAgent, NetworkLocationDetails, DeviceDetail, TokenIssuerType, TokenIssuerName, ResourceIdentity)
+      by IPAddress
+  | where DistinctFailureCount > DistinctSuccessCount and DistinctFailureCount >= accountthreshold
+  //| extend SuccessAccounts = iff(array_length(SuccessAccounts) != 0, SuccessAccounts, dynamic(["null"]))
+  //| mv-expand SuccessAccounts
+  | project TimeGenerated, Category, OperationName, IPAddress, DistinctFailureCount, DistinctSuccessCount, SuccessAccounts, AuthenticationRequirement, ConditionalAccessStatus, IsInteractive, UserAgent, NetworkLocationDetails, DeviceDetail, TokenIssuerType, TokenIssuerName, ResourceIdentity
+
+entityMappings:
+- entityType: IP
+  fieldMappings:
+    - identifier: Address
+      columnName: IPAddress
+version: 1.0.0
+kind: Scheduled

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -8,8 +8,8 @@ requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
       - ADFSSignInLogs
-queryFrequency: 15m
-queryPeriod: 15m
+queryFrequency: 30m
+queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -18,9 +18,9 @@ relevantTechniques:
   - T1110
 query: |
 
-  let queryfrequency = 15m;
+  let queryfrequency = 30m;
   let querywait = 15m;
-  let accountthreshold = 5;
+  let accountthreshold = 10;
   let successCodes = dynamic([0, 50144]);
   ADFSSignInLogs
   | where TimeGenerated between (ago(queryfrequency + querywait)..ago(querywait))

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -28,7 +28,7 @@ query: |
   | summarize
       DistinctFailureCount = dcountif(UserPrincipalName, ResultType !in (successCodes)),
       DistinctSuccessCount = dcountif(UserPrincipalName, ResultType in (successCodes)),
-      SuccessAccounts = make_set_if(UserPrincipalName, ResultType in (successCodes)),
+      SuccessAccounts = make_set_if(UserPrincipalName, ResultType in (successCodes), 250),
       arg_min(TimeGenerated, Category, OperationName, AuthenticationRequirement, ConditionalAccessStatus, IsInteractive, UserAgent, NetworkLocationDetails, DeviceDetail, TokenIssuerType, TokenIssuerName, ResourceIdentity)
       by IPAddress
   | where DistinctFailureCount > DistinctSuccessCount and DistinctFailureCount >= accountthreshold

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -4,10 +4,6 @@ description: |
   'Identifies evidence of password spray activity against Connect Health for AD FS sign-in events by looking for failures from multiple accounts from the same IP address within a time window.
   Reference: https://adfshelp.microsoft.com/References/ConnectHealthErrorCodeReference'
 severity: Medium
-requiredDataConnectors:
-  - connectorId: AzureActiveDirectory
-    dataTypes:
-      - ADFSSignInLogs
 queryFrequency: 30m
 queryPeriod: 1h
 triggerOperator: gt
@@ -17,7 +13,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let queryfrequency = 30m;
   let accountthreshold = 10;
   let successCodes = dynamic([0, 50144]);
@@ -35,7 +30,6 @@ query: |
   //| extend SuccessAccounts = iff(array_length(SuccessAccounts) != 0, SuccessAccounts, dynamic(["null"]))
   //| mv-expand SuccessAccounts
   | project TimeGenerated, Category, OperationName, IPAddress, DistinctFailureCount, DistinctSuccessCount, SuccessAccounts, AuthenticationRequirement, ConditionalAccessStatus, IsInteractive, UserAgent, NetworkLocationDetails, DeviceDetail, TokenIssuerType, TokenIssuerName, ResourceIdentity
-
 entityMappings:
 - entityType: IP
   fieldMappings:

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -3,6 +3,10 @@ name: Password spray attack against ADFSSignInLogs
 description: |
   'Identifies evidence of password spray activity against Connect Health for AD FS sign-in events by looking for failures from multiple accounts from the same IP address within a time window.
   Reference: https://adfshelp.microsoft.com/References/ConnectHealthErrorCodeReference'
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - ADFSSignInLogs
 severity: Medium
 queryFrequency: 30m
 queryPeriod: 1h

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -19,11 +19,11 @@ relevantTechniques:
 query: |
 
   let queryfrequency = 30m;
-  let querywait = 15m;
   let accountthreshold = 10;
   let successCodes = dynamic([0, 50144]);
   ADFSSignInLogs
-  | where TimeGenerated between (ago(queryfrequency + querywait)..ago(querywait))
+  | extend IngestionTime = ingestion_time()
+  | where IngestionTime > ago(queryfrequency)
   | where not(todynamic(AuthenticationDetails)[0].authenticationMethod == "Integrated Windows Authentication")
   | summarize
       DistinctFailureCount = dcountif(UserPrincipalName, ResultType !in (successCodes)),

--- a/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
+++ b/Detections/SigninLogs/ADFSSignInLogsPasswordSpray.yaml
@@ -28,7 +28,7 @@ query: |
       DistinctFailureCount = dcountif(UserPrincipalName, ResultType !in (successCodes)),
       DistinctSuccessCount = dcountif(UserPrincipalName, ResultType in (successCodes)),
       SuccessAccounts = make_set_if(UserPrincipalName, ResultType in (successCodes), 250),
-      arg_min(TimeGenerated, Category, OperationName, AuthenticationRequirement, ConditionalAccessStatus, IsInteractive, UserAgent, NetworkLocationDetails, DeviceDetail, TokenIssuerType, TokenIssuerName, ResourceIdentity)
+      arg_min(TimeGenerated, *)
       by IPAddress
   | where DistinctFailureCount > DistinctSuccessCount and DistinctFailureCount >= accountthreshold
   //| extend SuccessAccounts = iff(array_length(SuccessAccounts) != 0, SuccessAccounts, dynamic(["null"]))


### PR DESCRIPTION
   Change(s):
   - A detection for ADFSSignInLogs.

   Version Updated:
   - Does not apply

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - ADFSSignInLogs is not a correct dataType yet.

-----------------------------------------------------------------------------------------------------------
Feel free to change query frequency/period.

Please, could you check other scenarios where this detection might be a false positive? (for example depending on Authentication Details)
