### PR TITLE
Fix update trigger template ids

### DIFF
--- a/Playbooks/Jira-CreateAndUpdateIssue/azuredeploy.json
+++ b/Playbooks/Jira-CreateAndUpdateIssue/azuredeploy.json
@@ -607,8 +607,8 @@
             "type":  "Microsoft.Logic/workflows",
             "location":  "[resourceGroup().location]",
             "tags":  {
-                "hidden-SentinelTemplateName":  "CreateJiraIssue-Incident",
-                "hidden-SentinelTemplateVersion":  "2.0"
+                "hidden-SentinelTemplateName":  "CreateAndUpdateJiraIssue",
+                "hidden-SentinelTemplateVersion":  "1.0"
             },
             "identity":  {
                 "type":  "SystemAssigned"

--- a/Playbooks/Jira-CreateAndUpdateIssue/releaseNotes.md
+++ b/Playbooks/Jira-CreateAndUpdateIssue/releaseNotes.md
@@ -1,5 +1,0 @@
-### 1.0
-
--   New version of the playbook creates a record and updates it.
--   In creation part added step to add tag with Jira ID.
--   Added option to update Jira issue when incident updated in Microsoft Sentinel.

--- a/Playbooks/Jira-CreateAndUpdateIssue/releaseNotes.md
+++ b/Playbooks/Jira-CreateAndUpdateIssue/releaseNotes.md
@@ -1,9 +1,5 @@
-### 2.0 New version leverages incident update trigger 
+### 1.0
 
 -   New version of the playbook creates a record and updates it.
 -   In creation part added step to add tag with Jira ID.
 -   Added option to update Jira issue when incident updated in Microsoft Sentinel.
-
-### 1.0
-
--   Initial version

--- a/Playbooks/SNOW-CreateAndUpdateIncident/azuredeploy.json
+++ b/Playbooks/SNOW-CreateAndUpdateIncident/azuredeploy.json
@@ -717,8 +717,8 @@
             "type":  "Microsoft.Logic/workflows",
             "location":  "[resourceGroup().location]",
             "tags":  {
-                "hidden-SentinelTemplateName":  "CreateSNOWRecord-Incident",
-                "hidden-SentinelTemplateVersion":  "2.0"
+                "hidden-SentinelTemplateName":  "CreateAndUpdateSNOWRecord",
+                "hidden-SentinelTemplateVersion":  "1.0"
             },
             "identity":  {
                 "type":  "SystemAssigned"

--- a/Playbooks/SNOW-CreateAndUpdateIncident/releaseNotes.md
+++ b/Playbooks/SNOW-CreateAndUpdateIncident/releaseNotes.md
@@ -1,6 +1,0 @@
-### 1.0
-
--   New version of the playbook creates a record and updates it.
--   In creation part added step to add tag with SNOW ID
--   Added option to update SNOW incident when incident updated in Microsoft Sentinel.
--   When incident is closed in Microsoft Sentinel, playbok will run and close incident in SNOW

--- a/Playbooks/SNOW-CreateAndUpdateIncident/releaseNotes.md
+++ b/Playbooks/SNOW-CreateAndUpdateIncident/releaseNotes.md
@@ -1,10 +1,6 @@
-### 2.0 New version leverages incident update trigger 
+### 1.0
 
 -   New version of the playbook creates a record and updates it.
 -   In creation part added step to add tag with SNOW ID
 -   Added option to update SNOW incident when incident updated in Microsoft Sentinel.
 -   When incident is closed in Microsoft Sentinel, playbok will run and close incident in SNOW
-
-### 1.0
-
--   Initial version


### PR DESCRIPTION
   Change(s):
   - Change template ids for 2 recently added playbooks

   Reason for Change(s):
   - 2 new playbook templates using automation rule incident update trigger were added, but their ids are already used by other existing templates which causes a conflict. The new playbooks weren't exposed in the playbook gallery so changing their ids now avoids having any customer impact

   Version Updated:
   - N/A

   Testing Completed:
   - N/A
