### PR TITLE
Migrate to Teams as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,18 +5,18 @@
 
 # All up code owners - this should be limited to a select few - if specific code owner is needed, add to the specific folders below
 
-* @Amitbergman @ashwin-patil @oshezaf @petebryan @preetikr @sagamzu @shainw @thmcelro @YaronFruchtmann @Azure/sentinel-repo-admins
+* @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
 
 # This is copied from here: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-/.script/ @ashishsyal @ms-sapangoel @oshvartz @Amitbergman @ShaniFelig @laithhisham @oshezaf @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/DataConnectors/ @ashishsyal @ms-sapangoel @NoamLandress @shschwar @haim-na @Tichandr @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Detections/ @ashishsyal @ms-sapangoel @timbMSFT @juliango2100 @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers @Azure/sentinel-repo-hunt-detection-reviewers
-/Hunting\ Queries/ @ashishsyal @ms-sapangoel @timbMSFT @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers @Azure/sentinel-repo-hunt-detection-reviewers
-/Notebooks/ @ashishsyal @ms-sapangoel @ianhelle @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Parsers/ @ashishsyal @ms-sapangoel @Tichandr @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Playbooks/ @ashishsyal @ms-sapangoel @Yaniv-Shasha @sarah-yo @sreedharande @lior-tamir @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Workbooks/ @ashishsyal @ms-sapangoel @nazang @alexkarabas @Tichandr @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Solutions/HoneyTokens/ @haneuvir @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Solutions/SAP/ @udidekel @tamirkopitz @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
-/Solutions/ @ashishsyal @ms-sapangoel @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers @Azure/sentinel-repo-solution-reviewers
+/.script/ @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/DataConnectors/ @Azure/sentinel-repo-connectors-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Detections/ @Azure/sentinel-repo-hunt-detection-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Hunting\ Queries/ @Azure/sentinel-repo-hunt-detection-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Notebooks/ @Azure/sentinel-repo-books-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Parsers/ @Azure/sentinel-repo-tools-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Playbooks/ @Azure/sentinel-repo-books-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Workbooks/ @Azure/sentinel-repo-books-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers
+/Solutions/HoneyTokens/ @haneuvir
+/Solutions/SAP/ @udidekel @tamirkopitz
+/Solutions/ @Azure/sentinel-repo-solution-reviewers @Azure/sentinel-repo-admins @Azure/sentinel-repo-reviewers


### PR DESCRIPTION
   Change(s):
   - Code owners file now uses Teams references instead of individuals.

   Reason for Change(s):
   - This allows for better control and updating.

   Version Updated:
   - N/A

   Testing Completed:
   - Yes, file is valid
   - Tested various scenarios when building teams and assigning code owner and role level for each team

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
