### PR TITLE
changing TimeGenerated to createdTimeUtc

### DIFF
--- a/Playbooks/Restrict-MDEIPAddress/incident-trigger/azuredeploy.json
+++ b/Playbooks/Restrict-MDEIPAddress/incident-trigger/azuredeploy.json
@@ -108,7 +108,7 @@
                                             "action": "AlertAndBlock",
                                             "application": "Azure Sentinel",
                                             "description": "@{triggerBody()?['object']?['properties']?['incidentNumber']}-@{triggerBody()?['object']?['properties']?['title']}",
-                                            "expirationTime": "@{addDays(string(triggerbody()['TimeGenerated']), 90)}",
+                                            "expirationTime": "@{addDays(string(triggerbody()['object']?['properties']?['createdTimeUtc']), 90)}",
                                             "indicatorType": "IpAddress",
                                             "indicatorValue": "@{items('For_each')?['Address']}",
                                             "severity": "@{triggerBody()?['object']?['properties']?['severity']}",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - changing TimeGenerated to createdTimeUtc. TimeGenerated not avialable in incident trigger, only for alerts
