### PR TITLE
Add FileHash entity to TI map file hash detections

### DIFF
--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_CommonSecurityLog.yaml
@@ -42,7 +42,7 @@ query: |
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId, FileHashValue
   | project CommonSecurityLog_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction,
-  RequestURL, DestinationUserName, DestinationUserID, ApplicationProtocol, Activity
+  RequestURL, DestinationUserName, DestinationUserID, ApplicationProtocol, Activity, FileHashValue, FileHashType
   | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, AccountCustomEntity = SourceUserName, URLCustomEntity = Url
 entityMappings:
   - entityType: Account
@@ -61,5 +61,11 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+  - entityType: FileHash
+    fieldMappings:
+      - identifier: Value
+        columnName: FileHashValue
+      - identifier: Algorithm
+        columnName: FileHashType
+version: 1.3.0
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_Covid19_CommonSecurityLog.yaml
@@ -48,5 +48,11 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.2.0
+  - entityType: FileHash
+    fieldMappings:
+      - identifier: Value
+        columnName: FileHashValue
+      - identifier: Algorithm
+        columnName: FileHashType
+version: 1.3.0
 kind: Scheduled

--- a/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
+++ b/Detections/ThreatIntelligenceIndicator/FileHashEntity_SecurityEvent.yaml
@@ -52,7 +52,7 @@ query: |
   | where SecurityEvent_TimeGenerated < ExpirationDateTime
   | summarize SecurityEvent_TimeGenerated = arg_max(SecurityEvent_TimeGenerated, *) by IndicatorId, FileHash
   | project SecurityEvent_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
-  Process, FileHash, Computer, Account, Event
+  Process, FileHash, Computer, Account, Event, FileHashValue, FileHashType
   | extend timestamp = SecurityEvent_TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, URLCustomEntity = Url
 entityMappings:
   - entityType: Account
@@ -67,5 +67,11 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.3.1
+  - entityType: FileHash
+    fieldMappings:
+      - identifier: Value
+        columnName: FileHashValue
+      - identifier: Algorithm
+        columnName: FileHashType
+version: 1.4.0
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Adds FileHash entity mapping to Threat Intelligence detections relating to file hash indicators
   - Adds projection of FileHashValue and FileHashType to "TI map File Hash to CommonSecurityLog Event" and "TI map File Hash to Security Event"

   Reason for Change(s):
   - Incidents created with these detection rule templates would not indicate the identified file hash in the entity list, requiring analyst to spend extra time reviewing event information

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes