### PR TITLE
Fixing rename of count operation

### DIFF
--- a/Hunting Queries/MultipleDataSources/ApplicationGrantedEWSPermissions.yaml
+++ b/Hunting Queries/MultipleDataSources/ApplicationGrantedEWSPermissions.yaml
@@ -40,7 +40,7 @@ query: |
   | join kind=leftouter (SecurityAlert
   | where ProviderName == "IPC"
   | extend User = tolower(tostring(parse_json(ExtendedProperties).["User Account"]))
-  | summarize count() by bin(TimeGenerated, 1d), User) on TimeGenerated, User
+  | summarize count_AlertName = count() by bin(TimeGenerated, 1d), User) on TimeGenerated, User
   | extend NumberofAADAlerts = iif(isnotempty(count_AlertName), count_AlertName, 0)
   | sort by NumberofAADAlerts desc
   | extend AppName = tostring(set_AppName[1])


### PR DESCRIPTION
   
   Change(s):
   - count_Alertname is not brought thru

   Reason for Change(s):
   - query fails

   Version Updated:
   - Hunting, not needed

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Will do
