### PR TITLE
Update ServicePrincipalAssignedAppRoleWithSensitiveAccess.yaml

### DIFF
--- a/Detections/AuditLogs/ServicePrincipalAssignedAppRoleWithSensitiveAccess.yaml
+++ b/Detections/AuditLogs/ServicePrincipalAssignedAppRoleWithSensitiveAccess.yaml
@@ -38,7 +38,7 @@ query: |
     | extend InitiatedBy = tostring(iff(isnotempty(InitiatedBy.user.userPrincipalName),InitiatedBy.user.userPrincipalName, InitiatedBy.app.displayName))
     | extend ServicePrincipal = tostring(parse_json(tostring(parse_json(tostring(TargetResources[0].modifiedProperties))[4].newValue)))
     | extend SPID = tostring(parse_json(tostring(parse_json(tostring(TargetResources[0].modifiedProperties))[6].newValue)))
-    | extend InitiatedBy = pack("User", InitiatedBy, "UA", UserAgent, "IPAddress", IpAddress)
+    | extend InitiatedBy = pack("User", InitiatedBy, "UA", columnifexists("UserAgent",''), "IPAddress", columnifexists("IpAddress",''))
     | mv-expand kind=array AddedPermissions
     | summarize FirstSeen = min(TimeGenerated), LastSeen = max(TimeGenerated), make_set(InitiatedBy), make_set(AddedPermissions) by SPID, ServicePrincipal
 entityMappings:
@@ -50,5 +50,5 @@ entityMappings:
     fieldMappings:
       - identifier: AadUserId
         columnName: SPID
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Fixing InitiatedBy to include columnifexists 
   - updated line - | extend InitiatedBy = pack("User", InitiatedBy, "UA", columnifexists("UserAgent",''), "IPAddress", columnifexists("IpAddress",''))

   Reason for Change(s):
   - To avoid failure of query when column is not available after expansion.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes