### PR TITLE
Revert "Standalone playbook solution Update"

### DIFF
--- a/Solutions/Standalone/Playbooks/Add-IP-Entity-To-Named-Location/azuredeploy.json
+++ b/Solutions/Standalone/Playbooks/Add-IP-Entity-To-Named-Location/azuredeploy.json
@@ -8,12 +8,6 @@
         "lastUpdateTime": "2022-07-22T10:00:00.000Z", 
         "entities": ["Ip"], 
         "tags": ["Remediation"],
-        "support": {
-            "tier": "community" 
-        },
-        "author": {
-            "name": "Brian Delaney"
-        },
         "postDeployment":["- Grant the Logic App Managed Identity access to the Microsoft Graph Policy.Read.All & Policy.ReadWrite.Conditional Access which can be done with the included PowerShell script [AddApiPermissions.ps1](./AddApiPermissions.ps1) \n\n - Attach this playbook to an **automation rule** so it runs when specified incidents are created. \n\n [Learn more about automation rules](https://docs.microsoft.com/azure/sentinel/automate-incident-handling-with-automation-rules#creating-and-managing-automation-rules)"],
         "releaseNotes": [
             {

--- a/Solutions/Standalone/Playbooks/Create-AzureDevOpsTask/alert-trigger/azuredeploy.json
+++ b/Solutions/Standalone/Playbooks/Create-AzureDevOpsTask/alert-trigger/azuredeploy.json
@@ -6,14 +6,7 @@
         "description": "This playbook will create the Azure DevOps task filled with the Microsoft Sentinel incident details.  ",
         "prerequisites": ["None"],
         "lastUpdateTime": "2022-07-25T00:00:00.000Z",
-        "entities": [],
-        "tags": [],
-        "support": {
-            "tier": "Community" 
-        },
-        "author": {
-            "name": "Nicholas DiCola"
-        },
+        "tags": [""],
         "releaseNotes": [
             {
                 "version": "1.0.0",

--- a/Solutions/Standalone/Playbooks/Create-AzureDevOpsTask/incident-trigger/azuredeploy.json
+++ b/Solutions/Standalone/Playbooks/Create-AzureDevOpsTask/incident-trigger/azuredeploy.json
@@ -6,7 +6,6 @@
         "description": "This playbook will create the Azure DevOps task filled with the Microsoft Sentinel incident details.  ",
         "prerequisites": ["None"],
         "lastUpdateTime": "2022-07-25T00:00:00.000Z", 
-        "entities": [],
         "tags": ["Sync"], 
         "support": {
             "tier": "Community" 

--- a/Solutions/Standalone/Playbooks/Create-Zendesk-Ticket/azuredeploy.json
+++ b/Solutions/Standalone/Playbooks/Create-Zendesk-Ticket/azuredeploy.json
@@ -6,7 +6,6 @@
         "description": "This playbook will create a Zendesk ticket when a new incident is created in Microsoft Sentinel.",
         "prerequisites": ["Create a Zendesk user (for example, call it Microsoft Sentinel) which on behalf of its requester id new tickets will be created."],
         "lastUpdateTime": "2022-07-22T00:00:00.000Z", 
-        "entities": [],
         "tags": ["Sync"], 
         "support": {
             "tier": "community" 


### PR DESCRIPTION
Reverts Azure/Azure-Sentinel#5744

Reverting modification in the content because the Playbooks need to move to the original folder.