### PR TITLE
Add ADFSSignInLogs custom table for KQL Validation Tests

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/ADFSSignInLogs.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ADFSSignInLogs.json
@@ -1,0 +1,185 @@
+{
+    "Name": "ADFSSignInLogs",
+    "Properties": [
+        {
+          "name": "TenantId",
+          "type": "String"
+        },
+        {
+          "name": "SourceSystem",
+          "type": "String"
+        },
+        {
+          "name": "TimeGenerated",
+          "type": "DateTime"
+        },
+        {
+          "name": "OperationName",
+          "type": "String"
+        },
+        {
+          "name": "OperationVersion",
+          "type": "String"
+        },
+        {
+          "name": "Category",
+          "type": "String"
+        },
+        {
+          "name": "ResultType",
+          "type": "String"
+        },
+        {
+          "name": "ResultSignature",
+          "type": "String"
+        },
+        {
+          "name": "ResultDescription",
+          "type": "String"
+        },
+        {
+          "name": "DurationMs",
+          "type": "Double"
+        },
+        {
+          "name": "CorrelationId",
+          "type": "String"
+        },
+        {
+          "name": "ResourceGroup",
+          "type": "String"
+        },
+        {
+          "name": "Identity",
+          "type": "String"
+        },
+        {
+          "name": "Level",
+          "type": "String"
+        },
+        {
+          "name": "Location",
+          "type": "String"
+        },
+        {
+          "name": "AlternateSignInName",
+          "type": "String"
+        },
+        {
+          "name": "AppDisplayName",
+          "type": "String"
+        },
+        {
+          "name": "AppId",
+          "type": "String"
+        },
+        {
+          "name": "AuthenticationDetails",
+          "type": "String"
+        },
+        {
+          "name": "AuthenticationProcessingDetails",
+          "type": "String"
+        },
+        {
+          "name": "AuthenticationRequirement",
+          "type": "String"
+        },
+        {
+          "name": "AuthenticationRequirementPolicies",
+          "type": "String"
+        },
+        {
+          "name": "ConditionalAccessPolicies",
+          "type": "String"
+        },
+        {
+          "name": "ConditionalAccessStatus",
+          "type": "String"
+        },
+        {
+          "name": "CreatedDateTime",
+          "type": "DateTime"
+        },
+        {
+          "name": "DeviceDetail",
+          "type": "String"
+        },
+        {
+          "name": "IsInteractive",
+          "type": "Bool"
+        },
+        {
+          "name": "Id",
+          "type": "String"
+        },
+        {
+          "name": "IPAddress",
+          "type": "String"
+        },
+        {
+          "name": "NetworkLocationDetails",
+          "type": "String"
+        },
+		{
+          "name": "OriginalRequestId",
+          "type": "String"
+        },
+        {
+          "name": "ProcessingTimeInMs",
+          "type": "String"
+        },
+        {
+          "name": "ResourceDisplayName",
+          "type": "String"
+        },
+        {
+          "name": "ResourceIdentity",
+          "type": "String"
+        },
+        {
+          "name": "ResourceTenantId",
+          "type": "String"
+        },
+        {
+          "name": "Requirement",
+          "type": "String"
+        },
+        {
+          "name": "Status",
+          "type": "String"
+        },
+		{
+          "name": "TokenIssuerName",
+          "type": "String"
+        },
+        {
+          "name": "TokenIssuerType",
+          "type": "String"
+        },
+        {
+          "name": "UniqueTokenIdentifier",
+          "type": "String"
+        },
+        {
+          "name": "UserAgent",
+          "type": "String"
+        },
+        {
+          "name": "UserDisplayName",
+          "type": "String"
+        },
+        {
+          "name": "UserId",
+          "type": "String"
+        },
+        {
+          "name": "UserPrincipalName",
+          "type": "String"
+        },
+		{
+          "name": "Type",
+          "type": "String"
+        }
+    ]
+}


### PR DESCRIPTION
   Change(s):

- Add a custom table so KQL using ADFSSignInLogs might be correctly validated.

Reason for Change(s):

- Needed for https://github.com/Azure/Azure-Sentinel/pull/4349