### PR TITLE
fix(aws): do not trigger missing mfa on sso

### DIFF
--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ConsoleLogonWithoutMFA.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ConsoleLogonWithoutMFA.yaml
@@ -31,6 +31,7 @@ query: |
   | where EventName =~ "ConsoleLogin" 
   | extend MFAUsed = tostring(parse_json(AdditionalEventData).MFAUsed), LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin)
   | where MFAUsed !~ "Yes" and LoginResult !~ "Failure"
+  | where SessionIssuerUserName !contains "AWSReservedSSO"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, LoginResult, MFAUsed, UserIdentityAccountId,  UserIdentityPrincipalid, UserAgent, 
   UserIdentityUserName, SessionMfaAuthenticated, SourceIpAddress, AWSRegion
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserIdentityUserName, IPCustomEntity = SourceIpAddress

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ConsoleLogonWithoutMFA.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ConsoleLogonWithoutMFA.yaml
@@ -44,5 +44,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/NRT_AWS_ConsoleLogonWithoutMFA.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/NRT_AWS_ConsoleLogonWithoutMFA.yaml
@@ -26,6 +26,7 @@ query: |
   | where EventName =~ "ConsoleLogin"
   | extend MFAUsed = tostring(parse_json(AdditionalEventData).MFAUsed), LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin)
   | where MFAUsed !~ "Yes" and LoginResult !~ "Failure"
+  | where SessionIssuerUserName !contains "AWSReservedSSO"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, LoginResult, MFAUsed, UserIdentityAccountId,  UserIdentityPrincipalid, UserAgent,
   UserIdentityUserName, SessionMfaAuthenticated, SourceIpAddress, AWSRegion
 entityMappings:

--- a/Solutions/Amazon Web Services/Analytic Rules/NRT_AWS_ConsoleLogonWithoutMFA.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/NRT_AWS_ConsoleLogonWithoutMFA.yaml
@@ -38,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: SourceIpAddress
-version: 1.0.0
+version: 1.0.1
 kind: NRT


### PR DESCRIPTION
   Change(s):
   - Change AWS missing MFA rules (scheduled + NRT) to not detect SSO sessions since those will never use MFA, rather on IDP side.

   Reason for Change(s):
   - Fixes https://github.com/Azure/Azure-Sentinel/issues/6456

   Version Updated:
   - 1.0.0 -> 1.0.1
   
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes