### PR TITLE
Updating the Gitignore on request of the SAP solution team. It seems …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,6 @@ ipch/
 *.psess
 *.vsp
 *.vspx
-*.sap
 
 # Visual Studio Trace Files
 *.e2e


### PR DESCRIPTION

 Required items, please complete
   
   Change(s):
   - Updating the Gitignore file and removing the *.sap extension. 

   Reason for Change(s):
   - Removing the *.sap extension on request of the SAP solution team.  It seems the extension was just part of the default config when the repo was setup and ideally the removal should not have any impact.

   Version Updated:
   - Not needed

   Testing Completed:
   - Not needed

