### PR TITLE
Removes trailing whitespace

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-AVDetections.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-AVDetections.yaml
@@ -8,12 +8,12 @@ requiredDataConnectors:
       - SecurityAlert (MDATP)
 tactics:
 relevantTechniques:
-  - 
+  -
 query: |
   // AV Detections
   let knotweed_sigs = dynamic(["JumplumpDropper", "Jumplump", "Corelump", "Mexlib", "Medcerc ", "SuspModuleLoad"]);
-  AlertEvidence 
-  | where Timestamp > ago(30d) 
+  AlertEvidence
+  | where Timestamp > ago(30d)
   | where ThreatFamily in~ (knotweed_sigs)
   | join MtpAlerts on AlertId
   | project OriginalReportOccurrenceTime, LastSeen, MachineId1, ThreatFamily, AlertId

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-AVDetections.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-AVDetections.yaml
@@ -8,7 +8,6 @@ requiredDataConnectors:
       - SecurityAlert (MDATP)
 tactics:
 relevantTechniques:
-  -
 query: |
   // AV Detections
   let knotweed_sigs = dynamic(["JumplumpDropper", "Jumplump", "Corelump", "Mexlib", "Medcerc ", "SuspModuleLoad"]);

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-COMRegistryKeyModifiedtoPointtoColorProfileFolder.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-COMRegistryKeyModifiedtoPointtoColorProfileFolder.yaml
@@ -8,7 +8,6 @@ requiredDataConnectors:
       - DeviceRegistryEvents
 tactics:
 relevantTechniques:
-  -
 query: |
   // COM hi-jack via registry
   let guids = dynamic(["{ddc05a5a-351a-4e06-8eaf-54ec1bc2dcea}","{1f486a52-3cb1-48fd-8f50-b8dc300d9f9d}","{4590f811-1d3a-11d0-891f-00aa004b2e24}", "{4de225bf-cf59-4cfc-85f7-68b90f185355}", "{F56F6FDD-AA9D-4618-A949-C1B91AF43B1A}"]); 

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-COMRegistryKeyModifiedtoPointtoColorProfileFolder.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-COMRegistryKeyModifiedtoPointtoColorProfileFolder.yaml
@@ -8,12 +8,12 @@ requiredDataConnectors:
       - DeviceRegistryEvents
 tactics:
 relevantTechniques:
-  - 
+  -
 query: |
-  // COM hi-jack via registry 
+  // COM hi-jack via registry
   let guids = dynamic(["{ddc05a5a-351a-4e06-8eaf-54ec1bc2dcea}","{1f486a52-3cb1-48fd-8f50-b8dc300d9f9d}","{4590f811-1d3a-11d0-891f-00aa004b2e24}", "{4de225bf-cf59-4cfc-85f7-68b90f185355}", "{F56F6FDD-AA9D-4618-A949-C1B91AF43B1A}"]); 
-  DeviceRegistryEvents 
-  | where ActionType == "RegistryValueSet" 
-  | where RegistryKey startswith "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\CLSID" 
-  | where RegistryKey has_any (guids) 
-  | where RegistryValueData has "System32\\spool\\drivers\\color" 
+  DeviceRegistryEvents
+  | where ActionType == "RegistryValueSet"
+  | where RegistryKey startswith "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\CLSID"
+  | where RegistryKey has_any (guids)
+  | where RegistryValueData has "System32\\spool\\drivers\\color"

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DomainIOCsJuly2022.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DomainIOCsJuly2022.yaml
@@ -8,14 +8,14 @@ requiredDataConnectors:
       - DeviceNetworkEvents
 tactics:
 relevantTechniques:
-  - 
+  -
 query: |
-  // c2 domains 
-  let c2domains = dynamic(["acrobatrelay[.]com","finconsult[.]cc","realmetaldns[.]com"]); 
-  let iocs = print c2domains 
-  | mv-expand domains=print_0 
-  | extend domainioc = replace_string(tostring(domains),"[.]",".") 
-  | distinct domainioc; 
-  DeviceNetworkEvents 
-  | where Timestamp > ago(1d) 
+  // c2 domains
+  let c2domains = dynamic(["acrobatrelay[.]com","finconsult[.]cc","realmetaldns[.]com"]);
+  let iocs = print c2domains
+  | mv-expand domains=print_0
+  | extend domainioc = replace_string(tostring(domains),"[.]",".")
+  | distinct domainioc;
+  DeviceNetworkEvents
+  | where Timestamp > ago(1d)
   | where RemoteUrl has_any(iocs)

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DomainIOCsJuly2022.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DomainIOCsJuly2022.yaml
@@ -8,7 +8,6 @@ requiredDataConnectors:
       - DeviceNetworkEvents
 tactics:
 relevantTechniques:
-  -
 query: |
   // c2 domains
   let c2domains = dynamic(["acrobatrelay[.]com","finconsult[.]cc","realmetaldns[.]com"]);

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DownloadingnewfileusingCurl.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DownloadingnewfileusingCurl.yaml
@@ -8,7 +8,6 @@ requiredDataConnectors:
       - DeviceNetworkEvents
 tactics:
 relevantTechniques:
-  -
 query: |
   let known_files = DeviceNetworkEvents
   | where Timestamp between (ago(7d)..ago(1d))

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DownloadingnewfileusingCurl.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-DownloadingnewfileusingCurl.yaml
@@ -8,18 +8,18 @@ requiredDataConnectors:
       - DeviceNetworkEvents
 tactics:
 relevantTechniques:
-  - 
+  -
 query: |
   let known_files = DeviceNetworkEvents
   | where Timestamp between (ago(7d)..ago(1d))
-  | where InitiatingProcessFileName has "curl" 
+  | where InitiatingProcessFileName has "curl"
   | extend url = extract("http[s]?:\\/\\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", 0,InitiatingProcessCommandLine)
   | extend ip = extract("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}[^ ]*", 0, InitiatingProcessCommandLine)
   | extend remote_file = iif(isnotempty(url), url, ip)
   | summarize by remote_file;
   DeviceNetworkEvents
   | where Timestamp > ago(1d)
-  | where InitiatingProcessFileName has "curl" 
+  | where InitiatingProcessFileName has "curl"
   | extend url = extract("http[s]?:\\/\\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", 0,InitiatingProcessCommandLine)
   | extend ip = extract("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}[^ ]*", 0, InitiatingProcessCommandLine)
   | extend remote_file = iif(isnotempty(url), url, ip)

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-FileHashIOCsJuly2022.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-FileHashIOCsJuly2022.yaml
@@ -10,31 +10,31 @@ tactics:
   - InitialAccess
   - Execution
 relevantTechniques:
-  - 
+  -
 query: |
-  // malware hash indicators 
-  let hashes = dynamic([ 
-  "78c255a98003a101fa5ba3f49c50c6922b52ede601edac5db036ab72efc57629", // SHA-256 Malicious Excel document and VBA  
-  "0588f61dc7e4b24554cffe4ea56d043d8f6139d2569bc180d4a77cf75b68792f", // SHA-256 Malicious Excel document and VBA  
-  "441a3810b9e89bae12eea285a63f92e98181e9fb9efd6c57ef6d265435484964", // SHA-256 Jumplump malware  
-  "cbae79f66f724e0fe1705d6b5db3cc8a4e89f6bdf4c37004aa1d45eeab26e84b", // SHA-256 Jumplump malware  
-  "fd6515a71530b8329e2c0104d0866c5c6f87546d4b44cc17bbb03e64663b11fc", // SHA-256 Jumplump malware  
-  "5d169e083faa73f2920c8593fb95f599dad93d34a6aa2b0f794be978e44c8206", // SHA-256 Jumplump malware  
-  "7f29b69eb1af1cc6c1998bad980640bfe779525fd5bb775bc36a0ce3789a8bfc", // SHA-256 Jumplump malware  
-  "02a59fe2c94151a08d75a692b550e66a8738eb47f0001234c600b562bf8c227d", // SHA-256 Jumplump malware  
-  "7f84bf6a016ca15e654fb5ebc36fd7407cb32c69a0335a32bfc36cb91e36184d", // SHA-256 Jumplump malware  
-  "afab2e77dc14831f1719e746042063a8ec107de0e9730249d5681d07f598e5ec", // SHA-256 Jumplump malware  
-  "894138dfeee756e366c65a197b4dbef8816406bc32697fac6621601debe17d53", // SHA-256 Jumplump malware  
-  "4611340fdade4e36f074f75294194b64dcf2ec0db00f3d958956b4b0d6586431", // SHA-256 Jumplump malware  
-  "7f29b69eb1af1cc6c1998bad980640bfe779525fd5bb775bc36a0ce3789a8bfc", // SHA-256 Jumplump malware  
-  "c96ae21b4cf2e28eec222cfe6ca903c4767a068630a73eca58424f9a975c6b7d", // SHA-256 Corelump malware  
-  "fa30be45c5c5a8f679b42ae85410f6099f66fe2b38eb7aa460bcc022babb41ca", // SHA-256 Mex tool  
-  "e64bea4032cf2694e85ede1745811e7585d3580821a00ae1b9123bb3d2d442d6"  // SHA-256 Passlib tool  
-  ]); 
-  let iochashes =  
-  print hashes 
-  | mv-expand sha256hashes=hashes 
-  | distinct tostring(sha256hashes); 
-  union withsource=TableName Device* 
-  | where Timestamp > ago(7d) 
+  // malware hash indicators
+  let hashes = dynamic([
+  "78c255a98003a101fa5ba3f49c50c6922b52ede601edac5db036ab72efc57629", // SHA-256 Malicious Excel document and VBA
+  "0588f61dc7e4b24554cffe4ea56d043d8f6139d2569bc180d4a77cf75b68792f", // SHA-256 Malicious Excel document and VBA
+  "441a3810b9e89bae12eea285a63f92e98181e9fb9efd6c57ef6d265435484964", // SHA-256 Jumplump malware
+  "cbae79f66f724e0fe1705d6b5db3cc8a4e89f6bdf4c37004aa1d45eeab26e84b", // SHA-256 Jumplump malware
+  "fd6515a71530b8329e2c0104d0866c5c6f87546d4b44cc17bbb03e64663b11fc", // SHA-256 Jumplump malware
+  "5d169e083faa73f2920c8593fb95f599dad93d34a6aa2b0f794be978e44c8206", // SHA-256 Jumplump malware
+  "7f29b69eb1af1cc6c1998bad980640bfe779525fd5bb775bc36a0ce3789a8bfc", // SHA-256 Jumplump malware
+  "02a59fe2c94151a08d75a692b550e66a8738eb47f0001234c600b562bf8c227d", // SHA-256 Jumplump malware
+  "7f84bf6a016ca15e654fb5ebc36fd7407cb32c69a0335a32bfc36cb91e36184d", // SHA-256 Jumplump malware
+  "afab2e77dc14831f1719e746042063a8ec107de0e9730249d5681d07f598e5ec", // SHA-256 Jumplump malware
+  "894138dfeee756e366c65a197b4dbef8816406bc32697fac6621601debe17d53", // SHA-256 Jumplump malware
+  "4611340fdade4e36f074f75294194b64dcf2ec0db00f3d958956b4b0d6586431", // SHA-256 Jumplump malware
+  "7f29b69eb1af1cc6c1998bad980640bfe779525fd5bb775bc36a0ce3789a8bfc", // SHA-256 Jumplump malware
+  "c96ae21b4cf2e28eec222cfe6ca903c4767a068630a73eca58424f9a975c6b7d", // SHA-256 Corelump malware
+  "fa30be45c5c5a8f679b42ae85410f6099f66fe2b38eb7aa460bcc022babb41ca", // SHA-256 Mex tool
+  "e64bea4032cf2694e85ede1745811e7585d3580821a00ae1b9123bb3d2d442d6"  // SHA-256 Passlib tool
+  ]);
+  let iochashes =
+  print hashes
+  | mv-expand sha256hashes=hashes
+  | distinct tostring(sha256hashes);
+  union withsource=TableName Device*
+  | where Timestamp > ago(7d)
   | where SHA256 in (iochashes)

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-FileHashIOCsJuly2022.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-FileHashIOCsJuly2022.yaml
@@ -10,7 +10,6 @@ tactics:
   - InitialAccess
   - Execution
 relevantTechniques:
-  -
 query: |
   // malware hash indicators
   let hashes = dynamic([

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-PEFileDroppedinColorProfileFolder.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-PEFileDroppedinColorProfileFolder.yaml
@@ -8,11 +8,11 @@ requiredDataConnectors:
       - DeviceFileEvents
 tactics:
 relevantTechniques:
-  - 
+  -
 query: |
-  // PE file dropped in C:\Windows\System32\spool\drivers\color\ 
-  DeviceFileEvents 
-  | where Timestamp > ago(7d) 
-  | where ActionType == "FileCreated" 
-  | where FolderPath has "C:\\Windows\\System32\\spool\\drivers\\color\\" 
+  // PE file dropped in C:\Windows\System32\spool\drivers\color\
+  DeviceFileEvents
+  | where Timestamp > ago(7d)
+  | where ActionType == "FileCreated"
+  | where FolderPath has "C:\\Windows\\System32\\spool\\drivers\\color\\"
   | where FileName endswith ".exe" or FileName endswith ".dll"

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-PEFileDroppedinColorProfileFolder.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/KNOTWEED/KNOTWEED-PEFileDroppedinColorProfileFolder.yaml
@@ -8,7 +8,6 @@ requiredDataConnectors:
       - DeviceFileEvents
 tactics:
 relevantTechniques:
-  -
 query: |
   // PE file dropped in C:\Windows\System32\spool\drivers\color\
   DeviceFileEvents


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updates to several threathunting queries and a sentinel detection to remove trailing whitespace.

   Reason for Change(s):
   - The trailing whitespace leads to programmatical issues when trying to work with these rules.

   Version Updated:
   - Did not feel this was needed, no logic updates were made, please correct me if this is in error.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes, these now pass our validations, where they previously failed due to the trailing whitespace, not sure how they got through your validations.

