### PR TITLE
Fix "timstamp" column name, Linux failure and AAD Success conditions in HostAADCorrelation.yaml

### DIFF
--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -71,7 +71,7 @@ query: |
   | where ResultType !in ("0", "50125", "50140")
   | where IPAddress in (win_fails) or IPAddress in (nix_fails) or IPAddress in (wef_fails)
   | extend Reason=  "Multiple failed host logins from IP address with successful Azure AD login"
-  | extend timstamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, Type = Type
+  | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, Type = Type
   };
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
@@ -85,5 +85,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -59,7 +59,7 @@ query: |
   //Make a list of IPs with failed *nix host logins above threshold
   let nix_fails = 
   Syslog
-  | where Facility contains 'auth' and ProcessName != 'sudo' and SyslogMessage has ("from") and not(SyslogMessage has_any ("Disconnecting", "Disconnected", "Accepted", "disconnect", "[preauth]"))
+  | where Facility contains 'auth' and ProcessName != 'sudo' and SyslogMessage has ('from') and not(SyslogMessage has_any ('Disconnecting', 'Disconnected', 'Accepted', 'disconnect', @'[preauth]'))
   | extend SourceIP = extract("(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3})))",1,SyslogMessage)
   | where SourceIP != "" and SourceIP != "127.0.0.1"
   | summarize count() by SourceIP

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -59,7 +59,7 @@ query: |
   //Make a list of IPs with failed *nix host logins above threshold
   let nix_fails = 
   Syslog
-  | where Facility contains 'auth' and ProcessName != 'sudo' and SyslogMessage has ('from') and not(SyslogMessage has_any ('Disconnecting', 'Disconnected', 'Accepted', 'disconnect', @'[preauth]'))
+  | where Facility contains 'auth' and ProcessName != 'sudo' and SyslogMessage has 'from' and not(SyslogMessage has_any ('Disconnecting', 'Disconnected', 'Accepted', 'disconnect', @'[preauth]'))
   | extend SourceIP = extract("(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3})))",1,SyslogMessage)
   | where SourceIP != "" and SourceIP != "127.0.0.1"
   | summarize count() by SourceIP

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -59,7 +59,7 @@ query: |
   //Make a list of IPs with failed *nix host logins above threshold
   let nix_fails = 
   Syslog
-  | where Facility contains 'auth' and ProcessName != 'sudo'
+  | where Facility contains 'auth' and ProcessName != 'sudo' and SyslogMessage has ("from") and not(SyslogMessage has_any ("Disconnecting", "Disconnected", "Accepted", "disconnect", "[preauth]"))
   | extend SourceIP = extract("(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3})))",1,SyslogMessage)
   | where SourceIP != "" and SourceIP != "127.0.0.1"
   | summarize count() by SourceIP

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -68,7 +68,7 @@ query: |
   //See if any of the IPs with failed host logins hve had a sucessful Azure AD login
   let aadFunc = (tableName:string){
   table(tableName)
-  | where ResultType !in ("0", "50125", "50140")
+  | where ResultType in ("0")
   | where IPAddress in (win_fails) or IPAddress in (nix_fails) or IPAddress in (wef_fails)
   | extend Reason=  "Multiple failed host logins from IP address with successful Azure AD login"
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, Type = Type

--- a/Detections/MultipleDataSources/HostAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/HostAADCorrelation.yaml
@@ -68,7 +68,7 @@ query: |
   //See if any of the IPs with failed host logins hve had a sucessful Azure AD login
   let aadFunc = (tableName:string){
   table(tableName)
-  | where ResultType in ("0")
+  | where ResultType in ("0", "50125", "50140")
   | where IPAddress in (win_fails) or IPAddress in (nix_fails) or IPAddress in (wef_fails)
   | extend Reason=  "Multiple failed host logins from IP address with successful Azure AD login"
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress, Type = Type


### PR DESCRIPTION
  Change(s):
   1. Correct the column name "timstamp" as other detections have it.
   2. Add failure conditions to Syslog logs.
   3. Add success condition to AAD logs. (```in``` instead of ```!in```)

   Reason for Change(s):
   1. Personally I don't know if this makes a difference nowadays.
   2. Currently all logs, even successful logins contributed to IP addresses of linux "failures".
   3. It seems this rule has never worked as intended...

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes