### PR TITLE
ASIM - Changes Description fields to use regular multiline comment pipe.

### DIFF
--- a/Parsers/ASimProcessEvent/Parsers/vimProcessEventMD4IoT.yaml
+++ b/Parsers/ASimProcessEvent/Parsers/vimProcessEventMD4IoT.yaml
@@ -12,7 +12,7 @@ References:
   Link: https://aka.ms/ASimProcessEventDoc
 - Title: ASIM
   Link: https:/aka.ms/AboutASIM
-Description: !
+Description: |
     This ASIM parser supports normalizing Microsoft Defender for IoT events to the ASIM Process Event normalized schema. 
 ParserName: vimProcessEventMD4IoT
 ParserQuery: |

--- a/Parsers/ASimProcessEvent/Parsers/vimProcessEventMicrosoft365D.yaml
+++ b/Parsers/ASimProcessEvent/Parsers/vimProcessEventMicrosoft365D.yaml
@@ -12,7 +12,7 @@ References:
   Link: https://aka.ms/ASimProcessEventDoc
 - Title: ASIM
   Link: https:/aka.ms/AboutASIM
-Description: !
+Description: |
     This ASIM parser supports normalizing Microsoft 365 Defender for endpoint to the ASIM Process Event normalized schema.
 ParserName: vimProcessEventMicrosoft365D
 ParserQuery: |

--- a/Parsers/ASimProcessEvent/Parsers/vimProcessTerminateLinuxSysmon.yaml
+++ b/Parsers/ASimProcessEvent/Parsers/vimProcessTerminateLinuxSysmon.yaml
@@ -12,7 +12,7 @@ References:
   Link: https://aka.ms/ASimProcessEventDoc
 - Title: ASIM
   Link: https:/aka.ms/AboutASIM
-Description: !
+Description: |
   This ASIM parser supports normalizing Sysmon for Linux process terminate events (event 5) collected using the Syslog connector to the ASIM Process Event normalized schema. 
 ParserName: vimProcessTerminateLinuxSysmon
 ParserQuery: | 


### PR DESCRIPTION
A small change in YAML syntax.
   
   Change(s):
   - Changes the *Description* fields in these parsers to use a pipe `|` instead of an exclamation point `!`.

   Reason for Change(s):
   - While technically valid YAML, this was breaking [yamldecode()](https://www.terraform.io/language/functions/yamldecode) function.

   Testing Completed:
   - complete

