### PR TITLE
New Campaign - BPFDoor

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/redmenshen-bpfdoor-backdoor.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/redmenshen-bpfdoor-backdoor.yaml
@@ -14,7 +14,7 @@ tactics:
   - Execution
 relevantTechniques:
   - T1095
-  - TT1059.004
+  - T1059.004
   - T1070
 query: |
   DeviceProcessEvents

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/redmenshen-bpfdoor-backdoor.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/redmenshen-bpfdoor-backdoor.yaml
@@ -1,0 +1,21 @@
+id: bfb8eaed-941c-4866-a2cc-d5d4465bfc2a
+name: RedMenshen-BPFDoor-backdoor
+description: |
+  This query was originally published by PWC Security Research Team.
+  BPFDoor is custom backdoor malware used by Red Menshen. The BPFDoor allows an adversary to backdoor a system and remotely execute codes without opening any new network ports or firewall rules.
+References:
+  https://doublepulsar.com/bpfdoor-an-active-chinese-global-surveillance-tool-54b078f1a896
+  https://elastic.github.io/security-research/intelligence/2022/05/04.bpfdoor/article/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+tactics:
+  - Execution
+relevantTechniques:
+  - T1095
+  - TT1059.004
+  - T1070
+query: |
+  DeviceProcessEvents
+  | where InitiatingProcessCommandLine  has ("/dev/shm/kdmtmpflush") or FileName has ("haldrund.pid", "kdevrund.pid")


### PR DESCRIPTION
Required items, please complete

Change(s):

Create New rule to detect suspicious file of BPFDoor by RedMenshen APT
Reason for Change(s):

New rule to detect process or filename of BPFDoor
Version Updated: 1.0

Required only for Detections/Analytic Rule templates
Testing Completed:

Tested on event with sigma rule
Checked that the validations are passing and have addressed any issues that are present:

References: https://elastic.github.io/security-research/intelligence/2022/05/04.bpfdoor/article/