### PR TITLE
GetEnumerator() not returning array/ht when single result

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
@@ -1914,7 +1914,7 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
                                 }
                             }
                             function Remove-EmptyArrays($Object) {
-                                ($Object.GetEnumerator() | ? {
+                                (@($Object).GetEnumerator() | ? {
                                     if($_.GetType().fullname -eq "System.Collections.Hashtable"){
                                         -not $_.Values
                                     }


### PR DESCRIPTION
Change related to issue #6544 where create incident config is not emitted to maintemplate if value set to false  https://stackoverflow.com/questions/21939026/powershell-psobject-getenumerator-one

