### PR TITLE
IP to TI map insight updated

### DIFF
--- a/Insights/IP/IP_RemoteConnections.yaml
+++ b/Insights/IP/IP_RemoteConnections.yaml
@@ -1,0 +1,205 @@
+SchemaVersion: '1.0'
+Type: KQL
+Provider: Sentinel
+DataTypes:
+  - DataType: Heartbeat
+  - DataType: VMConnection
+  - DataType: VMComputer
+  - DataType: WireData
+  - DataType: ProtectionStatus
+  - DataType: DeviceNetworkInfo
+  - DataType: DeviceNetworkEvents
+  - DataType: DnsEvents
+  - DataType: CommonSecurityLog
+  - DataType: Event
+  - DataType: SecurityEvent
+  - DataType: Syslog
+EntitiesFilter: {}
+RequiredInputFieldsSets: 
+ - - Ip_Address
+BaseQuery: |  
+  let GetIPStats = (Ip_Address:string){
+  //checking time span to lock to 7 days or less for Entity page usage
+  let start = datetime('{{StartTimeISO}}');
+  let end = datetime('{{EndTimeISO}}');
+  let end_start = datetime_diff('day',end,start);
+  let start_time = iff(end_start > 7, end - 7d, start);
+  let end_time = end;
+  let IpStats = (union isfuzzy=true
+  (
+  VMConnection
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where SourceIp =~ Ip_Address
+  | where SourceIp != DestinationIp
+  | where Direction =~ "outbound"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(Direction =~ "outbound") by IPAddress = SourceIp, Type, RemoteIPAddress = DestinationIp, Direction, SentBytes = tolong(BytesSent), ReceivedBytes = tolong(BytesReceived)
+  ),
+  (
+  VMConnection
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where DestinationIp =~ Ip_Address
+  | where SourceIp != DestinationIp
+  | where Direction =~ "inbound"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction =~ "inbound") by IPAddress = DestinationIp, Type, RemoteIPAddress = SourceIp, Direction, SentBytes = tolong(BytesSent), ReceivedBytes = tolong(BytesReceived)
+  ),
+  (
+  WireData
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where LocalIP =~ Ip_Address
+  | where LocalIP != RemoteIP
+  | where Direction =~ "outbound"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(Direction =~ "outbound") by IPAddress = LocalIP, Type, RemoteIPAddress = RemoteIP, Direction
+  ),
+  (
+  WireData
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where RemoteIP =~ Ip_Address
+  | where LocalIP != RemoteIP
+  | where Direction =~ "inbound"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction =~ "inbound") by IPAddress = RemoteIP, Type, RemoteIPAddress = LocalIP, Direction
+  ),
+  (
+  DeviceNetworkEvents
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where LocalIP =~ Ip_Address
+  | where LocalIP != RemoteIP
+  | extend Direction = "outbound"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(ActionType =~ "ConnectionSuccess") by IPAddress = LocalIP, Type, RemoteIPAddress = RemoteIP, Direction
+  ),
+  (
+  DeviceNetworkEvents
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where RemoteIP =~ Ip_Address
+  | where LocalIP != RemoteIP
+  | extend Direction = "inbound"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(ActionType =~ "InboundConnectionAccepted") by IPAddress = RemoteIP, Type, RemoteIPAddress = LocalIP, Direction
+  ),
+  (
+  CommonSecurityLog
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where SourceIP =~ Ip_Address
+  | where SourceIP != DestinationIP
+  | extend Direction = iff(CommunicationDirection !in~ ('outbound','0') or CommunicationDirection !in~ ('inbound','1'), 'NotAvailable', CommunicationDirection)
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction in~ ('Inbound','1')), OutboundCount = countif(Direction in~ ('Outbound', '0')), UnknownDirection = countif(Direction =~ 'NotAvailable') by IPAddress = SourceIP, Type = strcat(Type,':', DeviceVendor,'-', DeviceProduct), RemoteIPAddress = DestinationIP, Direction, SentBytes = tolong(SentBytes), ReceivedBytes = tolong(ReceivedBytes)
+  ),
+  (
+  CommonSecurityLog
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated between (start_time..end_time)
+  | where DestinationIP =~ Ip_Address
+  | where SourceIP != DestinationIP
+  | extend Direction = iff(CommunicationDirection !in~ ('outbound','0') or CommunicationDirection !in~ ('inbound','1'), 'NotAvailable', CommunicationDirection)
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction in~ ('Inbound','1')), OutboundCount = countif(Direction in~ ('Outbound', '0')), UnknownDirection = countif(Direction =~ 'NotAvailable') by IPAddress = DestinationIP, Type = strcat(Type,':', DeviceVendor,'-', DeviceProduct), RemoteIPAddress = SourceIP, Direction, SentBytes = tolong(SentBytes), ReceivedBytes = tolong(ReceivedBytes)
+  )
+  );
+  IpStats
+  | join kind=inner (
+  ThreatIntelligenceIndicator
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated >= start_time
+  | where ExpirationDateTime > now()
+  | where Active = true
+  | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
+  | extend TI_ipEntity = case(
+  isnotempty(NetworkIP), NetworkIP,
+  isempty(NetworkIP) and isnotempty(NetworkSourceIP), NetworkSourceIP,
+  isempty(NetworkIP) and isempty(NetworkSourceIP) and isnotempty(NetworkDestinationIP), NetworkDestinationIP,
+  isempty(NetworkIP) and isempty(NetworkSourceIP) and isempty(NetworkDestinationIP), EmailSourceIpAddress,
+  "NotAvailable"
+  )
+  | summarize arg_max(TimeGenerated, *) by Description, ThreatType, TI_ipEntity
+  ) on $left.RemoteIPAddress == $right.TI_ipEntity
+  };
+  GetIPStats('{{Ip_Address}}')
+
+Insights:
+ Id: 340e5f6f-d218-4a11-8638-09e1af7847cc
+ DisplayName: "IP address remote connections with TI match"
+ Description: |
+  'Identifies when a connection is made outbound to or inbound from a remote IP address that is also an IOC in the ThreatIntelligenceIndicator table, along with how many times the connection was made during the indicated timeframe. 
+   Note: due to potential performance impact, data is limited to a 7 day max window.'
+ DefaultTimeRange: 
+  BeforeRange: 12h
+  AfterRange: 12h
+ TableQuery:
+  ColumnsDefinitions:
+  - Header: "Direction"
+    OutputType: String
+    SupportDeepLink: false
+  - Header: "IPAddress"
+    OutputType: String
+    SupportDeepLink: true
+  - Header: "RemoteIP"
+    OutputType: String
+    SupportDeepLink: true
+  - Header: "ThreatType"
+    OutputType: String
+    SupportDeepLink: false
+  QueriesDefinitions:
+  # Inbound TI Hits
+  - Filter:    "project IPAddress, RemoteIPAddress, InboundCount, ThreatType"
+    Summarize: "summarize Inbound = sum(InboundCount) by IPAddress, RemoteIPAddress, ThreatType | where Inbound > 0"
+    Project:   "project Direction = 'In', IPAddress, RemoteIP = RemoteIPAddress, ThreatType"
+    LinkColumnsDefinitions:
+    - ProjectedName: Direction
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: IPAddress
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: RemoteIP
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: ThreatType
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+  # Outbound TI Hits
+  - Filter:    "project IPAddress, RemoteIPAddress, OutboundCount, ThreatType"
+    Summarize: "summarize Outbound = sum(OutboundCount) by IPAddress, RemoteIPAddress, ThreatType | where Outbound > 0"
+    Project:   "project Direction = 'Out', IPAddress, RemoteIP = RemoteIPAddress, ThreatType"
+    LinkColumnsDefinitions:
+    - ProjectedName: Direction
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: IPAddress
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: RemoteIP
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: ThreatType
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+  # Direction Unknown TI Hits
+  - Filter:    "project IPAddress, RemoteIPAddress, UnknownDirection, ThreatType"
+    Summarize: "summarize UnknownCount = sum(UnknownDirection) by IPAddress, RemoteIPAddress, ThreatType | where UnknownCount > 0"
+    Project:   "project Direction = 'Unknown', IPAddress, RemoteIP = RemoteIPAddress, ThreatType"
+    LinkColumnsDefinitions:
+    - ProjectedName: Direction
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: IPAddress
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: RemoteIP
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+    - ProjectedName: ThreatType
+      Query: "{{BaseQuery}} | {{RowFilter}}"
+
+ ChartQuery: 
+  Title: "Connection Count to IP in TI"
+  DataSets: 
+   - Query: "summarize Count = max(InboundCount) by Time = bin(StartTime, 1d), RemoteIPAddress = strcat(RemoteIPAddress,' - In') | where isnotempty(Count) and Count > 0"
+     XColumnName: Time
+     YColumnName: Count
+     LegendColumnName: RemoteIPAddress
+   - Query: "summarize Count = max(OutboundCount) by Time = bin(StartTime, 1d), RemoteIPAddress = strcat(RemoteIPAddress,' - Out') | where isnotempty(Count) and Count > 0"
+     XColumnName: Time
+     YColumnName: Count
+     LegendColumnName: RemoteIPAddress
+   - Query: "summarize Count = max(UnknownDirection) by Time = bin(StartTime, 1d), RemoteIPAddress = strcat(RemoteIPAddress,' - UnknownDirection') | where isnotempty(Count) and Count > 0"
+     XColumnName: Time
+     YColumnName: Count
+     LegendColumnName: RemoteIPAddress
+  Type: BarChart
+
+ AdditionalQuery: 
+  Text: "See All connections"
+  Query: "project StartTime, EndTime, IPAddress, RemoteIPAddress, InboundCount, OutboundCount, ReceivedBytes, SentBytes, UnknownDirection, Type, ThreatType, Description"

--- a/Insights/IP/IP_RemoteConnections.yaml
+++ b/Insights/IP/IP_RemoteConnections.yaml
@@ -2,18 +2,9 @@ SchemaVersion: '1.0'
 Type: KQL
 Provider: Sentinel
 DataTypes:
-  - DataType: Heartbeat
   - DataType: VMConnection
-  - DataType: VMComputer
-  - DataType: WireData
-  - DataType: ProtectionStatus
-  - DataType: DeviceNetworkInfo
   - DataType: DeviceNetworkEvents
-  - DataType: DnsEvents
   - DataType: CommonSecurityLog
-  - DataType: Event
-  - DataType: SecurityEvent
-  - DataType: Syslog
 EntitiesFilter: {}
 RequiredInputFieldsSets: 
  - - Ip_Address
@@ -43,24 +34,6 @@ BaseQuery: |
   | where SourceIp != DestinationIp
   | where Direction =~ "inbound"
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction =~ "inbound") by IPAddress = DestinationIp, Type, RemoteIPAddress = SourceIp, Direction, SentBytes = tolong(BytesSent), ReceivedBytes = tolong(BytesReceived)
-  ),
-  (
-  WireData
-  | where isnotempty(Ip_Address)
-  | where TimeGenerated between (start_time..end_time)
-  | where LocalIP =~ Ip_Address
-  | where LocalIP != RemoteIP
-  | where Direction =~ "outbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(Direction =~ "outbound") by IPAddress = LocalIP, Type, RemoteIPAddress = RemoteIP, Direction
-  ),
-  (
-  WireData
-  | where isnotempty(Ip_Address)
-  | where TimeGenerated between (start_time..end_time)
-  | where RemoteIP =~ Ip_Address
-  | where LocalIP != RemoteIP
-  | where Direction =~ "inbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction =~ "inbound") by IPAddress = RemoteIP, Type, RemoteIPAddress = LocalIP, Direction
   ),
   (
   DeviceNetworkEvents
@@ -202,4 +175,4 @@ Insights:
 
  AdditionalQuery: 
   Text: "See All connections"
-  Query: "project StartTime, EndTime, IPAddress, RemoteIPAddress, InboundCount, OutboundCount, ReceivedBytes, SentBytes, UnknownDirection, Type, ThreatType, Description"
+  Query: "project StartTime, EndTime, IPAddress, RemoteIPAddress, InboundCount, OutboundCount, ReceivedBytes, SentBytes, UnknownDirection, Type, ThreatType, Description, Tags"

--- a/Insights/IP/IP_TI_map.yaml
+++ b/Insights/IP/IP_TI_map.yaml
@@ -22,7 +22,7 @@ BaseQuery: |
   | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
   | where NetworkIP == Ip_Address or NetworkDestinationIP == Ip_Address or NetworkSourceIP == Ip_Address or EmailSourceIpAddress == Ip_Address
   | extend FieldsMatched = pack("NetworkIP", NetworkIP == Ip_Address, "NetworkDestinationIP", NetworkDestinationIP == Ip_Address, "NetworkSourceIP", NetworkSourceIP == Ip_Address, "EmailSourceIpAddress", EmailSourceIpAddress == Ip_Address)
-  | project LatestIndicatorTime, ThreatType, IPAddress = Ip_Address, SourceSystem, ConfidenceScore, Description, FieldsMatched
+  | project LatestIndicatorTime, ThreatType, IPAddress = Ip_Address, SourceSystem, ConfidenceScore, Description, FieldsMatched, Tags
   };
   GetIPMatch('{{Ip_Address}}')
 
@@ -65,4 +65,4 @@ Insights:
 
  AdditionalQuery: 
   Text: "See All details"
-  Query: "project LatestIndicatorTime, ThreatType, IPAddress, SourceSystem, ConfidenceScore, Description, FieldsMatched"
+  Query: "project LatestIndicatorTime, ThreatType, IPAddress, SourceSystem, ConfidenceScore, Description, FieldsMatched, Tags"

--- a/Insights/IP/IP_TI_map.yaml
+++ b/Insights/IP/IP_TI_map.yaml
@@ -2,190 +2,67 @@ SchemaVersion: '1.0'
 Type: KQL
 Provider: Sentinel
 DataTypes:
-  - DataType: Heartbeat
-  - DataType: VMConnection
-  - DataType: VMComputer
-  - DataType: WireData
-  - DataType: ProtectionStatus
-  - DataType: DeviceNetworkInfo
-  - DataType: DeviceNetworkEvents
-  - DataType: DnsEvents
-  - DataType: CommonSecurityLog
-  - DataType: Event
-  - DataType: SecurityEvent
-  - DataType: Syslog
+  - DataType: ThreatIntelligenceIndicator
 EntitiesFilter: {}
 RequiredInputFieldsSets: 
  - - Ip_Address
 BaseQuery: |  
-  let GetIPStats = (Ip_Address:string){
-  //checking time span to lock to 7 days or less for Entity page usage
+  let GetIPMatch = (Ip_Address:string){
+  //checking time span to lock to 14 days or less for IP relevance and for Entity page perf
   let start = datetime('{{StartTimeISO}}');
   let end = datetime('{{EndTimeISO}}');
   let end_start = datetime_diff('day',end,start);
-  let start_time = iff(end_start > 7, end - 7d, start);
+  let start_time = iff(end_start > 14, end - 14d, start);
   let end_time = end;
-  let IpStats = (union isfuzzy=true
-  (
-  VMConnection
-  | where TimeGenerated between (start_time..end_time)
-  | where SourceIp =~ Ip_Address
-  | where SourceIp != DestinationIp
-  | where Direction =~ "outbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(Direction =~ "outbound") by IPAddress = SourceIp, Type, RemoteIPAddress = DestinationIp, Direction, SentBytes = tolong(BytesSent), ReceivedBytes = tolong(BytesReceived)
-  ),
-  (
-  VMConnection
-  | where TimeGenerated between (start_time..end_time)
-  | where DestinationIp =~ Ip_Address
-  | where SourceIp != DestinationIp
-  | where Direction =~ "inbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction =~ "inbound") by IPAddress = DestinationIp, Type, RemoteIPAddress = SourceIp, Direction, SentBytes = tolong(BytesSent), ReceivedBytes = tolong(BytesReceived)
-  ),
-  (
-  WireData
-  | where TimeGenerated between (start_time..end_time)
-  | where LocalIP =~ Ip_Address
-  | where LocalIP != RemoteIP
-  | where Direction =~ "outbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(Direction =~ "outbound") by IPAddress = LocalIP, Type, RemoteIPAddress = RemoteIP, Direction
-  ),
-  (
-  WireData
-  | where TimeGenerated between (start_time..end_time)
-  | where RemoteIP =~ Ip_Address
-  | where LocalIP != RemoteIP
-  | where Direction =~ "inbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction =~ "inbound") by IPAddress = RemoteIP, Type, RemoteIPAddress = LocalIP, Direction
-  ),
-  (
-  DeviceNetworkEvents
-  | where TimeGenerated between (start_time..end_time)
-  | where LocalIP =~ Ip_Address
-  | where LocalIP != RemoteIP
-  | extend Direction = "outbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OutboundCount = countif(ActionType =~ "ConnectionSuccess") by IPAddress = LocalIP, Type, RemoteIPAddress = RemoteIP, Direction
-  ),
-  (
-  DeviceNetworkEvents
-  | where TimeGenerated between (start_time..end_time)
-  | where RemoteIP =~ Ip_Address
-  | where LocalIP != RemoteIP
-  | extend Direction = "inbound"
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(ActionType =~ "InboundConnectionAccepted") by IPAddress = RemoteIP, Type, RemoteIPAddress = LocalIP, Direction
-  ),
-  (
-  CommonSecurityLog
-  | where TimeGenerated between (start_time..end_time)
-  | where SourceIP =~ Ip_Address
-  | where SourceIP != DestinationIP
-  | extend Direction = iff(CommunicationDirection !in~ ('outbound','0') or CommunicationDirection !in~ ('inbound','1'), 'NotAvailable', CommunicationDirection)
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction in~ ('Inbound','1')), OutboundCount = countif(Direction in~ ('Outbound', '0')), UnknownDirection = countif(Direction =~ 'NotAvailable') by IPAddress = SourceIP, Type = strcat(Type,':', DeviceVendor,'-', DeviceProduct), RemoteIPAddress = DestinationIP, Direction, SentBytes = tolong(SentBytes), ReceivedBytes = tolong(ReceivedBytes)
-  ),
-  (
-  CommonSecurityLog
-  | where TimeGenerated between (start_time..end_time)
-  | where DestinationIP =~ Ip_Address
-  | where SourceIP != DestinationIP
-  | extend Direction = iff(CommunicationDirection !in~ ('outbound','0') or CommunicationDirection !in~ ('inbound','1'), 'NotAvailable', CommunicationDirection)
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), InboundCount = countif(Direction in~ ('Inbound','1')), OutboundCount = countif(Direction in~ ('Outbound', '0')), UnknownDirection = countif(Direction =~ 'NotAvailable') by IPAddress = DestinationIP, Type = strcat(Type,':', DeviceVendor,'-', DeviceProduct), RemoteIPAddress = SourceIP, Direction, SentBytes = tolong(SentBytes), ReceivedBytes = tolong(ReceivedBytes)
-  )
-  );
-  IpStats
-  | join kind=inner (ThreatIntelligenceIndicator | where TimeGenerated < ago(1m)
+  ThreatIntelligenceIndicator
+  | where isnotempty(Ip_Address)
+  | where TimeGenerated >= start_time
+  | where ExpirationDateTime > now()
   | where Active = true
-  | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
-  | extend TI_ipEntity = case(
-  isnotempty(NetworkIP), NetworkIP,
-  isempty(NetworkIP) and isnotempty(NetworkSourceIP), NetworkSourceIP,
-  isempty(NetworkIP) and isempty(NetworkSourceIP) and isnotempty(NetworkDestinationIP), NetworkDestinationIP,
-  isempty(NetworkIP) and isempty(NetworkSourceIP) and isempty(NetworkDestinationIP), EmailSourceIpAddress,
-  "NotAvailable"
-  )
-  | summarize arg_max(TimeGenerated, *) by ThreatIntelMatch = Description, ThreatType, TI_ipEntity) on $left.RemoteIPAddress == $right.TI_ipEntity
+  | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+  | where NetworkIP == Ip_Address or NetworkDestinationIP == Ip_Address or NetworkSourceIP == Ip_Address or EmailSourceIpAddress == Ip_Address
+  | extend FieldsMatched = pack("NetworkIP", NetworkIP == Ip_Address, "NetworkDestinationIP", NetworkDestinationIP == Ip_Address, "NetworkSourceIP", NetworkSourceIP == Ip_Address, "EmailSourceIpAddress", EmailSourceIpAddress == Ip_Address)
+  | project LatestIndicatorTime, ThreatType, IPAddress = Ip_Address, SourceSystem, ConfidenceScore, Description, FieldsMatched
   };
-  GetIPStats('{{Ip_Address}}')
+  GetIPMatch('{{Ip_Address}}')
 
 Insights:
- Id: 340e5f6f-d218-4a11-8638-09e1af7847cc
- DisplayName: "IP address remote connections with TI match"
+ Id: 8b4c6812-1829-423d-bb1e-04e3d06095b0
+ DisplayName: "This IP has a TI match"
  Description: |
-  'Provides the threat intelligence related hits for the remote IP address. Note due to potential performance impact, data is limited to a 7 day max window.'
+  'IP match from your TI table. Note due to potential performance impact, data is limited to a 30 day look back in TI.'
  DefaultTimeRange: 
   BeforeRange: 12h
   AfterRange: 12h
  TableQuery:
   ColumnsDefinitions:
-  - Header: "Direction"
-    OutputType: String
-    SupportDeepLink: false
   - Header: "IPAddress"
     OutputType: String
     SupportDeepLink: true
-  - Header: "RemoteIP"
-    OutputType: String
-    SupportDeepLink: true
+  - Header: "ConfidenceScore"
+    OutputType: Int
+    SupportDeepLink: false
   - Header: "ThreatType"
     OutputType: String
     SupportDeepLink: false
+  - Header: "LatestIndicatorTime"
+    OutputType: Datetime
+    SupportDeepLink: false
   QueriesDefinitions:
-  # Inbound TI Hits
-  - Filter:    "project IPAddress, RemoteIPAddress, InboundCount, ThreatType"
-    Summarize: "summarize Inbound = sum(InboundCount) by IPAddress, RemoteIPAddress, ThreatType | where Inbound > 0"
-    Project:   "project Direction = 'In', IPAddress, RemoteIP = RemoteIPAddress, ThreatType"
+  # TI hits
+  - Filter:    "project IPAddress, ConfidenceScore, ThreatType, LatestIndicatorTime"
+    Summarize: "summarize by IPAddress, ConfidenceScore, ThreatType, LatestIndicatorTime"
+    Project:   "project IPAddress, ConfidenceScore, ThreatType, LatestIndicatorTime"
     LinkColumnsDefinitions:
-    - ProjectedName: Direction
-      Query: "{{BaseQuery}} | {{RowFilter}}"
     - ProjectedName: IPAddress
       Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: RemoteIP
+    - ProjectedName: ConfidenceScore
       Query: "{{BaseQuery}} | {{RowFilter}}"
     - ProjectedName: ThreatType
       Query: "{{BaseQuery}} | {{RowFilter}}"
-  # Outbound TI Hits
-  - Filter:    "project IPAddress, RemoteIPAddress, OutboundCount, ThreatType"
-    Summarize: "summarize Outbound = sum(OutboundCount) by IPAddress, RemoteIPAddress, ThreatType | where Outbound > 0"
-    Project:   "project Direction = 'Out', IPAddress, RemoteIP = RemoteIPAddress, ThreatType"
-    LinkColumnsDefinitions:
-    - ProjectedName: Direction
+    - ProjectedName: LatestIndicatorTime
       Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: IPAddress
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: RemoteIP
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: ThreatType
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-  # Direction Unknown TI Hits
-  - Filter:    "project IPAddress, RemoteIPAddress, UnknownDirection, ThreatType"
-    Summarize: "summarize UnknownCount = sum(UnknownDirection) by IPAddress, RemoteIPAddress, ThreatType | where UnknownCount > 0"
-    Project:   "project Direction = 'Unknown', IPAddress, RemoteIP = RemoteIPAddress, ThreatType"
-    LinkColumnsDefinitions:
-    - ProjectedName: Direction
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: IPAddress
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: RemoteIP
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-    - ProjectedName: ThreatType
-      Query: "{{BaseQuery}} | {{RowFilter}}"
-
- ChartQuery: 
-  Title: "Connection Count to IP in TI"
-  DataSets: 
-   - Query: "summarize Count = max(InboundCount) by Time = bin(StartTime, 1d), RemoteIPAddress = strcat(RemoteIPAddress,' - In') | where isnotempty(Count) and Count > 0"
-     XColumnName: Time
-     YColumnName: Count
-     LegendColumnName: RemoteIPAddress
-   - Query: "summarize Count = max(OutboundCount) by Time = bin(StartTime, 1d), RemoteIPAddress = strcat(RemoteIPAddress,' - Out') | where isnotempty(Count) and Count > 0"
-     XColumnName: Time
-     YColumnName: Count
-     LegendColumnName: RemoteIPAddress
-   - Query: "summarize Count = max(UnknownDirection) by Time = bin(StartTime, 1d), RemoteIPAddress = strcat(RemoteIPAddress,' - UnknownDirection') | where isnotempty(Count) and Count > 0"
-     XColumnName: Time
-     YColumnName: Count
-     LegendColumnName: RemoteIPAddress
-  Type: BarChart
 
  AdditionalQuery: 
-  Text: "See All connections"
-  Query: "project StartTime, EndTime, IPAddress, RemoteIPAddress, InboundCount, OutboundCount, ReceivedBytes, SentBytes, UnknownDirection, Type, ThreatType, ThreatIntelMatch"
+  Text: "See All details"
+  Query: "project LatestIndicatorTime, ThreatType, IPAddress, SourceSystem, ConfidenceScore, Description, FieldsMatched"


### PR DESCRIPTION
   Change(s):
   - Changing TI map to generic map if IP is passed in, moved old TI map logic to new insight called IP_RemoteConnections.yaml

   Reason for Change(s):
   - Change is to support Entity page search for IP only versus Investigation page mapping to specific data types.
   - Moved existing logic that maps to specific datatypes to a named Insight and updated description for clarity
   - Customer requested feature

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
