### PR TITLE
Remove duplicate entry in _ASIM_AADSTSErrorCodes

### DIFF
--- a/ASIM/lib/functions/ASIM_LookupAADcodes.yaml
+++ b/ASIM/lib/functions/ASIM_LookupAADcodes.yaml
@@ -30,7 +30,6 @@ FunctionQuery: |
     '50079', 'Logon violates policy',
     '50105', 'Logon violates policy',
     '50126', 'No such user or password',
-    '50126', 'No such user or password',
     '50132', 'Password expired',
     '50133', 'Password expired',
     '50144', 'Password expired',

--- a/Parsers/ASimAuthentication/Parsers/AADSTS.yaml
+++ b/Parsers/ASimAuthentication/Parsers/AADSTS.yaml
@@ -30,7 +30,6 @@ FunctionQuery: |
     '50079', 'Logon violates policy',
     '50105', 'Logon violates policy',
     '50126', 'No such user or password',
-    '50126', 'No such user or password',
     '50132', 'Password expired',
     '50133', 'Password expired',
     '50144', 'Password expired',


### PR DESCRIPTION
   Change(s):
   - Remove duplicate entry of 50126 ErrorCode.

   Reason for Change(s):
   - I assume it is not needed.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

Also, I don't know if 50064 is still used.