### PR TITLE
Create Linux Agent Age Report.yaml

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/General queries/Linux Agent Age Report.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/General queries/Linux Agent Age Report.yaml
@@ -1,0 +1,27 @@
+id: 392533b7-a31a-488e-a553-5223811092de
+name: Linux Agent Age Report
+description: |
+  This query uses the public MDE GitHub repo as a source to estimate the time that an agent build remains supported
+  based on the time it was uploaded. Please note that the timestamps used in this query are meant to estimate the
+  support period and will likely not represent the actual expiration of the package which will be based on the build.
+  If you would like an estimate of support, uncomment the extend statement to get an idea of what is \ is not 
+  supported and an idea of how long support will remain for current agents.
+  This query currently only supports GA builds, not preview builds.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceTvmSoftwareInventory
+query: |
+  let LinuxAgentVersions = 
+  externaldata (data:string)["https://packages.microsoft.com/rhel/8/prod/"]
+  | parse kind=regex data with @'.*">' Filename:string '</a>' Timestamp:datetime " " Size:int 
+  | where Filename startswith "mdatp_"
+  | parse Filename with "mdatp_" Version:string ".x86_64.rpm"
+  | extend SoftwareVersion = strcat(Version, ".0")
+  // The below line should NOT be considered a statement of support, but rather a rough estimate. Uncomment to use.
+  //| extend IsSupported = Timestamp > ago(270d), RemainingSupportInDays = 270 - datetime_diff('day', now(), Timestamp) 
+  | project-away data;
+  DeviceTvmSoftwareInventory
+  | where SoftwareName == "defender_for_linux"
+  | project DeviceId, DeviceName, SoftwareVersion
+  | lookup kind=leftouter (LinuxAgentVersions) on $left.SoftwareVersion == $right.SoftwareVersion


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - New file

   Reason for Change(s):
   - We haven't historically had the ability to report on Linux agent build age and the agent expires after 9 months

   Version Updated:
   - Not applicable

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - .Net testing failed to run on my device. Code runs in Advanced Hunting and YAML was validated using an open source validator.