### PR TITLE
Updated MicrosoftWindowsEventFullDeployment template

### DIFF
--- a/Parsers/ASim WindowsEvent/ARM/MicrosoftWindowsEventFullDeployment.json
+++ b/Parsers/ASim WindowsEvent/ARM/MicrosoftWindowsEventFullDeployment.json
@@ -105,7 +105,7 @@
                     "Workspace": {
                         "value": "[parameters('workspaceName')]"
                     },
-                    "Workspace Region": {
+                    "WorkspaceRegion": {
                         "value": "[parameters('location')]"
                     }
                 }


### PR DESCRIPTION
Change(s):
- Updated ASIM `MicrosoftWindowsEventFullDeployment` parser template to use the right parameter names while calling `ASimNetworkSessionMicrosoftWindowsEventFirewall` template. Parameter `Workspace Region` to `WorkspaceRegion`.

Reason for Change(s):
- Resolves ISSUE #4823

Testing Completed:
- Yes