### PR TITLE
Fix little errors in detection MaliciousWAFSessions.yaml

### DIFF
--- a/Detections/AzureDiagnostics/MaliciousWAFSessions.yaml
+++ b/Detections/AzureDiagnostics/MaliciousWAFSessions.yaml
@@ -20,41 +20,46 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-  let mode = 'Blocked'; 
+  let queryperiod = 1d;
+  let mode = 'Blocked';
   let successCode = dynamic(['200', '101','204', '400','504','304','401','500']);
-  let minTime = ago(1d);
-  let maxSessionWindow = 1h;
-  let sessionBin = maxSessionWindow/2.0;
+  let sessionBin = 30m;
   AzureDiagnostics
-  | where TimeGenerated > minTime
-  | where Category == 'ApplicationGatewayFirewallLog'
-  | where action_s == mode
+  | where TimeGenerated > ago(queryperiod)
+  | where Category == 'ApplicationGatewayFirewallLog' and action_s == mode
   | sort by hostname_s asc, clientIp_s asc, TimeGenerated asc
-  | extend SessionStarted = row_window_session(TimeGenerated, maxSessionWindow, 10m, ((clientIp_s != prev(clientIp_s)) or (hostname_s != prev(hostname_s))))
-  | summarize minTime = min(TimeGenerated), maxTime = max(TimeGenerated), SessionBlockedCount=count()  by hostname_s, clientIp_s, SessionStarted
-  | extend duration = maxTime - minTime
-  | extend TimeKey = bin(SessionStarted, sessionBin)
-  | join kind = inner(
-  AzureDiagnostics
-  | where TimeGenerated > minTime
-  | where Category == 'ApplicationGatewayAccessLog'
-  | where httpStatus_d in (successCode) or isempty(httpStatus_d)
-  | extend TimeKey = range(bin(TimeGenerated-maxSessionWindow, sessionBin), bin(TimeGenerated, sessionBin), sessionBin)
+  | extend SessionBlockedStarted = row_window_session(TimeGenerated, queryperiod, 10m, ((clientIp_s != prev(clientIp_s)) or (hostname_s != prev(hostname_s))))
+  | summarize SessionBlockedEnded = max(TimeGenerated), SessionBlockedCount = count() by hostname_s, clientIp_s, SessionBlockedStarted
+  | extend TimeKey = range(bin(SessionBlockedStarted, sessionBin), bin(SessionBlockedEnded, sessionBin), sessionBin)
   | mv-expand TimeKey to typeof(datetime)
-  ) on $left.hostname_s == $right.host_s, $left.clientIp_s == $right.clientIP_s, TimeKey
-  | where (TimeGenerated - SessionStarted) between (0m .. duration)
-  | extend originalRequestUriWithArgs_s = column_ifexists("originalRequestUriWithArgs_s", "")
-  | extend serverStatus_s = column_ifexists("serverStatus_s", "")
-  | extend timestamp = SessionStarted, IPCustomEntity = clientIP_s
-  | summarize SuccessfulAccessLogCount = count(), UserAgents = make_set(userAgent_s), RequestURIs = make_set(requestUri_s) , OriginalRequestURIs = make_set(originalRequestUriWithArgs_s), 
-  SuccessCodes = make_set(httpStatus_d), SuccessCodes_BackendServer = make_set(serverStatus_s) by timestamp, hostname_s, IPCustomEntity, SessionBlockedCount
-  | extend BlockvsSuccessRatio = SessionBlockedCount/SuccessfulAccessLogCount
+  | join kind = inner(
+      AzureDiagnostics
+      | where TimeGenerated > ago(queryperiod)
+      | where Category == 'ApplicationGatewayAccessLog' and isempty(httpStatus_d) or httpStatus_d in (successCode)
+      | extend TimeKey = bin(TimeGenerated, sessionBin)
+  ) on TimeKey, $left.hostname_s == $right.host_s, $left.clientIp_s == $right.clientIP_s
+  | where TimeGenerated between (SessionBlockedStarted..SessionBlockedEnded)
+  | extend
+      originalRequestUriWithArgs_s = column_ifexists("originalRequestUriWithArgs_s", ""),
+      serverStatus_s = column_ifexists("serverStatus_s", "")
+  | summarize
+      SuccessfulAccessCount = count(),
+      UserAgents = make_set(userAgent_s, 250),
+      RequestURIs = make_set(requestUri_s, 250),
+      OriginalRequestURIs = make_set(originalRequestUriWithArgs_s, 250),
+      SuccessCodes = make_set(httpStatus_d, 250),
+      SuccessCodes_BackendServer = make_set(serverStatus_s, 250),
+      take_any(SessionBlockedEnded, SessionBlockedCount)
+      by hostname_s, clientIp_s, SessionBlockedStarted
+  | where SessionBlockedCount > SuccessfulAccessCount
+  | extend timestamp = SessionBlockedStarted, IPCustomEntity = clientIp_s
+  | extend BlockvsSuccessRatio = SessionBlockedCount/toreal(SuccessfulAccessCount)
   | sort by BlockvsSuccessRatio desc, timestamp asc
-  | where SessionBlockedCount > SuccessfulAccessLogCount 
+  | project-reorder SessionBlockedStarted, SessionBlockedEnded, hostname_s, clientIp_s, SessionBlockedCount, SuccessfulAccessCount, BlockvsSuccessRatio, SuccessCodes, RequestURIs, OriginalRequestURIs, UserAgents
 entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   1. BlockvsSuccessRatio now is forced to be a real number.
   2. mv-expand the summarized left side of the join, instead of the right-side
   3. Put a limit size to make_set.
   4. Project the columns in a certain order.
   5. Harmonize some column names.

   Reason for Change(s):
   1. It was divided by an integer, and the operation returned an integer, not a ratio.
   2. I think this is more efficient. It was triplicating all the right records to be compared.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes, but, please could you test the efficiency of the query against a good dataset?

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes