### PR TITLE
Replacing Notebooks submodule with README.md with redirection to note…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Notebooks"]
-	path = Notebooks
-	url = https://github.com/Azure/Azure-Sentinel-Notebooks.git

--- a/Notebooks/README.md
+++ b/Notebooks/README.md
@@ -1,0 +1,13 @@
+# Microsoft Sentinel Notebooks
+
+## Content has moved
+
+---
+
+Microsoft Sentinel notebooks are now maintained in a separate GitHub repository.
+`https://github.com/Azure/Azure-Sentinel-Notebooks`
+
+Please use this link [Microsoft Sentinel Notebooks](https://github.com/Azure/Azure-Sentinel-Notebooks)
+to see the latest Sentinel notebooks.
+
+---


### PR DESCRIPTION
   Change(s):
   - Removing Notebooks submodule pointing to Azure-Sentinel-Notebooks repository
   - Adding Readme to Notebooks folder to point to Notebooks repo

   Reason for Change(s):
   - Submodule is frequently out-of-date and requires manual update
   - Problems with some of the validation checks on notebooks content.

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below
