### PR TITLE
Take last versions of indicators in some TI map rules

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
@@ -23,7 +23,8 @@ query: |
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
-  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now() 
+  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
   | where Active == true
   | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
   | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureKeyVault.yaml
@@ -52,5 +52,5 @@ entityMappings:
     fieldMappings:
       - identifier: ResourceId
         columnName: ResourceId
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
@@ -49,5 +49,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: ClientIP
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureSQL.yaml
@@ -20,7 +20,8 @@ query: |
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
-  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now() 
+  | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
   | where Active == true
   | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
   | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)


### PR DESCRIPTION
   Change(s):
   - Take last version of Indicator

   Reason for Change(s):
   - If not, the rules could be using outdated indicators.
   - Rest of TI map IP entity rules use this step.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes