### PR TITLE
Feature/noamlandress/change cefama installer to generic

### DIFF
--- a/DataConnectors/Syslog/Forwarder_AMA_installer.py
+++ b/DataConnectors/Syslog/Forwarder_AMA_installer.py
@@ -2,8 +2,8 @@
 # ----------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ----------------------------------------------------------------------------
-# This script is used to install the AMA connector on a linux machine and configure the
-# Syslog daemon on the linux machine for a data forwarding scenario.
+# This script is used to install the AMA on a linux machine and configure the
+# Syslog daemon on the linux machine for a data forwarding connector scenario.
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8

--- a/DataConnectors/Syslog/Forwarder_AMA_installer.py
+++ b/DataConnectors/Syslog/Forwarder_AMA_installer.py
@@ -2,8 +2,8 @@
 # ----------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ----------------------------------------------------------------------------
-# This script is used to install the CEF connector on a linux machine and configure the
-# Syslog daemon on the linux machine.
+# This script is used to install the AMA connector on a linux machine and configure the
+# Syslog daemon on the linux machine for a data forwarding scenario.
 # Supported OS:
 #   64-bit
 #       CentOS 7 and 8


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Change the CEF AMA installer name to a generic one for all forwarder based connectors.
   - Change comments at the beginning of the file.
   - Create a Syslog directory under DataConnectors and put the installer script there.

   Reason for Change(s):
   - Create a generic installer for multi-use.

 