### PR TITLE
Changing _SubscriptionId to SubscriptionId 

### DIFF
--- a/Hunting Queries/AzureActivity/AnomalousAzureOperationModel.yaml
+++ b/Hunting Queries/AzureActivity/AnomalousAzureOperationModel.yaml
@@ -51,7 +51,6 @@ query: |
   | where TimeGenerated between (ago(startDate) .. ago(endDetectDate))
   | where isnotempty(CallerIpAddress)
   | where ActivityStatusValue has_any ('Success', 'Succeeded')
-  | extend SubscriptionId = iff(isempty(_SubscriptionId), SubscriptionId, _SubscriptionId)
   | extend ResourceId = iff(isempty(_ResourceId), ResourceId, _ResourceId)
   | extend splitOp = split(OperationNameValue, '/')
   | extend splitRes = split(ResourceId, '/')

--- a/Hunting Queries/MultipleDataSources/StorageAccountKeyEnumerationWithSigninandAuditlogs.yaml
+++ b/Hunting Queries/MultipleDataSources/StorageAccountKeyEnumerationWithSigninandAuditlogs.yaml
@@ -29,10 +29,10 @@ query: |
   AzureActivity
   | where tolower(OperationNameValue) endswith "listkeys/action"
   | where ActivityStatus =~ "Succeeded"
-  | project CallerIpAddress, _ResourceId, _SubscriptionId, ActivityStatus, Category, Authorization,OperationName
+  | project CallerIpAddress, _ResourceId, SubscriptionId, ActivityStatus, Category, Authorization,OperationName
   )
   on $left.IPAddress == $right. CallerIpAddress
-  | project _SubscriptionId, ActivityStatus, IPAddress, OperationName, UserPrincipalName
+  | project SubscriptionId, ActivityStatus, IPAddress, OperationName, UserPrincipalName
   | join kind=inner 
   (
   AuditLogs


### PR DESCRIPTION
  Change(s):
   - Changing (or removing check) _SubscriptionId to SubscriptionId as schema was updated awhile back.  These still run, but we need to be using the update field name.
   Reason for Change(s):
   - Update Schema

   Version Updated:
   - Hunting, no version needed

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Will check