### PR TITLE
Improve SigninBruteForce-AzurePortal.yaml

### DIFF
--- a/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
+++ b/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
@@ -58,11 +58,7 @@ query: |
       SuccessCount = countif(FailureOrSuccess=="Success"),
       take_anyif(UserPrincipalName, not(UserPrincipalName matches regex @"[\d]+\-[\d]+\-[\d]+\-[\d]+\-[\d]+")),
       take_anyif(UserDisplayName, isnotempty(UserDisplayName))
-      by
-      bin(TimeGenerated, authenticationWindow),
-      UserId,
-      AppDisplayName,
-      Type
+      by bin(TimeGenerated, authenticationWindow), UserId, AppDisplayName, Type
   | where FailureCount >= failureCountThreshold and SuccessCount >= successCountThreshold
   | mv-expand IPAddress
   | extend IPAddress = tostring(IPAddress)

--- a/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
+++ b/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
@@ -29,18 +29,42 @@ query: |
   let authenticationWindow = 20m;
   let aadFunc = (tableName:string){
   table(tableName)
-  | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
-  | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
-  | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
-  | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion)
   | where AppDisplayName has "Azure Portal"
+  | extend
+      DeviceDetail = todynamic(DeviceDetail),
+      //Status = todynamic(Status),
+      LocationDetails = todynamic(LocationDetails)
+  | extend
+      OS = DeviceDetail.operatingSystem,
+      Browser = DeviceDetail.browser,
+      //StatusCode = tostring(Status.errorCode),
+      //StatusDetails = tostring(Status.additionalDetails),
+      State = tostring(LocationDetails.state),
+      City = tostring(LocationDetails.city),
+      Region = tostring(LocationDetails.countryOrRegion)
   // Split out failure versus non-failure types
   | extend FailureOrSuccess = iff(ResultType in ("0", "50125", "50140", "70043", "70044"), "Success", "Failure")
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), IPAddress = make_set(IPAddress), make_set(OS), make_set(Browser), make_set(City),
-  make_set(State), make_set(Region),make_set(ResultType), FailureCount = countif(FailureOrSuccess=="Failure"), SuccessCount = countif(FailureOrSuccess=="Success") 
-  by bin(TimeGenerated, authenticationWindow), UserDisplayName, UserPrincipalName, AppDisplayName, Type
+  | summarize
+      StartTime = min(TimeGenerated),
+      EndTime = max(TimeGenerated),
+      IPAddress = make_set(IPAddress),
+      make_set(OS),
+      make_set(Browser),
+      make_set(City),
+      make_set(State),
+      make_set(Region),
+      make_set(ResultType),
+      FailureCount = countif(FailureOrSuccess=="Failure"),
+      SuccessCount = countif(FailureOrSuccess=="Success"),
+      take_anyif(UserPrincipalName, not(UserPrincipalName matches regex @"[\d]+\-[\d]+\-[\d]+\-[\d]+\-[\d]+")),
+      take_anyif(UserDisplayName, isnotempty(UserDisplayName))
+      by
+      bin(TimeGenerated, authenticationWindow),
+      UserId,
+      AppDisplayName,
+      Type
   | where FailureCount >= failureCountThreshold and SuccessCount >= successCountThreshold
-  | mvexpand IPAddress
+  | mv-expand IPAddress
   | extend IPAddress = tostring(IPAddress)
   | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress 
   };
@@ -56,5 +80,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
+++ b/Detections/SigninLogs/SigninBruteForce-AzurePortal.yaml
@@ -56,7 +56,7 @@ query: |
       make_set(ResultType),
       FailureCount = countif(FailureOrSuccess=="Failure"),
       SuccessCount = countif(FailureOrSuccess=="Success"),
-      take_anyif(UserPrincipalName, not(UserPrincipalName matches regex @"[\d]+\-[\d]+\-[\d]+\-[\d]+\-[\d]+")),
+      take_anyif(UserPrincipalName, not(UserPrincipalName matches regex @"[a-f\d]+\-[a-f\d]+\-[a-f\d]+\-[a-f\d]+\-[a-f\d]+")),
       take_anyif(UserDisplayName, isnotempty(UserDisplayName))
       by bin(TimeGenerated, authenticationWindow), UserId, AppDisplayName, Type
   | where FailureCount >= failureCountThreshold and SuccessCount >= successCountThreshold


### PR DESCRIPTION
   Change(s):
   1. Comment lines that were not used in the results (because of the summarize)
   2. Use correct column for Status (instead of DeviceDetail)
   3. Summarize by UserId, instead of UserPrincipalName
   4. Put "Azure Portal" condition ahead of extends.

   Reason for Change(s):
   1. They were not used.
   2. Although it was not used, it was not correct.
   3. Column UserPrincipalName does not show always the UPN, sometimes it shows the UserId, specially in erroneous ResultTypes
   4. CPU may be wasted on unwanted events

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
   Additionally, maybe the ResultTypes accepted as "Success" should increase or be reviewed, in comparison with other detections that define ResultTypes lists.