### PR TITLE
Multiple Password Reset by User: Fix logic

### DIFF
--- a/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
+++ b/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
@@ -60,7 +60,7 @@ query: |
   | project TimeGenerated, Computer, AccountType, Account, Type, TargetUserName),
   (//Azure Active Directory Password reset events
   AuditLogs
-  | where OperationName has_any (pWord) and OperationName has_any (action) and Result =~ "success"
+  | where OperationName has_any (pWord) and OperationName has_any (action) and Result =~ "success"  and OperationName !contains "progress" and OperationName !contains "registration"
   | extend AccountType = tostring(TargetResources[0].type), Account = tostring(TargetResources[0].userPrincipalName), 
   TargetUserName = tolower(tostring(TargetResources[0].displayName))
   | project TimeGenerated, AccountType, Account, Computer = "", Type),

--- a/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
+++ b/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
@@ -105,5 +105,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: TargetUserName
-version: 2.1.1
+version: 2.1.2
 kind: Scheduled


### PR DESCRIPTION
Fixes #3837, where rule is triggered by password self-service reset or registration.
!contains may not be optimal, if you have a guide for best practices I'm happy to update to match.

   Required items, please complete
   
   Change(s):
   - Filters out "progress" and "registration" Azure self-service password reset events

   Reason for Change(s):
   - False positives when a user performs SSPR

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
  