### PR TITLE
Fix column names from external source

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Discovery/DetectTorRelayConnectivity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Discovery/DetectTorRelayConnectivity.yaml
@@ -14,11 +14,11 @@ tactics:
 - Command and control
 query: |
   let TorRelayData = (
-      externaldata (Nickname:string,Fingerprint:string,EntryAddress:string,IPv4Address:string,IPv4Port:string,IPv6Address:string,AddressType:string,Hostname:string,CountryCode:string,IsRunning:bool,RelayPublishDate:string,LastChangedIPData:string)
+      externaldata (Nickname:string,Fingerprint:string,EntryAddress:string,IPAddress:string,Port:string,AddressType:string,Hostname:string,CountryCode:string,IsRunning:bool,LastChangedIPData:string)
       [h@'https://torinfo.blob.core.windows.net/public/TorRelayIPs.csv'] with (ignoreFirstRecord=true,format="csv")
       | where AddressType == "IPv4"
   );
   TorRelayData
-  | join kind=inner DeviceNetworkEvents on $left.IPv4Address == $right.RemoteIP
+  | join kind=inner DeviceNetworkEvents on $left.IPAddress == $right.RemoteIP
   | join kind=inner (DeviceInfo | distinct DeviceId, PublicIP) on DeviceId
-  | project Timestamp, DeviceId, LocalPublicIP = PublicIP, LocalIP, RemoteIP, TorIP = IPv4Address, Hostname, CountryCode, ActionType, InitiatingProcessFileName, InitiatingProcessFolderPath
+  | project Timestamp, DeviceId, LocalPublicIP = PublicIP, LocalIP, RemoteIP, TorIP = IPAddress, Hostname, CountryCode, ActionType, InitiatingProcessFileName, InitiatingProcessFolderPath


### PR DESCRIPTION
   Change(s):
   - Removed no longer used external csv column names

   Reason for Change(s):
   - External source no longer includes Ipv6 addresses & some other fields

   Version Updated:
   - No
  
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes