### PR TITLE
Update UserAssignedPrivilegedRole.yaml

### DIFF
--- a/Detections/AuditLogs/UserAssignedPrivilegedRole.yaml
+++ b/Detections/AuditLogs/UserAssignedPrivilegedRole.yaml
@@ -31,6 +31,8 @@ query: |
   | where RoleName contains "Admin"
   | extend InitiatingApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
   | extend Initiator = iif(isnotempty(InitiatingApp), InitiatingApp, tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
+  // Uncomment below to not alert for PIM activations
+  //| where Initiator != "MS-PIM"
   | extend Target = tostring(TargetResources.userPrincipalName)
   | summarize by bin(TimeGenerated, 1h), OperationName,  RoleName, Target, Initiator, Result
   | extend AccountCustomEntity = Target
@@ -43,5 +45,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: scheduled


### PR DESCRIPTION
Adding a section to not alert for PIM when uncommented

   Required items, please complete
   
   Change(s):
   - | where Initiator != "MS-PIM"

   Reason for Change(s):
   - Alerts when user activates PIM assignment, which is not of high severity in my opinion.

