### PR TITLE
Create Fortinet-Fortigate-Traffic-parser

### DIFF
--- a/Fortinet-Fortigate-Traffic-parser
+++ b/Fortinet-Fortigate-Traffic-parser
@@ -1,0 +1,24 @@
+Syslog
+| where SyslogMessage contains "Fortigate"
+| where SyslogMessage contains "subtype=forward"
+| extend EventTime = unixtime_nanoseconds_todatetime(extract(@'(?:FortinetFortiGate|FTNTFGT)eventtime=(.+?)\s',1,SyslogMessage,typeof(long))),
+    EventType = extract(@'(?:FortinetFortiGate|FTNTFGT)eventtype=(.+?)\s',1,SyslogMessage),
+    Action = extract(@'\sact=(.+?)\s',1,SyslogMessage),
+    PolicyID = extract(@'(?:FortinetFortiGate|FTNTFGT)policyid=(.+?)\s',1,SyslogMessage),
+    DeviceID = extract(@'\|deviceExternalId=(.+?)\s',1,SyslogMessage),
+    SeverityLevel = extract(@'FTNTFGTlevel=(.+?)\s',1,SyslogMessage),
+    SrcIp = extract(@'(\s)src=(.+?)\s',2,SyslogMessage),
+    SrcPort = extract(@'(\s)spt=(.+?)\s',2,SyslogMessage),
+    SrcInt = extract(@'(\s)deviceInboundInterface=(.+?)\s',2,SyslogMessage),
+    SrcCountry = extract(@'(\s)FTNTFGTsrccountry=(.+?)\s',2,SyslogMessage),
+    DstIp = extract(@'(\s)dst=(.+?)\s',2,SyslogMessage),
+    DstPort = extract(@'(\s)dpt=(.+?)\s',2,SyslogMessage),
+    DstInt = extract(@'(\s)deviceOutboundInterface=(.+?)\s',2,SyslogMessage),
+    DstPortName = extract(@'(\s)app=(.+?)\s',2,SyslogMessage),
+    DstCountry = extract(@'(\s)FTNTFGTdstcountry=(.+?)\s',2,SyslogMessage),
+    Duration = extract(@'(\s)FTNTFGTduration=(.+?)\s',2,SyslogMessage),
+    BytesRcv = extract(@'(\s)in=(.+?)\s',2,SyslogMessage),
+    BytesSent = extract(@'(\s)out=(.+?)\s',2,SyslogMessage),
+    Category = extract(@'(\s)cat=(.+?)\s',2,SyslogMessage),
+    SubType = extract(@'(\s)FTNTFGTsubtype=(.+?)\s',2,SyslogMessage)
+| project EventTime, HostName, Category, Action, PolicyID, DeviceID,SeverityLevel,SrcIp,SrcPort,SrcInt,SrcCountry,DstIp,DstPort,DstPortName,DstInt, DstCountry,Duration, BytesSent,BytesRcv


### PR DESCRIPTION


   Required items, please complete
   
   Change(s):
   - New file - function to extract fields from SyslogMessage field in Fortinet Fortigate syslog messages into new columns.

   Reason for Change(s):
   - New function - not present on the repo

   Version Updated:
   - This is version 1.0

   Testing Completed:
   - Ran against my own data

   Checked that the validations are passing and have addressed any issues that are present:
   - No issues