### PR TITLE
Minimum requirements changed for function app reference bundle

### DIFF
--- a/DataConnectors/CiscoUmbrella/host.json
+++ b/DataConnectors/CiscoUmbrella/host.json
@@ -10,6 +10,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 2.0.0)"
+    "version": "[2.*, 3.0.0)"
   }
 }


### PR DESCRIPTION
The minimum version required to run function apps has been updated.  Modified the host.json to include Microsoft.Azure.FUnctions.ExtensionBundle 2.*

   Required items, please complete
   
   Change(s):
   - See guidance below

   Reason for Change(s):
   - Function app requires bundle 2.* to function.
   - Issue ##5179 has been created for this.

   Version Updated:
- Reference bundle requires an updated to run has been updated to 2.*

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - No KQL changes required
   - Testing and validation of function app trigger has been completed. 

