### PR TITLE
Replace dlp_verdict with tls_status

### DIFF
--- a/Solutions/CiscoSEG/Hunting Queries/CiscoSEGInsecureProtocol.yaml
+++ b/Solutions/CiscoSEG/Hunting Queries/CiscoSEGInsecureProtocol.yaml
@@ -16,7 +16,7 @@ query: |
   | where TimeGenerated > ago(24h)
   | where tostring(AdditionalFields) has 'ESATLSOutProtocol'
   | extend tls_status = extract(@'ESATLSOutProtocol":"(.*?)"', 1, tostring(AdditionalFields))
-  | where dlp_verdict != 'TLSv1.2'
+  | where tls_status != 'TLSv1.2'
   | extend AccountCustomEntity = SrcUserName
 entityMappings:
   - entityType: Account


### PR DESCRIPTION
Probably a copy and paste error when copying from another hunting query.

   
   Change(s):
   - Updated syntax for CiscoSEGInsecureProtocol.yaml

   Reason for Change(s):
   - Fix for non-existing column 'dlp_verdict' referenced in line 19

   Version Updated:
   - No, not required because it is a hunting query

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
