### PR TITLE
asim/remove-private-preview-connector

### DIFF
--- a/Detections/ASimDNS/imDNS_Miners.yaml
+++ b/Detections/ASimDNS/imDNS_Miners.yaml
@@ -29,9 +29,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -70,5 +67,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Detections/ASimDNS/imDNS_TorProxies.yaml
+++ b/Detections/ASimDNS/imDNS_TorProxies.yaml
@@ -26,9 +26,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -61,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Detections/ASimDNS/imDns_DomainEntity_DnsEvents.yaml
+++ b/Detections/ASimDNS/imDns_DomainEntity_DnsEvents.yaml
@@ -32,9 +32,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
 
   - connectorId: Corelight
     dataTypes: 
@@ -96,5 +93,5 @@ customDetails:
   SourceIPAddress: SrcIpAddr
   DnsQuery: DnsQuery
   QueryType: QueryType
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ASimDNS/imDns_ExcessiveNXDOMAINDNSQueries.yaml
+++ b/Detections/ASimDNS/imDns_ExcessiveNXDOMAINDNSQueries.yaml
@@ -26,9 +26,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
 
   - connectorId: Corelight
     dataTypes: 
@@ -62,5 +59,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Detections/ASimDNS/imDns_HighNXDomainCount_detection.yaml
+++ b/Detections/ASimDNS/imDns_HighNXDomainCount_detection.yaml
@@ -31,9 +31,6 @@ requiredDataConnectors:
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
 
 queryFrequency: 1d
 queryPeriod: 10d
@@ -76,5 +73,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Detections/ASimDNS/imDns_IPEntity_DnsEvents.yaml
+++ b/Detections/ASimDNS/imDns_IPEntity_DnsEvents.yaml
@@ -32,9 +32,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -104,5 +101,5 @@ customDetails:
   EventId: EventId
   SubType: SubType 
   DnsQuery: DnsQuery
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/BariumDomainIOC112020.yaml
+++ b/Detections/MultipleDataSources/BariumDomainIOC112020.yaml
@@ -41,9 +41,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -174,5 +171,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.6.0
+version: 1.6.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/BariumIPIOC112020.yaml
+++ b/Detections/MultipleDataSources/BariumIPIOC112020.yaml
@@ -74,9 +74,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -193,5 +190,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
+++ b/Detections/MultipleDataSources/CERIUMOct292020IOCs.yaml
@@ -38,9 +38,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -100,5 +97,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.2.0
+version: 1.2.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/ExchangeServerVulnerabilitiesMarch2021IoCs.yaml
+++ b/Detections/MultipleDataSources/ExchangeServerVulnerabilitiesMarch2021IoCs.yaml
@@ -70,9 +70,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -196,6 +193,6 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.7.1
+version: 1.7.2
 kind: Scheduled
 

--- a/Detections/MultipleDataSources/GalliumIOCs.yaml
+++ b/Detections/MultipleDataSources/GalliumIOCs.yaml
@@ -42,9 +42,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -120,5 +117,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.5.0
+version: 1.5.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/IridiumIOCs.yaml
+++ b/Detections/MultipleDataSources/IridiumIOCs.yaml
@@ -73,9 +73,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -180,5 +177,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/NICKELIOCsNov2021.yaml
+++ b/Detections/MultipleDataSources/NICKELIOCsNov2021.yaml
@@ -50,9 +50,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -222,5 +219,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.2.0
+version: 1.2.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/NOBELIUM_DomainIOCsMarch2021.yaml
+++ b/Detections/MultipleDataSources/NOBELIUM_DomainIOCsMarch2021.yaml
@@ -44,9 +44,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -127,5 +124,5 @@ entityMappings:
     fieldMappings:
       - identifier: DomainName
         columnName: DNSName
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/NOBELIUM_IOCsMay2021.yaml
+++ b/Detections/MultipleDataSources/NOBELIUM_IOCsMay2021.yaml
@@ -72,9 +72,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -204,5 +201,5 @@ entityMappings:
     fieldMappings:
       - identifier: DomainName
         columnName: DNSName
-version: 1.5.0
+version: 1.5.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
+++ b/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
@@ -44,9 +44,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -133,5 +130,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/STRONTIUMJuly2019IOCs.yaml
+++ b/Detections/MultipleDataSources/STRONTIUMJuly2019IOCs.yaml
@@ -38,9 +38,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -96,5 +93,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/Solorigate-Network-Beacon.yaml
+++ b/Detections/MultipleDataSources/Solorigate-Network-Beacon.yaml
@@ -39,9 +39,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -111,5 +108,5 @@ entityMappings:
     fieldMappings:
       - identifier: DomainName
         columnName: DNSName
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/ThalliumIOCs.yaml
+++ b/Detections/MultipleDataSources/ThalliumIOCs.yaml
@@ -39,9 +39,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-      - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -96,5 +93,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/ZincJan272021IOCs.yaml
+++ b/Detections/MultipleDataSources/ZincJan272021IOCs.yaml
@@ -49,9 +49,6 @@ requiredDataConnectors:
   - connectorId: CiscoUmbrellaDataConnector
     dataTypes: 
       - Cisco_Umbrella_dns_CL
-  - connectorId: ASimDnsActivityLogs
-    dataTypes: 
-          - ASimDnsActivityLogs
   - connectorId: Corelight
     dataTypes: 
       - Corelight_CL
@@ -174,5 +171,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.6.1
+version: 1.6.2
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Remove ASimDnsActivityLogs which is still in private preview from the connector list for detections.