### PR TITLE
Update azuredeploy.json

### DIFF
--- a/DataConnectors/O365 Data/azuredeploy.json
+++ b/DataConnectors/O365 Data/azuredeploy.json
@@ -235,7 +235,7 @@
                         "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('StorageAccountName'),';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', toLower(variables('StorageAccountName'))), '2019-06-01').keys[0].value, ';EndpointSuffix=core.windows.net')]",
                         "WEBSITE_CONTENTSHARE": "[variables('StorageAccountName')]",
                         "clientID": "[parameters('clientID')]",
-                        "clientSecret": "[concat('@Microsoft.KeyVault(SecretUri=https://', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('KeyVaultName'), 'clientSecret')).SecretUriWithVersion, ')')]",
+                        "clientSecret": "[concat('@Microsoft.KeyVault(SecretUri=', reference(resourceId('Microsoft.KeyVault/vaults/secrets', variables('KeyVaultName'), 'clientSecret')).SecretUriWithVersion, ')')]",
                         "domain": "[parameters('domain')]",
                         "tenantGuid": "[subscription().tenantId]",
                         "publisher": "[parameters('publisher')]",


### PR DESCRIPTION
Previous commit (bcbe8e45f6569c79441e4cfa6a4264ae1782361e) only fixed duplication on workspaceKey and not clientSecret.

   Required items, please complete
   
   Change(s):
   - Removed "https:\\" from line 238 of azuredeploy.json

   Reason for Change(s):
   - Previous commit (bcbe8e45f6569c79441e4cfa6a4264ae1782361e) only fixed duplication on workspaceKey and not clientSecret.  This resolves duplication error still occurring after deployment for clientSecret, allowing Function App to run correctly without additional "manual" correction from users via the Configuration section of the Function App.

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
