### PR TITLE
Update to workbook 8/15/2022

### DIFF
--- a/Solutions/GitHub/Workbooks/update-to-workbook-1
+++ b/Solutions/GitHub/Workbooks/update-to-workbook-1
@@ -1,0 +1,1793 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "f80bd5e4-0e9d-4dc7-b999-110328e5b08e",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "isGlobal": true,
+            "value": {
+              "durationMs": 259200000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ],
+              "allowCustom": true
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            }
+          },
+          {
+            "id": "1673856e-da45-4e3b-8c00-9790024bea39",
+            "version": "KqlParameterItem/1.0",
+            "name": "Repositories",
+            "type": 5,
+            "description": "Repository selector",
+            "isRequired": true,
+            "isGlobal": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s).full_name\n| distinct tostring(repository)\n| where isnotempty(repository)\n\n",
+            "value": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "defaultValue": "value::all",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 5"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "b7b61394-d7c7-4a2a-9e90-5d17ce94f8d8",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Advanced Security Overview",
+            "subTarget": "Advanced Security Overview",
+            "style": "link"
+          },
+          {
+            "id": "7b984311-578d-4162-8e03-1c82cfa37519",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Code Scanning Alerts",
+            "subTarget": "Code Scanning Alerts",
+            "style": "link"
+          },
+          {
+            "id": "03316284-9c39-4d15-853b-568d16d264f5",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Secret Scanning Alerts",
+            "subTarget": "Secret Scanning Alerts",
+            "style": "link"
+          },
+          {
+            "id": "8853be7b-58d0-45cc-89c3-1a9897f01b19",
+            "cellValue": "SelectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Dependabot Alerts",
+            "subTarget": "Dependabot Alerts",
+            "style": "link"
+          }
+        ]
+      },
+      "customWidth": "50",
+      "name": "links - 5",
+      "styleSettings": {
+        "margin": "0px",
+        "padding": "0px"
+      }
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "<h1 style=\"text-align:center; padding:20px\">Advanced Security Overview</h1>"
+            },
+            "name": "text - 7"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let RepositoryVulnerabilityAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create')\n| extend EventType='Dependabot Alert'\n| extend alert = todynamic(alert_s)                     \n| extend alertexternalidentifier= alert.external_identifier\n| extend Severity = tostring(alert.severity)\n| where isnotempty(alertexternalidentifier)\n| project EventType, Severity;\nlet CodeScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created') and isnotempty(commit_oid_s)\n| extend EventType='Code Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend Severity = tostring(alert.rule.security_severity_level)\n| where isnotempty(Severity) \n| project EventType, Severity;\nlet SecretScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend EventType='Secret Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| extend Severity = \"high\"\n| where isnotempty(alertSecretType)\n| project EventType, Severity;\nunion withsource=\"AllEvents\" RepositoryVulnerabilityAlerts, CodeScanningAlerts, SecretScanningAlerts\n|summarize  Count = count() by tostring(Severity)",
+              "size": 0,
+              "title": "Open Alerts By Severity",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart",
+              "chartSettings": {
+                "group": "Severity",
+                "createOtherGroup": null,
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "high",
+                    "label": "High",
+                    "color": "redBright"
+                  },
+                  {
+                    "seriesName": "moderate",
+                    "label": "Moderate",
+                    "color": "orange"
+                  },
+                  {
+                    "seriesName": "medium",
+                    "label": "Medium",
+                    "color": "brown"
+                  },
+                  {
+                    "seriesName": "critical",
+                    "label": "Critical",
+                    "color": "redDark"
+                  },
+                  {
+                    "seriesName": "low",
+                    "label": "Low",
+                    "color": "yellow"
+                  }
+                ]
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 8"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let RepositoryVulnerabilityAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create')\n| extend EventType='Dependabot Alert'\n| extend alert = todynamic(alert_s) \n| extend repo = todynamic(repository_s)   \n| extend Repository = repo.full_name               \n| extend alertexternalidentifier= alert.external_identifier\n| where isnotempty(alertexternalidentifier);\nlet CodeScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created') and isnotempty(commit_oid_s)\n| extend EventType='Code Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)   \n| extend Repository = repo.full_name                 \n| extend Severity = alert.rule.security_severity_level;\nlet SecretScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend EventType='Secret Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)\n| extend Repository = repo.full_name                 \n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType);\nunion withsource=\"AllEvents\" RepositoryVulnerabilityAlerts, CodeScanningAlerts, SecretScanningAlerts\n|summarize  Count = count() by tostring(Repository)",
+              "size": 0,
+              "title": "Open Alerts by Repository",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart",
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "repositoryfullname",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "repositoryfullname",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Count",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 8 - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let RepositoryVulnerabilityAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create')\n| extend EventType='Dependabot Alert'\n| extend alert = todynamic(alert_s)                     \n| extend alertexternalidentifier= alert.external_identifier\n| extend Severity = alert.severity\n| where isnotempty(alertexternalidentifier)\n| project EventType, Severity;\nlet CodeScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created') and isnotempty(commit_oid_s)\n| extend EventType='Code Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend Severity = alert.rule.security_severity_level\n| project EventType, Severity;\nlet SecretScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend EventType='Secret Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| extend Severity = \"High\"\n| where isnotempty(alertSecretType)\n| project EventType, Severity;\nunion withsource=\"AllEvents\" RepositoryVulnerabilityAlerts, CodeScanningAlerts, SecretScanningAlerts\n|summarize  Count = count() by tostring(EventType)",
+              "size": 0,
+              "title": "Open Alerts by Type",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart"
+            },
+            "customWidth": "25",
+            "name": "query - 8 - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let RepositoryVulnerabilityAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('dismiss', 'resolve')\n| extend EventType='Dependabot Alert'\n| extend alert = todynamic(alert_s) \n| extend repo = todynamic(repository_s)   \n| extend Repository = repo.full_name               \n| extend alertexternalidentifier= alert.external_identifier\n| where isnotempty(alertexternalidentifier);\nlet CodeScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('closed_by_user', 'fixed') and isnotempty(commit_oid_s)\n| extend EventType='Code Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)   \n| extend Repository = repo.full_name                 \n| extend Severity = alert.rule.security_severity_level;\nlet SecretScanningAlerts = githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolved')\n| extend EventType='Secret Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)\n| extend Repository = repo.full_name                 \n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType);\nunion withsource=\"AllEvents\" RepositoryVulnerabilityAlerts, CodeScanningAlerts, SecretScanningAlerts\n| count",
+              "size": 4,
+              "title": "Resolved Alert Count",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 8 - Copy - Copy",
+            "styleSettings": {
+              "padding": "50px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let RepositoryVulnerabilityAlerts = \ngithubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create', 'dismiss', 'resolve')\n| extend EventType='Dependabot Alert'\n| extend alert = todynamic(alert_s)                     \n| extend alertexternalidentifier= alert.external_identifier\n| extend Severity = alert.severity\n| extend repo = todynamic(repository_s)   \n| extend Repository = repo.full_name \n| extend id = alert.ghsa_id  \n| extend Status = action_s\n| extend Reason = alert.affected_package_name\n| extend Created_at = alert.created_at\n| extend Number = alert.number\n| extend Age = now() - todatetime(Created_at) \n| where isnotempty(alertexternalidentifier)\n|project Repository, Reason, id, EventType, tostring(Severity), Status, Created_at, Number, format_timespan(Age, 'dd:hh:mm:ss');\nlet CodeScanningAlerts =\ngithubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', 'reopened_by_user', 'closed_by_user', 'fixed', 'appeared_in_branch', 'reopened') and isnotempty(commit_oid_s)\n| extend EventType='Code Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend Severity = alert.rule.security_severity_level\n| extend repo = todynamic(repository_s)   \n| extend Repository = repo.full_name \n| extend Reason = alert.rule.name\n| extend id = alert.rule.id\n| extend Severity = alert.rule.security_severity_level\n| extend Status = action_s\n| extend Created_at = alert.created_at\n| extend Number = alert.number\n| where isnotempty(Severity) \n| extend Age = now() - todatetime(Created_at)\n|project Repository, Reason, id, EventType, tostring(Severity), Status, Created_at, Number, format_timespan(Age, 'dd:hh:mm:ss');\nlet SecretScanningAlerts = \ngithubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', 'resolved', 'reopened')\n| extend EventType='Secret Scanning Alert'\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)\n| extend Repository = repo.full_name \n| extend Severity = \"high\"\n| extend Reason = alert.secret_type \n| extend id = alert.number\n| extend alertSecretType = alert.secret_type\n| extend Status = action_s\n| extend Created_at = alert.created_at\n| extend Number = alert.number\n| extend Age = now() - todatetime(Created_at)\n| where isnotempty(alertSecretType)\n| project Repository, Reason, id, EventType, tostring(Severity), Status, Created_at, Number, format_timespan(Age, 'dd:hh:mm:ss');\nunion withsource=\"AllEvents\" RepositoryVulnerabilityAlerts, CodeScanningAlerts, SecretScanningAlerts",
+              "size": 0,
+              "title": "Alert Details",
+              "timeContextFromParameter": "TimeRange",
+              "showExportToExcel": true,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "AllEvents",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Severity",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "contains",
+                          "thresholdValue": "high",
+                          "representation": "redBright",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "contains",
+                          "thresholdValue": "critical",
+                          "representation": "redDark"
+                        },
+                        {
+                          "operator": "contains",
+                          "thresholdValue": "moderate",
+                          "representation": "red"
+                        },
+                        {
+                          "operator": "contains",
+                          "thresholdValue": "medium",
+                          "representation": "orange"
+                        },
+                        {
+                          "operator": "contains",
+                          "thresholdValue": "low",
+                          "representation": "yellow"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "gray",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "rowLimit": 5000,
+                "filter": true,
+                "labelSettings": [
+                  {
+                    "columnId": "Age",
+                    "label": "Age(dd:hh:mm:ss)"
+                  }
+                ]
+              }
+            },
+            "name": "query - 5"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "Advanced Security Overview"
+      },
+      "name": "Advanced Security Overview"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "<h1 style=\"text-align:center; padding:20px\">Code Scanning Alerts</h1>"
+            },
+            "name": "text - 0"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('closed_by_user', 'fixed') and isnotempty(commit_oid_s)\n| extend alert = todynamic(alert_s)\n| extend url  = alert.url\n| extend repo = todynamic(repository_s)\n| extend repository = repo.name\n| extend created_at = alert.created_at\n| extend resolved_at = alert.fixed_at\n| extend day = todatetime(resolved_at) - todatetime(created_at)\n| summarize format_timespan(avg(day), 'dd:hh:mm:ss')",
+              "size": 4,
+              "title": "Mean Time to Resolution (dd:hh:mm:ss)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "sortBy": [
+                  {
+                    "itemKey": "MTTR",
+                    "sortOrder": 2
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "MTTR",
+                  "sortOrder": 2
+                }
+              ],
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 5"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created') and isnotempty(commit_oid_s)\n| extend Status = action_s\n| count",
+              "size": 4,
+              "title": "Created",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ],
+                "sortBy": [
+                  {
+                    "itemKey": "Count",
+                    "sortOrder": 1
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Count",
+                  "sortOrder": 1
+                }
+              ],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 2"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('fixed') and isnotempty(commit_oid_s)\n| extend Status = action_s\n| count",
+              "size": 4,
+              "title": "Fixed",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ],
+                "sortBy": [
+                  {
+                    "itemKey": "Count",
+                    "sortOrder": 1
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Count",
+                  "sortOrder": 1
+                }
+              ],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 2 - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('reopened') and isnotempty(commit_oid_s)\n| extend Status = action_s\n| count",
+              "size": 4,
+              "title": "Reopened",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ],
+                "sortBy": [
+                  {
+                    "itemKey": "Count",
+                    "sortOrder": 1
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Count",
+                  "sortOrder": 1
+                }
+              ],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 2 - Copy - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', \"fixed\") and isnotempty(commit_oid_s)\n| summarize event_count=count() by tostring(action_s), bin(TimeGenerated,1d)",
+              "size": 0,
+              "title": "Alert Found/Fixed Ratio",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "timechart",
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "action_s",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "event_count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "chartSettings": {
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "created",
+                    "label": "Created"
+                  },
+                  {
+                    "seriesName": "fixed",
+                    "label": "Fixed"
+                  }
+                ]
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 7",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let GithubPushes = githubscanaudit_CL\n| extend EventType='Push'\n| extend status = todynamic(action_s)\n| extend commit = todynamic(commits_s)[0]\n| extend added = commit.added\n| extend modified = commit.modified\n| extend removed = commit.removed\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories})\n| where isnotempty(modified[0]) or isnotempty(added[0]);\nlet CodeScanningAlerts = \ngithubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', 'reopened') and isnotempty(commit_oid_s)\n| extend EventType='Code Scanning Alert';\nunion withsource=\"AllEvents\" CodeScanningAlerts, GithubPushes\n| summarize event_count=count() by EventType, bin(TimeGenerated,1d)\n",
+              "size": 0,
+              "title": "Commit/Alert Ratio",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "timechart",
+              "chartSettings": {
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "Push",
+                    "label": "Commits"
+                  },
+                  {
+                    "seriesName": "Code Scanning Alert",
+                    "label": "Alerts"
+                  }
+                ]
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 7 - Copy",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', \"appeared_in_branch\") and isnotempty(commit_oid_s)\n| extend alert = todynamic(alert_s)\n| extend Tool = alert.tool.name\n| project TimeGenerated, Tool\n| summarize Count = count() by tostring(Tool), bin(TimeGenerated,1d)",
+              "size": 0,
+              "title": "New Alerts by Tool",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "unstackedbar"
+            },
+            "customWidth": "33",
+            "name": "query - 7 - Copy",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('closed_by_user', 'fixed') and isnotempty(commit_oid_s)\n| extend alert = todynamic(alert_s)\n| extend URL  = alert.html_url\n| extend tool = alert.tool.name\n| extend repo = todynamic(repository_s)\n| extend repository = repo.name\n| extend created_at = alert.created_at\n| extend resolved_at = alert.fixed_at\n| extend Time_To_Resolution = format_timespan(todatetime(resolved_at) - todatetime(created_at), 'dd:hh:mm:ss')\n| project repository, URL, tool, created_at, resolved_at, Time_To_Resolution",
+              "size": 0,
+              "title": "Fixed Alerts",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "URL",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "Url"
+                    }
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "repository",
+                    "label": "Repository"
+                  },
+                  {
+                    "columnId": "tool",
+                    "label": "Tool"
+                  },
+                  {
+                    "columnId": "created_at",
+                    "label": "Created at"
+                  },
+                  {
+                    "columnId": "resolved_at",
+                    "label": "Resolved at"
+                  },
+                  {
+                    "columnId": "Time_To_Resolution",
+                    "label": "Time to Resolution(dd:hh:mm:ss)"
+                  }
+                ]
+              }
+            },
+            "name": "query - 4"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', 'reopened_by_user', 'reopened') and isnotempty(commit_oid_s)\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)\n|extend repository = repo.full_name\n| extend severity = alert.rule.security_severity_level\n| where isnotempty(severity)\n| summarize Total=count(severity), Critical=countif(severity=='critical'), High=countif(severity=='high'), Medium=countif(severity=='medium'), Low=countif(severity=='low') by tostring(repository)\n",
+              "size": 0,
+              "title": "Alerts by Severity",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Critical",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "representation": "redDark",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "red",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "High",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "redBright",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "Medium",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "orange",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "Low",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "yellow",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "filter": true,
+                "labelSettings": [
+                  {
+                    "columnId": "repository",
+                    "label": "Repository"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "severity",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "event_count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "severity",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "event_count",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "event_count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "event_count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "event_count",
+                  "heatmapPalette": "greenRed"
+                }
+              }
+            },
+            "customWidth": "50",
+            "name": "query - 3",
+            "styleSettings": {
+              "margin": "10px",
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', 'reopened') and isnotempty(commit_oid_s)\n| extend alert = todynamic(alert_s)\n| extend repo = todynamic(repository_s)\n| extend Tool = tostring(alert.tool.name)\n| extend Repository = repo.full_name\n| project Repository, Tool\n| evaluate pivot(tostring(Tool))\n| order by tostring(Repository) asc",
+              "size": 0,
+              "title": "Alerts by Repo",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "filter": true,
+                "sortBy": [
+                  {
+                    "itemKey": "Repository",
+                    "sortOrder": 1
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Repository",
+                  "sortOrder": 1
+                }
+              ]
+            },
+            "customWidth": "45",
+            "name": "query - 1",
+            "styleSettings": {
+              "margin": "10px",
+              "padding": "20px"
+            }
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "Code Scanning Alerts"
+      },
+      "name": "Code Scanning Alerts"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "<h1 style=\"text-align:center; padding:20px\">Secret Scanning Alerts</h1>"
+            },
+            "conditionalVisibility": {
+              "parameterName": "SelectedTab",
+              "comparison": "isEqualTo",
+              "value": "Secret Scanning Alerts"
+            },
+            "name": "text - 0"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "\ngithubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolved')\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType)\n| extend created_at = alert.created_at\n| extend resolved_at = alert.resolved_at\n| extend day = todatetime(resolved_at) - todatetime(created_at)\n| summarize format_timespan(avg(day), 'dd:hh:mm:ss')",
+              "size": 4,
+              "title": "Mean Time to Resolution (dd:hh:mm:ss)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "sortBy": [
+                  {
+                    "itemKey": "MTTR",
+                    "sortOrder": 2
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "MTTR",
+                  "sortOrder": 2
+                }
+              ],
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 5"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL\n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType)\n| count ",
+              "size": 4,
+              "title": "Found Secrets",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ],
+                "sortBy": [
+                  {
+                    "itemKey": "Count",
+                    "sortOrder": 1
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Count",
+                  "sortOrder": 1
+                }
+              ],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 2"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "\ngithubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolved')\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType)\n| count \n",
+              "size": 4,
+              "title": "Fixed Secrets",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 9"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType)\n| summarize Count = count() by tostring(alertSecretType)",
+              "size": 0,
+              "title": "Secrets by Type",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart"
+            },
+            "customWidth": "33",
+            "name": "query - 7 - Copy",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| extend  repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where isnotempty(alertSecretType)\n| summarize Count = count() by tostring(repositoryfullname)",
+              "size": 0,
+              "title": "Secrets by Repository",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart",
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "action_s",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "event_count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 7",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created', 'resolved')\n| extend alert = todynamic(alert_s)\n| extend alertSecretType = alert.secret_type\n| where isnotempty(alertSecretType)\n| summarize Count = count() by  bin(TimeGenerated, 1d), action_s",
+              "size": 0,
+              "title": "Secrets Found/Fixed Ratio",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "timechart"
+            },
+            "customWidth": "33",
+            "name": "query - 7 - Copy",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolved')\n| extend alert = todynamic(alert_s)\n| extend Secret_Type = alert.secret_type\n| extend Repository = todynamic(repository_s).full_name\n| extend Organization = todynamic(organization_s).login\n| extend Created_at = alert.created_at\n| extend Resolved_at = alert.resolved_at\n| extend Time_to_Resolution= format_timespan(todatetime(Resolved_at) - todatetime(Created_at), 'dd:hh:mm:ss' )\n| extend Resolution = case(isnotnull(alert.resolution), alert.resolution, \"Null\") \n| extend URL = todynamic(repository_s).url       \n| where isnotempty(Secret_Type)\n|project Secret_Type, Organization, Repository, Resolution, Time_to_Resolution",
+              "size": 0,
+              "title": "Fixed Secrets",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "filter": true,
+                "sortBy": [
+                  {
+                    "itemKey": "Time_to_Resolution",
+                    "sortOrder": 2
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Secret_Type",
+                    "label": "Secret Type"
+                  },
+                  {
+                    "columnId": "Time_to_Resolution",
+                    "label": "Time to Resolution(dd:hh:mm:ss)"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Time_to_Resolution",
+                  "sortOrder": 2
+                }
+              ]
+            },
+            "name": "query - 4"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('created')\n| extend alert = todynamic(alert_s)\n| extend Secret_Type = alert.secret_type\n| extend Repository = todynamic(repository_s).full_name\n| extend Organization = todynamic(organization_s).login\n| extend Created_at = alert.created_at\n| extend URL = alert.html_url       \n| where isnotempty(Secret_Type)\n| project tostring(Secret_Type), tostring(Organization), tostring(Repository), tostring(URL), tostring(Created_at)",
+              "size": 0,
+              "title": "Found Secrets",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "URL",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "Url"
+                    }
+                  }
+                ],
+                "filter": true,
+                "sortBy": [
+                  {
+                    "itemKey": "Created_at",
+                    "sortOrder": 2
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Secret_Type",
+                    "label": "Secret Type"
+                  },
+                  {
+                    "columnId": "Created_at",
+                    "label": "Created at"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Created_at",
+                  "sortOrder": 2
+                }
+              ]
+            },
+            "name": "query - 1"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "Secret Scanning Alerts"
+      },
+      "name": "Secret Scanning Alerts"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "<h1 style=\"text-align:center; padding:20px\">Dependabot Alerts</h1>"
+            },
+            "name": "text - 0"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "\ngithubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolve')\n| extend alert = todynamic(alert_s)\n| extend created_at = alert.created_at \n| extend resolved_at = alert.fixed_at\n| extend alertexternalidentifier= alert.external_identifier\n| where isnotempty(alertexternalidentifier)\n| extend day = todatetime(resolved_at) - todatetime(created_at)\n| summarize format_timespan(avg(day), 'dd:hh:mm:ss')\n",
+              "size": 4,
+              "title": "Mean Time to Resolution (dd:hh:mm:ss)",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "sortBy": [
+                  {
+                    "itemKey": "MTTR",
+                    "sortOrder": 2
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "MTTR",
+                  "sortOrder": 2
+                }
+              ],
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 5"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create')\n| extend alert = todynamic(alert_s)\n| extend Status = action_s\n| extend alertexternalidentifier= alert.external_identifier\n| where isnotempty(alertexternalidentifier)\n| count",
+              "size": 4,
+              "title": "Created",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ]
+              },
+              "sortBy": [],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 2"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolve')\n| extend alert = todynamic(alert_s)\n| extend Status = action_s\n| extend alertexternalidentifier= alert.external_identifier\n| where isnotempty(alertexternalidentifier)\n| count",
+              "size": 4,
+              "title": "Resolved",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ]
+              },
+              "sortBy": [],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 2 - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('dismiss')\n| extend alert = todynamic(alert_s)\n| extend Status = action_s\n| extend alertexternalidentifier= alert.external_identifier\n| where isnotempty(alertexternalidentifier)\n| count",
+              "size": 4,
+              "title": "Dismissed",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 1
+                  }
+                ]
+              },
+              "sortBy": [],
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Status",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "LatLong",
+                "sizeSettings": "Count",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Count",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Count",
+                  "heatmapPalette": "greenRed"
+                }
+              },
+              "textSettings": {
+                "style": "bignumber"
+              }
+            },
+            "customWidth": "25",
+            "name": "query - 2 - Copy - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create', 'dismiss', 'resolve')\n| extend alert = todynamic(alert_s)\n| extend alertexternalidentifier = alert.external_identifier   \n| where isnotempty(alertexternalidentifier)\n| summarize Count = count() by tostring(action_s), bin(TimeGenerated,1d)",
+              "size": 0,
+              "title": "Alert Found/Fixed Ratio",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "timechart",
+              "chartSettings": {
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "create",
+                    "label": "Found"
+                  },
+                  {
+                    "seriesName": "resolve",
+                    "label": "Fixed"
+                  },
+                  {
+                    "seriesName": "dismiss",
+                    "label": "Dismissed"
+                  }
+                ]
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 7 - Copy",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create')\n| extend EventType='RepositoryVulnerabilityAlert'\n| extend alert = todynamic(alert_s)\n| extend alertexternalidentifier = alert.external_identifier  \n| extend Severity = alert.severity\n| extend Repository = todynamic(repository_s).full_name\n| where isnotempty(alertexternalidentifier)\n| summarize Count=count() by tostring(Repository)",
+              "size": 0,
+              "title": "Vulnerabilities by Repo",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "piechart",
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "action_s",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "event_count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              }
+            },
+            "customWidth": "33",
+            "name": "query - 7",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('create')\n| extend EventType='RepositoryVulnerabilityAlert'\n| extend alert = todynamic(alert_s)\n| extend alertexternalidentifier = alert.external_identifier  \n| extend Severity = alert.severity\n| extend Repository = todynamic(repository_s).full_name\n| where isnotempty(alertexternalidentifier)\n| summarize Count=count() by tostring(Severity),  bin(TimeGenerated,1d)",
+              "size": 0,
+              "title": "New Alerts by Severity",
+              "timeContextFromParameter": "TimeRange",
+              "timeBrushParameterName": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "barchart"
+            },
+            "customWidth": "33",
+            "name": "query - 7 - Copy",
+            "styleSettings": {
+              "padding": "20px"
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and action_s in ('resolve', 'dismiss')\n| extend alert = todynamic(alert_s)\n|extend Action = todynamic(action_s)\n| extend alertexternalidentifier = alert.external_identifier  \n| extend Severity = alert.severity\n| extend repo =  todynamic(repository_s)\n| extend Alert_URL = alert.external_reference\n| extend Repository = repo.full_name\n| extend created_at = alert.created_at\n| extend resolved_at = case(isnotnull(alert.fixed_at), alert.fixed_at, alert.dismissed_at)\n| extend Time_to_Resolution = format_timespan(todatetime(resolved_at) - todatetime(created_at), 'dd:hh:mm:ss')\n| where isnotempty(alertexternalidentifier)\n| project Action, Repository, Severity, Alert_URL, Time_to_Resolution",
+              "size": 0,
+              "title": "Fixed Alerts",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Alert_URL",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "Url"
+                    }
+                  }
+                ],
+                "filter": true,
+                "sortBy": [
+                  {
+                    "itemKey": "Repository",
+                    "sortOrder": 2
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Time_to_Resolution",
+                    "label": "Time to Resolution(dd:hh:mm:ss)"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Repository",
+                  "sortOrder": 2
+                }
+              ]
+            },
+            "name": "query - 4"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "githubscanaudit_CL \n| extend repository = todynamic(repository_s)\n| extend repositoryfullname = repository.full_name\n| where repositoryfullname in ({Repositories}) and  action_s in ('create')\n| extend alert = todynamic(alert_s)\n| extend Action = todynamic(action_s)\n| extend alertexternalidentifier = alert.external_identifier  \n| extend Severity = alert.severity\n| extend repo =  todynamic(repository_s)\n| extend Alert_URL = alert.external_reference\n| extend Repository = repo.full_name\n| extend created_at = alert.created_at\n| extend resolved_at = alert.fixed_at\n| extend Time_to_Resolution = todatetime(resolved_at) - todatetime(created_at)\n| where isnotempty(alertexternalidentifier)\n| summarize Total=count(Severity), Critical=countif(Severity=='critical'), High=countif(Severity=='high'), Medium=countif(Severity=='moderate'), Low=countif(Severity=='low') by tostring(Repository)",
+              "size": 0,
+              "title": "Alerts by Repo",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Critical",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "redDark",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "High",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "redBright",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "Medium",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "orange",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "Low",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "yellow",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "filter": true
+              },
+              "sortBy": []
+            },
+            "name": "query - 1"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "SelectedTab",
+        "comparison": "isEqualTo",
+        "value": "Dependabot Alerts"
+      },
+      "name": "Dependabot Alerts"
+    }
+  ],
+  "fallbackResourceIds": [],
+  "fromTemplateId": "sentinel-UserWorkbook-alexdemichieli-github-update-1",
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}


### PR DESCRIPTION
The current update fixes a few small bugs:

Within the `Secret Scanning Alerts` panel:

- Found Secrets view:
 The `distinct` keyword is removed as it could potentially remove valid results from the list

Within the `Dependabot Alerts` panel:

- `Dismissed` and `Alert Found/Fixed ratio` views:
 The time query parameters aren't set within the panel, but are now set to take the global time query parameters

Within the `Advanced Security` panel:

- `Alerts Details` and `Open Alerts by Severity` views:
 The time query parameters aren't set within the panel, but are now set to take the global time query parameters
 
 - `Open alerts by Repository`, `Open alerts by Type` and `Resolved alert count` views:
Removed `| where isnotempty(Severity)` from each Code Scanning Alert section. Some Code Scanning events do not have a severity level, however are still valid alerts and should be counted. 
