### PR TITLE
Fix a few small typos in Unisolate-MDEMachine playbook release notes

### DIFF
--- a/Playbooks/Unisolate-MDEMachine/incident-trigger/releaseNotes.md
+++ b/Playbooks/Unisolate-MDEMachine/incident-trigger/releaseNotes.md
@@ -1,7 +1,7 @@
-### 1.1 Alligned MDE Device ID with Incident trigger scheme
+### 1.1 Aligned MDE Device ID with Incident trigger scheme
 
--   Alligned MDE Device ID with Incident trigger scheme
--   Added pre-requisite of assigning Microsoft Sentienl Responder role to the managed identity
+-   Aligned MDE Device ID with Incident trigger scheme
+-   Added pre-requisite of assigning Microsoft Sentinel Responder role to the managed identity
 
 ### 1.0
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Fix some small typo in the release notes which are displayed in the Sentinel portal

   Reason for Change(s):
   - Typos
   
   Version Updated:
   - N/A

   Testing Completed:
   - N/A

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A
