### PR TITLE
Create UnusualAnomaly.yaml scheduled Analytics Rule detection

### DIFF
--- a/Detections/Anomalies/UnusualAnomaly.yaml
+++ b/Detections/Anomalies/UnusualAnomaly.yaml
@@ -1,0 +1,33 @@
+id: d0255b5f-2a3c-4112-8744-e6757af3283a
+name: Unusual Anomaly
+description: |
+  'Anomaly Rules generate events in the Anomalies table. This scheduled rule tries to detect Anomalies that are not usual, they could be a type of Anomaly that has recently been activated, or an infrequent type. The detected Anomaly should be reviewed, if it is relevant enough, eventually a separate scheduled Analytics Rule could be created specifically for that Anomaly Type, so an alert and/or incident is generated everytime that type of Anomaly happens.'
+severity: Medium
+requiredDataConnectors:
+  - connectorId: Anomalies
+    dataTypes:
+      - Anomalies
+queryFrequency: 1h
+queryPeriod: 4d
+triggerOperator: gt
+triggerThreshold: 0
+query: |
+  // You can leave out Anomalies that are already monitored through other Analytics Rules
+  //let _MonitoredRules = dynamic(["TestAlertName"]);
+  let query_frequency = 1h;
+  let query_lookback = 3d;
+  Anomalies
+  | where TimeGenerated > ago(query_frequency)
+  //| where not(RuleName has_any (_MonitoredRules))
+  | join kind = leftanti (
+      Anomalies
+      | where TimeGenerated between (ago(query_frequency + query_lookback)..ago(query_frequency))
+      | distinct RuleName
+  ) on RuleName
+entityMappings: []
+eventGroupingSettings:
+  aggregationKind: AlertPerResult
+alertDetailsOverride:
+  alertDisplayNameFormat: Unusual Anomaly - {{RuleName}}
+version: 1.0.0
+kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Add a scheduled rule for unusual anomalies.

   Reason for Change(s):
   - I think workspaces could benefit by starting to check Anomalies, specially the ones that do not happen everyday. But I would understand if this detection does not fit here, or a "Solutions" resource for Anomalies will be deployed in the future.

   Version Updated:
   - Not apply.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Please, I would like to know how to specify "Sentinel Entities" in ```entityMappings```, I would like to add the table column ```Entities```. I don't think the validator can check the value "Sentinel Entities" yet.