### PR TITLE
Revert role assignment addition to Run-MDEAntivirus playbook

### DIFF
--- a/Playbooks/Run-MDEAntivirus/incident-trigger/azuredeploy.json
+++ b/Playbooks/Run-MDEAntivirus/incident-trigger/azuredeploy.json
@@ -19,22 +19,11 @@
         "PlaybookName": {
             "defaultValue": "Run-MDEAntivirus",
             "type": "string"
-        },
-        "SentinelResourceGroupName": {
-            "defaultValue": "",
-            "type": "string"
-        },
-        "SentinelSubscriptionId": {
-            "defaultValue": "",
-            "type": "string"
         }
     },
     "variables": {
         "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
-        "MDATPConnectionName": "[concat('wdatp-', parameters('PlaybookName'))]",
-        "roleAssignmentName": "[guid(subscription().id, resourceGroup().id)]",
-        "ASResourceGroup": "[if(empty(parameters('SentinelResourceGroupName')), resourceGroup().name, parameters('SentinelResourceGroupName'))]",
-        "ASSubscriptionId": "[if(empty(parameters('SentinelSubscriptionId')), subscription().id, parameters('SentinelSubscriptionId'))]"
+        "MDATPConnectionName": "[concat('wdatp-', parameters('PlaybookName'))]"
     },
     "resources": [
         {
@@ -75,7 +64,7 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "hidden-SentinelTemplateName": "Run-MDEAntivirus",
-                "hidden-SentinelTemplateVersion": "1.0"
+                "hidden-SentinelTemplateVersion": "1.1"
             },
             "identity": {
                 "type": "SystemAssigned"
@@ -333,18 +322,6 @@
                         }
                     }
                 }
-            }
-        },
-        {
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2021-04-01-preview",
-            "name": "[variables('roleAssignmentName')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Logic/workflows', parameters('PlaybookName'))]"
-            ],
-            "properties": {
-                "roleDefinitionId": "[concat('/subscriptions/', variables('ASSubscriptionId'), '/', variables('ASResourceGroup'), '/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade')]",
-                "principalId": "[reference(concat(resourceId('Microsoft.Logic/workflows', parameters('PlaybookName')), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2018-11-30').principalId]"
             }
         }
     ]


### PR DESCRIPTION
   Change(s):
   - Revert addition of role assignment deployment in Run-MDEAntivirus playbook template

   Reason for Change(s):
   - Role assignment deployment isn't aligned with the rest of the playbook templates, and as such this change was never reflected in the playbook templates gallery in the portal

   Version Updated:
   - N/A

   Testing Completed:
   - Yes, this content of the playbook template is the one exposed in the portal for the last several months + manually double-checked that it deploys successfully

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
