### PR TITLE
The alistair ross patch 1

### DIFF
--- a/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileCreated.yaml
+++ b/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileCreated.yaml
@@ -20,7 +20,7 @@ ParserQuery: |
           Event
           | where Source == "Microsoft-Windows-Sysmon"
           | where EventID == 11
-          | parse EventData with '<DataItem type="System.XmlData" time="'Time:datetime
+          | parse EventData with '<DataItem Type="System.XmlData" time="'Time:datetime
             '" sourceHealthServiceId="'sourceHealthServiceId
             '"><EventData xmlns="http://schemas.microsoft.com/win/2004/08/events/event"><Data Name="RuleName">'RuleName:string
             '</Data><Data Name="UtcTime">'UtcTime:datetime'</Data><Data Name="ProcessGuid">{'ProcessGuid:string

--- a/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileCreated.yaml
+++ b/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileCreated.yaml
@@ -6,7 +6,7 @@ Product:
   Name: Windows Sysmon
 Normalization:
   Schema: FileEvent
-  Version: '0.1.0'
+  Version: '0.1.1'
 References:
 - Title: ASIM File Schema
   Link: https://aka.ms/ASimFileEventDoc

--- a/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileDeleted.yaml
+++ b/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileDeleted.yaml
@@ -6,7 +6,7 @@ Product:
   Name: Windows Sysmon
 Normalization:
   Schema: FileEvent
-  Version: '0.1.0'
+  Version: '0.1.1'
 References:
 - Title: ASIM File Schema
   Link: https://aka.ms/ASimFileEventDoc 

--- a/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileDeleted.yaml
+++ b/Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileDeleted.yaml
@@ -20,7 +20,7 @@ ParserQuery: |
             | where Source == "Microsoft-Windows-Sysmon"
             | where EventID in (23,26)
             | parse EventData with 
-            '<DataItem type="System.XmlData" time="'Time:datetime
+            '<DataItem Type="System.XmlData" time="'Time:datetime
                     '" sourceHealthServiceId="'sourceHealthServiceId
                     '"><EventData xmlns="http://schemas.microsoft.com/win/2004/08/events/event"><Data Name="RuleName">'RuleName:string
                     '</Data><Data Name="UtcTime">'UtcTime:datetime


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated parser for Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileCreated.yaml
   - Updated parser for Parsers/ASimFileEvent/ProductParsers/FileEventMicrosoftSysmonFileDeleted.yaml
   Reason for Change(s):
   - The parser for EventData contains a case-sensitive typo. This will mean that the query will succeed, but it will fail to extract the data. The value of the typo "DataItem Type" is defined here https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-datafieldtype-complextype

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

