### PR TITLE
Update MFARejectedByUser to include AAD IDs

### DIFF
--- a/Detections/SigninLogs/MFARejectedbyUser.yaml
+++ b/Detections/SigninLogs/MFARejectedbyUser.yaml
@@ -29,9 +29,13 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
+      - identifier: AadUserId
+        columnName: UserId
+      - identifier: AadTenantId
+        columnName: AADTenantId
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: scheduled


### PR DESCRIPTION
Change(s):
- Include `AadUserId` and `AadTenantId` in the `Account` entityMapping for the MFARejectedByUser rule.

Reason for Change(s):
- In my experience, Sentinel will not properly link the alerts / incidents created by the MFARejectedByUser rule to an AAD account unless extra `fieldMappings` for the `AadUserId` and `AadTenantId` are set. Changing the rule like this allowed the data to be linked correctly.
- I assume that most of the other rules in this folder could benefit from this change as well, but I have no way of testing them, so I did not modify them.

Version Updated:
- Yes

Testing Completed:
   - Yes

Checked that the validations are passing and have addressed any issues that are present:
   - No (did not understand the documentation on running the validation, so I'll let the PR CI take care of it)