### PR TITLE
Add two DSM detections: Access to sensitive data from "terminated employees" / TI matched IPs

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/DSMAzureBlobStorageLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DSMAzureBlobStorageLogs.json
@@ -1,0 +1,33 @@
+{
+    "Name": "DSMAzureBlobStorageLogs",
+    "Properties": [
+        {
+            "Name": "CorrelationId",
+            "Type": "String"
+        },
+        {
+            "Name": "Uri",
+            "Type": "String"
+        },
+        {
+            "Name": "RequesterObjectId",
+            "Type": "String"
+        },
+        {
+            "Name": "StatusCode",
+            "Type": "Int"
+        },
+        {
+            "Name": "AggregationCount",
+            "Type": "Int"
+        },
+        {
+            "Name": "TimeGenerated",
+            "Type": "DateTime"
+        },
+        {
+            "Name": "CallerIpAddress",
+            "Type": "String"
+        }
+    ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DSMAzureBlobStorageLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DSMAzureBlobStorageLogs.json
@@ -15,11 +15,11 @@
         },
         {
             "Name": "StatusCode",
-            "Type": "Int"
+            "Type": "String"
         },
         {
             "Name": "AggregationCount",
-            "Type": "Int"
+            "Type": "Long"
         },
         {
             "Name": "TimeGenerated",

--- a/.script/tests/KqlvalidationsTests/CustomTables/DSMDataClassificationLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DSMDataClassificationLogs.json
@@ -1,0 +1,17 @@
+{
+    "Name": "DSMDataLabelingLogs",
+    "Properties": [
+        {
+            "Name": "CorrelationId",
+            "Type": "String"
+        },
+        {
+            "Name": "SensitivityLabelName",
+            "Type": "String"
+        },
+        {
+            "Name": "TimeGenerated",
+            "Type": "DateTime"
+        }
+    ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DSMDataClassificationLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DSMDataClassificationLogs.json
@@ -1,13 +1,13 @@
 {
-    "Name": "DSMDataLabelingLogs",
+    "Name": "DSMDataClassificationLogs",
     "Properties": [
         {
             "Name": "CorrelationId",
             "Type": "String"
         },
         {
-            "Name": "SensitivityLabelName",
-            "Type": "String"
+            "Name": "ClassificationDetails",
+            "Type": "Dynamic"
         },
         {
             "Name": "TimeGenerated",

--- a/.script/tests/KqlvalidationsTests/CustomTables/DSMDataLabelingLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DSMDataLabelingLogs.json
@@ -1,0 +1,17 @@
+{
+    "Name": "DSMDataClassificationLogs",
+    "Properties": [
+        {
+            "Name": "CorrelationId",
+            "Type": "String"
+        },
+        {
+            "Name": "ClassificationDetails",
+            "Type": "Dynamic"
+        },
+        {
+            "Name": "TimeGenerated",
+            "Type": "DateTime"
+        }
+    ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/DSMDataLabelingLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DSMDataLabelingLogs.json
@@ -1,13 +1,13 @@
 {
-    "Name": "DSMDataClassificationLogs",
+    "Name": "DSMDataLabelingLogs",
     "Properties": [
         {
             "Name": "CorrelationId",
             "Type": "String"
         },
         {
-            "Name": "ClassificationDetails",
-            "Type": "Dynamic"
+            "Name": "SensitivityLabelName",
+            "Type": "String"
         },
         {
             "Name": "TimeGenerated",

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -4,12 +4,18 @@ description: |
   This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), by users that are marked as terminated employees.
   Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
   Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
-requiredDataConnectors: []
-severity: Medium  # detections
-queryPeriod: 7d   # detections
-queryFrequency: 7d  # detections
-triggerOperator: gt # detections
-triggerThreshold: 0 # detections
+requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
+severity: High
+queryPeriod: 1d
+queryFrequency: 1d
+triggerOperator: gt
+triggerThreshold: 0
 tactics:
   - Exfiltration
   - Collection
@@ -79,6 +85,4 @@ entityMappings:
       - identifier: ObjectGuid
         columnName: UserObjectId
 version: 1.0.0
-kind: Scheduled # detections
-
-
+kind: Scheduled

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -78,6 +78,7 @@ entityMappings:
     fieldMappings:
       - identifier: ObjectGuid
         columnName: UserObjectId
+version: 1.0.0
 kind: Scheduled # detections
 
 

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -1,0 +1,83 @@
+id: 5feef89a-d632-4294-a05c-988a1c64da23
+name: Access to sensitive data by terminated employees
+description: |
+  This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), by users that are marked as terminated employees.
+  Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
+  Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
+requiredDataConnectors: []
+severity: Medium  # detections
+queryPeriod: 7d   # detections
+queryFrequency: 7d  # detections
+triggerOperator: gt # detections
+triggerThreshold: 0 # detections
+tactics:
+  - Exfiltration
+  - Collection
+relevantTechniques:
+  - T1567
+  - T1530
+query: |
+
+  // accesses to labeled and/or classified data
+  let AccessLogs = DSMAzureBlobStorageLogs
+      | where isnotempty(CorrelationId)
+      | project
+          Asset = tostring(parse_url(Uri).Path),
+          UserObjectId=RequesterObjectId,
+          StatusCode,
+          AggregationCount,
+          CorrelationId,
+          TimeGenerated;
+  let ScanDataLookback = now() - 30d;
+  // labeled data
+  let Sensitivity = 
+      DSMDataLabelingLogs
+      | where TimeGenerated > ScanDataLookback
+      | where isnotempty(SensitivityLabelName)
+      | project
+          SensitivityLabelName = replace(@'\[|\]|\"', @'', SensitivityLabelName),
+          CorrelationId
+      | distinct *;
+  // classified data
+  let Classification = 
+      DSMDataClassificationLogs
+      | where TimeGenerated > ScanDataLookback
+      | where isnotempty(ClassificationDetails)
+      | mv-expand ClassificationDetails
+      | project
+          ClassificationName = tostring(ClassificationDetails.Name),
+          UniqueCount = tostring(ClassificationDetails.UniqueCount),
+          Confidence = tostring(ClassificationDetails.Confidence),
+          CorrelationId
+      | distinct *;
+  // all labeled and/or classified data
+  let ScanData = Classification
+      | join kind=fullouter Sensitivity
+          on CorrelationId;
+  // a list of terminated employees by user's object id
+  let TerminatedEmployees = _GetWatchlist("TerminatedEmployees")
+      | project UserObjectId = tostring(["User AAD Object Id"])
+      | distinct UserObjectId;
+  AccessLogs
+  | join kind=inner ScanData on CorrelationId
+  | join kind=inner TerminatedEmployees on UserObjectId
+  | summarize
+      AccessCount = sum(AggregationCount),
+      StartTime = min(TimeGenerated),
+      EndTime = max(TimeGenerated)
+      by
+      UserObjectId,
+      ClassificationName,
+      UniqueCount,
+      Confidence,
+      SensitivityLabelName,
+      StatusCode,
+      Asset
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: ObjectGuid
+        columnName: UserObjectId
+kind: Scheduled # detections
+
+

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -28,8 +28,8 @@ query: |
           AggregationCount,
           CorrelationId,
           TimeGenerated;
-  let ScanDataLookback = now() - 30d;
   // labeled data
+  let ScanDataLookback = now() - 30d;
   let Sensitivity = 
       DSMDataLabelingLogs
       | where TimeGenerated > ScanDataLookback

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -1,16 +1,11 @@
 id: 5feef89a-d632-4294-a05c-988a1c64da23
 name: Access to sensitive data by Terminated Employees
 description: |
-  This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), by users that are marked as terminated employees.
-  Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
-  Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
-requiredDataConnectors:
-  - connectorId: ThreatIntelligence
-    dataTypes:
-      - ThreatIntelligenceIndicator
-  - connectorId: ThreatIntelligenceTaxii
-    dataTypes:
-      - ThreatIntelligenceIndicator
+  'This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), by users that are marked as terminated employees.
+  References:
+  - [Classification insights](https://docs.microsoft.com/azure/purview/classification-insights)
+  - [Sensitivity label insights](https://docs.microsoft.com/azure/purview/sensitivity-insights)'
+requiredDataConnectors: []
 severity: High
 queryPeriod: 1d
 queryFrequency: 1d
@@ -23,7 +18,6 @@ relevantTechniques:
   - T1567
   - T1530
 query: |
-
   // accesses to labeled and/or classified data
   let AccessLogs = DSMAzureBlobStorageLogs
       | where isnotempty(CorrelationId)

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -29,27 +29,28 @@ query: |
           CorrelationId,
           TimeGenerated;
   // labeled data
-  let ScanDataLookback = now() - 30d;
   let Sensitivity = 
       DSMDataLabelingLogs
-      | where TimeGenerated > ScanDataLookback
+      // to bypass the defined timeframe, we filter by TimeGenerated explicitly
+      | where TimeGenerated < now()
       | where isnotempty(SensitivityLabelName)
+      | summarize arg_max(TimeGenerated, SensitivityLabelName) by CorrelationId
       | project
           SensitivityLabelName = replace(@'\[|\]|\"', @'', SensitivityLabelName),
-          CorrelationId
-      | distinct *;
+          CorrelationId;
   // classified data
   let Classification = 
       DSMDataClassificationLogs
-      | where TimeGenerated > ScanDataLookback
+      // to bypass the defined timeframe, we filter by TimeGenerated explicitly
+      | where TimeGenerated < now()
       | where isnotempty(ClassificationDetails)
+      | summarize arg_max(TimeGenerated, ClassificationDetails) by CorrelationId
       | mv-expand ClassificationDetails
       | project
           ClassificationName = tostring(ClassificationDetails.Name),
           UniqueCount = tostring(ClassificationDetails.UniqueCount),
           Confidence = tostring(ClassificationDetails.Confidence),
-          CorrelationId
-      | distinct *;
+          CorrelationId;
   // all labeled and/or classified data
   let ScanData = Classification
       | join kind=fullouter Sensitivity

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataByTerminatedEmployees.yaml
@@ -1,5 +1,5 @@
 id: 5feef89a-d632-4294-a05c-988a1c64da23
-name: Access to sensitive data by terminated employees
+name: Access to sensitive data by Terminated Employees
 description: |
   This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), by users that are marked as terminated employees.
   Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -4,13 +4,7 @@ description: |
   This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), from IP adresses that are marked via the TI.
   Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
   Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
-requiredDataConnectors:
-  - connectorId: ThreatIntelligence
-    dataTypes:
-      - ThreatIntelligenceIndicator
-  - connectorId: ThreatIntelligenceTaxii
-    dataTypes:
-      - ThreatIntelligenceIndicator
+requiredDataConnectors: []
 severity: Medium  # detections
 queryPeriod: 7d   # detections
 queryFrequency: 7d  # detections
@@ -88,6 +82,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: NetworkIP
+version: 1.0.0
 kind: Scheduled # detections
 
 

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -1,0 +1,93 @@
+id: e3c63c74-1140-406b-bfd6-9ddee2677f9e
+name: Access to sensitive data from known TI matched IP Addresses
+description: |
+  This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), from IP adresses that are marked via the TI.
+  Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
+  Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
+requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
+severity: Medium  # detections
+queryPeriod: 7d   # detections
+queryFrequency: 7d  # detections
+triggerOperator: gt # detections
+triggerThreshold: 0 # detections
+tactics:
+  - Exfiltration
+  - Collection
+relevantTechniques:
+  - T1567
+  - T1530
+query: |
+
+  // accesses to labeled and/or classified data
+  let AccessLogs = DSMAzureBlobStorageLogs
+      | where isnotempty(CorrelationId)
+      | project
+          Asset = tostring(parse_url(Uri).Path),
+          UserObjectId=RequesterObjectId,
+          StatusCode,
+          AggregationCount,
+          CorrelationId,
+          TimeGenerated,
+          NetworkIP = CallerIpAddress;
+  let ScanDataLookback = now() - 30d;
+  let Sensitivity = 
+      DSMDataLabelingLogs
+      | where TimeGenerated > ScanDataLookback
+      | where isnotempty(SensitivityLabelName)
+      | project
+          SensitivityLabelName = replace(@'\[|\]|\"', @'', SensitivityLabelName),
+          CorrelationId
+      | distinct *;
+  // classified data
+  let Classification = 
+      DSMDataClassificationLogs
+      | where TimeGenerated > ScanDataLookback
+      | where isnotempty(ClassificationDetails)
+      | mv-expand ClassificationDetails
+      | project
+          ClassificationName = tostring(ClassificationDetails.Name),
+          UniqueCount = tostring(ClassificationDetails.UniqueCount),
+          Confidence = tostring(ClassificationDetails.Confidence),
+          CorrelationId
+      | distinct *;
+  // all labeled and/or classified data
+  let ScanData = Classification
+      | join kind=fullouter Sensitivity
+          on CorrelationId;
+  let TI_IPs = ThreatIntelligenceIndicator
+      | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+      | project NetworkIP;
+  AccessLogs
+  | join kind=inner ScanData on CorrelationId
+  | join kind=inner TI_IPs on NetworkIP
+  | summarize 
+      AccessCount = sum(AggregationCount),
+      StartTime = min(TimeGenerated),
+      EndTime = max(TimeGenerated)
+      by
+      NetworkIP,
+      UserObjectId,
+      ClassificationName,
+      UniqueCount,
+      Confidence,
+      SensitivityLabelName,
+      StatusCode,
+      Asset
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: ObjectGuid
+        columnName: UserObjectId
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: NetworkIP
+kind: Scheduled # detections
+
+

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -5,11 +5,11 @@ description: |
   Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
   Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
 requiredDataConnectors: []
-severity: Medium  # detections
-queryPeriod: 7d   # detections
-queryFrequency: 7d  # detections
-triggerOperator: gt # detections
-triggerThreshold: 0 # detections
+severity: High
+queryPeriod: 1d
+queryFrequency: 1d
+triggerOperator: gt
+triggerThreshold: 0
 tactics:
   - Exfiltration
   - Collection
@@ -83,6 +83,6 @@ entityMappings:
       - identifier: Address
         columnName: NetworkIP
 version: 1.0.0
-kind: Scheduled # detections
+kind: Scheduled
 
 

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -62,6 +62,7 @@ query: |
           on CorrelationId;
   let TI_IPs = ThreatIntelligenceIndicator
       | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+      | where Active == true
       | project NetworkIP;
   AccessLogs
   | join kind=inner ScanData on CorrelationId

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -35,6 +35,7 @@ query: |
           CorrelationId,
           TimeGenerated,
           NetworkIP = CallerIpAddress;
+  // labeled data
   let ScanDataLookback = now() - 30d;
   let Sensitivity = 
       DSMDataLabelingLogs

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -1,10 +1,17 @@
 id: e3c63c74-1140-406b-bfd6-9ddee2677f9e
 name: Access to sensitive data from known TI matched IP addresses
 description: |
-  This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), from IP adresses that are marked via the TI.
-  Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
-  Sensitivty label insigths: https://docs.microsoft.com/en-us/azure/purview/sensitivity-insights
-requiredDataConnectors: []
+  'This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), from IP adresses that are marked via the TI.
+  References:
+  - [Classification insights](https://docs.microsoft.com/azure/purview/classification-insights)
+  - [Sensitivity label insights](https://docs.microsoft.com/azure/purview/sensitivity-insights)'
+requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
 severity: High
 queryPeriod: 1d
 queryFrequency: 1d
@@ -17,7 +24,6 @@ relevantTechniques:
   - T1567
   - T1530
 query: |
-
   // accesses to labeled and/or classified data
   let AccessLogs = DSMAzureBlobStorageLogs
       | where isnotempty(CorrelationId)

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -36,27 +36,28 @@ query: |
           TimeGenerated,
           NetworkIP = CallerIpAddress;
   // labeled data
-  let ScanDataLookback = now() - 30d;
   let Sensitivity = 
       DSMDataLabelingLogs
-      | where TimeGenerated > ScanDataLookback
+      // to bypass the defined timeframe, we filter by TimeGenerated explicitly
+      | where TimeGenerated < now()
       | where isnotempty(SensitivityLabelName)
+      | summarize arg_max(TimeGenerated, SensitivityLabelName) by CorrelationId
       | project
           SensitivityLabelName = replace(@'\[|\]|\"', @'', SensitivityLabelName),
-          CorrelationId
-      | distinct *;
+          CorrelationId;
   // classified data
   let Classification = 
       DSMDataClassificationLogs
-      | where TimeGenerated > ScanDataLookback
+      // to bypass the defined timeframe, we filter by TimeGenerated explicitly
+      | where TimeGenerated < now()
       | where isnotempty(ClassificationDetails)
+      | summarize arg_max(TimeGenerated, ClassificationDetails) by CorrelationId
       | mv-expand ClassificationDetails
       | project
           ClassificationName = tostring(ClassificationDetails.Name),
           UniqueCount = tostring(ClassificationDetails.UniqueCount),
           Confidence = tostring(ClassificationDetails.Confidence),
-          CorrelationId
-      | distinct *;
+          CorrelationId;
   // all labeled and/or classified data
   let ScanData = Classification
       | join kind=fullouter Sensitivity

--- a/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
+++ b/Detections/DSMAzureBlobStorageLogs/AccessToSensitiveDataFromKnownTiMatchedIpAdresses.yaml
@@ -1,5 +1,5 @@
 id: e3c63c74-1140-406b-bfd6-9ddee2677f9e
-name: Access to sensitive data from known TI matched IP Addresses
+name: Access to sensitive data from known TI matched IP addresses
 description: |
   This query detects access to data that has classification insights (link below) and/or sensitivity label insights (link below), from IP adresses that are marked via the TI.
   Classification insights: https://docs.microsoft.com/en-us/azure/purview/classification-insights
@@ -84,5 +84,3 @@ entityMappings:
         columnName: NetworkIP
 version: 1.0.0
 kind: Scheduled
-
-


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added two detections:
   1. Access to sensitive data from known TI matched IP Addresses
   2. Access to sensitive data by terminated employees

   Reason for Change(s):
   - New DSM feature that is integrated in Sentinel

   Version Updated:
   - New detections.

   Testing Completed:
   - Not sure

   Checked that the validations are passing and have addressed any issues that are present:
   - KQL validation fails locally. Help is needed
