### PR TITLE
Add more PowerShell apps in UnusualGuestActivity.yaml

### DIFF
--- a/Detections/MultipleDataSources/UnusualGuestActivity.yaml
+++ b/Detections/MultipleDataSources/UnusualGuestActivity.yaml
@@ -52,7 +52,8 @@ query: |
            "9bc3ab49-b65d-410a-85ad-de819febfddc",// Microsoft SharePoint Online Management Shell
            "12128f48-ec9e-42f0-b203-ea49fb6af367",// MS Teams Powershell Cmdlets
            "23d8f6bd-1eb0-4cc2-a08c-7bf525c67bcd",// Power BI PowerShell
-           "31359c7f-bd7e-475c-86db-fdb8c937548e" // PnP Management Shell
+           "31359c7f-bd7e-475c-86db-fdb8c937548e",// PnP Management Shell
+           "90f610bf-206d-4950-b61d-37fa6fd1b224" // Aadrm Admin Powershell
           )
       | summarize arg_min(TimeGenerated, *) by UserPrincipalName
       | extend
@@ -70,5 +71,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Add one more PowerShell app
   
   Reason for Change(s):
   - It may be useful to check attempts to use this app by guests. This may trigger when connecting to Azure Information Protection service.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
   Please, could you check if this attempts by guests (failed or not) could be possible or not? Thank you in advance.