### PR TITLE
AzureActivity schema is added to KQLValidation tests 

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/AzureActivity.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/AzureActivity.json
@@ -1,0 +1,137 @@
+{
+  "Name": "AzureActivity",
+  "Properties": [
+    {
+      "Name": "OperationName",
+      "Type": "String"
+    },
+    {
+      "Name": "OperationNameValue",
+      "Type": "String"
+    },
+    {
+      "Name": "Level",
+      "Type": "String"
+    },
+    {
+      "Name": "ActivityStatus",
+      "Type": "String"
+    },
+    {
+      "Name": "ActivityStatusValue",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceGroup",
+      "Type": "String"
+    },
+    {
+      "Name": "SubscriptionId",
+      "Type": "String"
+    },
+    {
+      "Name": "CorrelationId",
+      "Type": "String"
+    },
+    {
+      "Name": "Caller",
+      "Type": "String"
+    },
+    {
+      "Name": "CallerIpAddress",
+      "Type": "String"
+    },
+    {
+      "Name": "Category",
+      "Type": "String"
+    },
+    {
+      "Name": "CategoryValue",
+      "Type": "String"
+    },
+    {
+      "Name": "HTTPRequest",
+      "Type": "String"
+    },
+    {
+      "Name": "Properties",
+      "Type": "String"
+    },
+    {
+      "Name": "EventSubmissionTimestamp",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "Authorization",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceId",
+      "Type": "String"
+    },
+    {
+      "Name": "OperationId",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceProvider",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceProviderValue",
+      "Type": "String"
+    },
+    {
+      "Name": "Resource",
+      "Type": "string"
+    },
+    {
+      "Name": "EventDataId",
+      "Type": "String"
+    },
+    {
+      "Name": "TenantId",
+      "Type": "String"
+    },
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "SourceSystem",
+      "Type": "String"
+    },
+    {
+      "Name": "Authorization_d",
+      "Type": "String"
+    },
+    {
+      "Name": "Claims",
+      "Type": "String"
+    },
+    {
+      "Name": "Claims_d",
+      "Type": "String"
+    },
+    {
+      "Name": "Properties_d",
+      "Type": "String"
+    },
+    {
+      "Name": "Hierarchy",
+      "Type": "string"
+    },
+    {
+      "Name": "Type",
+      "Type": "String"
+    },
+    {
+      "Name": "_ResourceId",
+      "Type": "String"
+    },
+    {
+      "Name": "log_s",
+      "Type": "String"
+    }
+   ]
+}


### PR DESCRIPTION
Azure activity schema is added as part of on-going AKS enrichment

   Required items, please complete
   
   Change(s):
   - AzureActivity schema added to KQLValidation test

   Reason for Change(s):
   - AKS enrichment

   Version Updated:
   - NA

   Testing Completed:
   - yes

   Checked that the validations are passing and have addressed any issues that are present:
   - yes


---------------------------------------------------------------------------------------------------------
