### PR TITLE
Added validation to query incase displayName not populated by data

### DIFF
--- a/Detections/AuditLogs/Useraccountcreatedwithoutexpectedattributesdefined.yaml
+++ b/Detections/AuditLogs/Useraccountcreatedwithoutexpectedattributesdefined.yaml
@@ -29,6 +29,7 @@ query: |
     | extend properties = TargetResources[0].modifiedProperties
     | mv-expand properties
     | evaluate bag_unpack(properties)
+    | extend displayName = column_ifexists("displayName", "Unknown Value")
     | summarize count() by displayName, TenantId
     | where displayName !in (default_ad_attributes)
     | top threshold by count_ desc

--- a/Detections/AuditLogs/Useraccountcreatedwithoutexpectedattributesdefined.yaml
+++ b/Detections/AuditLogs/Useraccountcreatedwithoutexpectedattributesdefined.yaml
@@ -60,5 +60,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: CreatedUserPrincipalName
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated query to provide validation to query incase displayName not populated by data

   Reason for Change(s):
   - Query couldn't be deployed as an analytic

   Version Updated:
   - Y

   Testing Completed:
   - Y

   Checked that the validations are passing and have addressed any issues that are present:
   - Y
