### PR TITLE
Show only ConditionalAccessPolicies that failed

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
@@ -33,32 +33,32 @@ relevantTechniques:
   - T1098
 query: |
 
-let threshold = 1;
-let aadFunc = (tableName:string){
-table(tableName)
-| where ConditionalAccessStatus == 1 or ConditionalAccessStatus =~ "failure"
-| extend d = parse_json(ConditionalAccessPolicies)
-| mv-apply d on (
+  let threshold = 1;
+  let aadFunc = (tableName:string){
+  table(tableName)
+  | where ConditionalAccessStatus == 1 or ConditionalAccessStatus =~ "failure"
+  | extend d = parse_json(ConditionalAccessPolicies)
+  | mv-apply d on (
     project ConditionalAccessPoliciesName = d.displayName, result = d.result
     | where result == "failure"
-)
-| extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
-| extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
-| extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion) 
-| extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
-| extend Status = strcat(StatusCode, ": ", ResultDescription) 
-| summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Status = make_list(Status), StatusDetails = make_list(StatusDetails), IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress), CorrelationIds = make_list(CorrelationId), ConditionalAccessPoliciesName = make_list(ConditionalAccessPoliciesName)
-by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, Type
-| where IPAddressCount > threshold and StatusDetails !has "MFA successfully completed"
-| mvexpand IPAddresses, Status, StatusDetails, CorrelationIds
-| extend Status = strcat(Status, " ", StatusDetails)
-| summarize IPAddresses = make_set(IPAddresses), Status = make_set(Status), CorrelationIds = make_set(CorrelationIds), ConditionalAccessPoliciesName = make_set(ConditionalAccessPoliciesName)
-by StartTime, EndTime, UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, IPAddressCount, Type
-| extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = tostring(IPAddresses)
-};
-let aadSignin = aadFunc("SigninLogs");
-let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
-union isfuzzy=true aadSignin, aadNonInt
+  )
+  | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
+  | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
+  | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion) 
+  | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
+  | extend Status = strcat(StatusCode, ": ", ResultDescription) 
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Status = make_list(Status), StatusDetails = make_list(StatusDetails), IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress), CorrelationIds = make_list(CorrelationId), ConditionalAccessPoliciesName = make_list(ConditionalAccessPoliciesName)
+  by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, Type
+  | where IPAddressCount > threshold and StatusDetails !has "MFA successfully completed"
+  | mvexpand IPAddresses, Status, StatusDetails, CorrelationIds
+  | extend Status = strcat(Status, " ", StatusDetails)
+  | summarize IPAddresses = make_set(IPAddresses), Status = make_set(Status), CorrelationIds = make_set(CorrelationIds), ConditionalAccessPoliciesName = make_set(ConditionalAccessPoliciesName)
+  by StartTime, EndTime, UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, IPAddressCount, Type
+  | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = tostring(IPAddresses)
+  };
+  let aadSignin = aadFunc("SigninLogs");
+  let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
+  union isfuzzy=true aadSignin, aadNonInt
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
@@ -37,23 +37,38 @@ query: |
   let aadFunc = (tableName:string){
   table(tableName)
   | where ConditionalAccessStatus == 1 or ConditionalAccessStatus =~ "failure"
-  | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
+  | extend d = parse_json(ConditionalAccessPolicies)
+  | mv-apply d on (
+  project ConditionalAccessPoliciesName = d.displayName, result = d.result
+  | where result == "failure"
+  )
+  | extend DeviceDetail = todynamic(DeviceDetail), Status =
+  todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
-  | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion) 
-  | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
-  | extend ConditionalAccessPolicies = todynamic(ConditionalAccessPolicies)
-  | extend ConditionalAccessPol0Name = tostring(ConditionalAccessPolicies[0].displayName)
-  | extend ConditionalAccessPol1Name = tostring(ConditionalAccessPolicies[1].displayName)
-  | extend ConditionalAccessPol2Name = tostring(ConditionalAccessPolicies[2].displayName)
+  | extend State = tostring(LocationDetails.state), City =
+  tostring(LocationDetails.city), Region =
+  tostring(LocationDetails.countryOrRegion) 
+  | extend StatusCode = tostring(Status.errorCode), StatusDetails =
+  tostring(Status.additionalDetails)
   | extend Status = strcat(StatusCode, ": ", ResultDescription) 
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Status = make_list(Status), StatusDetails = make_list(StatusDetails), IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress), CorrelationIds = make_list(CorrelationId) 
-  by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, ConditionalAccessPol0Name, ConditionalAccessPol1Name, ConditionalAccessPol2Name, Type
-  | where IPAddressCount > threshold and StatusDetails !has "MFA successfully completed"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),
+  Status = make_list(Status), StatusDetails = make_list(StatusDetails),
+  IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress),
+  CorrelationIds = make_list(CorrelationId), ConditionalAccessPoliciesName =
+  make_list(ConditionalAccessPoliciesName)
+  by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City,
+  State, Region, Type
+  | where IPAddressCount > threshold and StatusDetails !has "MFA successfully
+  completed"
   | mvexpand IPAddresses, Status, StatusDetails, CorrelationIds
   | extend Status = strcat(Status, " ", StatusDetails)
-  | summarize IPAddresses = make_set(IPAddresses), Status = make_set(Status), CorrelationIds = make_set(CorrelationIds) 
-  by StartTime, EndTime, UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, ConditionalAccessPol0Name, ConditionalAccessPol1Name, ConditionalAccessPol2Name, IPAddressCount, Type
-  | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = tostring(IPAddresses)
+  | summarize IPAddresses = make_set(IPAddresses), Status = make_set(Status),
+  CorrelationIds = make_set(CorrelationIds), ConditionalAccessPoliciesName =
+  make_set(ConditionalAccessPoliciesName)
+  by StartTime, EndTime, UserPrincipalName, AppDisplayName, tostring(Browser),
+  tostring(OS), City, State, Region, IPAddressCount, Type
+  | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName,
+  IPCustomEntity = tostring(IPAddresses)
   };
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
@@ -67,5 +82,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.1.0
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
@@ -33,46 +33,32 @@ relevantTechniques:
   - T1098
 query: |
 
-  let threshold = 1;
-  let aadFunc = (tableName:string){
-  table(tableName)
-  | where ConditionalAccessStatus == 1 or ConditionalAccessStatus =~ "failure"
-  | extend d = parse_json(ConditionalAccessPolicies)
-  | mv-apply d on (
-  project ConditionalAccessPoliciesName = d.displayName, result = d.result
-  | where result == "failure"
-  )
-  | extend DeviceDetail = todynamic(DeviceDetail), Status =
-  todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
-  | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
-  | extend State = tostring(LocationDetails.state), City =
-  tostring(LocationDetails.city), Region =
-  tostring(LocationDetails.countryOrRegion) 
-  | extend StatusCode = tostring(Status.errorCode), StatusDetails =
-  tostring(Status.additionalDetails)
-  | extend Status = strcat(StatusCode, ": ", ResultDescription) 
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),
-  Status = make_list(Status), StatusDetails = make_list(StatusDetails),
-  IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress),
-  CorrelationIds = make_list(CorrelationId), ConditionalAccessPoliciesName =
-  make_list(ConditionalAccessPoliciesName)
-  by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City,
-  State, Region, Type
-  | where IPAddressCount > threshold and StatusDetails !has "MFA successfully
-  completed"
-  | mvexpand IPAddresses, Status, StatusDetails, CorrelationIds
-  | extend Status = strcat(Status, " ", StatusDetails)
-  | summarize IPAddresses = make_set(IPAddresses), Status = make_set(Status),
-  CorrelationIds = make_set(CorrelationIds), ConditionalAccessPoliciesName =
-  make_set(ConditionalAccessPoliciesName)
-  by StartTime, EndTime, UserPrincipalName, AppDisplayName, tostring(Browser),
-  tostring(OS), City, State, Region, IPAddressCount, Type
-  | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName,
-  IPCustomEntity = tostring(IPAddresses)
-  };
-  let aadSignin = aadFunc("SigninLogs");
-  let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
-  union isfuzzy=true aadSignin, aadNonInt
+let threshold = 1;
+let aadFunc = (tableName:string){
+table(tableName)
+| where ConditionalAccessStatus == 1 or ConditionalAccessStatus =~ "failure"
+| extend d = parse_json(ConditionalAccessPolicies)
+| mv-apply d on (
+    project ConditionalAccessPoliciesName = d.displayName, result = d.result
+    | where result == "failure"
+)
+| extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
+| extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
+| extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion) 
+| extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
+| extend Status = strcat(StatusCode, ": ", ResultDescription) 
+| summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Status = make_list(Status), StatusDetails = make_list(StatusDetails), IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress), CorrelationIds = make_list(CorrelationId), ConditionalAccessPoliciesName = make_list(ConditionalAccessPoliciesName)
+by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, Type
+| where IPAddressCount > threshold and StatusDetails !has "MFA successfully completed"
+| mvexpand IPAddresses, Status, StatusDetails, CorrelationIds
+| extend Status = strcat(Status, " ", StatusDetails)
+| summarize IPAddresses = make_set(IPAddresses), Status = make_set(Status), CorrelationIds = make_set(CorrelationIds), ConditionalAccessPoliciesName = make_set(ConditionalAccessPoliciesName)
+by StartTime, EndTime, UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, IPAddressCount, Type
+| extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = tostring(IPAddresses)
+};
+let aadSignin = aadFunc("SigninLogs");
+let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
+union isfuzzy=true aadSignin, aadNonInt
 entityMappings:
   - entityType: Account
     fieldMappings:


### PR DESCRIPTION
User can have defined lot of policies and original query was showing only 3. New query will filter only on ConditionalAccessPoliciesName that failed during the login process.

   Required items, please complete
   
   Change(s):
   - Added filter that will show only ConditionalAccessPolicies that have failed

   Reason for Change(s):
   - Results were too broad

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
