### PR TITLE
Update the projected values in Extend

### DIFF
--- a/Detections/ASimNetworkSession/ExcessiveHTTPFailuresFromSource.yaml
+++ b/Detections/ASimNetworkSession/ExcessiveHTTPFailuresFromSource.yaml
@@ -6,7 +6,7 @@ description: |
 severity: Medium
 tags:
   - ParentAlert: https://github.com/Azure/Azure-Sentinel/blob/master/Detections/SophosXGFirewall/ExcessiveAmountofDeniedConnectionsfromASingleSource.yaml
-    version: 1.0.0
+    version: 1.0.1
   - Schema: ASimNetworkSessions
     SchemaVersion: 0.2.1
 requiredDataConnectors:
@@ -48,7 +48,7 @@ query: |
   _Im_NetworkSession(eventresult='Failure')
   | summarize Count=count() by SrcIpAddr, bin(TimeGenerated,5m)
   | where Count > threshold
-  | extend timestamp = TimeGenerated, IPCustomEntity = SrcIpAddr
+  | extend timestamp = TimeGenerated, IPCustomEntity = SrcIpAddr, threshold
 entityMappings:
   - entityType: IP
     fieldMappings:

--- a/Detections/ASimNetworkSession/ExcessiveHTTPFailuresFromSource.yaml
+++ b/Detections/ASimNetworkSession/ExcessiveHTTPFailuresFromSource.yaml
@@ -6,7 +6,7 @@ description: |
 severity: Medium
 tags:
   - ParentAlert: https://github.com/Azure/Azure-Sentinel/blob/master/Detections/SophosXGFirewall/ExcessiveAmountofDeniedConnectionsfromASingleSource.yaml
-    version: 1.0.1
+    version: 1.0.0
   - Schema: ASimNetworkSessions
     SchemaVersion: 0.2.1
 requiredDataConnectors:
@@ -60,5 +60,5 @@ customDetails:
 alertDetailsOverride:
   alertDisplayNameFormat: Excessive number of failed connections from {{SrcIpAddr}}
   alertDescriptionFormat: 'The client at address {{SrcIpAddr}} generated more than {{threshold}} failures over a 5 minutes time window, which may indicate malicious activity.'
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled


### PR DESCRIPTION
There is currently an issue with this analytic rule because the "threshold" value is not projected. The issue is within the Alert description tab

   Required items, please complete
   
   Change(s):
   - added the threshold in the extended properties to mitigate an issue with the Alert Description tab - This allows the threshold to be projected as a value in the title

   Reason for Change(s):
   - Error, that prevents the rule from being created - "Column name threshold does not exist. Please check the query results and try again"

   Version Updated:
   - Yes
   - 1.0.1

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

