### PR TITLE
Update PotentialKerberoast.yaml

### DIFF
--- a/Detections/SecurityEvent/PotentialKerberoast.yaml
+++ b/Detections/SecurityEvent/PotentialKerberoast.yaml
@@ -51,7 +51,7 @@ query: |
   (
   WindowsEvent
   | where TimeGenerated >= ago(starttime)
-  | where EventID == 4769 and EventData has '0x17' and EventData has '0x40810000' and EventData has 'krbtgt'
+  | where EventID == 4769 and EventData has '0x17' and EventData has '0x40810000'
   | extend TicketEncryptionType = tostring(EventData.TicketEncryptionType)
   | where TicketEncryptionType == '0x17'
   | extend TicketOptions = tostring(EventData.TicketOptions)
@@ -97,5 +97,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled


### PR DESCRIPTION
Removed the filter "EventData has 'krbtgt'", it was probably an error.
   
   Change(s):
   - Updated PotentialKerberoast.yaml
 
   Reason for Change(s):
   - A kind customer noticed that the filter "and EventData has 'krbtgt'" in line 54 doesn't make sense. I believe it was maybe intended as something like "and EventData !has 'krbtgt'" but I removed it because a few lines after we are filtering out krbtgt ServiceNames based on EventData.

   Version Updated:
   - Yes

   Testing Completed:
   - No, I don't think is needed for this change.