### PR TITLE
Fix default name of PAN-OS playbook custom connector

### DIFF
--- a/Playbooks/PaloAlto-PAN-OS/Playbooks/PaloAlto-PAN-OS-BlockIP/azuredeploy.json
+++ b/Playbooks/PaloAlto-PAN-OS/Playbooks/PaloAlto-PAN-OS-BlockIP/azuredeploy.json
@@ -29,7 +29,7 @@
       }
     },
     "CustomConnectorName":{
-        "defaultValue": "PAN-OSCustomConnector",
+        "defaultValue": "PAN-OSRestApiCustomConnector",
         "type": "string",
         "metadata": {
           "description": "Name of the custom connector which interacts with PAN-OS"

--- a/Playbooks/PaloAlto-PAN-OS/Playbooks/PaloAlto-PAN-OS-BlockURL/azuredeploy.json
+++ b/Playbooks/PaloAlto-PAN-OS/Playbooks/PaloAlto-PAN-OS-BlockURL/azuredeploy.json
@@ -29,7 +29,7 @@
       }
     },
     "CustomConnectorName":{
-        "defaultValue": "PAN-OSCustomConnector",
+        "defaultValue": "PAN-OSRestApiCustomConnector",
         "type": "string",
         "metadata": {
           "description": "Name of the custom connector which interacts with PAN-OS"


### PR DESCRIPTION

   Change(s):
   - Fix default value of custom connector resource name in PAN-OS playbook templates, to match the updated default name in the customer connector template

   Reason for Change(s):
   - Playbooks gallery in the portal expects the default name in the playbook template to match the default name in a custom connector template, to allow correlating them - otherwise there's no way to know which custom connector the playbook depends on.

   Version Updated:
   - N/A

   Testing Completed:
   - N/A

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A
