### PR TITLE
fixed broken McAfee link and improved wording

### DIFF
--- a/Detections/readme.md
+++ b/Detections/readme.md
@@ -2,7 +2,7 @@
 
 This folder contains Detections based on different types of data sources that you can leverage in order to create alerts and respond to threats in your environment. These detections are termed as Analytics Rule templates in Microsoft Sentinel.
 
-**Note**: Many of these analytic rule templates are being delivered in Solutions for Microsoft Sentinel. You can discover and deploy those in [Microsoft Sentinel Content Hub](https://docs.microsoft.com/azure/sentinel/sentinel-solutions-deploy). These are available in this repository under [Solutions](https://github.com/Azure/Azure-Sentinel/tree/master/Solutions) folder. For e.g. Analytic rules for McAfee solution are at https://github.com/Azure/Azure-Sentinel/tree/master/Solutions/McAfeeePO/Analytic%20Rules. 
+**Note**: Many of these analytic rule templates are being delivered in Solutions for Microsoft Sentinel. You can discover and deploy those in [Microsoft Sentinel Content Hub](https://docs.microsoft.com/azure/sentinel/sentinel-solutions-deploy). These are available in this repository under [Solutions](https://github.com/Azure/Azure-Sentinel/tree/master/Solutions) folder. For example, Analytic rules for the McAfee ePolicy Orchestrator solution are found [here](https://github.com/Azure/Azure-Sentinel/tree/master/Solutions/McAfee%20ePolicy%20Orchestrator/Analytic%20Rules).
 
 For general information please start with the [Wiki](https://github.com/Azure/Azure-Sentinel/wiki) pages.
 


### PR DESCRIPTION
   Change(s):
   - Fixed broken links and improved documentation wording

   Reason for Change(s):
   - McAfee link was broken

   Version updated:
   - No

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - No