### PR TITLE
Fix RuleName field in Mail_redirect_via_ExO_transport_rule_hunting.yaml

### DIFF
--- a/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
+++ b/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
@@ -19,35 +19,25 @@ relevantTechniques:
   - T1114
   - T1020
 query: |
-
   OfficeActivity
   | where OfficeWorkload == "Exchange"
   | where Operation in~ ("New-TransportRule", "Set-TransportRule")
-  | extend p = parse_json(Parameters)
+  | extend ParametersValues = extract_all(@'Name\":\"(?P<Name>\w+)\",\"Value\":\"(?P<Value>[^\"]*)', dynamic(["Name", "Value"]), Parameters)
+  | mv-apply ParametersValues on (summarize ParsedParameters = make_bag(pack(tostring(ParametersValues[0]), ParametersValues[1])))
   | extend RuleName = case(
-    Operation =~ "Set-TransportRule", tostring(OfficeObjectId),
-    Operation =~ "New-TransportRule", tostring(p[1].Value),
-    "Unknown"
-    ) 
-  | mvexpand p
-  | where (p.Name =~ "BlindCopyTo" or p.Name =~ "RedirectMessageTo") and isnotempty(p.Value)
-  | extend RedirectTo = p.Value
-  | extend ClientIPOnly = case( 
-    ClientIP has "." and ClientIP has ":", tostring(split(ClientIP,":")[0]), 
-    ClientIP has "." and ClientIP has "-", tostring(split(ClientIP,"-")[0]), 
-    ClientIP has "[", tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
-    ClientIP
-    )  
-  | extend Port = case(
-    ClientIP has "." and ClientIP has ":", (split(ClientIP,":")[1]),
-    ClientIP has "." and ClientIP has "-", (split(ClientIP,"-")[1]),
-    ClientIP has "[" and ClientIP has ":", tostring(split(ClientIP,"]:")[1]),
-    ClientIP has "[" and ClientIP has "-", tostring(split(ClientIP,"]-")[1]),
-    ClientIP
-    )
-  | extend ClientIP = ClientIPOnly
-  | project TimeGenerated, RedirectTo, ClientIP, Port, UserId, Operation, RuleName
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP 
+      Operation =~ "Set-TransportRule", OfficeObjectId,
+      Operation =~ "New-TransportRule", ParsedParameters.Name,
+      "Unknown")
+  | mv-expand Parameters = todynamic(Parameters)
+  | where Parameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(Parameters.Value)
+  | extend RedirectTo = Parameters.Value
+  | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
+  | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
+  | extend
+      timestamp = TimeGenerated,
+      AccountCustomEntity = UserId,
+      IPCustomEntity = IPAddress
+      
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -57,5 +47,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
+++ b/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
@@ -22,15 +22,14 @@ query: |
   OfficeActivity
   | where OfficeWorkload == "Exchange"
   | where Operation in~ ("New-TransportRule", "Set-TransportRule")
-  | extend ParametersValues = extract_all(@'Name\":\"(?P<Name>\w+)\",\"Value\":\"(?P<Value>[^\"]*)', dynamic(["Name", "Value"]), Parameters)
-  | mv-apply ParametersValues on (summarize ParsedParameters = make_bag(pack(tostring(ParametersValues[0]), ParametersValues[1])))
+  | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
   | extend RuleName = case(
       Operation =~ "Set-TransportRule", OfficeObjectId,
       Operation =~ "New-TransportRule", ParsedParameters.Name,
       "Unknown")
-  | mv-expand Parameters = todynamic(Parameters)
-  | where Parameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(Parameters.Value)
-  | extend RedirectTo = Parameters.Value
+  | mv-expand ExpandedParameters = todynamic(Parameters)
+  | where ExpandedParameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(ExpandedParameters.Value)
+  | extend RedirectTo = ExpandedParameters.Value
   | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
   | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = IPAddress

--- a/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
+++ b/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
@@ -33,10 +33,7 @@ query: |
   | extend RedirectTo = Parameters.Value
   | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
   | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
-  | extend
-      timestamp = TimeGenerated,
-      AccountCustomEntity = UserId,
-      IPCustomEntity = IPAddress
+  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = IPAddress
       
 entityMappings:
   - entityType: Account

--- a/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
+++ b/Detections/OfficeActivity/Mail_redirect_via_ExO_transport_rule.yaml
@@ -31,7 +31,7 @@ query: |
   | where ExpandedParameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(ExpandedParameters.Value)
   | extend RedirectTo = ExpandedParameters.Value
   | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
-  | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
+  | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, Parameters
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = IPAddress
       
 entityMappings:

--- a/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
+++ b/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
@@ -18,31 +18,22 @@ query: |
   OfficeActivity
   | where OfficeWorkload == "Exchange"
   | where Operation in~ ("New-TransportRule", "Set-TransportRule")
-  | extend p = parse_json(Parameters)
+  | extend ParametersValues = extract_all(@'Name\":\"(?P<Name>\w+)\",\"Value\":\"(?P<Value>[^\"]*)', dynamic(["Name", "Value"]), Parameters)
+  | mv-apply ParametersValues on (summarize ParsedParameters = make_bag(pack(tostring(ParametersValues[0]), ParametersValues[1])))
   | extend RuleName = case(
-    Operation =~ "Set-TransportRule", tostring(OfficeObjectId),
-    Operation =~ "New-TransportRule", tostring(p[1].Value),
-    "Unknown"
-    ) 
-  | mvexpand p
-  | where (p.Name =~ "BlindCopyTo" or p.Name =~ "RedirectMessageTo") and isnotempty(p.Value)
-  | extend RedirectTo = p.Value
-  | extend ClientIPOnly = case( 
-    ClientIP has "." and ClientIP has ":", tostring(split(ClientIP,":")[0]), 
-    ClientIP has "." and ClientIP has "-", tostring(split(ClientIP,"-")[0]), 
-    ClientIP has "[", tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
-    ClientIP
-    )  
-  | extend Port = case(
-    ClientIP has "." and ClientIP has ":", (split(ClientIP,":")[1]),
-    ClientIP has "." and ClientIP has "-", (split(ClientIP,"-")[1]),
-    ClientIP has "[" and ClientIP has ":", tostring(split(ClientIP,"]:")[1]),
-    ClientIP has "[" and ClientIP has "-", tostring(split(ClientIP,"]-")[1]),
-    ClientIP
-    )
-  | extend ClientIP = ClientIPOnly
-  | project TimeGenerated, RedirectTo, ClientIP, Port, UserId, Operation, RuleName
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
+      Operation =~ "Set-TransportRule", OfficeObjectId,
+      Operation =~ "New-TransportRule", ParsedParameters.Name,
+      "Unknown")
+  | mv-expand Parameters = todynamic(Parameters)
+  | where Parameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(Parameters.Value)
+  | extend RedirectTo = Parameters.Value
+  | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
+  | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
+  | extend
+      timestamp = TimeGenerated,
+      AccountCustomEntity = UserId,
+      IPCustomEntity = IPAddress
+    
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
+++ b/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
@@ -27,7 +27,7 @@ query: |
   | where ExpandedParameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(ExpandedParameters.Value)
   | extend RedirectTo = ExpandedParameters.Value
   | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
-  | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
+  | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, Parameters
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = IPAddress
     
 entityMappings:

--- a/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
+++ b/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
@@ -29,10 +29,7 @@ query: |
   | extend RedirectTo = Parameters.Value
   | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
   | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
-  | extend
-      timestamp = TimeGenerated,
-      AccountCustomEntity = UserId,
-      IPCustomEntity = IPAddress
+  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = IPAddress
     
 entityMappings:
   - entityType: Account

--- a/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
+++ b/Hunting Queries/OfficeActivity/Mail_redirect_via_ExO_transport_rule_hunting.yaml
@@ -18,15 +18,14 @@ query: |
   OfficeActivity
   | where OfficeWorkload == "Exchange"
   | where Operation in~ ("New-TransportRule", "Set-TransportRule")
-  | extend ParametersValues = extract_all(@'Name\":\"(?P<Name>\w+)\",\"Value\":\"(?P<Value>[^\"]*)', dynamic(["Name", "Value"]), Parameters)
-  | mv-apply ParametersValues on (summarize ParsedParameters = make_bag(pack(tostring(ParametersValues[0]), ParametersValues[1])))
+  | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
   | extend RuleName = case(
       Operation =~ "Set-TransportRule", OfficeObjectId,
       Operation =~ "New-TransportRule", ParsedParameters.Name,
       "Unknown")
-  | mv-expand Parameters = todynamic(Parameters)
-  | where Parameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(Parameters.Value)
-  | extend RedirectTo = Parameters.Value
+  | mv-expand ExpandedParameters = todynamic(Parameters)
+  | where ExpandedParameters.Name in~ ("BlindCopyTo", "RedirectMessageTo") and isnotempty(ExpandedParameters.Value)
+  | extend RedirectTo = ExpandedParameters.Value
   | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
   | project TimeGenerated, RedirectTo, IPAddress = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1]), UserId, Operation, RuleName, ParsedParameters
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = IPAddress


### PR DESCRIPTION
   Change(s):
   - Take correct value for RuleName.
   - Use a regex to parse ClientIP.
   - Project Rule Parameters.

   Reason for Change(s):
   - RuleName value might not be always on ```p[1].Value```
   - Just to simplify.
   - Just to add information.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

-----------------------------------------------------------------------------------------------------------
I have not found example addresses with ```-``` character.