### PR TITLE
Unable to package new workbooks locally

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
@@ -151,7 +151,7 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
     $baseCreateUiDefinitionPath = "$PSScriptRoot/templating/baseCreateUiDefinition.json"
     $metadataPath = "$PSScriptRoot/../../../Solutions/$($contentToImport.Name)/$($contentToImport.Metadata)"
 
-    $workbookMetadataPath = "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/"
+    $workbookMetadataPath = "$PSScriptRoot/../../../"
     # Base JSON Objects
     $baseMainTemplate = Get-Content -Raw $baseMainTemplatePath | Out-String | ConvertFrom-Json
     $baseCreateUiDefinition = Get-Content -Raw $baseCreateUiDefinitionPath | Out-String | ConvertFrom-Json


### PR DESCRIPTION
Propose fix for issue #6141

   Required items, please complete
   
   Change(s):
   use local copy of the workbook metadata to build package

   Reason for Change(s):
  packaging is broken locally

   Version Updated:
No

   Testing Completed:
Yes

   Checked that the validations are passing and have addressed any issues that are present:
Yes
