### PR TITLE
Change default playbook name for 'Watchlist-ChangeIncidentSeverityandTitleIFUserVIP'

### DIFF
--- a/Playbooks/Watchlist-ChangeIncidentSeverityandTitleIFUserVIP/alert-trigger/azuredeploy.json
+++ b/Playbooks/Watchlist-ChangeIncidentSeverityandTitleIFUserVIP/alert-trigger/azuredeploy.json
@@ -22,7 +22,7 @@
     },
     "parameters":  {
         "PlaybookName":  {
-            "defaultValue":  "Watchlist-ChangeIncidentSeverityandTitleIFUserVIP-AlertTrigger",
+            "defaultValue":  "Watchlist-ChangeIncidentSeverityandTitleIFUserVIP",
             "type":  "string"
         },
         "WatchlistAlias":  {

--- a/Playbooks/Watchlist-ChangeIncidentSeverityandTitleIFUserVIP/incident-trigger/azuredeploy.json
+++ b/Playbooks/Watchlist-ChangeIncidentSeverityandTitleIFUserVIP/incident-trigger/azuredeploy.json
@@ -22,7 +22,7 @@
     },
     "parameters":  {
         "PlaybookName":  {
-            "defaultValue":  "Watchlist-ChangeIncidentSeverityandTitleIFUserVIP-IncidentTrigger",
+            "defaultValue":  "Watchlist-ChangeIncidentSeverityandTitleIFUserVIP",
             "type":  "string"
         },
         "WatchlistAlias":  {


### PR DESCRIPTION
   Change(s):
   - Shorten the default playbook name in the 2 version of template 'Watchlist-ChangeIncidentSeverityandTitleIFUserVIP'

   Reason for Change(s):
   - Existing default name is very long so when trying to deploy the template as-is with the default values the deployment will fail due to the API connection name (which is the playbook name + a 'microsoftsentinel-' prefix) being longer than the max allowed length of 80 characters

   Version Updated:
   - N/A

   Testing Completed:
   - N/A

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A
