### PR TITLE
Fixing missing day due to midtime usage

### DIFF
--- a/Hunting Queries/AWSCloudTrail/AWS_SuspiciousCredentialTokenAccessOfValid_IAM_Roles.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_SuspiciousCredentialTokenAccessOfValid_IAM_Roles.yaml
@@ -20,7 +20,6 @@ query: |
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = starttime - 14d;
-  let midtime = starttime - 1d;
   // Generating historical table of AssumeRole operations for IAM Roles to be compared with last 24 hour
   AWSCloudTrail
   | where TimeGenerated between (starttime..endtime)
@@ -30,7 +29,7 @@ query: |
   | join kind= leftanti
   (
     AWSCloudTrail
-    | where TimeGenerated  between (lookback..midtime)
+    | where TimeGenerated  between (lookback..starttime)
     | where EventName == "AssumeRole" | extend RoleArn = tostring(parse_json(RequestParameters).roleArn)
     | project TimeGenerated, EventSource, EventName, UserIdentityType, UserIdentityInvokedBy , SourceIpAddress, RoleArn
   ) on RoleArn, UserIdentityInvokedBy

--- a/Hunting Queries/AWSCloudTrail/AWS_Unused_UnsupportedCloudRegions.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_Unused_UnsupportedCloudRegions.yaml
@@ -17,10 +17,9 @@ query: |
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = starttime - 14d;
-  let midtime = starttime - 1d;
   // Generating historical table of all events per AccountId and Region
   let EventInfo_CurrentDay =  materialize (AWSCloudTrail | where TimeGenerated between(starttime..endtime));
-  let EventInfo_historical = AWSCloudTrail  | where TimeGenerated  between (lookback..midtime) | summarize max(TimeGenerated) by AWSRegion, UserIdentityAccountId;
+  let EventInfo_historical = AWSCloudTrail  | where TimeGenerated  between (lookback..starttime) | summarize max(TimeGenerated) by AWSRegion, UserIdentityAccountId;
   // Doing Leftanti join to find new regions historically not seen for the same account.
   let EventInfo_Unseen = materialize (
   EventInfo_CurrentDay

--- a/Hunting Queries/AWSS3/AWSBucketAPILogs-SuspiciousDataAccessToS3BucketsfromUnknownIP.yaml
+++ b/Hunting Queries/AWSS3/AWSBucketAPILogs-SuspiciousDataAccessToS3BucketsfromUnknownIP.yaml
@@ -16,17 +16,17 @@ relevantTechniques:
 query: |
 
   let EventNameList = dynamic(["ListBucket","ListObjects","GetObject"]);
-  let starttime = 14d;
-  let midtime = 2d;
-  let endtime = 1d;
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let lookback = starttime - 14d;
   AwsBucketAPILogs_CL 
-  | where EventTime >= ago(endtime)
+  | where EventTime TimeGenerated between(starttime..endtime)
   | where EventName in (EventNameList)
   | project EventTime, EventSource,EventName, SourceIPAddress, UserIdentityType, UserIdentityArn, UserIdentityUserName, BucketName, Host, AuthenticationMethod, SessionMfaAuthenticated, SessionUserName, Key
   | join kind=leftanti
   (
     AWSS3BucketAPILogParsed 
-    | where EventTime between (ago(starttime)..ago(midtime))
+    | where EventTime between (lookback..starttime)
     | where EventName in (EventNameList)
   ) on SourceIPAddress
   | summarize EventCount=count(), StartTimeUtc = min(EventTime), EndTimeUtc = max(EventTime), Files= makeset(Key), EventNames = makeset(EventName) by EventSource, SourceIPAddress, UserIdentityType, UserIdentityArn, UserIdentityUserName, BucketName, Host, AuthenticationMethod, SessionMfaAuthenticated, SessionUserName


### PR DESCRIPTION
   Change(s):
   - Removed usage of midtime value for time frame

   Reason for Change(s):
   - midtime filter on timegenerated was causing a gap in days for historical comparison

   Version Updated:
   - Not needed for hunting queries

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

