### PR TITLE
Update LegacyAuthAttempt.yaml

### DIFF
--- a/Hunting Queries/SigninLogs/LegacyAuthAttempt.yaml
+++ b/Hunting Queries/SigninLogs/LegacyAuthAttempt.yaml
@@ -19,7 +19,7 @@ query: |
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = totimespan((endtime-starttime)*7);
-  let legacy_auth_protocols = dynamic(["Authenticated SMTP", "Autodiscover", "Exchange ActiveSync", "Exchange Online PowerShell", "Exchange Web Services", "IMAP4", "MAPI over HTTP", "Outlook Anywhere", "Outlook Service", "POP3", "Reporting Web Services", "Other clients"]);
+  let legacy_auth_protocols = dynamic(["Authenticated SMTP", "AutoDiscover", "Exchange ActiveSync", "Exchange Online PowerShell", "Exchange Web Services", "IMAP4", "MAPI Over HTTP", "Outlook Anywhere (RPC over HTTP)", "Outlook Service", "POP3", "Reporting Web Services", "Other clients"]);
   let legacyAuthentications =
   SigninLogs
   | where TimeGenerated >= ago(lookback)


### PR DESCRIPTION
    Change(s):
Fixed capitalization for "AutoDiscover" and "MAPI Over HTTP" and added parenthetical to "Outlook Anywhere (RPC over HTTP)" to match how it's stored in the logs. 

   Reason for Change(s):
Without this change, query will not properly display all legacy protocols.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes