### PR TITLE
Fix typo in Reset-AADUserPassword playbook title

### DIFF
--- a/Playbooks/Reset-AADUserPassword/incident-trigger/azuredeploy.json
+++ b/Playbooks/Reset-AADUserPassword/incident-trigger/azuredeploy.json
@@ -2,7 +2,7 @@
     "$schema":  "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion":  "1.0.0.0",
     "metadata":  {
-        "title":  "Reset Aazure AD User Password - Incident Trigger",
+        "title":  "Reset Azure AD User Password - Incident Trigger",
         "description": "This playbook will reset the user password using Graph API.  It will send the password (which is a random guid substring) to the user's manager.  The user will have to reset the password upon login.",
         "prerequisites": "",
         "postDeployment": ["1. Assign Password Administrator permission to managed identity.", "2. Assign Microsoft Sentinel Responder permission to managed identity.", "3. Authorize Office 365 Outlook connection"],


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Fix typo in Reset-AADUserPassword playbook title

   Reason for Change(s):
   - N/A

   Version Updated:
   - N/A

   Testing Completed:
   - N/A

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A
