### PR TITLE
Fix error in expanding IPAddresses in IPEntity_DnsEvents.yaml

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
+++ b/Detections/ThreatIntelligenceIndicator/IPEntity_DnsEvents.yaml
@@ -36,11 +36,10 @@ query: |
   | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
-      DnsEvents | where TimeGenerated >= ago(dt_lookBack)
+      DnsEvents
+      | where TimeGenerated >= ago(dt_lookBack)
       | where SubType =~ "LookupQuery" and isnotempty(IPAddresses)
-      | extend SingleIP = split(IPAddresses, ",")
-      | mvexpand SingleIP
-      | extend SingleIP = tostring(SingleIP)
+      | mv-expand SingleIP = split(IPAddresses, ", ") to typeof(string)
       // renaming time column so it is clear the log this came from
       | extend DNS_TimeGenerated = TimeGenerated
   )
@@ -63,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Split multiple ip addresses by ```, ``` instead of ```,```

   Reason for Change(s):
   - Spaces are important when comparing the join key, so until now there were only matches with the first ip address (the one that did not start with a space), the rest of ip addresses would not match.

   Version Updated:
   - Yes

   Testing Completed:
   - No, please, could you check if DnsEvents tables **always** has ip addresses separated by ```, ``` instead of ```,``` ?

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes