### PR TITLE
Removing unneeded filter on membername

### DIFF
--- a/Detections/SecurityEvent/GroupCreatedAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/GroupCreatedAddedToPrivlegeGroup_1h.yaml
@@ -33,8 +33,8 @@ query: |
   // 4728 - A member was added to a security-enabled global group
   // 4732 - A member was added to a security-enabled local group
   // 4756 - A member was added to a security-enabled universal group  
-  | where EventID in ("4728", "4732", "4756") 
-  | where AccountType =~ "User" and MemberName == "-"
+  | where EventID in ("4728", "4732", "4756")
+  | where AccountType =~ "User"
   // Exclude Remote Desktop Users group: S-1-5-32-555
   | where TargetSid !in ("S-1-5-32-555")
   | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
@@ -51,7 +51,7 @@ query: |
   | extend Account = strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
   | extend AccountType=case(Account endswith "$" or SubjectUserSid in ("S-1-5-18", "S-1-5-19", "S-1-5-20"), "Machine", isempty(SubjectUserSid), "", "User")
   | extend MemberName = tostring(EventData.MemberName)
-  | where AccountType =~ "User" and MemberName == "-"
+  | where AccountType =~ "User"
   // Exclude Remote Desktop Users group: S-1-5-32-555
   | extend TargetSid = tostring(EventData.TargetSid)
   | where TargetSid !in ("S-1-5-32-555")
@@ -91,18 +91,17 @@ query: |
   GroupCreated
   | join (
   GroupAddition
-  ) on GroupSid 
-  | extend timestamp = GroupCreateTime, AccountCustomEntity = GroupCreateSubjectAccount, HostCustomEntity = GroupCreateComputer
+  ) on GroupSid
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: GroupCreateSubjectAccount
       - identifier: Sid
         columnName: GroupCreateSubjectUserSid
   - entityType: Host
     fieldMappings:
       - identifier: FullName
-        columnName: HostCustomEntity
-version: 1.1.1
+        columnName: GroupCreateComputer
+version: 1.1.2
 kind: Scheduled

--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -31,13 +31,12 @@ query: |
   let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-498$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1000$";
   union isfuzzy=true 
   (
-  SecurityEvent 
-  // When MemberName contains '-' this indicates addition of a group to a group
-  | where AccountType == "User" and MemberName != "-"
+  SecurityEvent
   // 4728 - A member was added to a security-enabled global group
   // 4732 - A member was added to a security-enabled local group
   // 4756 - A member was added to a security-enabled universal group
-  | where EventID in (4728, 4732, 4756)   
+  | where EventID in (4728, 4732, 4756)
+  | where AccountType == "User"
   | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
   // Exclude Remote Desktop Users group: S-1-5-32-555
   | where TargetSid !in ("S-1-5-32-555")
@@ -50,13 +49,12 @@ query: |
   // 4728 - A member was added to a security-enabled global group
   // 4732 - A member was added to a security-enabled local group
   // 4756 - A member was added to a security-enabled universal group
-  | where EventID in (4728, 4732, 4756)  and  not(EventData has "S-1-5-32-555")
+  | where EventID in (4728, 4732, 4756) and not(EventData has "S-1-5-32-555")
   | extend SubjectUserSid = tostring(EventData.SubjectUserSid)
   | extend Account =  strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
   | extend AccountType=case(Account endswith "$" or SubjectUserSid in ("S-1-5-18", "S-1-5-19", "S-1-5-20"), "Machine", isempty(SubjectUserSid), "", "User")
   | extend MemberName = tostring(EventData.MemberName)
-  // When MemberName contains '-' this indicates addition of a group to a group
-  | where AccountType == "User" and MemberName != "-"
+  | where AccountType == "User"
   | extend TargetSid = tostring(EventData.TargetSid)
   | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
   // Exclude Remote Desktop Users group: S-1-5-32-555
@@ -68,16 +66,15 @@ query: |
   | extend UserPrincipalName = tostring(EventData.UserPrincipalName)
   | extend SubjectUserName = tostring(EventData.SubjectUserName)
   | project TimeGenerated, EventID, Computer, SimpleMemberName, MemberName, MemberSid, TargetUserName, TargetDomainName, TargetSid, UserPrincipalName, SubjectUserName, SubjectUserSid
-  | extend timestamp = TimeGenerated, AccountCustomEntity = SimpleMemberName, HostCustomEntity = Computer
   )
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: SimpleMemberName
   - entityType: Host
     fieldMappings:
       - identifier: FullName
-        columnName: HostCustomEntity
+        columnName: Computer
 version: 1.3.2
 kind: Scheduled

--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -42,7 +42,6 @@ query: |
   | where TargetSid !in ("S-1-5-32-555")
   | extend SimpleMemberName = substring(MemberName, 3, indexof_regex(MemberName, @",OU|,CN") - 3)
   | project TimeGenerated, EventID, Activity, Computer, SimpleMemberName, MemberName, MemberSid, TargetUserName, TargetDomainName, TargetSid, UserPrincipalName, SubjectUserName, SubjectUserSid
-  | extend timestamp = TimeGenerated, AccountCustomEntity = SimpleMemberName, HostCustomEntity = Computer
   ),
   (
   WindowsEvent 

--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -76,5 +76,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: Computer
-version: 1.3.2
+version: 1.3.3
 kind: Scheduled


### PR DESCRIPTION
   
   Change(s):
   - Filtering on membername with a hyphen may have created some misses.
   - Also removing from Group Created as the join on SID keeps users out.

   Reason for Change(s):
   - Could miss if membername is populated but still a group addition

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
