### PR TITLE
Hunting Query to detect User password reset in Okta

### DIFF
--- a/Solutions/Okta Single Sign-On/Hunting Queries/UserPasswordReset.yaml
+++ b/Solutions/Okta Single Sign-On/Hunting Queries/UserPasswordReset.yaml
@@ -3,7 +3,8 @@ name: User password reset(Okta)
 description: |
   'Adversaries often manipulate accounts to maintain access to victim systems. Account manipulation may consist of actions that preserves adversary access to a compromised account, such as by modifying credentials. 
    This query searches for attempts to reset user passwords in Okta logs by an admin. Since this can also be a known activity, please filter out anything that is expected.
-   Refrence: https://developer.okta.com/docs/reference/api/event-types/'
+   Refrence: https://developer.okta.com/docs/reference/api/event-types/
+   Refrence: https://blog.cloudflare.com/cloudflare-investigation-of-the-january-2022-okta-compromise/'
 requiredDataConnectors:
   - connectorId: OktaSSO
     dataTypes: 

--- a/Solutions/Okta Single Sign-On/Hunting Queries/UserPasswordReset.yaml
+++ b/Solutions/Okta Single Sign-On/Hunting Queries/UserPasswordReset.yaml
@@ -3,8 +3,8 @@ name: User password reset(Okta)
 description: |
   'Adversaries often manipulate accounts to maintain access to victim systems. Account manipulation may consist of actions that preserves adversary access to a compromised account, such as by modifying credentials. 
    This query searches for attempts to reset user passwords in Okta logs by an admin. Since this can also be a known activity, please filter out anything that is expected.
-   Refrence: https://developer.okta.com/docs/reference/api/event-types/
-   Refrence: https://blog.cloudflare.com/cloudflare-investigation-of-the-january-2022-okta-compromise/'
+   Reference: https://developer.okta.com/docs/reference/api/event-types/
+   Reference: https://blog.cloudflare.com/cloudflare-investigation-of-the-january-2022-okta-compromise/'
 requiredDataConnectors:
   - connectorId: OktaSSO
     dataTypes: 

--- a/Solutions/Okta Single Sign-On/Hunting Queries/UserPasswordReset.yaml
+++ b/Solutions/Okta Single Sign-On/Hunting Queries/UserPasswordReset.yaml
@@ -1,0 +1,24 @@
+id: 38da2aa3-4778-4d88-9178-3c5c14758b05
+name: User password reset(Okta)
+description: |
+  'Adversaries often manipulate accounts to maintain access to victim systems. Account manipulation may consist of actions that preserves adversary access to a compromised account, such as by modifying credentials. 
+   This query searches for attempts to reset user passwords in Okta logs by an admin. Since this can also be a known activity, please filter out anything that is expected.
+   Refrence: https://developer.okta.com/docs/reference/api/event-types/'
+requiredDataConnectors:
+  - connectorId: OktaSSO
+    dataTypes: 
+      - Okta_CL
+tactics:
+  -  Persistence
+relevantTechniques:
+  - T1098
+query: |
+  let Events = dynamic(["user.account.reset_password"]);
+  Okta_CL
+  | where eventType_s in (Events)
+  | where outcome_result_s =~ "SUCCESS"
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: actor_displayName_s


### PR DESCRIPTION
Hunting Query to detect User password reset in Okta

   Change(s):
   -Hunting Query to detect User password reset in Okta

   Reason for Change(s):
   - New query added

   Version Updated:
  - Not applicable

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - 

