### PR TITLE
SysmonForLinuxFullDeployment using Wrong Input Parameters for ASimNetworkSessionMicrosoftLinuxSysmon

### DIFF
--- a/Parsers/ASim Sysmon for Linux/SysmonForLinuxFullDeployment.json
+++ b/Parsers/ASim Sysmon for Linux/SysmonForLinuxFullDeployment.json
@@ -105,7 +105,7 @@
               "Workspace": {
                 "value": "[parameters('workspaceName')]"
               },
-              "Workspace Region": {
+              "WorkspaceRegion": {
                 "value": "[parameters('location')]"
               }
             }


### PR DESCRIPTION
Change(s):
 Updated ARM input parameter in SysmonForLinuxFullDeployment template when referencing ASimNetworkSessionMicrosoftLinuxSysmon template as a resource.

https://github.com/Azure/Azure-Sentinel/blob/master/Parsers/ASim%20Sysmon%20for%20Linux/SysmonForLinuxFullDeployment.json#L108

 Reason for Change(s):
 - See Issue: https://github.com/Azure/Azure-Sentinel/issues/4859

 Testing Completed:
 - Yes