### PR TITLE
Ignore expired token due to signin frequency expired

### DIFF
--- a/Detections/SigninLogs/FailedLogonToAzurePortal.yaml
+++ b/Detections/SigninLogs/FailedLogonToAzurePortal.yaml
@@ -49,7 +49,7 @@ query: |
   let failPortalSignins = azPortalSignins
   | where TimeGenerated >= ago(timeRange)
   // Azure Portal only and exclude non-failure Result Types
-  | where ResultType !in ("0", "50125", "50140")
+  | where ResultType !in ("0", "50125", "50140", "70044", "70043")
   // Tagging identities not resolved to friendly names
   | extend Unresolved = iff(Identity matches regex isGUID, true, false)
   ;
@@ -99,5 +99,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
  
   Change(s):
   - Added ignore for two very noisy result types

   Reason for Change(s):
   - Noise

   Version updated:
   - Yes

   Testing Completed:
   - Yes