### PR TITLE
MerakiParser - Wrong handling of EventEndTime epoch with nanoseconds

### DIFF
--- a/Solutions/CiscoMeraki/Parsers/CiscoMeraki.txt
+++ b/Solutions/CiscoMeraki/Parsers/CiscoMeraki.txt
@@ -61,11 +61,7 @@ union isfuzzy=true
         Substring = tostring(Parser[3])        
 | extend EpochTimestamp = split(Epoch,".")
 | extend EventTimestamp = unixtime_seconds_todatetime(tolong(EpochTimestamp[0]))
-| extend EventStartTime = coalesce(EventTimestamp,column_ifexists("EventStartTime",datetime(null))),
-         EventEndTime = coalesce(
-                            unixtime_seconds_todatetime(tolong(EpochTimestamp[1])),
-                            unixtime_seconds_todatetime(tolong(column_ifexists("EventEndTime","")))
-                        )
+| extend EventStartTime = coalesce(EventTimestamp,column_ifexists("EventStartTime",datetime(null)))
 | extend SrcIpAddr = case(
                         isnotempty(column_ifexists("SrcIpAddr","")), column_ifexists("SrcIpAddr",""),
                         LogType has "urls", extract(@"src=([0-9\.]+)\:",1,Substring),


### PR DESCRIPTION
EventEndTime seems to be a bogus value, as it is parsed from the nanosecond part of Epoch timestamp (after the dot). From the examples from Cisco, this seems to be Epoch timestamp with nanoseconds after the decimal, and not an "endtime". https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/Syslog_Event_Types_and_Log_Samples

Graylog seems to drop event completely where Meraki is configured to log timestamps with nanoseconds (https://docs.graylog.org/docs/cisco-meraki), but in Sentinel's case it would be possible to discard the part after the dot, as the split is already in place.

Change(s):
Removed extraction of EventEndTime from Epoch for Solutions/CiscoMeraki/Parsers/CiscoMeraki.txt

Reason for Change(s):
EventEndTime does not seem to be something that is part of the raw Syslog from Meraki.

Testing Completed:
Yes

Checked that the validations are passing and have addressed any issues that are present:
Need Help?