### PR TITLE
fixed typo

### DIFF
--- a/DataConnectors/CEF-VMSS/README.md
+++ b/DataConnectors/CEF-VMSS/README.md
@@ -1,7 +1,7 @@
 # Scaleable SYSLOG CEF Collection using VMSS
 author: Nicholas DiCola
 
-Sample is an ARM template that will deploy a Linux (RedHat or Unbuntu) Virtual Machine Scale Set.
+Sample is an ARM template that will deploy a Linux (RedHat or Ubuntu) Virtual Machine Scale Set.
 
 The ARM template will deploy everything needed:
 * Virtual Machine Scale
@@ -19,6 +19,6 @@ The ARM template includes the cloud init files which runs commands on the VM ins
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FDataConnectors%2FCEF-VMSS%2FCEF-VMSS-RH-Templatev2.json)
 [![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FDataConnectors%2FCEF-VMSS%2FCEF-VMSS-RH-Templatev2.json)
 
-## Deploy Unbuntu VMSS
+## Deploy Ubuntu VMSS
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FDataConnectors%2FCEF-VMSS%2FCEF-VMSS-UB-Templatev2.json)
 [![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FDataConnectors2FCEF-VMSS%2FCEF-VMSS-UB-Templatev2.json)


### PR DESCRIPTION
  
   Change(s):
   - Fixed a spelling typo. Changed the word Unbuntu to the correct spelling, Ubuntu.

   Reason for Change(s):
   - To fix spelling typo.

   Version Updated:
   - No

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - No