### PR TITLE
Adjusting Owners so that proper PR approval occurs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,15 +8,15 @@
 
 # This is copied from here: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-/.script/ @oshvartz @Amitbergman @ShaniFelig @laithhisham @shainw @oshezaf
+/.script/ @oshvartz @Amitbergman @ShaniFelig @laithhisham @oshezaf
 /ASIM/ @oshezaf @YaronFruchtmann
-/DataConnectors/ @NoamLandress @shschwar @ashishsyal @preetikr @haim-na
-/Detections/ @timbMSFT @juliango2100 @oshezaf @ashwin-patil @petebryan @shainw @thmcelro
-/Hunting\ Queries/ @timbMSFT @ashwin-patil @petebryan @shainw @thmcelro
+/DataConnectors/ @NoamLandress @shschwar @ashishsyal @haim-na
+/Detections/ @timbMSFT @juliango2100 @oshezaf @ashwin-patil @petebryan @thmcelro
+/Hunting\ Queries/ @timbMSFT @ashwin-patil @petebryan @thmcelro
 /Notebooks/ @ianhelle @petebryan @ashwin-patil
-/Parsers/ @oshezaf @ashishsyal @YaronFruchtmann @ashwin-patil @petebryan @shainw @preetikr
+/Parsers/ @oshezaf @ashishsyal @YaronFruchtmann @ashwin-patil @petebryan
 /Playbooks/ @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir
-/Workbooks/ @nazang @alexkarabas @ashwin-patil @petebryan @shainw @thmcelro
-/Solutions/ @ashishsyal @preetikr @Tichandr
-/Solutions/HoneyTokens @haneuvir @ashishsyal @preetikr
-/Solutions/SAP @udidekel @tamirkopitz @ashishsyal @preetikr
+/Workbooks/ @nazang @alexkarabas @ashwin-patil @petebryan @thmcelro
+/Solutions/ @ashishsyal @Tichandr
+/Solutions/HoneyTokens/ @haneuvir
+/Solutions/SAP/ @udidekel @tamirkopitz


### PR DESCRIPTION

   Change(s):
   - Removing accounts that are under subfolders that are in Global owners list

   Reason for Change(s):
   - Accounts that are being limited on PR approvals due to the last pattern match precedence causing lower approval privileges than expected.

   Version Updated:
   - N/A

   Testing Completed:
   - Yep

   Checked that the validations are passing and have addressed any issues that are present:
   - yep