### PR TITLE
Update Infoblox_dhcpdiscover.txt

### DIFF
--- a/Solutions/Infoblox NIOS/Parser/Infoblox_dhcpack.txt
+++ b/Solutions/Infoblox NIOS/Parser/Infoblox_dhcpack.txt
@@ -1,8 +1,8 @@
 // Title:           Infoblox parser for type - DHCPACK
 // Author:          Microsoft
-// Version:         1.1
-// Last Updated:    20/05/2022
-// Comment:         Updated to only parse the MSG (RFC3164) part of the Syslog message. Excluded the Header.
+// Version:         1.2
+// Last Updated:    15 oct 2022
+// Comment:         Actually updated to only parse the MSG (RFC3164) part of the Syslog message and excluded the header. Fixed parser to accept for message formats within this message type not previously accounted for.  Added Relay field in output, excluded by final parse-away to maintain consistent output format.
 //
 // DESCRIPTION:
 // This parser comprised of function - Infoblox_dhcpack
@@ -12,26 +12,24 @@
 // Infoblox NIOS logging formats: https://docs.infoblox.com/display/NAG8/Using+a+Syslog+Server
 //
 // LOG SAMPLES:
-// This parser assumes the raw log are formatted as follows:
+// This parser assumes the log messages are formatted as these examples:
 // 
-//      May 13 12:05:52 10.0.0.0 dhcpd[30174]: DHCPDISCOVER from 0a:0b:0c:0d::0f via eth2 TransID 5daf9374: network 10.0.0.0/24: no free leases
-//      May 13 12:05:52 10.1.1.1 named[11325]: zone voip.abc.com/IN: ZRQ applied transaction 0101010 with SOA serial 9191919. Zone version is now 0202020
+//      DHCPACK on 10.1.2.3 to 9c:99:99:99:99:da (hostname-pc) via eth2 relay 11.22.33.44 lease-duration 1234 (RENEW) uid 01:9c:99:99:99:99:da
+//      DHCPACK on 172.21.7.17 to 7e:88:88:88:88:76 via eth3 relay 1.22.33.44 lease-duration 4321 uid 01:7e:88:88:88:88:76
+//      DHCPACK to 10.4.5.67 (f8:99:99:99:99:b5) via eth2
+//
 let datasource = (_GetWatchlist('Sources_by_SourceType')| where SearchKey == 'InfobloxNIOS' | project Source);
-let RawData = Syslog
+Syslog
     | where Computer in (datasource) 
-    | where ProcessName == "dhcpd" and SyslogMessage has "DHCPACK"
-    | extend Parser = extract_all(@"^(\d{2}\-[a-zA-Z]{3}\-\d{4}\s[0-9\.\:]+)?\s?([a-zA-Z-_]+)(\s|\:)?(.*)", dynamic([1,2,3,4]), SyslogMessage)[0]
-    | extend responseTime = todatetime(Parser[0]),
-            Log_Type = tostring(Parser[1]),
-            RawData_subString = tostring(Parser[3])
-    | project-away Parser;
-RawData
-    | extend dhcpack = extract_all(@"(\s\w+\s(\S+))\sto\s(\S+)\svia\s(\S+)(\srelay\s(\S+))?(\slease-duration\s(\d+))?(\s\(([a-zA-Z]+)\))?(\suid\s(\S+))?", dynamic([1,2,3,4,5,6,7,8,9,10,11]), RawData_subString)[0]
-    | extend IPAddress = tostring(dhcpack[1]), 
-        SrcMacAddr = tostring(dhcpack[2]),
-        Interface = tostring(dhcpack[4]),
-        Relay = tostring(dhcpack[5]), 
-        LeaseDuration = tostring(dhcpack[7]),
-        SrcHostname = tostring(dhcpack[3]),
-        State = tostring(dhcpack[10])
-       | project-away SyslogMessage, dhcpack,RawData_subString;
+    | where ProcessName == "dhcpd" and SyslogMessage startswith_cs "DHCPACK"
+    | extend Parser = extract_all(@"^([^\s]+)\s(?:on\s([\d\.]+)\s)?(?:to\s([^\s]+)(?:\s\(([^\)]+)\))?)(?:\svia\s([^\s]+))?(?:\srelay\s([^\s]+))?(?:\slease-duration\s([\d]+))?(?:\s\(([^\)]+)\))?(?:\suid\s([^\s]+))?", dynamic([1,2,3,4,5,6,7,8,9]), SyslogMessage)[0]
+    | extend responseTime = EventTime,
+            Log_Type = tostring(Parser[0]),
+            IPAddress = tostring(Parser[1]), 
+            SrcMacAddr = tostring(Parser[2]),
+            SrcHostname = tostring(Parser[3]),
+            Interface = tostring(Parser[4]),
+            Relay = tostring(Parser[5]), 
+            LeaseDuration = tostring(Parser[6]),
+            State = tostring(Parser[8])
+    | project-away Parser

--- a/Solutions/Infoblox NIOS/Parser/Infoblox_dhcpdiscover.txt
+++ b/Solutions/Infoblox NIOS/Parser/Infoblox_dhcpdiscover.txt
@@ -1,8 +1,8 @@
 // Title:           Infoblox parser for type - DHCPDISCOVER
 // Author:          Microsoft
-// Version:         1.1
-// Last Updated:    20/05/2022
-// Comment:         Updated to only parse the MSG (RFC3164) part of the Syslog message. Excluded the Header.
+// Version:         1.2
+// Last Updated:    15 oct 2022
+// Comment:         Updated to only parse the MSG (RFC3164) part of the Syslog message. Excluded the Header.  Except for real this time.  Added optional router field.  Fixed parser to account for message formats in this type not previously considered.
 //
 // DESCRIPTION:
 // This parser comprised of function - Infoblox_dhcpdiscover 
@@ -13,22 +13,23 @@
 // LOG SAMPLES:
 // This parser assumes the raw log are formatted as follows:
 // 
-//      May 13 12:05:52 10.0.0.0 dhcpd[30174]: DHCPDISCOVER from 0a:0b:0c:0d::0f via eth2 TransID 5daf9374: network 10.0.0.0/24: no free leases
-//      May 13 12:05:52 10.1.1.1 named[11325]: zone voip.abc.com/IN: ZRQ applied transaction 0101010 with SOA serial 9191919. Zone version is now 0202020
+//      DHCPDISCOVER from b8:99:99:99:b3:6e via 172.16.4.3: unknown network segment
+//      DHCPDISCOVER from 80:99:99:99:6d:22 (host.example) via 10.2.3.1 TransID 30af3458 uid 01:80:99:99:99:6d:22
+//      DHCPDISCOVER from b8:99:99:99:ec:88 via 10.1.4.2 TransID 4e62bd99 uid 01:b8:99:99:99:ec:88
+//      DHCPDISCOVER from 0a:99:99:99:0f:2d via eth2 TransID 4daf9394: network 10.0.0.0/24: no free leases
+//
 let datasource = (_GetWatchlist('Sources_by_SourceType')| where SearchKey == 'InfobloxNIOS' | project Source);
-let RawData = Syslog
+Syslog
     | where Computer in (datasource) 
-    | where ProcessName == "dhcpd" and SyslogMessage has "DHCPDISCOVER"
-    | extend Parser = extract_all(@"^(\d{2}\-[a-zA-Z]{3}\-\d{4}\s[0-9\.\:]+)?\s?([a-zA-Z-_]+)(\s|\:)?(.*)", dynamic([1,2,3,4]), SyslogMessage)[0]
-    | extend responseTime = todatetime(Parser[0]),
-            Log_Type = tostring(Parser[1]),
-            RawData_subString = tostring(Parser[3])
-    | project-away Parser;
-RawData
-    | extend dhcpdiscover = extract_all(@"\w+\s((\S+)(\s\(\S+\))?)\s\w+\s(\S+)\sTransID\s([a-z0-9]+)\:?(\suid\s(\S+))?(\snetwork\s(\S+)\:)?\s?(.*)?", dynamic([1,2,3,4,5,6,7,8,9,10]), RawData_subString)[0]
-    | extend SrcMacAddr = tostring(dhcpdiscover[0]), 
-        DhcpSessionId = tostring(dhcpdiscover[4]),
-        SrcUserIdType = tostring(dhcpdiscover[6]), 
-        Network = tostring(dhcpdiscover[8]),
-        EventMessage = tostring(dhcpdiscover[9])
-    | project-away SyslogMessage, dhcpdiscover,RawData_subString;
+    | where ProcessName == "dhcpd" and SyslogMessage startswith_cs "DHCPDISCOVER"
+    | extend responseTime = EventTime
+    | extend Parser = extract_all(@"^(\w+)\sfrom\s([a-z0-9\:]+)(?:\s\(([^\)]+)\)|)(?:\svia\s([^\s\:]+[^\:\s]))(?:\sTransID\s([^\s\:]+)?)?(?:\suid\s([\S]+))?(?:\:?\snetwork\s([^\s\:]+)?)?(:?\:\s(.*))?", dynamic([1,2,3,4,5,6,7,8,9,10]), SyslogMessage)[0]
+    | extend Log_Type = tostring(Parser[0]),
+        SrcMacAddr = tostring(Parser[1]), 
+        SrcHostName = tostring(Parser[2]), 
+        SrcRouterAddress = tostring(Parser[3]), 
+        DhcpSessionId = tostring(Parser[4]),
+        SrcUserIdType = tostring(Parser[5]), 
+        Network = tostring(Parser[6]),
+        EventMessage = tostring(Parser[8])
+    | project-away SrcHostName,SrcRouterAddress,Parser;


### PR DESCRIPTION
Added optional router field.  Fixed parser to account for more message formats in this type not previously considered.  Simplified parser logic.  Fixed parsing in edge cases with unexpected colons.

   Required items, please complete
   
   Change(s):
   Updated infoblox parser functions with similar fixes: Updated to only parse the MSG (RFC3164) part of the Syslog message. Excluded the Header. (actually in code and not just saying it was done in the comments). Added optional router field (excluded with final parse-away so output format is identical to previous version).  Fixed parser to account for message formats in this type not previously considered.

   Reason for Change(s):
   To resolve issues in #6397

   Version Updated:
   Yes.

   Testing Completed:
   Yes, tested against real world data in an LA workspace.  Which does not seem to have previously been done.

   Checked that the validations are passing and have addressed any issues that are present:
   Yes
