### PR TITLE
Palo Alto Threat signatures from Unusual IP addresses - Fusion scenario rule

### DIFF
--- a/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
+++ b/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
@@ -1,0 +1,49 @@
+id: 89a86f70-615f-4a79-9621-6f68c50f365f
+name: Palo Alto Threat signatures from Unusual IP addresses 
+description: |
+  'Identifies Palo Alto Threat signatures from unusual IP addresses which are not historically seen. 
+  This detection is also leveraged and required for MDE and PAN Fusion scenario
+  https://docs.microsoft.com/en-US/Azure/sentinel/fusion-scenario-reference#network-request-to-tor-anonymization-service-followed-by-anomalous-traffic-flagged-by-palo-alto-networks-firewall'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: PaloAltoNetworks
+    dataTypes:
+      - CommonSecurityLog
+queryFrequency: 1d
+queryPeriod: 14d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CommandAndControl
+relevantTechniques:
+  - T1071.001
+tags:
+  - Fusion
+query: |
+  let starttime = 14d;
+  let endtime = 1d;
+  let timeframe = 1d;
+  let histthreshold = 25; 
+  let HistoricalThreats = CommonSecurityLog
+  | where isnotempty(SourceIP)
+  | where TimeGenerated between (startofday(ago(starttime))..startofday(ago(endtime)))
+  | where DeviceVendor =~ "Palo Alto Networks" 
+  | where Activity =~ "THREAT" and SimplifiedDeviceAction =~ "alert" 
+  | where DeviceEventClassID in ('spyware', 'scan', 'file', 'vulnerability', 'flood', 'packet', 'virus','wildfire', 'wildfire-virus')
+  | summarize TotalEvents = count(), ThreatTypes = make_set(DeviceEventClassID), FirstSeen = min(TimeGenerated) , LastSeen = max(TimeGenerated) by  SourceIP, DeviceAction, DeviceProduct, DeviceVendor;
+  let CurrentDayThreats =  CommonSecurityLog
+  | where isnotempty(SourceIP)
+  | where TimeGenerated > (startofday(ago(timeframe)))
+  | where DeviceVendor =~ "Palo Alto Networks"
+  | where Activity =~ "THREAT" and SimplifiedDeviceAction =~ "alert" 
+  | where DeviceEventClassID in ('spyware', 'scan', 'file', 'vulnerability', 'flood', 'packet', 'virus','wildfire', 'wildfire-virus')
+  | summarize TotalEvents = count(), ThreatTypes = make_set(DeviceEventClassID), DestinationIpList = make_set(DestinationIP), FirstSeen = min(TimeGenerated) , LastSeen = max(TimeGenerated) by SourceIP, DeviceAction, DeviceProduct, DeviceVendor;
+  HistoricalThreats 
+  | where TotalEvents > histthreshold | join kind = leftanti (CurrentDayThreats) on SourceIP
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceIP
+version: 1.0.0
+kind: Scheduled

--- a/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
+++ b/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
@@ -14,8 +14,12 @@ queryPeriod: 14d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
+  - Discovery
+  - Exfiltration
   - CommandAndControl
 relevantTechniques:
+  - T1046
+  - T1030
   - T1071.001
 tags:
   - Fusion

--- a/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
+++ b/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
@@ -9,8 +9,8 @@ requiredDataConnectors:
   - connectorId: PaloAltoNetworks
     dataTypes:
       - CommonSecurityLog
-queryFrequency: 1d
-queryPeriod: 14d
+queryFrequency: 1h
+queryPeriod: 7d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -24,26 +24,29 @@ relevantTechniques:
 tags:
   - Fusion
 query: |
-  let starttime = 14d;
+  let starttime = 7d;
   let endtime = 1d;
-  let timeframe = 1d;
-  let histthreshold = 25; 
+  let timeframe = 1h;
+  let HistThreshold = 25; 
+  let CurrThreshold = 10; 
   let HistoricalThreats = CommonSecurityLog
   | where isnotempty(SourceIP)
   | where TimeGenerated between (startofday(ago(starttime))..startofday(ago(endtime)))
-  | where DeviceVendor =~ "Palo Alto Networks" 
+  | where DeviceVendor =~ "Palo Alto Networks"
   | where Activity =~ "THREAT" and SimplifiedDeviceAction =~ "alert" 
   | where DeviceEventClassID in ('spyware', 'scan', 'file', 'vulnerability', 'flood', 'packet', 'virus','wildfire', 'wildfire-virus')
-  | summarize TotalEvents = count(), ThreatTypes = make_set(DeviceEventClassID), FirstSeen = min(TimeGenerated) , LastSeen = max(TimeGenerated) by  SourceIP, DeviceAction, DeviceProduct, DeviceVendor;
-  let CurrentDayThreats =  CommonSecurityLog
+  | summarize TotalEvents = count(), ThreatTypes = make_set(DeviceEventClassID), DestinationIpList = make_set(DestinationIP), FirstSeen = min(TimeGenerated) , LastSeen = max(TimeGenerated) by SourceIP, DeviceAction, DeviceVendor;
+  let CurrentHourThreats =  CommonSecurityLog
   | where isnotempty(SourceIP)
-  | where TimeGenerated > (startofday(ago(timeframe)))
+  | where TimeGenerated > ago(timeframe)
   | where DeviceVendor =~ "Palo Alto Networks"
   | where Activity =~ "THREAT" and SimplifiedDeviceAction =~ "alert" 
   | where DeviceEventClassID in ('spyware', 'scan', 'file', 'vulnerability', 'flood', 'packet', 'virus','wildfire', 'wildfire-virus')
   | summarize TotalEvents = count(), ThreatTypes = make_set(DeviceEventClassID), DestinationIpList = make_set(DestinationIP), FirstSeen = min(TimeGenerated) , LastSeen = max(TimeGenerated) by SourceIP, DeviceAction, DeviceProduct, DeviceVendor;
-  HistoricalThreats 
-  | where TotalEvents > histthreshold | join kind = leftanti (CurrentDayThreats) on SourceIP
+  CurrentHourThreats 
+  | where TotalEvents < CurrThreshold
+  | join kind = leftanti (HistoricalThreats 
+  | where TotalEvents > HistThreshold) on SourceIP
 entityMappings:
   - entityType: IP
     fieldMappings:

--- a/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
+++ b/Detections/CommonSecurityLog/PaloAlto-UnusualThreatSignatures.yaml
@@ -3,7 +3,7 @@ name: Palo Alto Threat signatures from Unusual IP addresses
 description: |
   'Identifies Palo Alto Threat signatures from unusual IP addresses which are not historically seen. 
   This detection is also leveraged and required for MDE and PAN Fusion scenario
-  https://docs.microsoft.com/en-US/Azure/sentinel/fusion-scenario-reference#network-request-to-tor-anonymization-service-followed-by-anomalous-traffic-flagged-by-palo-alto-networks-firewall'
+  https://docs.microsoft.com/Azure/sentinel/fusion-scenario-reference#network-request-to-tor-anonymization-service-followed-by-anomalous-traffic-flagged-by-palo-alto-networks-firewall'
 severity: Medium
 requiredDataConnectors:
   - connectorId: PaloAltoNetworks


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - new rule for PAN threat signatures from unusual IP addresses historically not seen
   - Also it will be used to correlated with Tor alert for Fusion scenario
   - Hourly frequency is required to correlate with MDE alert and create fusion incident

   Reason for Change(s):
   - New scheduled rule for PAN-MDE fusion scenario 

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - Tested on sample workspaces for noise and performance efficiency

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

