### PR TITLE
Fix errors in KeyvaultMassSecretRetrieval.yaml

### DIFF
--- a/Solutions/Azure Key Vault/Analytic Rules/KeyvaultMassSecretRetrieval.yaml
+++ b/Solutions/Azure Key Vault/Analytic Rules/KeyvaultMassSecretRetrieval.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
     dataTypes:
       - KeyVaultData
 queryFrequency: 1d
-queryPeriod: 1d                
+queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -20,40 +20,51 @@ tactics:
 relevantTechniques:
   - T1003
 query: |
-
   let EventCountThreshold = 25;
   // To avoid any False Positives, filtering using AppId is recommended.
-  // For example the AppId 509e4652-da8d-478d-a730-e9d4a1996ca4 has been added in the query as it corresponds 
-  // to Azure Resource Graph performing VaultGet operations for indexing and syncing all tracked resources across Azure.
+  // The AppId 509e4652-da8d-478d-a730-e9d4a1996ca4 has been added in the query as it corresponds to Azure Resource Graph performing VaultGet operations for indexing and syncing all tracked resources across Azure.
   // The AppId 8cae6e77-e04e-42ce-b5cb-50d82bce26b1 has been added as it correspond to Microsoft Policy Insights Provider Data Plane performing VaultGet operations for policies checks.
-  let Allowedappid = dynamic(["509e4652-da8d-478d-a730-e9d4a1996ca4","8cae6e77-e04e-42ce-b5cb-50d82bce26b1"]);
-  let OperationList = dynamic(
-  ["SecretGet", "KeyGet", "VaultGet"]);
+  let AllowedAppId = dynamic(["509e4652-da8d-478d-a730-e9d4a1996ca4","8cae6e77-e04e-42ce-b5cb-50d82bce26b1"]);
+  let OperationList = dynamic(["SecretGet", "KeyGet", "VaultGet"]);
   AzureDiagnostics
-  | where not((identity_claim_appid_g in (Allowedappid)) and OperationName == 'VaultGet')
-  | extend ResultType = columnifexists("ResultType", "None"), identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g = columnifexists("identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g", "None")
-  | where ResultType !~ "None" and isnotempty(ResultType)
-  | where identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g !~ "None" and isnotempty(identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g)
-  | where ResourceType =~ "VAULTS" and ResultType =~ "Success"
-  | where OperationName in (OperationList) 
-  | summarize count() by identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g, OperationName
-  | where count_ > EventCountThreshold  
-  | join (
-  AzureDiagnostics
-  | where not((identity_claim_appid_g in (Allowedappid)) and OperationName == 'VaultGet')
-  | extend ResultType = columnifexists("ResultType", "NoResultType")
-  | extend requestUri_s = columnifexists("requestUri_s", "None"), identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g = columnifexists("identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g", "None")
-  | extend id_s = columnifexists("id_s", "None"), CallerIPAddress = columnifexists("CallerIPAddress", "None"), clientInfo_s = columnifexists("clientInfo_s", "None")
-  | where ResultType !~ "None" and isnotempty(ResultType)
-  | where identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g !~ "None" and isnotempty(identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g)
-  | where id_s !~ "None" and isnotempty(id_s)
-  | where CallerIPAddress !~ "None" and isnotempty(CallerIPAddress)
-  | where clientInfo_s !~ "None" and isnotempty(clientInfo_s)
-  | where requestUri_s !~ "None" and isnotempty(requestUri_s)
-  | where OperationName in~ (OperationList)   
-  ) on identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g 
-  | summarize EventCount=sum(count_), StartTimeUtc=min(TimeGenerated), EndTimeUtc=max(TimeGenerated), TimeTriggered=makelist(TimeGenerated),OperationNameList=make_set(OperationName), RequestURLList=make_set(requestUri_s), CallerIPList = make_set(CallerIPAddress),  CallerIPMax= arg_max(CallerIPAddress,*) by ResourceType, ResultType, Resource, id_s, identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g, clientInfo_s
-  | extend timestamp = EndTimeUtc, IPCustomEntity = CallerIPMax, AccountCustomEntity = identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g
+  | where OperationName in (OperationList) and ResourceType =~ "VAULTS"
+  | where not(identity_claim_appid_g in (AllowedAppId) and OperationName == 'VaultGet')
+  | extend
+      ResultType = column_ifexists("ResultType", ""),
+      identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g = column_ifexists("identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g", ""),
+      identity_claim_http_schemas_xmlsoap_org_ws_2005_05_identity_claims_upn_s = column_ifexists("identity_claim_http_schemas_xmlsoap_org_ws_2005_05_identity_claims_upn_s", ""),
+      identity_claim_oid_g = column_ifexists("identity_claim_oid_g", ""),
+      identity_claim_upn_s = column_ifexists("identity_claim_upn_s", "")
+  | extend
+      CallerObjectId = iff(isempty(identity_claim_oid_g), identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g, identity_claim_oid_g),
+      CallerObjectUPN = iff(isempty(identity_claim_upn_s), identity_claim_http_schemas_xmlsoap_org_ws_2005_05_identity_claims_upn_s, identity_claim_upn_s)
+  | as _Retrievals
+  | where CallerObjectId in (toscalar(
+      _Retrievals
+      | where ResultType == "Success"
+      | summarize Count = count() by OperationName, CallerObjectId
+      | where Count > EventCountThreshold
+      | summarize make_set(CallerObjectId)
+  ))
+  | extend
+      requestUri_s = column_ifexists("requestUri_s", ""),
+      id_s = column_ifexists("id_s", ""),
+      CallerIPAddress = column_ifexists("CallerIPAddress", ""),
+      clientInfo_s = column_ifexists("clientInfo_s", "")
+  | summarize
+      EventCount = count(),
+      StartTime = min(TimeGenerated),
+      EndTime = max(TimeGenerated),
+      //TimeTriggered = make_list(TimeGenerated, 50),
+      OperationNameList = make_set(OperationName, 50),
+      RequestURLList = make_set(requestUri_s, 50),
+      CallerIPList = make_set(CallerIPAddress, 50),
+      clientInfo_sList = make_set(clientInfo_s, 50),
+      CallerIPMax = max(CallerIPAddress)
+      //CallerIPMax = arg_max(CallerIPAddress,*)
+      by ResourceType, ResultType, Resource, id_s, identity_claim_appid_g, CallerObjectId, CallerObjectUPN
+  | project-reorder StartTime, EndTime, EventCount, ResourceType, Resource, id_s, identity_claim_appid_g, CallerObjectId, CallerObjectUPN, ResultType, OperationNameList, RequestURLList, CallerIPList, clientInfo_sList
+  | extend timestamp = EndTime, IPCustomEntity = CallerIPMax, AccountCustomEntity = CallerObjectId
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -63,5 +74,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
This Pull Request comes from 2 pull requests that I couldn't manage to be merged properly after some later changes, #5751 and #4568
   
   Change(s):
   1. Remove ```isnotempty(``` conditions, that are removing desired results.
   2. Put a limit in make_set and make_list.
   3. Do not show by default all columns from ```arg_max(CalledIPAddress, *)```

   Reason for Change(s):
   1. Different operations do not have the same columns. For example ```SecretGet``` uses ```identity_claim_oid_g``` instead of ```identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g```. The same happened with ```clientInfo_s```, not every operation has this column.
   2. Put a limit on results size.
   3. It's difficult to interpret results.

The same happens with:

https://github.com/Azure/Azure-Sentinel/blob/ee97399b426a21878776c4c7b4835efc04b47393/Detections/AzureDiagnostics/TimeSeriesKeyvaultAccessAnomaly.yaml
https://github.com/Azure/Azure-Sentinel/blob/ee97399b426a21878776c4c7b4835efc04b47393/Detections/AzureDiagnostics/KeyVaultSensitiveOperations.yaml
https://github.com/Azure/Azure-Sentinel/blob/d11b7c5e8610b075bd0284044153c7a1e75d720d/Detections/AzureDiagnostics/NRT_KeyVaultSensitiveOperations.yaml
...

   Version Updated:
   - Yes

   Testing Completed:
   - No, this query needs to be checked against tenants that do not have some of the columns.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes