### PR TITLE
Rename field in TI workbook template

### DIFF
--- a/Workbooks/ThreatIntelligence.json
+++ b/Workbooks/ThreatIntelligence.json
@@ -347,7 +347,7 @@
                   "id": "9aec751b-07bd-43ba-80b9-f711887dce45",
                   "version": "KqlParameterItem/1.0",
                   "name": "Indicator",
-                  "label": "Indicator Search",
+                  "label": "Search Event Indicators",
                   "type": 1,
                   "value": "",
                   "timeContext": {


### PR DESCRIPTION
Renamed field "Indicator Search" to "Search Event Indicators" to clarify that event indicators (not TI data) will be searched, based on conversation with Rijuta.

   Required items, please complete
   
   Change(s):
   - Updated field name in TI workbook template

   Reason for Change(s):
   - Clarify what information will be searched in template

   Version Updated:
   - N/A

   Testing Completed:
   - Yes, N/A

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes, N/A