### PR TITLE
New Hunting - VMWare-LPE-2022-22960 Exploit

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Exploits/VMWare-LPE-2022-22960.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Exploits/VMWare-LPE-2022-22960.yaml
@@ -1,0 +1,25 @@
+id: 1d468d49-ffea-4daf-ba6b-72525ec17b61
+name: VMWare-LPE-2022-22960
+description: |
+  The query checks process command being placed into the script; CVE-2022-22960 allows a user to write to it and be executed as root.
+  This vulnerability of VMware Workspace ONE Access, Identity Manager and vRealize Automation contain a privilege escalation vulnerability due to improper permissions in support scripts.
+  CVE: CVE-2022-22960.
+  Read more here:.
+  https://www.cisa.gov/uscert/ncas/alerts/aa22-138b
+  https://www.vmware.com/security/advisories/VMSA-2022-0011.html
+  Tags: #exploit #CVE-2022-22960
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+tactics:
+  - Execution
+  - Privilege Escalation
+relevantTechniques:
+  - T1204
+  - T1548
+query: |
+  DeviceProcessEvents
+  | where InitiatingProcessCommandLine has ("/opt/vmware/certproxy/bing/certproxyService.sh", "/horizon/scripts/exportCustomGroupUsers.sh", "/horizon/scripts/extractUserIdFromDatabase.sh")
+      or FileName has ("certproxyService.sh", "exportCustomGroupUsers.sh", "extractUserIdFromDatabase.sh ")
+  | project Timestamp, DeviceName , FileName, ProcessCommandLine, InitiatingProcessCommandLine 


### PR DESCRIPTION
Required items, please complete

Change(s):

Create New rule to detect suspicious script for CVE-2022-22960 exploit
Reason for Change(s):

New rule to detect process command or filename of CVE-2022-22960 exploit
Version Updated: 1.0

Required only for Detections/Analytic Rule templates
Testing Completed:

Tested on event with sigma rule
Checked that the validations are passing and have addressed any issues that are present:

References: https://www.cisa.gov/uscert/ncas/alerts/aa22-138b