### PR TITLE
Update Creating_Anomalous_Number_Of_Resources.yaml

### DIFF
--- a/Hunting Queries/AzureActivity/Creating_Anomalous_Number_Of_Resources.yaml
+++ b/Hunting Queries/AzureActivity/Creating_Anomalous_Number_Of_Resources.yaml
@@ -18,7 +18,7 @@ query: |
   | where ActivityStatusValue == "Succeeded" 
   | make-series dcount(ResourceId)  default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
   | extend AccountCustomEntity = Caller
-  | extend timestamp = todatetime(EventSubmissionTimestamp[0])
+  | extend timestamp = todatetime(EventSubmissionTimestamp[7])
 
 entityMappings:
   - entityType: Account


### PR DESCRIPTION
Timestamp should be latest in the series, not the first day since this makes it appear out of order for when the query was executed.

   Required items, please complete
   
   Change(s):
   - Changed to output most recent day of make series timestamp

   Reason for Change(s):
   - First day in series is looking back 7 days ago and conflicts with when the query was run, so taking the last day in the series for timestamp
   - 
   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Checking