### PR TITLE
Removed unsupported sub technique

### DIFF
--- a/Detections/DeviceEvents/SolarWinds_TEARDROP_Process-IOCs.yaml
+++ b/Detections/DeviceEvents/SolarWinds_TEARDROP_Process-IOCs.yaml
@@ -19,7 +19,7 @@ tactics:
   - Persistence
   - DefenseEvasion
 relevantTechniques:
-  - T1543.003
+  - T1543
   - T1059
   - T1027
 tags:
@@ -49,5 +49,5 @@ entityMappings:
         columnName: FileHashType
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated "Detections/DeviceEvents/SolarWinds_TEARDROP_Process-IOCs.yaml"

   Reason for Change(s):
   - Added unsupported sub-technique, because this is not accepted by the MS Sentinel API

   Version Updated:
   - [x] yes
   
   Testing Completed:
   - [x] See attached image.
 
![image](https://user-images.githubusercontent.com/40334679/176659503-dbd6d20b-7ef4-4f33-94b9-ea1342001dc2.png)

   Checked that the validations are passing and have addressed any issues that are present:
 