### PR TITLE
Add more cases to Office_MailForwarding.yaml

### DIFF
--- a/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
@@ -15,7 +15,6 @@ relevantTechniques:
   - T1114
   - T1020
 query: |
-
   OfficeActivity
   | where OfficeWorkload =~ "Exchange"
   | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
@@ -33,7 +32,6 @@ query: |
   | where DistinctUserCount > 1
   | mv-expand UserId
   | extend UserId = tostring(UserId)
-
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
@@ -15,47 +15,25 @@ relevantTechniques:
   - T1114
   - T1020
 query: |
+
   OfficeActivity
   | where OfficeWorkload =~ "Exchange"
-  | where Parameters has "ForwardingSmtpAddress"
-  | extend parsed = parse_json(Parameters)
-  | mv-expand parsed
-  | where parsed.Name == "ForwardingSmtpAddress"
-  | extend parameterName = tostring(parsed.Name), fwdingDestination = tostring(parsed.Value)
-  | where isnotempty(fwdingDestination)
-  | extend ClientIPOnly = case(
-  ClientIP has "." and ClientIP has ':', tostring(split(ClientIP,":")[0]),
-  ClientIP has "." and ClientIP has '-', tostring(split(ClientIP,"-")[0]),
-  ClientIP has ']-', tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
-  ClientIP has ']:', tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has ':', tostring(split(ClientIP_,":")[0]),
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has '-', tostring(split(ClientIP_,"-")[0]),
-  isempty(ClientIP) and ClientIP_ has ']-', tostring(trim_start(@'[[]',tostring(split(ClientIP_,"]")[0]))),
-  isempty(ClientIP) and ClientIP_ has ']:', tostring(trim_start(@'[[]',tostring(split(ClientIP_,"]")[0]))),
-  isnotempty(ClientIP), ClientIP,
-  isnotempty(ClientIP_), ClientIP_,
-  "IP Not Available"
-  )
-  | extend Port = case(
-  ClientIP has "." and ClientIP has ':', tostring(split(ClientIP,":")[1]),
-  ClientIP has "." and ClientIP has '-', tostring(split(ClientIP,"-")[1]),
-  ClientIP has ']-', tostring(split(ClientIP,"]-")[1]),
-  ClientIP has ']:', tostring(split(ClientIP,"]:")[1]),
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has ':', tostring(split(ClientIP_,":")[1]),
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has '-', tostring(split(ClientIP_,"-")[1]),
-  isempty(ClientIP) and ClientIP_ has ']-', tostring(split(ClientIP_,"]-")[1]),
-  isempty(ClientIP) and ClientIP_ has ']:', tostring(split(ClientIP_,"]:")[1]),
-  isnotempty(ClientIP), ClientIP,
-  isnotempty(ClientIP_), ClientIP_,
-  "IP Not Available"
-  )
-  | extend UserId = iff(isempty(UserId), UserId_, UserId)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), DistinctUserCount = dcount(UserId), UserId = make_set(UserId),
-  Ports = make_set(Port), EventCount = count() by fwdingDestination, ClientIP = ClientIPOnly
+  | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
+  | evaluate bag_unpack(ParsedParameters, columnsConflict='replace_source')
+  | extend DestinationMailAddress = tolower(case(
+      isnotempty(column_ifexists("ForwardTo", "")), column_ifexists("ForwardTo", ""),
+      isnotempty(column_ifexists("RedirectTo", "")), column_ifexists("RedirectTo", ""),
+      isnotempty(column_ifexists("ForwardingSmtpAddress", "")), trim_start(@"smtp:", column_ifexists("ForwardingSmtpAddress", "")),
+      ""))
+  | where isnotempty(DestinationMailAddress)
+  | mv-expand split(DestinationMailAddress, ";")
+  | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
+  | extend ClientIP = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1])
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), DistinctUserCount = dcount(UserId), UserId = make_set(UserId, 250), Ports = make_set(Port, 250), EventCount = count() by tostring(DestinationMailAddress), ClientIP
   | where DistinctUserCount > 1
   | mv-expand UserId
-  | extend UserId = tostring(UserId), Ports = tostring(Ports)
-  | distinct StartTimeUtc, EndTimeUtc, UserId, DistinctUserCount, ClientIP, Ports, fwdingDestination, EventCount
+  | extend UserId = tostring(UserId)
+
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -65,5 +43,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: ClientIP
-version: 1.0.1
+version: 1.0.2
 kind: NRT

--- a/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
@@ -31,8 +31,7 @@ query: |
   | extend ClientIP = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1])
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), DistinctUserCount = dcount(UserId), UserId = make_set(UserId, 250), Ports = make_set(Port, 250), EventCount = count() by tostring(DestinationMailAddress), ClientIP
   | where DistinctUserCount > 1
-  | mv-expand UserId
-  | extend UserId = tostring(UserId)
+  | mv-expand UserId to typeof(string)
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/NRT_Office_MailForwarding.yaml
@@ -17,6 +17,7 @@ relevantTechniques:
 query: |
   OfficeActivity
   | where OfficeWorkload =~ "Exchange"
+  | where Parameters has_any ("ForwardTo", "RedirectTo", "ForwardingSmtpAddress")
   | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
   | evaluate bag_unpack(ParsedParameters, columnsConflict='replace_source')
   | extend DestinationMailAddress = tolower(case(

--- a/Detections/OfficeActivity/Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/Office_MailForwarding.yaml
@@ -20,48 +20,29 @@ relevantTechniques:
   - T1020
 query: |
 
+  let queryfrequency = 1d;
+  let queryperiod = 7d;
   OfficeActivity
-  | where Operation =~ "Set-Mailbox"
-  | where Parameters has "ForwardingSmtpAddress"
-  | extend parsed = parse_json(Parameters)
-  | mv-expand parsed
-  | where parsed.Name == "ForwardingSmtpAddress"
-  | extend parameterName = tostring(parsed.Name), fwdingDestination = tostring(parsed.Value)
-  | where isnotempty(fwdingDestination)
-  | extend ClientIPOnly = case( 
-  ClientIP has "." and ClientIP has ':', tostring(split(ClientIP,":")[0]), 
-  ClientIP has "." and ClientIP has '-', tostring(split(ClientIP,"-")[0]), 
-  ClientIP has ']-', tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
-  ClientIP has ']:', tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has ':', tostring(split(ClientIP_,":")[0]), 
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has '-', tostring(split(ClientIP_,"-")[0]), 
-  isempty(ClientIP) and ClientIP_ has ']-', tostring(trim_start(@'[[]',tostring(split(ClientIP_,"]")[0]))),
-  isempty(ClientIP) and ClientIP_ has ']:', tostring(trim_start(@'[[]',tostring(split(ClientIP_,"]")[0]))),
-  isnotempty(ClientIP), ClientIP,
-  isnotempty(ClientIP_), ClientIP_,
-  "IP Not Available"
-  )  
-  | extend Port = case(
-  ClientIP has "." and ClientIP has ':', tostring(split(ClientIP,":")[1]), 
-  ClientIP has "." and ClientIP has '-', tostring(split(ClientIP,"-")[1]), 
-  ClientIP has ']-', tostring(split(ClientIP,"]-")[1]), 
-  ClientIP has ']:', tostring(split(ClientIP,"]:")[1]), 
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has ':', tostring(split(ClientIP_,":")[1]), 
-  isempty(ClientIP) and ClientIP_ has "." and ClientIP_ has '-', tostring(split(ClientIP_,"-")[1]), 
-  isempty(ClientIP) and ClientIP_ has ']-', tostring(split(ClientIP_,"]-")[1]),
-  isempty(ClientIP) and ClientIP_ has ']:', tostring(split(ClientIP_,"]:")[1]),
-  isnotempty(ClientIP), ClientIP,
-  isnotempty(ClientIP_), ClientIP_,
-  "IP Not Available"
-  )
-  | extend UserId = iff(isempty(UserId), UserId_, UserId)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), DistinctUserCount = dcount(UserId), UserId = make_set(UserId), 
-  Ports = make_set(Port), EventCount = count() by fwdingDestination, ClientIP = ClientIPOnly 
-  | where DistinctUserCount > 1
+  | where TimeGenerated > ago(queryperiod)
+  //| where OfficeWorkload =~ "Exchange"
+  | where Operation in ("Set-Mailbox", "New-InboxRule", "Set-InboxRule")
+  | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
+  | evaluate bag_unpack(ParsedParameters, columnsConflict='replace_source')
+  | extend DestinationMailAddress = tolower(case(
+      isnotempty(column_ifexists("ForwardTo", "")), column_ifexists("ForwardTo", ""),
+      isnotempty(column_ifexists("RedirectTo", "")), column_ifexists("RedirectTo", ""),
+      isnotempty(column_ifexists("ForwardingSmtpAddress", "")), trim_start(@"smtp:", column_ifexists("ForwardingSmtpAddress", "")),
+      ""))
+  | where isnotempty(DestinationMailAddress)
+  | mv-expand split(DestinationMailAddress, ";")
+  | extend ClientIPValues = extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?([-:](?P<Port>\d+))?', dynamic(["IPAddress", "Port"]), ClientIP)[0]
+  | extend ClientIP = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1])
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), DistinctUserCount = dcount(UserId), UserId = make_set(UserId, 250), Ports = make_set(Port, 250), EventCount = count() by tostring(DestinationMailAddress), ClientIP
+  | where DistinctUserCount > 1 and EndTime > ago(queryfrequency)
   | mv-expand UserId
-  | extend UserId = tostring(UserId), Ports = tostring(Ports)
-  | distinct StartTimeUtc, EndTimeUtc, UserId, DistinctUserCount, ClientIP, Ports, fwdingDestination, EventCount
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
+  | extend UserId = tostring(UserId)
+  | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
+
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -71,5 +52,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/OfficeActivity/Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/Office_MailForwarding.yaml
@@ -19,7 +19,6 @@ relevantTechniques:
   - T1114
   - T1020
 query: |
-
   let queryfrequency = 1d;
   let queryperiod = 7d;
   OfficeActivity
@@ -42,7 +41,6 @@ query: |
   | mv-expand UserId
   | extend UserId = tostring(UserId)
   | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
-
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Detections/OfficeActivity/Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/Office_MailForwarding.yaml
@@ -38,8 +38,7 @@ query: |
   | extend ClientIP = tostring(ClientIPValues[0]), Port = tostring(ClientIPValues[1])
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), DistinctUserCount = dcount(UserId), UserId = make_set(UserId, 250), Ports = make_set(Port, 250), EventCount = count() by tostring(DestinationMailAddress), ClientIP
   | where DistinctUserCount > 1 and EndTime > ago(queryfrequency)
-  | mv-expand UserId
-  | extend UserId = tostring(UserId)
+  | mv-expand UserId to typeof(string)
   | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
 entityMappings:
   - entityType: Account

--- a/Detections/OfficeActivity/Office_MailForwarding.yaml
+++ b/Detections/OfficeActivity/Office_MailForwarding.yaml
@@ -23,8 +23,9 @@ query: |
   let queryperiod = 7d;
   OfficeActivity
   | where TimeGenerated > ago(queryperiod)
-  //| where OfficeWorkload =~ "Exchange"
-  | where Operation in ("Set-Mailbox", "New-InboxRule", "Set-InboxRule")
+  | where OfficeWorkload =~ "Exchange"
+  //| where Operation in ("Set-Mailbox", "New-InboxRule", "Set-InboxRule")
+  | where Parameters has_any ("ForwardTo", "RedirectTo", "ForwardingSmtpAddress")
   | mv-apply DynamicParameters = todynamic(Parameters) on (summarize ParsedParameters = make_bag(pack(tostring(DynamicParameters.Name), DynamicParameters.Value)))
   | evaluate bag_unpack(ParsedParameters, columnsConflict='replace_source')
   | extend DestinationMailAddress = tolower(case(


### PR DESCRIPTION
   Change(s):
   1. Add more operation cases where mails can be forwarded to other mail addresses.
   2. In case of the scheduled query specify a queryfrequency.
   3. Remove the final ```distinct```.
   4. Put a limit to make_sets.

   Reason for Change(s):
   1. Other rules have these cases.
   2. If not, the scheduled query will generate the same alert every day for 7 days straight.
   3. It is not necessary, it was already summarized, and the dynamic of UserId was a set, not a list.
   4. Just as a good practice.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
   Are ```in~``` and ```=~``` operators necessary instead of ```in``` and ```==```?
   Also, I don't understand why to summarize by ClientIP, is there that much noise?