### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,17 +5,18 @@
 
 # All up code owners - this should be limited to a select few - if specific code owner is needed, add to the specific folders below
 
-* @Amitbergman @aprakash13 @ashwin-patil @oshezaf @petebryan @preetikr @sagamzu @shainw @thmcelro @YaronFruchtmann
+* @Amitbergman @aprakash13 @ashwin-patil @oshezaf @petebryan @preetikr @sagamzu @shainw @thmcelro @YaronFruchtmann @azure/global_Sentinel_CodeOwners
 
 # This is copied from here: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-/.script/ @oshvartz @Amitbergman @ShaniFelig @laithhisham @oshezaf
-/DataConnectors/ @ashishsyal @NoamLandress @shschwar @haim-na @Tichandr
-/Hunting\ Queries/ @timbMSFT 
-/Notebooks/ @ianhelle
-/Parsers/ @ashishsyal @Tichandr
-/Playbooks/ @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir
-/Workbooks/ @ashishsyal @nazang @alexkarabas @Tichandr
-/Solutions/HoneyTokens/ @haneuvir
-/Solutions/SAP/ @udidekel @tamirkopitz
-/Solutions/ @ashishsyal @Tichandr
+/.script/ @ashishsyal @ms-sapangoel @oshvartz @Amitbergman @ShaniFelig @laithhisham @oshezaf @azure/global_Sentinel_CodeOwners
+/DataConnectors/ @ashishsyal @ms-sapangoel @NoamLandress @shschwar @haim-na @Tichandr @azure/global_Sentinel_CodeOwners
+/Detections/ @ashishsyal @ms-sapangoel @timbMSFT @juliango2100 @azure/global_Sentinel_CodeOwners
+/Hunting\ Queries/ @ashishsyal @ms-sapangoel @timbMSFT @azure/global_Sentinel_CodeOwners
+/Notebooks/ @ashishsyal @ms-sapangoel @ianhelle @azure/global_Sentinel_CodeOwners
+/Parsers/ @ashishsyal @ms-sapangoel @Tichandr @azure/global_Sentinel_CodeOwners
+/Playbooks/ @ashishsyal @ms-sapangoel @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir @azure/global_Sentinel_CodeOwners
+/Workbooks/ @ashishsyal @ms-sapangoel @nazang @alexkarabas @Tichandr @azure/global_Sentinel_CodeOwners
+/Solutions/HoneyTokens/ @haneuvir @azure/global_Sentinel_CodeOwners
+/Solutions/SAP/ @udidekel @tamirkopitz @azure/global_Sentinel_CodeOwners
+/Solutions/ @ashishsyal @ms-sapangoel @Tichandr @azure/global_Sentinel_CodeOwners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,18 +5,18 @@
 
 # All up code owners - this should be limited to a select few - if specific code owner is needed, add to the specific folders below
 
-* @Amitbergman @aprakash13 @ashwin-patil @oshezaf @petebryan @preetikr @sagamzu @shainw @thmcelro @YaronFruchtmann @azure/global_Sentinel_CodeOwners
+* @Amitbergman @ashwin-patil @oshezaf @petebryan @preetikr @sagamzu @shainw @thmcelro @YaronFruchtmann @Azure/sentinel-repo-admins
 
 # This is copied from here: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-/.script/ @ashishsyal @ms-sapangoel @oshvartz @Amitbergman @ShaniFelig @laithhisham @oshezaf @azure/global_Sentinel_CodeOwners
-/DataConnectors/ @ashishsyal @ms-sapangoel @NoamLandress @shschwar @haim-na @Tichandr @azure/global_Sentinel_CodeOwners
-/Detections/ @ashishsyal @ms-sapangoel @timbMSFT @juliango2100 @azure/global_Sentinel_CodeOwners
-/Hunting\ Queries/ @ashishsyal @ms-sapangoel @timbMSFT @azure/global_Sentinel_CodeOwners
-/Notebooks/ @ashishsyal @ms-sapangoel @ianhelle @azure/global_Sentinel_CodeOwners
-/Parsers/ @ashishsyal @ms-sapangoel @Tichandr @azure/global_Sentinel_CodeOwners
-/Playbooks/ @ashishsyal @ms-sapangoel @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir @azure/global_Sentinel_CodeOwners
-/Workbooks/ @ashishsyal @ms-sapangoel @nazang @alexkarabas @Tichandr @azure/global_Sentinel_CodeOwners
-/Solutions/HoneyTokens/ @haneuvir @azure/global_Sentinel_CodeOwners
-/Solutions/SAP/ @udidekel @tamirkopitz @azure/global_Sentinel_CodeOwners
-/Solutions/ @ashishsyal @ms-sapangoel @Tichandr @azure/global_Sentinel_CodeOwners
+/.script/ @ashishsyal @ms-sapangoel @oshvartz @Amitbergman @ShaniFelig @laithhisham @oshezaf @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/DataConnectors/ @ashishsyal @ms-sapangoel @NoamLandress @shschwar @haim-na @Tichandr @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Detections/ @ashishsyal @ms-sapangoel @timbMSFT @juliango2100 @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers @Azure/sentinel-repo-hunt-detection-reviewers
+/Hunting\ Queries/ @ashishsyal @ms-sapangoel @timbMSFT @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers @Azure/sentinel-repo-hunt-detection-reviewers
+/Notebooks/ @ashishsyal @ms-sapangoel @ianhelle @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Parsers/ @ashishsyal @ms-sapangoel @Tichandr @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Playbooks/ @ashishsyal @ms-sapangoel @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Workbooks/ @ashishsyal @ms-sapangoel @nazang @alexkarabas @Tichandr @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Solutions/HoneyTokens/ @haneuvir @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Solutions/SAP/ @udidekel @tamirkopitz @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Solutions/ @ashishsyal @ms-sapangoel @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers @Azure/sentinel-repo-solution-reviewers


### PR DESCRIPTION
Adding in a new global code owner group so we can remove individuals and to allow for inclusion in any specific paths since lack of this will cause PR approval to not work as expected.
