### PR TITLE
Fix missing parentheses in MaliciousWAFSessions.yaml

### DIFF
--- a/Detections/AzureDiagnostics/MaliciousWAFSessions.yaml
+++ b/Detections/AzureDiagnostics/MaliciousWAFSessions.yaml
@@ -35,7 +35,7 @@ query: |
   | join kind = inner(
       AzureDiagnostics
       | where TimeGenerated > ago(queryperiod)
-      | where Category == 'ApplicationGatewayAccessLog' and isempty(httpStatus_d) or httpStatus_d in (successCode)
+      | where Category == 'ApplicationGatewayAccessLog' and (isempty(httpStatus_d) or httpStatus_d in (successCode))
       | extend TimeKey = bin(TimeGenerated, sessionBin)
   ) on TimeKey, $left.hostname_s == $right.host_s, $left.clientIp_s == $right.clientIP_s
   | where TimeGenerated between (SessionBlockedStarted..SessionBlockedEnded)
@@ -61,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
   I'm sorry, with the previous pull request accepted I saw this error. If needed, return the version to 1.0.1 , please.
   
   Change(s):
   - Add parentheses to clarify condition logic.

   Reason for Change(s):
   - If ```httpStatus_d``` is used by other events with ```Category``` different from ```ApplicationGatewayAccessLog```, they will effectively be added to the join unnecessarily, when the original rule only wanted ```ApplicationGatewayAccessLog``` events.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes