### PR TITLE
Make the "-EncodedCommand " parameter case insensitive while parsing

### DIFF
--- a/Hunting Queries/SecurityEvent/powershell_newencodedscipts.yaml
+++ b/Hunting Queries/SecurityEvent/powershell_newencodedscipts.yaml
@@ -30,13 +30,13 @@ query: |
   encodedPSScripts
   | where TimeGenerated between(starttime..endtime)
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), count() by Computer, Account, NewProcessName, FileName, ProcessCommandLine, ParentProcessName
-  | parse ProcessCommandLine with * "-EncodedCommand " encodedCommand
+  | parse kind=regex flags=i ProcessCommandLine with * "-EncodedCommand " encodedCommand
   | extend decodedCommand = base64_decode_tostring(substring(encodedCommand, 0, strlen(encodedCommand) - (strlen(encodedCommand) %8)))
   | join kind=leftanti (
     encodedPSScripts
     | where TimeGenerated between(ago(lookback)..starttime)
     | summarize count() by ProcessCommandLine
-    | parse ProcessCommandLine with * "-EncodedCommand " encodedCommand
+    | parse kind=regex flags=i ProcessCommandLine with * "-EncodedCommand " encodedCommand
     | extend decodedCommand = base64_decode_tostring(substring(encodedCommand, 0, strlen(encodedCommand) - (strlen(encodedCommand) %8)))
   ) on encodedCommand, decodedCommand
   | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = Computer


### PR DESCRIPTION
   Change(s):
   - Made the parsing of encoded command case insensitive

   Reason for Change(s):
   - Encoded PowerShell scripts like "powershell.exe -encodedcommand <cmd>" will not get detected for the current rule implementation.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
