### PR TITLE
Create PulseConnectSecureVPN-CVE_2021_22893_Exploit.yaml

### DIFF
--- a/Detections/PulseConnectSecure/PulseConnectSecureVPN-CVE_2021_22893_Exploit.yaml
+++ b/Detections/PulseConnectSecure/PulseConnectSecureVPN-CVE_2021_22893_Exploit.yaml
@@ -1,0 +1,31 @@
+id: d0c82b7f-40b2-4180-a4d6-7aa0541b7599
+name: PulseConnectSecure - CVE-2021-22893 Possible Pulse Connect Secure RCE Vulnerability Attack
+description: |
+  'This query identifies exploitation attempts using Pulse Connect Secure(PCS) vulnerability (CVE-2021-22893) to the VPN server'
+severity: High
+requiredDataConnectors:
+  - connectorId: PulseConnectSecure
+    dataTypes: 
+      - Syslog
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess 
+relevantTechniques:
+  - T1190
+query: |
+  let threshold = 3;
+  PulseConnectSecure
+  | where Messages contains "Unauthenticated request url /dana-na/"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), count() by Source_IP
+  | where count_ > threshold
+  | extend timestamp = StartTime, IPCustomEntity = Source_IP
+entityMappings:
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPCustomEntity
+version: 1.0.0
+kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Create New rule to detect  CVE-2021-22893 Pulse Connect Secure exploit

   Reason for Change(s):
   - New rule to CVE-2021-22893 Pulse Connect Secure RCE Vulnerability Attack 

   Version Updated:
   - Yes
   - Detections Rule templates are required to have the version updated

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below
   
   References:
  - https://www.cisa.gov/uscert/ncas/alerts/aa21-110a
  - https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44784