### PR TITLE
Fix analytic rule

### DIFF
--- a/Solutions/Azure Active Directory Identity Protection/Analytic Rules/CorrelateIPC_Unfamiliar-Atypical.yaml
+++ b/Solutions/Azure Active Directory Identity Protection/Analytic Rules/CorrelateIPC_Unfamiliar-Atypical.yaml
@@ -55,5 +55,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Azure Active Directory Identity Protection/Analytic Rules/CorrelateIPC_Unfamiliar-Atypical.yaml
+++ b/Solutions/Azure Active Directory Identity Protection/Analytic Rules/CorrelateIPC_Unfamiliar-Atypical.yaml
@@ -20,6 +20,7 @@ query: |
   let Alert1 = 
   SecurityAlert
   | where AlertName == "Unfamiliar sign-in properties"
+  | where Status == "New"
   | extend UserPrincipalName = tostring(parse_json(ExtendedProperties).["User Account"])
   | extend Alert1Time = TimeGenerated
   | extend Alert1 = AlertName
@@ -28,6 +29,7 @@ query: |
   let Alert2 = 
   SecurityAlert
   | where AlertName == "Atypical travel"
+  | where Status == "New"
   | extend UserPrincipalName = tostring(parse_json(ExtendedProperties).["User Account"])
   | extend Alert2Time = TimeGenerated
   | extend Alert2 = AlertName


### PR DESCRIPTION

   Change(s):
   - Updated alert queries to filter on "New" status alerts. Currently, this analytic rule will trigger when alert statuses are changed. A customer has reported that moving the alert to in-progress of resolved was causing duplicate alerts to fire.
   - Added Status check to Alert 1
   - Added Status check to Alert 2

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes