### PR TITLE
Add more operations and more efficient parsing in IPEntity_AzureFirewall.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -59,7 +59,7 @@ query: |
   | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
   | project AzureFirewall_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, 
-  TI_ipEntity, Resource, Category, msg_s, Protocol, SourceAddress, DestinationAddress, Firewall_Action, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
+  TI_ipEntity, Resource, Category, OperationName, msg_s, Protocol, SourceAddress, DestinationAddress, Firewall_Action, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureFirewall_TimeGenerated, IPCustomEntity = TI_ipEntity, URLCustomEntity = Url
 entityMappings:
   - entityType: IP

--- a/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_AzureFirewall.yaml
@@ -38,20 +38,28 @@ query: |
   | join kind=innerunique (
       AzureDiagnostics
       | where TimeGenerated >= ago(dt_lookBack)
-      | where OperationName in ("AzureFirewallApplicationRuleLog", "AzureFirewallNetworkRuleLog")
-      | parse kind=regex flags=U msg_s with Protocol 'request from ' SourceHost 'to ' DestinationHost @'\.? Action: ' Firewall_Action @'\.' Rest_msg
-      | extend SourceAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, SourceHost)
-      | extend DestinationAddress = extract(@'([\.0-9]+)(:[\.0-9]+)?', 1, DestinationHost)
+      | where Category in ("AzureFirewallNetworkRule", "AzureFirewallApplicationRule")
+      // Some kinds of operations could be excluded
+      //| where OperationName !in ("AzureFirewallNetworkRuleLog", "AzureFirewallNatRuleLog", "AzureFirewallApplicationRuleLog", "AzureFirewallIDSLog", "AzureFirewallThreatIntelLog")
+      | parse msg_s with Protocol " request from " SourceAddress1 ":" SourcePort:int " to " DestinationAddress1 ":" DestinationPort:int *
+      | parse msg_s with * ". Action: " Action1a "." *
+      | parse msg_s with * " was " Action1b " to " NatDestination
+      | parse msg_s with Protocol2 " request from " SourceAddress2 " to " DestinationAddress2 ". Action: " Action2 "." *
+      | extend
+          Firewall_Action = case(isempty(Action1a), case(isempty(Action1b), Action2, Action1b), Action1a),
+          Protocol = case(isempty(Protocol), Protocol2, Protocol),
+          SourceAddress = case(isempty(SourceAddress1), SourceAddress2, SourceAddress1),
+          DestinationAddress = case(isempty(DestinationAddress1), DestinationAddress2, DestinationAddress1)
       | extend RemoteIP = case(not(ipv4_is_private(DestinationAddress)), DestinationAddress, not(ipv4_is_private(SourceAddress)), SourceAddress, "")
-      // Traffic that involves a public address, and in case this is the source address then the traffic was not denied
+      // We are interested in traffic that involves a public address
       | where isnotempty(RemoteIP)
-      | project-rename AzureFirewall_TimeGenerated = TimeGenerated
+      | extend AzureFirewall_TimeGenerated = TimeGenerated
   )
   on $left.TI_ipEntity == $right.RemoteIP
   | where AzureFirewall_TimeGenerated < ExpirationDateTime
   | summarize AzureFirewall_TimeGenerated = arg_max(AzureFirewall_TimeGenerated, *) by IndicatorId, RemoteIP
-  | project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, AzureFirewall_TimeGenerated,
-  TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Firewall_Action, Protocol, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
+  | project AzureFirewall_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, DomainName, ExpirationDateTime, ConfidenceScore, 
+  TI_ipEntity, Resource, Category, msg_s, Protocol, SourceAddress, DestinationAddress, Firewall_Action, NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress
   | extend timestamp = AzureFirewall_TimeGenerated, IPCustomEntity = TI_ipEntity, URLCustomEntity = Url
 entityMappings:
   - entityType: IP
@@ -62,5 +70,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled


### PR DESCRIPTION
I have added more operations to compare, and I think clients should select which events they want this rule to trigger. Azure Firewall might add more operations in the long run. The clients can uncomment a specific line to exclude certain operations.

Please, could you check this query against a big dataset?
   
   Change(s):
   - Changed the parsing of msg_s
   - Filter by Category, not by OperationName.

   Reason for Change(s):
   - Azure Monitor has some queries for Azure Firewall events, with a more efficient parsing (I think).
   - With new capabilities, more operations might be added in Azure Firewall and we might want check those events, we don't want to limit ourselves.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes