### PR TITLE
Removed the 'space' character in the parameter 'Workspace Region' in …

### DIFF
--- a/Parsers/ASimRegistryEvent/ARM/FullDeploymentRegistryEvent.json
+++ b/Parsers/ASimRegistryEvent/ARM/FullDeploymentRegistryEvent.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -32,8 +32,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -52,8 +52,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -72,8 +72,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -92,8 +92,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -112,8 +112,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }
@@ -132,8 +132,8 @@
           "Workspace": {
             "value": "[parameters('Workspace')]"
           },
-          "Workspace Region": {
-            "value": "[parameters('Workspace Region')]"
+          "WorkspaceRegion": {
+            "value": "[parameters('WorkspaceRegion')]"
           }
         }
       }

--- a/Parsers/ASimRegistryEvent/ARM/imRegistry/imRegistry.json
+++ b/Parsers/ASimRegistryEvent/ARM/imRegistry/imRegistry.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimRegistryEvent/ARM/vimRegistryEventEmpty/vimRegistryEventEmpty.json
+++ b/Parsers/ASimRegistryEvent/ARM/vimRegistryEventEmpty/vimRegistryEventEmpty.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoft365D/vimRegistryEventMicrosoft365D.json
+++ b/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoft365D/vimRegistryEventMicrosoft365D.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoftSecurityEvent/vimRegistryEventMicrosoftSecurityEvent.json
+++ b/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoftSecurityEvent/vimRegistryEventMicrosoftSecurityEvent.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoftSysmon/vimRegistryEventMicrosoftSysmon.json
+++ b/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoftSysmon/vimRegistryEventMicrosoftSysmon.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",

--- a/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoftWindowsEvent/vimRegistryEventMicrosoftWindowsEvent.json
+++ b/Parsers/ASimRegistryEvent/ARM/vimRegistryEventMicrosoftWindowsEvent/vimRegistryEventMicrosoftWindowsEvent.json
@@ -8,7 +8,7 @@
         "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "Workspace Region": {
+    "WorkspaceRegion": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
@@ -21,7 +21,7 @@
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2017-03-15-preview",
       "name": "[parameters('Workspace')]",
-      "location": "[parameters('Workspace Region')]",
+      "location": "[parameters('WorkspaceRegion')]",
       "resources": [
         {
           "type": "savedSearches",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Removed the 'space' character in the ARM Templkate parameter 'Workspace Region'.  Same change as PR [#4443](https://github.com/Azure/Azure-Sentinel/pull/4443).

   Reason for Change(s):
   - Can't be deployed in Azure DevOps if the parameter has a 'space' into it.

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes