### PR TITLE
Removing list of allowed values for region

### DIFF
--- a/Tools/Transformations-Library/Masking/MaskingDCR.json
+++ b/Tools/Transformations-Library/Masking/MaskingDCR.json
@@ -10,11 +10,6 @@
         },
         "location": {
             "defaultValue": "westus2",
-            "allowedValues": [
-                "westus2",
-                "eastus2",
-                "eastus2euap"
-            ],
             "type": "String",
             "metadata": {
                 "description": "Specifies the location in which to create the Data Collection Rule."


### PR DESCRIPTION
All regions are now supported, so removing the allowed list from the DCR template

  