### PR TITLE
Update ExplicitMFADeny detection

### DIFF
--- a/Detections/SigninLogs/ExplicitMFADeny.yaml
+++ b/Detections/SigninLogs/ExplicitMFADeny.yaml
@@ -22,7 +22,7 @@ query: |
   let aadFunc = (tableName:string){
   table(tableName)
   | where ResultType == 500121
-  | where Status has "MFA Denied; user declined the authentication"
+  | where Status has "MFA Denied; user declined the authentication" or Status has "MFA denied; Phone App Reported Fraud"
   | extend Type = Type
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, URLCustomEntity = ClientAppUsed
   };

--- a/Detections/SigninLogs/ExplicitMFADeny.yaml
+++ b/Detections/SigninLogs/ExplicitMFADeny.yaml
@@ -42,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - If a user selects "Report Fraud" after declining a MFA push notification, the Status is "MFA denied; Phone App Reported Fraud" instead of "MFA Denied; user declined the authentication". Added a OR statement to detect both situations.

   Reason for Change(s):
   - Expands detection when Fraud Report is enabled in the tenant.

   Version Updated:
   - Yes (1.0.1)

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes