### PR TITLE
Add TimeRange parameter instead of defined time context

### DIFF
--- a/Solutions/GitHub/Workbooks/GithubWorkbook.json
+++ b/Solutions/GitHub/Workbooks/GithubWorkbook.json
@@ -1,5 +1,5 @@
 {
-  "version": "Notebook/1.1",
+  "version": "Notebook/1.0",
   "items": [
     {
       "type": 1,

--- a/Solutions/GitHub/Workbooks/GithubWorkbook.json
+++ b/Solutions/GitHub/Workbooks/GithubWorkbook.json
@@ -1,5 +1,5 @@
 {
-  "version": "Notebook/1.0",
+  "version": "Notebook/1.1",
   "items": [
     {
       "type": 1,

--- a/Solutions/GitHub/Workbooks/GithubWorkbook.json
+++ b/Solutions/GitHub/Workbooks/GithubWorkbook.json
@@ -85,10 +85,7 @@
         "query": "GitHubAuditData \n| where Action == \"org.add_member\" or Action == \"org.remove_member\"\n| extend Action = iif(Action==\"org.add_member\", \"Added\", \"Removed\")\n| sort by TimeGenerated desc\n| project MemberName=Actor, Action, Organization\n",
         "size": 1,
         "title": "Members Added or Removed",
-        "timeContext": {
-          "durationMs": 11318400000,
-          "endTime": "2021-08-10T16:00:00.000Z"
-        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "sortBy": []
@@ -103,10 +100,7 @@
         "query": "GitHubAuditData \r\n| where Action == \"repo.create\"\r\n| sort by TimeGenerated desc\r\n| project Repository, Actor, Visibility\r\n\r\n\r\n\r\n",
         "size": 0,
         "title": "Repositories Created",
-        "timeContext": {
-          "durationMs": 15116400000,
-          "endTime": "2021-08-10T16:04:00.000Z"
-        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
@@ -120,10 +114,7 @@
         "query": "GitHubAuditData \r\n| where Action == \"team.add_repository\" or Action == \"team.remove_repository\"\r\n| extend Action = iif(Action==\"team.add_repository\", \"Added\", \"Removed\")\r\n| sort by TimeGenerated desc\r\n| project Organization, Repository, Action",
         "size": 0,
         "title": "Teams Added/Removed Repository",
-        "timeContext": {
-          "durationMs": 37411200000,
-          "endTime": "2021-08-10T16:06:00.000Z"
-        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
@@ -137,10 +128,7 @@
         "query": "GitHubAuditData \r\n| where Action == \"repo.access\"  and Visibility == \"PUBLIC\"\r\n| sort by TimeGenerated desc\r\n| project Organization, Repository, Actor\r\n",
         "size": 0,
         "title": "Private Repos made Public",
-        "timeContext": {
-          "durationMs": 19263600000,
-          "endTime": "2021-08-10T16:08:00.000Z"
-        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated [Solutions/GitHub/Workbooks/GithubWorkbook.json](https://github.com/Azure/Azure-Sentinel/compare/master...Official-James:patch-1#diff-191566d9e044781fe2e98ff89f0ac0416e89548bcf9fe5e7f57f7b9953b2fb72) to replace timeContext with TimeRange

   Reason for Change(s):
   - If used as it is, it will filter based on the timeContext defined by the creator and would require manual editing. By replacing with timeContextFromParameter and setting it to TimeRange, it enables users to use the time range filter within the workbook (no editing required).

   Version Updated:
   - Yes (from v1.0 to v1.1)

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
