### PR TITLE
asim/fix-websession-rule

### DIFF
--- a/Detections/ASimWebSession/ExcessiveNetworkFailuresFromSource.yaml
+++ b/Detections/ASimWebSession/ExcessiveNetworkFailuresFromSource.yaml
@@ -30,7 +30,7 @@ tags:
 
 query: | 
     let error403_count_threshold=200;
-    _Im_WebSession(eventresultdetails_in="403")
+    _Im_WebSession(eventresultdetails_in=dynamic(["403"]))
     | extend ParsedUrl=parse_url(Url)
     | extend UrlHost=tostring(ParsedUrl["Host"]), UrlSchema=tostring(ParsedUrl["Schema"])
     | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), NumberOfErrors = count(), Urls=makeset(Url) by UrlHost, SrcIpAddr
@@ -54,5 +54,5 @@ customDetails:
 alertDetailsOverride:
     alertDisplayNameFormat: Excessive number of HTTP authentication failures from {{SrcIpAddr} 
     alertDescriptionFormat: A client with address {{SrcIpAddr}} generated a large number of failed authentication HTTP requests. This may indicate a [brute force](https://en.wikipedia.org/wiki/Brute-force_attack) or [credential stuffing](https://en.wikipedia.org/wiki/Credential_stuffing) attack.
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - asim/fix-websession-rule

   Reason for Change(s):
   - eventresultdetails_in can get only dynamic values and parsers may fail if it passed a string. Parsers will be made more resilient later on.