### PR TITLE
Add detection for Password Spray against Seamless SSO

### DIFF
--- a/Detections/SigninLogs/SeamlessSSOPasswordSpray.yaml
+++ b/Detections/SigninLogs/SeamlessSSOPasswordSpray.yaml
@@ -1,0 +1,46 @@
+id: fb7ca1c9-e14c-40a3-856e-28f3c14ea1ba
+name: Password spray attack against Azure AD Seamless SSO
+description: |
+  'This query detects when there is a spike in Azure AD Seamless SSO errors. They may not be caused by a Password Spray attack, but the cause of the errors might need to be investigated.
+  Azure AD only logs the requests that matched existing accounts, thus there might have been unlogged requests for non-existing accounts.'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AADNonInteractiveUserSignInLogs
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1110
+query: |
+
+  let account_threshold = 5;
+  AADNonInteractiveUserSignInLogs
+  //| where ResultType == "81016"
+  | where ResultType startswith "81"
+  | summarize DistinctAccounts = dcount(UserPrincipalName), DistinctAddresses = make_set(IPAddress) by ResultType
+  | where DistinctAccounts > account_threshold
+  | mv-expand IPAddress = DistinctAddresses
+  | extend IPAddress = tostring(IPAddress)
+  | join kind=leftouter (union isfuzzy=true SigninLogs, AADNonInteractiveUserSignInLogs) on IPAddress
+  | summarize
+      StartTime = min(TimeGenerated),
+      EndTime = max(TimeGenerated),
+      UserPrincipalName = make_set(UserPrincipalName),
+      UserAgent = make_set(UserAgent),
+      ResultDescription = take_any(ResultDescription),
+      ResultSignature = take_any(ResultSignature)
+      by IPAddress, Type, ResultType
+  | project Type, StartTime, EndTime, IPAddress, ResultType, ResultDescription, ResultSignature, UserPrincipalName, UserAgent = iff(array_length(UserAgent) == 1, UserAgent[0], UserAgent)
+
+entityMappings:
+- entityType: IP
+  fieldMappings:
+    - identifier: Address
+      columnName: IPAddress
+version: 1.0.0
+kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Add a specific detection for Password Spray against Seamless SSO.

   Reason for Change(s):
   - Theoretically this could be detected by Password Spray against Azure AD application, but the actor may change IPAddresses very quickly.

   Version Updated:
   - Does not apply

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

-----------------------------------------------------------------------------------------------------------

Please, could you check if 81XXX ResultTypes are uncommon or not?

Please, could you check if there are more ResultTypes other than 81016 when an actor is trying unsuccessful passwords, or just checking which accounts might exist in a tenant?

![image](https://user-images.githubusercontent.com/2527990/157749269-502657a6-16c1-434f-95cc-c9640937d8dd.png)
