### PR TITLE
Added Exchange File Download Detection.

### DIFF
--- a/Detections/http_proxy_oab_CL/ExchagngeSuspiciousFileDownloads.yaml
+++ b/Detections/http_proxy_oab_CL/ExchagngeSuspiciousFileDownloads.yaml
@@ -1,0 +1,34 @@
+id: 8955c0fb-3408-47b0-a3b9-a1faec41e427
+name: Exchange Server Suspicious File Downloads.
+description: |
+  'This query looks for messages related to file downloads of suspicious file types on an Exchange Server. This could indicate attempted deployment of webshells. 
+  This query uses the Exchange HttpProxy AOBGeneratorLog, you will need to onboard this log as a custom log under the table http_proxy_oab_CL before using this query. 
+  This log is commonly found at C:\Program Files\Microsoft\Exchange Server\V15\Logging\OABGeneratorLog on the Exchange server. Details on collecting custom logs into Sentinel
+  can be found here: https://learn.microsoft.com/azure/sentinel/connect-custom-logs
+severity: Medium
+requiredDataConnectors: []
+queryFrequency: 1d
+queryPeriod: 1d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1190
+query: |
+  let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);
+  http_proxy_oab_CL
+  | where RawData contains "Download failed and temporary file"
+  | extend File = extract("([^\\\\]*)(\\\\[^']*)",2,RawData)
+  | extend Extension = strcat(".",split(File, ".")[-1])
+  | extend InteractiveFile = iif(Extension in (scriptExtensions), "Yes", "No")
+  // Uncomment the following line to alert only on interactive file download type
+  //| where InteractiveFile =~ "Yes"
+  | extend timestamp = TimeGenerated, HostCustomEntity = Computer
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity
+version: 1.0.0
+kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added a new scheduled detection for suspicous file downloads on an Exchange Server

   Reason for Change(s):
   - New Content

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
