### PR TITLE
Renamed the "Workspace Region" parameter to "location"

### DIFF
--- a/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
+++ b/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
@@ -25,7 +25,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -45,7 +45,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -65,7 +65,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -85,7 +85,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -105,7 +105,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -125,7 +125,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -145,7 +145,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -165,7 +165,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -185,7 +185,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -205,7 +205,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -225,7 +225,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -245,7 +245,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -265,7 +265,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -285,7 +285,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
+++ b/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
@@ -25,7 +25,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -45,7 +45,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -65,7 +65,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -85,7 +85,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -105,7 +105,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -125,7 +125,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -145,7 +145,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -165,7 +165,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -185,7 +185,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -205,7 +205,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -225,7 +225,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -245,7 +245,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -265,7 +265,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -285,7 +285,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
+++ b/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -32,8 +32,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -52,8 +52,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -72,8 +72,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -92,8 +92,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -112,8 +112,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -132,8 +132,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -152,8 +152,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -172,8 +172,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -192,8 +192,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -212,8 +212,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -232,8 +232,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -252,8 +252,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -272,8 +272,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -292,8 +292,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }

--- a/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
+++ b/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -33,7 +33,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -53,7 +53,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -73,7 +73,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -93,7 +93,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -113,7 +113,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -133,7 +133,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -153,7 +153,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -173,7 +173,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -193,7 +193,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -213,7 +213,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -233,7 +233,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -253,7 +253,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -273,7 +273,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -293,7 +293,7 @@
             "value": "[parameters('Workspace')]"
           },
           "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+            "value": "[parameters('location')]"
           }
         }
       }

--- a/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
+++ b/Parsers/ASimProcessEvent/ARM/FullDeploymentProcessEvent.json
@@ -32,7 +32,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -52,7 +52,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -72,7 +72,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -92,7 +92,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -112,7 +112,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -132,7 +132,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -152,7 +152,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -172,7 +172,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -192,7 +192,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -212,7 +212,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -232,7 +232,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -252,7 +252,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -272,7 +272,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }
@@ -292,7 +292,7 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
+          "location": {
             "value": "[parameters('location')]"
           }
         }

--- a/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json
+++ b/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json
+++ b/Parsers/ASimProcessEvent/ARM/imProcess/imProcess.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json
+++ b/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json
+++ b/Parsers/ASimProcessEvent/ARM/imProcessCreate/imProcessCreate.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json
+++ b/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json
+++ b/Parsers/ASimProcessEvent/ARM/imProcessTerminate/imProcessTerminate.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateLinuxSysmon/vimProcessCreateLinuxSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSecurityEvents/vimProcessCreateMicrosoftSecurityEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftSysmon/vimProcessCreateMicrosoftSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessCreateMicrosoftWindowsEvents/vimProcessCreateMicrosoftWindowsEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessEmpty/vimProcessEmpty.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessEventMD4IoT/vimProcessEventMD4IoT.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessEventMicrosoft365D/vimProcessEventMicrosoft365D.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateLinuxSysmon/vimProcessTerminateLinuxSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSecurityEvents/vimProcessTerminateMicrosoftSecurityEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftSysmon/vimProcessTerminateMicrosoftSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json
+++ b/Parsers/ASimProcessEvent/ARM/vimProcessTerminateMicrosoftWindowsEvents/vimProcessTerminateMicrosoftWindowsEvents.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json
+++ b/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json
+++ b/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json
+++ b/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json
+++ b/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json
+++ b/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json
+++ b/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
+++ b/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -32,8 +32,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -52,8 +52,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -72,8 +72,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -92,8 +92,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -112,8 +112,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -132,8 +132,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -152,8 +152,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "location": {
-            "value": "[parameters('location')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }

--- a/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
+++ b/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
@@ -25,7 +25,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -45,7 +45,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -65,7 +65,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -85,7 +85,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -105,7 +105,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -125,7 +125,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -145,7 +145,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json",
+          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
+++ b/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
@@ -25,7 +25,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSession/ASimWebSession.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -45,7 +45,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionSquidProxy/ASimWebSessionSquidProxy.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -65,7 +65,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/ASimWebSessionZscalerZIA/ASimWebSessionZscalerZIA.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -85,7 +85,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -105,7 +105,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -125,7 +125,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -145,7 +145,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/fidelcasto/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json",
+          "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
+++ b/Parsers/ASimWebSession/ARM/FullDeploymentWebSession.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -32,8 +32,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -52,8 +52,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -72,8 +72,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -92,8 +92,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -112,8 +112,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -132,8 +132,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }
@@ -152,8 +152,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "location": {
+            "value": "[parameters('location')]"
           }
         }
       }

--- a/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json
+++ b/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json
+++ b/Parsers/ASimWebSession/ARM/imWebSession/imWebSession.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json
+++ b/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json
+++ b/Parsers/ASimWebSession/ARM/vimWebSessionEmpty/vimWebSessionEmpty.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json
+++ b/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json
+++ b/Parsers/ASimWebSession/ARM/vimWebSessionSquidProxy/vimWebSessionSquidProxy.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json
+++ b/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('location')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json
+++ b/Parsers/ASimWebSession/ARM/vimWebSessionZscalerZIA/vimWebSessionZscalerZIA.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "location": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Renamed the "Workspace Region" parameter to "location" in each file where it was used.

   Reason for Change(s):
   - Causes issue when attempting to automate the deployment using Azure DevOps since the parameter have spaces in it.  It also seems to be in best practice to use CamelCase.  

   Version Updated:
   -  N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes