### PR TITLE
Rename TI workbook template field

### DIFF
--- a/Workbooks/ThreatIntelligence.json
+++ b/Workbooks/ThreatIntelligence.json
@@ -347,7 +347,7 @@
                   "id": "9aec751b-07bd-43ba-80b9-f711887dce45",
                   "version": "KqlParameterItem/1.0",
                   "name": "Indicator",
-                  "label": "Indicator Search",
+                  "label": "Search Indicator in Events",
                   "type": 1,
                   "value": "",
                   "timeContext": {

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -214,7 +214,7 @@
     "dataTypesDependencies": [ "ThreatIntelligenceIndicator", "SecurityIncident" ],
     "dataConnectorsDependencies": [ "ThreatIntelligence", "ThreatIntelligenceTaxii" ],
     "previewImagesFileNames": [ "ThreatIntelligenceWhite.png", "ThreatIntelligenceBlack.png" ],
-    "version": "5.1.0",
+    "version": "5.2.0",
     "title": "Threat Intelligence",
     "templateRelativePath": "ThreatIntelligence.json",
     "subtitle": "",


### PR DESCRIPTION
Renamed field "Indicator Search" to "Search Indicator in Events" to clarify that event indicators (not TI data) will be searched, based on conversation with Rijuta.

Change(s):
- Updated field name in TI workbook template

Reason for Change(s):
- Clarify what information will be searched in template

Version Updated:
- N/A

Testing Completed:
- Yes, N/A

Checked that the validations are passing and have addressed any issues that are present:
- Yes, N/A

