### PR TITLE
Updating WAF query to account for column limit of AzureDiagnostic. 

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/AzureDiagnostics.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/AzureDiagnostics.json
@@ -674,6 +674,10 @@
       "Type": "String"
     },
     {
+      "Name": "AdditionalFields",
+      "Type": "dynamic"
+    },
+    {
       "Name": "_ResourceId",
       "Type": "String"
     }

--- a/Detections/AzureDiagnostics/AzureWAFmatching_log4j_vuln.yaml
+++ b/Detections/AzureDiagnostics/AzureWAFmatching_log4j_vuln.yaml
@@ -22,15 +22,18 @@ tags:
   - log4shell
 query: |
   AzureDiagnostics
-  | extend details_data_s = column_ifexists("details_data_s", AdditionalFields)
+  | where ResourceProvider == "MICROSOFT.NETWORK" and Category in ("ApplicationGatewayFirewallLog", "FrontdoorWebApplicationFirewallLog")
+  | extend details_data_s = column_ifexists("details_data_s", tostring(AdditionalFields.details_data))
   | where details_data_s has "jndi:"
-  | parse details_data_s with * '${' MaliciousCommand '}' *
+  | parse details_data_s with * '${' MaliciousCommand '} ' *
   | extend EncodeCmd = iff(MaliciousCommand has 'Base64/', split(split(MaliciousCommand, "Base64/",1)[0], "}", 0)[0], "")
   | extend EncodeCmd1 = iff(MaliciousCommand has 'base64/', split(split(MaliciousCommand, "base64/",1)[0], "}", 0)[0], "")
   | extend CmdLine = iff( isnotempty(EncodeCmd), EncodeCmd, EncodeCmd1)
   | extend DecodedCmdLine = base64_decode_tostring(tostring(CmdLine))
-  | extend DecodedCmdLine = iff( isnotempty(DecodedCmdLine), DecodedCmdLine, "Unable to decode")
-  | project TimeGenerated, Target=hostname_s, MaliciousHost = clientIp_s, MaliciousCommand, details_data_s, DecodedCmdLine, Message, ruleSetType_s, OperationName, SubscriptionId, details_message_s, details_file_s 
+  | extend DecodedCmdLine = iff( isnotempty(DecodedCmdLine), DecodedCmdLine, "Unable to decode/Doesn't need decoding")
+  | project TimeGenerated, Target=column_ifexists("hostname_s", tostring(AdditionalFields.hostname)), MaliciousHost = column_ifexists("clientIp_s", tostring(AdditionalFields.clientIp)) , MaliciousCommand, details_data_s = column_ifexists("details_data_s", tostring(AdditionalFields.details_data)), DecodedCmdLine, Message,
+  ruleSetType_s = column_ifexists("ruleSetType_s", tostring(AdditionalFields.ruleSetType)), OperationName, SubscriptionId, details_message_s = column_ifexists("details_message_s", tostring(AdditionalFields.details_message)), 
+  details_file_s = column_ifexists("details_message_s", tostring(AdditionalFields.details_file))
   | extend IPCustomEntity = MaliciousHost, timestamp = TimeGenerated
 entityMappings: 
 - entityType: IP

--- a/Detections/AzureDiagnostics/AzureWAFmatching_log4j_vuln.yaml
+++ b/Detections/AzureDiagnostics/AzureWAFmatching_log4j_vuln.yaml
@@ -22,6 +22,7 @@ tags:
   - log4shell
 query: |
   AzureDiagnostics
+  | extend details_data_s = column_ifexists("details_data_s", AdditionalFields)
   | where details_data_s has "jndi:"
   | parse details_data_s with * '${' MaliciousCommand '}' *
   | extend EncodeCmd = iff(MaliciousCommand has 'Base64/', split(split(MaliciousCommand, "Base64/",1)[0], "}", 0)[0], "")
@@ -36,5 +37,5 @@ entityMappings:
   fieldMappings:
     - identifier: Address
       columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
If the total number of columns is at or above 500 in AzureDiagnostic , the excess data is added to AdditionalFields column.
Updating WAF query to account for column limit of AzureDiagnostic. 

   Required items, please complete
   
   Change(s):
   - Updating WAF query to account for column limit of AzureDiagnostic. 

   Reason for Change(s):
   - If the total number of columns is at or above 500 in AzureDiagnostic , the excess data is added to AdditionalFields column.
Updating WAF query to account for column limit of AzureDiagnostic. 

   Version Updated:
   - Yes
