### PR TITLE
Fix small condition in UnusualGuestActivity.yaml

### DIFF
--- a/Detections/MultipleDataSources/UnusualGuestActivity.yaml
+++ b/Detections/MultipleDataSources/UnusualGuestActivity.yaml
@@ -36,7 +36,7 @@ query: |
   | mv-expand UserToCompare = pack_array(InitiatedBy, InvitedUser)
   | where UserToCompare has_any ("live.com#", "#EXT#")
   | extend
-      parsedUser = replace_string((iff(UserToCompare has "live.com#", tostring(split(UserToCompare, "#")[1]), tostring(split(UserToCompare, "#EXT#")[0]))), "@", "_"),
+      parsedUser = replace_string((iff(UserToCompare startswith "live.com#", tostring(split(UserToCompare, "#")[1]), tostring(split(UserToCompare, "#EXT#")[0]))), "@", "_"),
       InvitationTime = TimeGenerated
   | join (
       (union isfuzzy=true SigninLogs, AADNonInteractiveUserSignInLogs)

--- a/Detections/MultipleDataSources/UnusualGuestActivity.yaml
+++ b/Detections/MultipleDataSources/UnusualGuestActivity.yaml
@@ -75,5 +75,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.4
+version: 1.0.5
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Distinguish between starting with live.com# ```live.com#example1@example2.com``` and containing live.com# ```example1_live.com#EXT#example2.onmicrosoft.com```

   Reason for Change(s):
   - As live.com is a valid domain, the parsing of the invited user might be incorrect in the current state.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes