### PR TITLE
Fix "Vlaue" dictionary key in URLEntity_OfficeActivity.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
@@ -28,7 +28,7 @@ query: |
   | where isnotempty(Url)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
-   OfficeActivity
+    OfficeActivity
     | where TimeGenerated >= ago(dt_lookBack)
     //Extract the Url from a number of potential fields
     | extend Url = iif(OfficeWorkload == "AzureActiveDirectory",extract("(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+);", 1,ModifiedProperties),tostring(parse_json(ModifiedProperties)[12].NewValue))

--- a/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
+++ b/Detections/ThreatIntelligenceIndicator/URLEntity_OfficeActivity.yaml
@@ -37,7 +37,7 @@ query: |
     | extend Url = tostring(split(Url, ';')[0])
     | extend OfficeActivity_TimeGenerated = TimeGenerated
     // Project a single user identity that we can use for entity mapping
-    | extend User = iif(isnotempty(UserId), UserId, iif(isnotempty(Actor), tostring(parse_json(Actor)[0].ID), tostring(parse_json(Parameters)[0].Vlaue))) 
+    | extend User = iif(isnotempty(UserId), UserId, iif(isnotempty(Actor), tostring(parse_json(Actor)[0].ID), tostring(parse_json(Parameters)[0].Value)))
   ) on Url
   | where OfficeActivity_TimeGenerated < ExpirationDateTime
   | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId, Url
@@ -53,5 +53,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Call the correct key "Value"

   Reason for Change(s):
   - If not, it will never resolve correctly. Although a user doesn't have to be in position 0 of the array... So a bigger fix might be needed.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes