### PR TITLE
[Fix] Extract ClientIp for proper entity extraction

### DIFF
--- a/Detections/OfficeActivity/RareOfficeOperations.yaml
+++ b/Detections/OfficeActivity/RareOfficeOperations.yaml
@@ -22,7 +22,8 @@ query: |
   OfficeActivity
   | where Operation in~ ( "Add-MailboxPermission", "Add-MailboxFolderPermission", "Set-Mailbox", "New-ManagementRoleAssignment", "New-InboxRule", "Set-InboxRule", "Set-TransportRule")
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
+  | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
+  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIPOnly
 
 entityMappings:
   - entityType: Account
@@ -33,5 +34,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
  
   Change(s):
   - Updated Detections/OfficeActivity/RareOfficeOperations.yaml

   Reason for Change(s):
   - Extract ClientIp for proper entity extraction, ClientIPs with port number were not mapped to an entity
   
   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

