### PR TITLE
🐛 Remove preceding newlines in queries

### DIFF
--- a/Detections/AzureAppServices/AVScan_Failure.yaml
+++ b/Detections/AzureAppServices/AVScan_Failure.yaml
@@ -9,7 +9,6 @@ queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 1
 query: |
-
   let timeframe = ago(1d);
   AppServiceAntivirusScanAuditLogs
   | where ScanStatus == "Failed"
@@ -19,7 +18,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/AzureAppServices/AVScan_Infected_Files_Found.yaml
+++ b/Detections/AzureAppServices/AVScan_Infected_Files_Found.yaml
@@ -9,7 +9,6 @@ queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 1
 query: |
-
   let timeframe = ago(1d);
   AppServiceAntivirusScanAuditLogs
   | where NumberOfInfectedFiles > 0
@@ -19,7 +18,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/CommonSecurityLog/Fortinet-NetworkBeaconPattern.yaml
+++ b/Detections/CommonSecurityLog/Fortinet-NetworkBeaconPattern.yaml
@@ -24,9 +24,8 @@ relevantTechniques:
   - T1071
   - T1571
 query: |
-
     let starttime = 1d;
-    let TimeDeltaThresholdInSeconds = 60; // we ignore beacons diffs that fall below this threshold 
+    let TimeDeltaThresholdInSeconds = 60; // we ignore beacons diffs that fall below this threshold
     let TotalBeaconsThreshold = 4; // minimum number of beacons required in a session to surface a row
     let JitterTolerance = 0.2; // tolerance to jitter, e.g. - 0.2 = 20% jitter is tolerated either side of the periodicity
     CommonSecurityLog
@@ -37,7 +36,7 @@ query: |
     // filter out deny, close, rst and SNMP to reduce data volume
     | where DeviceAction !in ("close", "client-rst", "server-rst", "deny") and DestinationPort != 161
     // map input fields
-    | project TimeGenerated , SourceIP, DestinationIP, DestinationPort, ReceivedBytes, SentBytes, DeviceAction 
+    | project TimeGenerated , SourceIP, DestinationIP, DestinationPort, ReceivedBytes, SentBytes, DeviceAction
     // where destination IPs are public
     | where ipv4_is_private(DestinationIP) == false
     // sort into source->destination 'sessions'
@@ -76,7 +75,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/CommonSecurityLog/MultiVendor-PossibleDGAContacts.yaml
+++ b/Detections/CommonSecurityLog/MultiVendor-PossibleDGAContacts.yaml
@@ -41,7 +41,6 @@ tactics:
 relevantTechniques:
   - T1568
 query: |
-
     let triThreshold = 500;
     let startTime = 6h;
     let dgaLengthThreshold = 8;
@@ -121,7 +120,7 @@ entityMappings:
     fieldMappings:
       - identifier: DomainName
         columnName: Name
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/CommonSecurityLog/TimeSeriesAnomaly-MultiVendor_NetworkTraffic.yaml
+++ b/Detections/CommonSecurityLog/TimeSeriesAnomaly-MultiVendor_NetworkTraffic.yaml
@@ -40,7 +40,6 @@ tactics:
 relevantTechniques:
   - T1030
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   let timeframe = 1h;
@@ -82,7 +81,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/CommonSecurityLog/Wazuh-Large_Number_of_Web_errors_from_an_IP.yaml
+++ b/Detections/CommonSecurityLog/Wazuh-Large_Number_of_Web_errors_from_an_IP.yaml
@@ -10,8 +10,7 @@ triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - Persistence
-query: | 
-
+query: |
   CommonSecurityLog
   | where DeviceProduct =~ "Wazuh"
   | where Activity has "Web server 400 error code."
@@ -30,7 +29,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/DeviceProcessEvents/SolarWinds_SUNBURST_Process-IOCs.yaml
+++ b/Detections/DeviceProcessEvents/SolarWinds_SUNBURST_Process-IOCs.yaml
@@ -21,7 +21,6 @@ tags:
   - Solorigate
   - NOBELIUM
 query:  |
-
   let excludeProcs = dynamic([@"\SolarWinds\Orion\APM\APMServiceControl.exe", @"\SolarWinds\Orion\ExportToPDFCmd.Exe", @"\SolarWinds.Credentials\SolarWinds.Credentials.Orion.WebApi.exe", @"\SolarWinds\Orion\Topology\SolarWinds.Orion.Topology.Calculator.exe", @"\SolarWinds\Orion\Database-Maint.exe", @"\SolarWinds.Orion.ApiPoller.Service\SolarWinds.Orion.ApiPoller.Service.exe", @"\Windows\SysWOW64\WerFault.exe"]);
   DeviceProcessEvents
   | where InitiatingProcessFileName =~ "solarwinds.businesslayerhost.exe"
@@ -47,5 +46,5 @@ entityMappings:
         columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Detections/DuoSecurity/TrustMonitorEvent.yaml
+++ b/Detections/DuoSecurity/TrustMonitorEvent.yaml
@@ -11,7 +11,6 @@ triggerThreshold: 0
 tactics:
   - CredentialAccess
 query: |
-
   let timeframe = ago(5m);
   DuoSecurityTrustMonitor_CL
   | where TimeGenerated >= timeframe
@@ -25,7 +24,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/GitHub/NRT Two Factor Authentication Disabled.yaml
+++ b/Detections/GitHub/NRT Two Factor Authentication Disabled.yaml
@@ -9,7 +9,6 @@ tactics:
 relevantTechniques:
   - T1562
 query: |
-
   GitHubAudit
   | where Action == "org.disable_two_factor_requirement"
   | project TimeGenerated, Action, Actor, Country, IPaddress, Repository
@@ -23,5 +22,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: NRT

--- a/Detections/GitHub/Security Vulnerability in Repo.yaml
+++ b/Detections/GitHub/Security Vulnerability in Repo.yaml
@@ -9,9 +9,8 @@ queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 query: |
-
   GitHubRepo
   | where Action == "vulnerabilityAlert"
   | project TimeGenerated, DismmisedAt, Reason, vulnerableManifestFilename, Description, Link, PublishedAt, Severity, Summary
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/GitHub/Threat Intel Matches to GitHub Audit Logs.yaml
+++ b/Detections/GitHub/Threat Intel Matches to GitHub Audit Logs.yaml
@@ -17,7 +17,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   ThreatIntelligenceIndicator
   | where Action == true
   // Picking up only IOC's that contain the entities we want
@@ -43,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/Heartbeat/MissingDCHearbeat.yaml
+++ b/Detections/Heartbeat/MissingDCHearbeat.yaml
@@ -12,7 +12,6 @@ tactics:
   - Impact
   - DefenseEvasion
 query: |
-
   let query_frequency = 15m;
   let missing_period = 1h;
   //Enter a reference list of hostnames for your DC servers
@@ -32,7 +31,7 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: Computer
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADAWSConsoleCorrelation.yaml
@@ -25,12 +25,11 @@ relevantTechniques:
   - T1078
   - T1110
 query: |
-
   //Adjust this threshold to fit your environment
-  let signin_threshold = 5; 
+  let signin_threshold = 5;
   //Make a list of IPs with AAD signin failures above our threshold
   let aadFunc = (tableName:string){
-  let Suspicious_signins = 
+  let Suspicious_signins =
   table(tableName)
   | where ResultType !in ("0", "50125", "50140")
   | where IPAddress !in ("127.0.0.1", "::1")
@@ -41,18 +40,18 @@ query: |
   };
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
-  let Suspicious_signins = 
+  let Suspicious_signins =
   union isfuzzy=true aadSignin, aadNonInt
   | summarize make_set(set_IPAddress);
   //See if any of those IPs have sucessfully logged into the AWS console
   AWSCloudTrail
   | where EventName =~ "ConsoleLogin"
-  | extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin) 
+  | extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin)
   | where LoginResult =~ "Success"
   | where SourceIpAddress in (Suspicious_signins)
   | extend Reason = "Multiple failed AAD logins from IP address"
   | extend MFAUsed = tostring(parse_json(AdditionalEventData).MFAUsed)
-  | extend User = iif(isempty(UserIdentityUserName), UserIdentityType, UserIdentityUserName) 
+  | extend User = iif(isempty(UserIdentityUserName), UserIdentityType, UserIdentityUserName)
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by Reason, LoginResult, EventTypeName, UserIdentityType, User, AWSRegion, SourceIpAddress, UserAgent, MFAUsed
   | extend timestamp = StartTimeUtc, AccountCustomEntity = User, IPCustomEntity = SourceIpAddress
 entityMappings:
@@ -64,7 +63,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
+++ b/Detections/MultipleDataSources/AADHostLoginCorrelation.yaml
@@ -16,13 +16,13 @@ requiredDataConnectors:
       - SecurityEvent
   - connectorId: Syslog
     dataTypes:
-      - Syslog 
+      - Syslog
   - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents 
+    dataTypes:
+      - SecurityEvents
   - connectorId: WindowsForwardedEvents
-    dataTypes: 
-      - WindowsEvent 
+    dataTypes:
+      - WindowsEvent
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -34,7 +34,6 @@ relevantTechniques:
   - T1078
   - T1110
 query: |
-
   //Adjust this threshold to fit the environment
   let signin_threshold = 5;
   //Make a list of all IPs with failed signins to AAD above our threshold
@@ -101,7 +100,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/AWSConsoleAADCorrelation.yaml
+++ b/Detections/MultipleDataSources/AWSConsoleAADCorrelation.yaml
@@ -21,15 +21,14 @@ tactics:
 relevantTechniques:
   - T1078
   - T1110
-  
-query: |
 
+query: |
   //Adjust this threshold to fit environment
-  let  signin_threshold = 5; 
+  let  signin_threshold = 5;
   //Make a list of IPs with failed AWS console logins
   let aws_fails = AWSCloudTrail
   | where EventName == "ConsoleLogin"
-  | extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin) 
+  | extend LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin)
   | where LoginResult != "Success"
   | where SourceIpAddress != "127.0.0.1"
   | summarize count() by SourceIpAddress
@@ -38,7 +37,7 @@ query: |
   //See if any of those IPs have sucessfully logged into Azure AD.
   SigninLogs
   | where ResultType in ("0", "50125", "50140")
-  | where IPAddress in (aws_fails) 
+  | where IPAddress in (aws_fails)
   | extend Reason = "Multiple failed AWS Console logins from IP address"
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress
 entityMappings:
@@ -50,7 +49,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
+++ b/Detections/MultipleDataSources/AnomalousIPUsageFollowedByTeamsAction.yaml
@@ -29,7 +29,6 @@ relevantTechniques:
   - T1078
   - T1098
 query: |
-
   //The bigger the window the better the data sample size, as we use IP prevalence, more sample data is better.
   //The minimum number of countries that the account has been accessed from [default: 2]
   let minimumCountries = 2;
@@ -110,7 +109,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/KnownPHOSPHORUSDomainsIP-October2020.yaml
+++ b/Detections/MultipleDataSources/KnownPHOSPHORUSDomainsIP-October2020.yaml
@@ -40,32 +40,31 @@ relevantTechniques:
   - T1071
   - T1566
 query: |
-
   let DomainNames = dynamic(["de-ma.online", "g20saudi.000webhostapp.com", "ksat20.000webhostapp.com"]);
   let EmailAddresses = dynamic(["munichconference1962@gmail.com","munichconference@outlook.de", "munichconference@outlook.com", "t20saudiarabia@gmail.com", "t20saudiarabia@hotmail.com", "t20saudiarabia@outlook.sa"]);
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
   (union isfuzzy=true
-  (CommonSecurityLog 
-  | parse Message with * '(' DNSName ')' * 
+  (CommonSecurityLog
+  | parse Message with * '(' DNSName ')' *
   | extend MessageIP = extract(IPRegex, 0, Message)
   | extend RequestURLIP = extract(IPRegex, 0, Message)
-  | where (isnotempty(DNSName) and DNSName has_any (DomainNames)) 
-    or (isnotempty(DestinationHostName) and DestinationHostName has_any (DomainNames)) 
+  | where (isnotempty(DNSName) and DNSName has_any (DomainNames))
+    or (isnotempty(DestinationHostName) and DestinationHostName has_any (DomainNames))
     or (isnotempty(RequestURL) and (RequestURL has_any (DomainNames)))
   | extend timestamp = TimeGenerated , AccountCustomEntity = SourceUserID, HostCustomEntity = DeviceName
   ),
-  (DnsEvents 
+  (DnsEvents
   | extend DestinationIPAddress = IPAddresses, DNSName = Name, Host = Computer
-  | where DNSName has_any (DomainNames) 
+  | where DNSName has_any (DomainNames)
   | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIPAddress, HostCustomEntity = Host),
-  (VMConnection 
+  (VMConnection
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | where isnotempty(DNSName)
   | where DNSName has_any (DomainNames)
   | extend timestamp = TimeGenerated , HostCustomEntity = Computer),
   (SecurityAlert
   | where ProviderName =~ 'OATP'
-  | extend UPN = case(isnotempty(parse_json(Entities)[0].Upn), parse_json(Entities)[0].Upn, 
+  | extend UPN = case(isnotempty(parse_json(Entities)[0].Upn), parse_json(Entities)[0].Upn,
                       isnotempty(parse_json(Entities)[1].Upn), parse_json(Entities)[1].Upn,
                       isnotempty(parse_json(Entities)[2].Upn), parse_json(Entities)[2].Upn,
                       isnotempty(parse_json(Entities)[3].Upn), parse_json(Entities)[3].Upn,
@@ -95,5 +94,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/MalformedUserAgents.yaml
+++ b/Detections/MultipleDataSources/MalformedUserAgents.yaml
@@ -36,7 +36,6 @@ relevantTechniques:
   - T1071
   - T1203
 query: |
-
   (union isfuzzy=true
   (OfficeActivity | where UserAgent != ""),
   (OfficeActivity
@@ -49,8 +48,8 @@ query: |
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent, SourceIP = ClientIP, Account = UserId, Type, RecordType, Operation
   ),
   (AzureDiagnostics
-  | where ResourceType =~ "APPLICATIONGATEWAYS" 
-  | where OperationName =~ "ApplicationGatewayAccess" 
+  | where ResourceType =~ "APPLICATIONGATEWAYS"
+  | where OperationName =~ "ApplicationGatewayAccess"
   | extend ClientIP = columnifexists("clientIP_s", "None"), UserAgent = columnifexists("userAgent_s", "None")
   | where UserAgent != '-'
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent, SourceIP = ClientIP,  requestUri_s, httpMethod_s, host_s, requestQuery_s, Type
@@ -69,7 +68,7 @@ query: |
   | where isnotempty(UserAgent)
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent, SourceIP = IPAddress, Account = UserPrincipalName, Type, OperationName, tostring(LocationDetails), tostring(DeviceDetail), AppDisplayName, ClientAppUsed
   ),
-  (AADNonInteractiveUserSignInLogs 
+  (AADNonInteractiveUserSignInLogs
   | where isnotempty(UserAgent)
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent, SourceIP = IPAddress, Account = UserPrincipalName, Type, OperationName, tostring(LocationDetails), tostring(DeviceDetail), AppDisplayName, ClientAppUsed
   )
@@ -95,7 +94,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/Manganese_VPN-IOCs.yaml
+++ b/Detections/MultipleDataSources/Manganese_VPN-IOCs.yaml
@@ -2,7 +2,7 @@ id: a04cf847-a832-4c60-b687-b0b6147da219
 name: Known Manganese IP and UserAgent activity
 description: |
   'Matches IP plus UserAgent IOCs in OfficeActivity data, along with IP plus Connection string information in the CommonSecurityLog data related to Manganese group activity.
-  References: 
+  References:
   https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44101/
   https://fortiguard.com/psirt/FG-IR-18-384'
 severity: High
@@ -21,7 +21,6 @@ relevantTechniques:
   - T1133
   - T1114
 query: |
-
   let IPList = dynamic(["45.63.52.41","140.82.17.161","207.148.101.95","45.32.87.51","66.42.98.156","45.76.144.105","217.163.28.35","45.32.141.174","149.28.165.249","209.250.225.247","45.63.100.115","95.179.229.230","209.250.233.247","45.77.121.232","45.76.175.65","104.238.160.237","45.77.181.97","95.179.192.125","149.28.93.184","140.82.16.81","45.76.173.103","45.77.255.22","45.32.11.71","149.28.77.26","45.32.54.50","104.156.233.156","45.32.21.118","45.63.62.109","45.77.244.202","149.248.11.205","104.238.190.244"]);
   let IOCTerms = "\\?lang=[/..]*/dev/cmdb/sslvpn_websession|/dana-na/jam/[/..]*home/webserver/htdocs/dana/html5acc/guacamole[/..]*etc/passwd\\?";
   (union isfuzzy=true
@@ -29,12 +28,12 @@ query: |
   | where isnotempty(SourceIP) or isnotempty(DestinationIP)
   | where SourceIP in (IPList) or DestinationIP in (IPList) or has_any_ipv4 (Message, IPList)
   | extend IPMatch = case(
-  SourceIP in (IPList), "SourceIP", 
+  SourceIP in (IPList), "SourceIP",
   DestinationIP in (IPList), "DestinationIP",
-  "Message") 
+  "Message")
   | where Message matches regex IOCTerms
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by SourceIP, DestinationIP, DeviceProduct, DeviceAction, Message, Protocol, SourcePort, DestinationPort, DeviceAddress, DeviceName, IPMatch
-  | extend timestamp = StartTimeUtc, IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "IP in Message Field") 
+  | extend timestamp = StartTimeUtc, IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP, "IP in Message Field")
   ),
   (OfficeActivity
   | where isnotempty(UserAgent) and ClientIP in (IPList)
@@ -52,5 +51,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
+++ b/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
@@ -1,8 +1,8 @@
 id:  0b9ae89d-8cad-461c-808f-0494f70ad5c4
 name: Multiple Password Reset by user
 description: |
-  'This query will determine multiple password resets by user across multiple data sources. 
-  Account manipulation including password reset may aid adversaries in maintaining access to credentials 
+  'This query will determine multiple password resets by user across multiple data sources.
+  Account manipulation including password reset may aid adversaries in maintaining access to credentials
   and certain permission levels within an environment.'
 severity: Low
 requiredDataConnectors:
@@ -19,11 +19,11 @@ requiredDataConnectors:
     dataTypes:
       - OfficeActivity
   - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents 
+    dataTypes:
+      - SecurityEvents
   - connectorId: WindowsForwardedEvents
-    dataTypes: 
-      - WindowsEvent   
+    dataTypes:
+      - WindowsEvent
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -35,7 +35,6 @@ relevantTechniques:
   - T1078
   - T1110
 query: |
-
   let PerUserThreshold = 5;
   let TotalThreshold = 100;
   let action = dynamic(["change", "changed", "reset"]);
@@ -61,14 +60,14 @@ query: |
   (//Azure Active Directory Password reset events
   AuditLogs
   | where OperationName has_any (pWord) and OperationName has_any (action) and Result =~ "success"
-  | extend AccountType = tostring(TargetResources[0].type), Account = tostring(TargetResources[0].userPrincipalName), 
+  | extend AccountType = tostring(TargetResources[0].type), Account = tostring(TargetResources[0].userPrincipalName),
   TargetUserName = tolower(tostring(TargetResources[0].displayName))
   | project TimeGenerated, AccountType, Account, Computer = "", Type),
   (//OfficeActive ActiveDirectory Password reset events
   OfficeActivity
-  | where OfficeWorkload == "AzureActiveDirectory" 
+  | where OfficeWorkload == "AzureActiveDirectory"
   | where (ExtendedProperties has_any (pWord) or ModifiedProperties has_any (pWord)) and (ExtendedProperties has_any (action) or ModifiedProperties has_any (action))
-  | extend AccountType = UserType, Account = OfficeObjectId 
+  | extend AccountType = UserType, Account = OfficeObjectId
   | project TimeGenerated, AccountType, Account, Type, Computer = ""),
   (// Unix syslog password reset events
   Syslog
@@ -81,11 +80,11 @@ query: |
   );
   let pwrmd = PasswordResetMultiDataSource
   | project TimeGenerated, Computer, AccountType, Account, Type, TargetUserName;
-  (union isfuzzy=true  
+  (union isfuzzy=true
   (pwrmd
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), Computerlist = make_set(Computer, 25), AccountType = make_set(AccountType, 25), Computer = arg_max(Computer , TimeGenerated), TargetUserList = make_set(TargetUserName, 25), TargetUserName = arg_max(TargetUserName, TimeGenerated), Total=count() by Account, Type
   | where Total > PerUserThreshold
-  | extend ResetPivot = "PerUserReset"),  
+  | extend ResetPivot = "PerUserReset"),
   (pwrmd
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ComputerList = make_set(Computer, 25), AccountList = make_set(Account, 25), AccountType = make_set(AccountType, 25), Computer = arg_max(Computer , TimeGenerated), TargetUserList = make_set(TargetUserName, 25), TargetUserName = arg_max(TargetUserName, TimeGenerated), Total=count() by Type
   | where Total > TotalThreshold
@@ -105,7 +104,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: TargetUserName
-version: 2.1.2
+version: 2.1.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
+++ b/Detections/MultipleDataSources/PHOSPHORUSMarch2019IOCs.yaml
@@ -27,25 +27,25 @@ requiredDataConnectors:
     dataTypes:
       - OfficeActivity
   - connectorId: AzureFirewall
-    dataTypes: 
+    dataTypes:
       - AzureDiagnostics
   - connectorId: Zscaler
     dataTypes:
       - CommonSecurityLog
   - connectorId: InfobloxNIOS
-    dataTypes: 
+    dataTypes:
       - Syslog
   - connectorId: GCPDNSDataConnector
-    dataTypes: 
+    dataTypes:
       - GCP_DNS_CL
   - connectorId: NXLogDnsLogs
-    dataTypes: 
+    dataTypes:
       - NXLog_DNS_Server_CL
   - connectorId: CiscoUmbrellaDataConnector
-    dataTypes: 
+    dataTypes:
       - Cisco_Umbrella_dns_CL
   - connectorId: Corelight
-    dataTypes: 
+    dataTypes:
       - Corelight_CL
 
 queryFrequency: 1d
@@ -57,9 +57,8 @@ tactics:
 relevantTechniques:
   - T1071
 query: |
-
   let DomainNames = dynamic(["yahoo-verification.org","support-servics.com","verification-live.com","com-mailbox.com","com-myaccuants.com","notification-accountservice.com",
-  "accounts-web-mail.com","customer-certificate.com","session-users-activities.com","user-profile-credentials.com","verify-linke.com","support-servics.net","verify-linkedin.net", 
+  "accounts-web-mail.com","customer-certificate.com","session-users-activities.com","user-profile-credentials.com","verify-linke.com","support-servics.net","verify-linkedin.net",
   "yahoo-verification.net","yahoo-verify.net","outlook-verify.net","com-users.net","verifiy-account.net","te1egram.net","account-verifiy.net","myaccount-services.net",
   "com-identifier-servicelog.name","microsoft-update.bid","outlook-livecom.bid","update-microsoft.bid","documentsfilesharing.cloud","com-microsoftonline.club",
   "confirm-session-identifier.info","session-management.info","confirmation-service.info","document-share.info","broadcast-news.info","customize-identity.info","webemail.info",
@@ -77,14 +76,14 @@ query: |
   let IPList = dynamic(["51.91.200.147"]);
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
   (union isfuzzy=true
-  (CommonSecurityLog 
-  | parse Message with * '(' DNSName ')' * 
+  (CommonSecurityLog
+  | parse Message with * '(' DNSName ')' *
   | extend MessageIP = extract(IPRegex, 0, Message)
   | extend RequestURLIP = extract(IPRegex, 0, Message)
-  | where (isnotempty(SourceIP) and SourceIP in (IPList)) or (isnotempty(DestinationIP) and DestinationIP in (IPList)) 
-  or (isnotempty(DNSName) and DNSName in~ (DomainNames)) or (isnotempty(DestinationHostName) and DestinationHostName in~ (DomainNames)) or (isnotempty(RequestURL) and (RequestURL has_any (DomainNames) or RequestURLIP in (IPList))) 
+  | where (isnotempty(SourceIP) and SourceIP in (IPList)) or (isnotempty(DestinationIP) and DestinationIP in (IPList))
+  or (isnotempty(DNSName) and DNSName in~ (DomainNames)) or (isnotempty(DestinationHostName) and DestinationHostName in~ (DomainNames)) or (isnotempty(RequestURL) and (RequestURL has_any (DomainNames) or RequestURLIP in (IPList)))
   or (isnotempty(Message) and MessageIP in (IPList))
-  | extend IPMatch = case(SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", MessageIP in (IPList), "Message", RequestURLIP in (IPList), "RequestUrl", "NoMatch") 
+  | extend IPMatch = case(SourceIP in (IPList), "SourceIP", DestinationIP in (IPList), "DestinationIP", MessageIP in (IPList), "Message", RequestURLIP in (IPList), "RequestUrl", "NoMatch")
   | extend timestamp = TimeGenerated , IPCustomEntity = case(IPMatch == "SourceIP", SourceIP, IPMatch == "DestinationIP", DestinationIP,IPMatch == "Message", MessageIP,
   IPMatch == "RequestUrl", RequestURLIP,"NoMatch"), Account = SourceUserID, Host = DeviceName
   ),
@@ -97,24 +96,24 @@ query: |
   (_Im_WebSession(url_has_any=DomainNames)
   | extend DestinationIPAddress = DstIpAddr, DNSName = tostring(parse_url(Url)["Host"]), Host = Dvc
   | extend timestamp = TimeGenerated, IPCustomEntity = SrcIpAddr, HostCustomEntity = Host),
-  (VMConnection 
+  (VMConnection
   | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
   | where isnotempty(SourceIp) or isnotempty(DestinationIp) or isnotempty(DNSName)
   | where SourceIp in (IPList) or DestinationIp in (IPList) or DNSName in~ (DomainNames)
-  | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None") 
+  | extend IPMatch = case( SourceIp in (IPList), "SourceIP", DestinationIp in (IPList), "DestinationIP", "None")
   | extend timestamp = TimeGenerated , IPCustomEntity = case(IPMatch == "SourceIP", SourceIp, IPMatch == "DestinationIP", DestinationIp, "None"), Host = Computer),
   (OfficeActivity
   | extend SourceIPAddress = ClientIP, Account = UserId
   | where  SourceIPAddress in (IPList)
   | extend timestamp = TimeGenerated , IPCustomEntity = SourceIPAddress , AccountCustomEntity = Account),
-  (AzureDiagnostics 
+  (AzureDiagnostics
   | where ResourceType == "AZUREFIREWALLS"
   | where Category == "AzureFirewallApplicationRule"
   | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
   | where isnotempty(DestinationHost)
-  | where DestinationHost has_any (DomainNames)  
-  | extend DNSName = DestinationHost 
-  | extend IPCustomEntity = SourceHost 
+  | where DestinationHost has_any (DomainNames)
+  | extend DNSName = DestinationHost
+  | extend IPCustomEntity = SourceHost
   )
   )
 entityMappings:
@@ -130,5 +129,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.4.1
+version: 1.4.2
 kind: Scheduled

--- a/Detections/MultipleDataSources/SigninFirewallCorrelation.yaml
+++ b/Detections/MultipleDataSources/SigninFirewallCorrelation.yaml
@@ -1,7 +1,7 @@
 id: 157c0cfc-d76d-463b-8755-c781608cdc1a
 name: Cisco - firewall block but success logon to Azure AD
 description: |
-  'Correlate IPs blocked by a Cisco firewall appliance with successful Azure Active Directory signins. 
+  'Correlate IPs blocked by a Cisco firewall appliance with successful Azure Active Directory signins.
   Because the IP was blocked by the firewall, that same IP logging on successfully to AAD is potentially suspect
   and could indicate credential compromise for the user account.'
 severity: Medium
@@ -24,7 +24,6 @@ tactics:
 relevantTechniques:
   - T1078
 query: |
-
   let aadFunc = (tableName:string){
   CommonSecurityLog
   | where DeviceVendor =~ "Cisco"
@@ -36,7 +35,7 @@ query: |
       // Include fully successful sign-ins, but also ones that failed only at MFA stage
       // as that supposes the password was sucessfully guessed.
     table(tableName)
-    | where ResultType in ("0", "50074", "50076") 
+    | where ResultType in ("0", "50074", "50076")
   ) on $left.SourceIP == $right.IPAddress
   | extend timestamp = TimeGenerated, IPCustomEntity = SourceIP, AccountCustomEntity = UserPrincipalName
   };
@@ -52,7 +51,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/Solorigate-VM-Network.yaml
+++ b/Detections/MultipleDataSources/Solorigate-VM-Network.yaml
@@ -1,34 +1,33 @@
 id: ab4b6944-a20d-42ab-8b63-238426525801
 name: Solorigate Domains Found in VM Insights
-description: | 
+description: |
   'Identifies connections to Solorigate-related DNS records based on VM insights data'
-severity: High 
-requiredDataConnectors: 
-  - connectorId: AzureMonitor(VMInsights) 
-    dataTypes: 
-      - VMConnection 
-  - connectorId: AzureMonitor(VMInsights) 
-    dataTypes: 
+severity: High
+requiredDataConnectors:
+  - connectorId: AzureMonitor(VMInsights)
+    dataTypes:
+      - VMConnection
+  - connectorId: AzureMonitor(VMInsights)
+    dataTypes:
       - VMProcess
-  - connectorId: AzureMonitor(VMInsights) 
-    dataTypes: 
+  - connectorId: AzureMonitor(VMInsights)
+    dataTypes:
       - VMComputer
-queryFrequency: 1h 
+queryFrequency: 1h
 queryPeriod: 1h
-triggerOperator: gt 
-triggerThreshold: 0 
-tactics: 
-  - CommandAndControl 
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CommandAndControl
 relevantTechniques:
   - T1102
 tags:
   - Solorigate
   - NOBELIUM
-query:  |  
-
+query:  |
   let domains = dynamic(["incomeupdate.com","zupertech.com","databasegalore.com","panhardware.com","avsvmcloud.com","digitalcollege.org","freescanonline.com","deftsecurity.com","thedoccloud.com","virtualdataserver.com","lcomputers.com","webcodez.com","globalnetworkissues.com","kubecloud.com","seobundlekit.com","solartrackingsystem.net","virtualwebdata.com"]);
   let timeframe = 1h;
-  let connections = VMConnection 
+  let connections = VMConnection
       | where TimeGenerated >= ago(timeframe)
       | extend DNSName = set_union(todynamic(RemoteDnsCanonicalNames),todynamic(RemoteDnsQuestions))
       | mv-expand DNSName
@@ -48,7 +47,7 @@ query:  |
       | project HostCustomEntity = HostName, AzureResourceId = _ResourceId, AgentId, Machine;
   connections | join kind = inner (processes) on AgentId, Machine, Process
               | join kind = inner (computers) on AgentId, Machine
-               
+
 
 entityMappings:
   - entityType: Host
@@ -58,7 +57,7 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity 
+        columnName: IPCustomEntity
   - entityType: DNS
     fieldMappings:
       - identifier: DomainName
@@ -74,6 +73,6 @@ entityMappings:
       - identifier: Directory
         columnName: DirectoryName
       - identifier: Name
-        columnName: Filename       
-version: 1.0.0
+        columnName: Filename
+version: 1.0.1
 kind: Scheduled

--- a/Detections/MultipleDataSources/TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
+++ b/Detections/MultipleDataSources/TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
@@ -29,7 +29,6 @@ relevantTechniques:
 tags:
   - DEV-0537
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   let timeframe = 1h;
@@ -113,7 +112,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled
 metadata:
     source:

--- a/Detections/QualysVM/HighNumberofVulnDetected.yaml
+++ b/Detections/QualysVM/HighNumberofVulnDetected.yaml
@@ -5,7 +5,7 @@ description: |
 severity: Medium
 requiredDataConnectors:
   - connectorId: QualysVulnerabilityManagement
-    dataTypes: 
+    dataTypes:
       - QualysHostDetection_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -16,7 +16,6 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-
   let threshold = 10;
   QualysHostDetection_CL
   | mv-expand todynamic(Detections_s)
@@ -33,7 +32,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/QualysVM/NewHighSeverityVulnDetectedAcrossMulitpleHosts.yaml
+++ b/Detections/QualysVM/NewHighSeverityVulnDetectedAcrossMulitpleHosts.yaml
@@ -5,7 +5,7 @@ description: |
 severity: Medium
 requiredDataConnectors:
   - connectorId: QualysVulnerabilityManagement
-    dataTypes: 
+    dataTypes:
       - QualysHostDetection_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -16,7 +16,6 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-
   let threshold = 10;
   QualysHostDetection_CL
   | mv-expand todynamic(Detections_s)
@@ -25,7 +24,7 @@ query: |
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), dcount(NetBios_s) by tostring(Detections_s.QID)
   | where dcount_NetBios_s >= threshold
   | extend timestamp = StartTime
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityAlert/Solorigate-Defender-Detections.yaml
+++ b/Detections/SecurityAlert/Solorigate-Defender-Detections.yaml
@@ -1,7 +1,7 @@
 id: e70fa6e0-796a-4e85-9420-98b17b0bb749
 name: Solorigate Defender Detections
 description: |
-  'Surfaces any Defender Alert for Solorigate Events. In Microsoft Sentinel the SecurityAlerts table includes only the Device Name of the affected device, this query joins the DeviceInfo table to clearly connect other information such as 
+  'Surfaces any Defender Alert for Solorigate Events. In Microsoft Sentinel the SecurityAlerts table includes only the Device Name of the affected device, this query joins the DeviceInfo table to clearly connect other information such as
    Device group, ip, logged on users etc. This way, the Microsoft Sentinel user can have all the pertinent device info in one view for all the the Solarigate Defender alerts.'
 severity: High
 requiredDataConnectors:
@@ -23,7 +23,6 @@ tags:
   - Solorigate
   - NOBELIUM
 query: |
-
   DeviceInfo
   | extend DeviceName = tolower(DeviceName)
   | join (SecurityAlert
@@ -34,7 +33,7 @@ query: |
   ) on $left.DeviceName == $right.HostCustomEntity
   | project TimeGenerated, DisplayName, ThreatName, CompromisedEntity, PublicIP, MachineGroup, AlertSeverity, Description, LoggedOnUsers, DeviceId, TenantId, HostCustomEntity
   | extend timestamp = TimeGenerated, IPCustomEntity = PublicIP
-  
+
 entityMappings:
   - entityType: Host
     fieldMappings:
@@ -44,7 +43,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/PotentialKerberoast.yaml
+++ b/Detections/SecurityEvent/PotentialKerberoast.yaml
@@ -1,11 +1,11 @@
 id: 1572e66b-20a7-4012-9ec4-77ec4b101bc8
 name: Potential Kerberoasting
 description: |
-  'A service principal name (SPN) is used to uniquely identify a service instance in a Windows environment. 
-  Each SPN is usually associated with a service account. Organizations may have used service accounts with weak passwords in their environment. 
-  An attacker can try requesting Kerberos ticket-granting service (TGS) service tickets for any SPN from a domain controller (DC) which contains 
-  a hash of the Service account. This can then be used for offline cracking. This hunting query looks for accounts that are generating excessive 
-  requests to different resources within the last hour compared with the previous 24 hours.  Normal users would not make an unusually large number 
+  'A service principal name (SPN) is used to uniquely identify a service instance in a Windows environment.
+  Each SPN is usually associated with a service account. Organizations may have used service accounts with weak passwords in their environment.
+  An attacker can try requesting Kerberos ticket-granting service (TGS) service tickets for any SPN from a domain controller (DC) which contains
+  a hash of the Service account. This can then be used for offline cracking. This hunting query looks for accounts that are generating excessive
+  requests to different resources within the last hour compared with the previous 24 hours.  Normal users would not make an unusually large number
   of request within a small time window. This is based on 4769 events which can be very noisy so environment based tweaking might be needed.'
 severity: Medium
 requiredDataConnectors:
@@ -27,7 +27,6 @@ tactics:
 relevantTechniques:
   - T1558
 query: |
-
   let starttime = 1d;
   let endtime = 1h;
   let prev23hThreshold = 4;
@@ -43,7 +42,7 @@ query: |
   | parse EventData with * 'Status">' Status "<" *
   | where Status == '0x0'
   | parse EventData with * 'ServiceName">' ServiceName "<" *
-  | where ServiceName !contains "$" and ServiceName !contains "krbtgt" 
+  | where ServiceName !contains "$" and ServiceName !contains "krbtgt"
   | parse EventData with * 'TargetUserName">' TargetUserName "<" *
   | where TargetUserName !contains "$@" and TargetUserName !contains ServiceName
   | parse EventData with * 'IpAddress">::ffff:' ClientIPAddress "<" *
@@ -60,28 +59,28 @@ query: |
   | where Status == '0x0'
   | extend ServiceName = tostring(EventData.ServiceName)
   | where ServiceName !contains "$" and ServiceName !contains "krbtgt"
-  | extend TargetUserName = tostring(EventData.TargetUserName) 
+  | extend TargetUserName = tostring(EventData.TargetUserName)
   | where TargetUserName !contains "$@" and TargetUserName !contains ServiceName
-  | extend ClientIPAddress = tostring(EventData.IpAddress) 
+  | extend ClientIPAddress = tostring(EventData.IpAddress)
   ));
   let Kerbevent23h = Kerbevent
   | where TimeGenerated >= ago(starttime) and TimeGenerated < ago(endtime)
-  | summarize ServiceNameCountPrev23h = dcount(ServiceName), ServiceNameSet23h = makeset(ServiceName) 
+  | summarize ServiceNameCountPrev23h = dcount(ServiceName), ServiceNameSet23h = makeset(ServiceName)
   by Computer, TargetUserName,TargetDomainName, ClientIPAddress, TicketOptions, TicketEncryptionType, Status
   | where ServiceNameCountPrev23h < prev23hThreshold;
-  let Kerbevent1h = 
+  let Kerbevent1h =
   Kerbevent
   | where TimeGenerated >= ago(endtime)
-  | summarize min(TimeGenerated), max(TimeGenerated), ServiceNameCountPrev1h = dcount(ServiceName), ServiceNameSet1h = makeset(ServiceName) 
+  | summarize min(TimeGenerated), max(TimeGenerated), ServiceNameCountPrev1h = dcount(ServiceName), ServiceNameSet1h = makeset(ServiceName)
   by Computer, TargetUserName,TargetDomainName, ClientIPAddress, TicketOptions, TicketEncryptionType, Status;
-  Kerbevent1h 
+  Kerbevent1h
   | join kind=leftanti
   (
   Kerbevent23h
   ) on TargetUserName, TargetDomainName
   // Threshold value set above is based on testing, this value may need to be changed for your environment.
   | where ServiceNameCountPrev1h > prev1hThreshold
-  | project StartTimeUtc = min_TimeGenerated, EndTimeUtc = max_TimeGenerated, TargetUserName, Computer, ClientIPAddress, TicketOptions, 
+  | project StartTimeUtc = min_TimeGenerated, EndTimeUtc = max_TimeGenerated, TargetUserName, Computer, ClientIPAddress, TicketOptions,
   TicketEncryptionType, Status, ServiceNameCountPrev1h, ServiceNameSet1h, TargetDomainName
   | extend timestamp = StartTimeUtc, AccountCustomEntity = strcat(TargetDomainName,"\\", TargetUserName), HostCustomEntity = Computer, IPCustomEntity = ClientIPAddress
 entityMappings:
@@ -97,7 +96,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
+++ b/Detections/SecurityEvent/RDP_MultipleConnectionsFromSingleSystem.yaml
@@ -24,7 +24,6 @@ tactics:
 relevantTechniques:
   - T1021
 query: |
-
   let endtime = 1d;
   let starttime = 8d;
   let threshold = 2.0;
@@ -36,7 +35,7 @@ query: |
   by Account, IpAddress, AccountType, Activity, LogonTypeName),
   (WindowsEvent
   | where TimeGenerated >= ago(endtime)
-  | where EventID == 4624 
+  | where EventID == 4624
   | extend LogonType = tostring(EventData.LogonType)
   | where  LogonType == 10
   | extend ProcessName = tostring(EventData.ProcessName)
@@ -80,7 +79,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/RDP_Nesting.yaml
+++ b/Detections/SecurityEvent/RDP_Nesting.yaml
@@ -24,7 +24,6 @@ tactics:
 relevantTechniques:
   - T1021
 query: |
-
   let endtime = 1d;
   let starttime = 8d;
   // The threshold below excludes matching on RDP connection computer counts of 5 or more by a given account and IP in a given day.  Change the threshold as needed.
@@ -86,7 +85,7 @@ query: |
   | where TimeGenerated >= ago(starttime) and TimeGenerated < ago(endtime)
   | where EventID == 4624 and EventData has ("10")
   | extend LogonType = tostring(EventData.LogonType)
-  | where  LogonType == 10 
+  | where  LogonType == 10
   | extend Account = strcat(tostring(EventData.TargetDomainName),"\\", tostring(EventData.TargetUserName))
   | extend IpAddress = tostring(EventData.IpAddress)
   | summarize makeset(Computer), ComputerCount = dcount(Computer) by bin(TimeGenerated, 1d), Account = tolower(Account), IpAddress
@@ -96,7 +95,7 @@ query: |
   | extend Computer = toupper(set_Computer)
   ))
   ) on Account, $left.SecondComputer == $right.Computer, $left.SecondIPAddress == $right.IpAddress
-  | summarize FirstHopFirstSeen = min(FirstHop), FirstHopLastSeen = max(FirstHop) by Account, FirstComputer, FirstIPAddress, SecondHop, SecondComputer, 
+  | summarize FirstHopFirstSeen = min(FirstHop), FirstHopLastSeen = max(FirstHop) by Account, FirstComputer, FirstIPAddress, SecondHop, SecondComputer,
   SecondIPAddress, AccountType, Activity, LogonTypeName, ProcessName
   | extend timestamp = FirstHopFirstSeen, AccountCustomEntity = Account, HostCustomEntity = FirstComputer, IPCustomEntity = FirstIPAddress
 entityMappings:
@@ -112,7 +111,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/RDP_RareConnection.yaml
+++ b/Detections/SecurityEvent/RDP_RareConnection.yaml
@@ -23,7 +23,6 @@ tactics:
 relevantTechniques:
   - T1021
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   (union isfuzzy=true
@@ -38,7 +37,7 @@ query: |
   | where TimeGenerated >= ago(endtime)
   | where EventID == 4624 and EventData has ("10")
   | extend LogonType = tostring(EventData.LogonType)
-  | where  LogonType == 10 
+  | where  LogonType == 10
   | extend Account = strcat(tostring(EventData.TargetDomainName),"\\", tostring(EventData.TargetUserName))
   | extend ProcessName = tostring(EventData.ProcessName)
   | extend IpAddress = tostring(EventData.IpAddress)
@@ -80,7 +79,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/SolorigateNamedPipe.yaml
+++ b/Detections/SecurityEvent/SolorigateNamedPipe.yaml
@@ -1,5 +1,5 @@
 id: 11b4c19d-2a79-4da3-af38-b067e1273dee
-name: Solorigate Named Pipe 
+name: Solorigate Named Pipe
 description: |
   'Identifies a match across various data feeds for named pipe IOCs related to the Solorigate incident.
    For the sysmon events required for this detection, logging for Named Pipe Events needs to be configured in Sysmon config (Event ID 17 and Event ID 18)
@@ -28,7 +28,6 @@ tags:
   - Solorigate
   - NOBELIUM
 query: |
-
   (union isfuzzy=true
   (Event
   | where Source == "Microsoft-Windows-Sysmon"
@@ -45,16 +44,16 @@ query: |
   (
   SecurityEvent
   | where EventID == '5145'
-  // %%4418 looks for presence of CreatePipeInstance value 
-  | where AccessList has '%%4418'     
+  // %%4418 looks for presence of CreatePipeInstance value
+  | where AccessList has '%%4418'
   | where RelativeTargetName has '583da945-62af-10e8-4902-a8f205c72b2e'
   ),
   (
   WindowsEvent
-  | where EventID == '5145' and EventData has '%%4418'  and EventData has '583da945-62af-10e8-4902-a8f205c72b2e' 
-  // %%4418 looks for presence of CreatePipeInstance value 
+  | where EventID == '5145' and EventData has '%%4418'  and EventData has '583da945-62af-10e8-4902-a8f205c72b2e'
+  // %%4418 looks for presence of CreatePipeInstance value
   | extend AccessList= tostring(EventData.AccessList)
-  | where AccessList has '%%4418'     
+  | where AccessList has '%%4418'
   | extend RelativeTargetName= tostring(EventData.RelativeTargetName)
   | where RelativeTargetName has '583da945-62af-10e8-4902-a8f205c72b2e'
   | extend Account =  strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
@@ -71,7 +70,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/UserAccountAdd-Removed.yaml
+++ b/Detections/SecurityEvent/UserAccountAdd-Removed.yaml
@@ -1,7 +1,7 @@
 id: 7efc75ce-e2a4-400f-a8b1-283d3b0f2c60
 name: Account added and removed from privileged groups
 description: |
-  'Identifies accounts that are added to privileged group and then quickly removed, which could be a sign of compromise.' 
+  'Identifies accounts that are added to privileged group and then quickly removed, which could be a sign of compromise.'
 severity: Low
 requiredDataConnectors:
   - connectorId: SecurityEvents
@@ -24,26 +24,25 @@ relevantTechniques:
   - T1098
   - T1078
 query: |
-
   let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]$";
   let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-498$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1000$";
-  let AC_Add = 
-  (union isfuzzy=true 
+  let AC_Add =
+  (union isfuzzy=true
   (SecurityEvent
   // Event ID related to member addition.
-  | where EventID in (4728, 4732,4756) 
-  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID  
+  | where EventID in (4728, 4732,4756)
+  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
   | parse EventData with * '"MemberName">' * '=' AccountAdded ",OU" *
   | where isnotempty(AccountAdded)
-  | extend GroupAddedTo = TargetUserName, AddingAccount = Account 
+  | extend GroupAddedTo = TargetUserName, AddingAccount = Account
   | extend  AccountAdded_GroupAddedTo_AddingAccount = strcat(AccountAdded, "||", GroupAddedTo, "||", AddingAccount )
   | project AccountAdded_GroupAddedTo_AddingAccount, AccountAddedTime = TimeGenerated
   ),
   (WindowsEvent
   // Event ID related to member addition.
-  | where EventID in (4728, 4732,4756) 
+  | where EventID in (4728, 4732,4756)
   | extend TargetSid = tostring(EventData.TargetSid)
-  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID  
+  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
   | parse EventData.MemberName with * '"MemberName">' * '=' AccountAdded ",OU" *
   | where isnotempty(AccountAdded)
   | extend TargetUserName = tostring(EventData.TargetUserName)
@@ -53,25 +52,25 @@ query: |
   | project AccountAdded_GroupAddedTo_AddingAccount, AccountAddedTime = TimeGenerated
   )
   );
-  let AC_Remove = 
-  ( union isfuzzy=true 
+  let AC_Remove =
+  ( union isfuzzy=true
   (SecurityEvent
   // Event IDs related to member removal.
   | where EventID in (4729,4733,4757)
-  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID 
-  | parse EventData with * '"MemberName">' * '=' AccountRemoved ",OU" * 
+  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
+  | parse EventData with * '"MemberName">' * '=' AccountRemoved ",OU" *
   | where isnotempty(AccountRemoved)
   | extend GroupRemovedFrom = TargetUserName, RemovingAccount = Account
   | extend AccountRemoved_GroupRemovedFrom_RemovingAccount = strcat(AccountRemoved, "||", GroupRemovedFrom, "||", RemovingAccount)
-  | project AccountRemoved_GroupRemovedFrom_RemovingAccount, AccountRemovedTime = TimeGenerated, Computer, RemovedAccountId = tolower(AccountRemoved), 
+  | project AccountRemoved_GroupRemovedFrom_RemovingAccount, AccountRemovedTime = TimeGenerated, Computer, RemovedAccountId = tolower(AccountRemoved),
   RemovedByUser = SubjectUserName, RemovedByUserLogonId = SubjectLogonId,  GroupRemovedFrom = TargetUserName, TargetDomainName
   ),
   (WindowsEvent
   // Event IDs related to member removal.
   | where EventID in (4729,4733,4757)
   | extend TargetSid = tostring(EventData.TargetSid)
-  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID 
-  | parse EventData.MemberName with * '"MemberName">' * '=' AccountRemoved ",OU" * 
+  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
+  | parse EventData.MemberName with * '"MemberName">' * '=' AccountRemoved ",OU" *
   | where isnotempty(AccountRemoved)
   | extend TargetUserName = tostring(EventData.TargetUserName)
   | extend RemovingAccount =  strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
@@ -80,11 +79,11 @@ query: |
   | extend SubjectUserName = tostring(EventData.SubjectUserName)
   | extend SubjectLogonId = tostring(EventData.SubjectLogonId)
   | extend TargetDomainName = tostring(EventData.TargetDomainName)
-  | project AccountRemoved_GroupRemovedFrom_RemovingAccount, AccountRemovedTime = TimeGenerated, Computer, RemovedAccountId = tolower(AccountRemoved), 
+  | project AccountRemoved_GroupRemovedFrom_RemovingAccount, AccountRemovedTime = TimeGenerated, Computer, RemovedAccountId = tolower(AccountRemoved),
   RemovedByUser = SubjectUserName, RemovedByUserLogonId = SubjectLogonId,  GroupRemovedFrom = TargetUserName, TargetDomainName
-  )); 
-  AC_Add 
-  | join kind= inner AC_Remove on $left.AccountAdded_GroupAddedTo_AddingAccount == $right.AccountRemoved_GroupRemovedFrom_RemovingAccount 
+  ));
+  AC_Add
+  | join kind= inner AC_Remove on $left.AccountAdded_GroupAddedTo_AddingAccount == $right.AccountRemoved_GroupRemovedFrom_RemovingAccount
   | extend DurationinSecondAfter_Removed = datetime_diff ('second', AccountRemovedTime, AccountAddedTime)
   | where DurationinSecondAfter_Removed > 0
   | project-away AccountRemoved_GroupRemovedFrom_RemovingAccount
@@ -98,7 +97,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -1,7 +1,7 @@
 id: a35f2c18-1b97-458f-ad26-e033af18eb99
 name: User account added to built in domain local or global group
 description: |
-  'Identifies when a user account has been added to a privileged built in domain local group or global group 
+  'Identifies when a user account has been added to a privileged built in domain local group or global group
   such as the Enterprise Admins, Cert Publishers or DnsAdmins. Be sure to verify this is an expected addition.'
 severity: Low
 requiredDataConnectors:
@@ -25,11 +25,10 @@ relevantTechniques:
   - T1098
   - T1078
 query: |
-
   // For AD SID mappings - https://docs.microsoft.com/windows/security/identity-protection/access-control/active-directory-security-groups
   let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]$";
   let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-498$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1000$";
-  union isfuzzy=true 
+  union isfuzzy=true
   (
   SecurityEvent
   // 4728 - A member was added to a security-enabled global group
@@ -44,7 +43,7 @@ query: |
   | project TimeGenerated, EventID, Activity, Computer, SimpleMemberName, MemberName, MemberSid, TargetUserName, TargetDomainName, TargetSid, UserPrincipalName, SubjectUserName, SubjectUserSid
   ),
   (
-  WindowsEvent 
+  WindowsEvent
   // 4728 - A member was added to a security-enabled global group
   // 4732 - A member was added to a security-enabled local group
   // 4756 - A member was added to a security-enabled universal group
@@ -75,7 +74,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: Computer
-version: 1.3.4
+version: 1.3.5
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityEvent/password_never_expires.yaml
+++ b/Detections/SecurityEvent/password_never_expires.yaml
@@ -24,17 +24,16 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
- union isfuzzy=true 
+ union isfuzzy=true
  (
   SecurityEvent
   | where EventID == 4738
   // 2089 value indicates the Don't Expire Password value has been set
-  | where UserAccountControl has "%%2089" 
+  | where UserAccountControl has "%%2089"
   | extend Value_2089 = iff(UserAccountControl has "%%2089","'Don't Expire Password' - Enabled", "Not Changed")
-  // 2050 indicates that the Password Not Required value is NOT set, this often shows up at the same time as a 2089 and is the recommended value.  This value may not be in the event. 
+  // 2050 indicates that the Password Not Required value is NOT set, this often shows up at the same time as a 2089 and is the recommended value.  This value may not be in the event.
   | extend Value_2050 = iff(UserAccountControl has "%%2050","'Password Not Required' - Disabled", "Not Changed")
-  // If value %%2082 is present in the 4738 event, this indicates the account has been configured to logon WITHOUT a password. Generally you should only see this value when an account is created and only in Event 4720: Account Creation Event.  
+  // If value %%2082 is present in the 4738 event, this indicates the account has been configured to logon WITHOUT a password. Generally you should only see this value when an account is created and only in Event 4720: Account Creation Event.
   | extend Value_2082 = iff(UserAccountControl has "%%2082","'Password Not Required' - Enabled", "Not Changed")
   | project StartTime = TimeGenerated, EventID, Activity, Computer, TargetAccount, TargetSid, AccountType, UserAccountControl, Value_2089, Value_2050, Value_2082, SubjectAccount
   | extend timestamp = StartTime, AccountCustomEntity = TargetAccount, HostCustomEntity = Computer
@@ -44,11 +43,11 @@ query: |
   | where EventID == 4738 and EventData has '2089'
   // 2089 value indicates the Don't Expire Password value has been set
   | extend UserAccountControl = tostring(EventData.UserAccountControl)
-  | where UserAccountControl has "%%2089" 
+  | where UserAccountControl has "%%2089"
   | extend Value_2089 = iff(UserAccountControl has "%%2089","'Don't Expire Password' - Enabled", "Not Changed")
-  // 2050 indicates that the Password Not Required value is NOT set, this often shows up at the same time as a 2089 and is the recommended value.  This value may not be in the event. 
+  // 2050 indicates that the Password Not Required value is NOT set, this often shows up at the same time as a 2089 and is the recommended value.  This value may not be in the event.
   | extend Value_2050 = iff(UserAccountControl has "%%2050","'Password Not Required' - Disabled", "Not Changed")
-  // If value %%2082 is present in the 4738 event, this indicates the account has been configured to logon WITHOUT a password. Generally you should only see this value when an account is created and only in Event 4720: Account Creation Event.  
+  // If value %%2082 is present in the 4738 event, this indicates the account has been configured to logon WITHOUT a password. Generally you should only see this value when an account is created and only in Event 4720: Account Creation Event.
   | extend Value_2082 = iff(UserAccountControl has "%%2082","'Password Not Required' - Enabled", "Not Changed")
   | extend Activity="4738 - A user account was changed."
   | extend TargetAccount = strcat(EventData.TargetDomainName,"\\", EventData.TargetUserName)
@@ -71,7 +70,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.2
+version: 1.1.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/Syslog/squid_cryptomining_pools.yaml
+++ b/Detections/Syslog/squid_cryptomining_pools.yaml
@@ -1,12 +1,12 @@
 id: 80733eb7-35b2-45b6-b2b8-3c51df258206
 name: Squid proxy events related to mining pools
 description: |
-  'Checks for Squid proxy events in Syslog associated with common mining pools .This query presumes the default Squid log format is being used. 
+  'Checks for Squid proxy events in Syslog associated with common mining pools .This query presumes the default Squid log format is being used.
    http://www.squid-cache.org/Doc/config/access_log/'
 severity: Low
 requiredDataConnectors:
   - connectorId: Syslog
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1d
 queryPeriod: 1d
@@ -17,21 +17,20 @@ tactics:
 relevantTechniques:
   - T1102
 query: |
-
-  let DomainList = dynamic(["monerohash.com", "do-dear.com", "xmrminerpro.com", "secumine.net", "xmrpool.com", "minexmr.org", "hashanywhere.com", "xmrget.com", 
+  let DomainList = dynamic(["monerohash.com", "do-dear.com", "xmrminerpro.com", "secumine.net", "xmrpool.com", "minexmr.org", "hashanywhere.com", "xmrget.com",
   "mininglottery.eu", "minergate.com", "moriaxmr.com", "multipooler.com", "moneropools.com", "xmrpool.eu", "coolmining.club", "supportxmr.com",
-  "minexmr.com", "hashvault.pro", "xmrpool.net", "crypto-pool.fr", "xmr.pt", "miner.rocks", "walpool.com", "herominers.com", "gntl.co.uk", "semipool.com", 
-  "coinfoundry.org", "cryptoknight.cc", "fairhash.org", "baikalmine.com", "tubepool.xyz", "fairpool.xyz", "asiapool.io", "coinpoolit.webhop.me", "nanopool.org", 
-  "moneropool.com", "miner.center", "prohash.net", "poolto.be", "cryptoescrow.eu", "monerominers.net", "cryptonotepool.org", "extrmepool.org", "webcoin.me", 
-  "kippo.eu", "hashinvest.ws", "monero.farm", "supportxmr.com", "xmrpool.eu", "linux-repository-updates.com", "1gh.com", "dwarfpool.com", "hash-to-coins.com", 
+  "minexmr.com", "hashvault.pro", "xmrpool.net", "crypto-pool.fr", "xmr.pt", "miner.rocks", "walpool.com", "herominers.com", "gntl.co.uk", "semipool.com",
+  "coinfoundry.org", "cryptoknight.cc", "fairhash.org", "baikalmine.com", "tubepool.xyz", "fairpool.xyz", "asiapool.io", "coinpoolit.webhop.me", "nanopool.org",
+  "moneropool.com", "miner.center", "prohash.net", "poolto.be", "cryptoescrow.eu", "monerominers.net", "cryptonotepool.org", "extrmepool.org", "webcoin.me",
+  "kippo.eu", "hashinvest.ws", "monero.farm", "supportxmr.com", "xmrpool.eu", "linux-repository-updates.com", "1gh.com", "dwarfpool.com", "hash-to-coins.com",
   "hashvault.pro", "pool-proxy.com", "hashfor.cash", "fairpool.cloud", "litecoinpool.org", "mineshaft.ml", "abcxyz.stream", "moneropool.ru", "cryptonotepool.org.uk",
   "extremepool.org", "extremehash.com", "hashinvest.net", "unipool.pro", "crypto-pools.org", "monero.net", "backup-pool.com", "mooo.com", "freeyy.me", "cryptonight.net",
   "shscrypto.net"]);
   Syslog
   | where ProcessName contains "squid"
-  | extend URL = extract("(([A-Z]+ [a-z]{4,5}:\\/\\/)|[A-Z]+ )([^ :]*)",3,SyslogMessage), 
-          SourceIP = extract("([0-9]+ )(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3}))",2,SyslogMessage), 
-          Status = extract("(TCP_(([A-Z]+)(_[A-Z]+)*)|UDP_(([A-Z]+)(_[A-Z]+)*))",1,SyslogMessage), 
+  | extend URL = extract("(([A-Z]+ [a-z]{4,5}:\\/\\/)|[A-Z]+ )([^ :]*)",3,SyslogMessage),
+          SourceIP = extract("([0-9]+ )(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3}))",2,SyslogMessage),
+          Status = extract("(TCP_(([A-Z]+)(_[A-Z]+)*)|UDP_(([A-Z]+)(_[A-Z]+)*))",1,SyslogMessage),
           HTTP_Status_Code = extract("(TCP_(([A-Z]+)(_[A-Z]+)*)|UDP_(([A-Z]+)(_[A-Z]+)*))/([0-9]{3})",8,SyslogMessage),
           User = extract("(CONNECT |GET )([^ ]* )([^ ]+)",3,SyslogMessage),
           RemotePort = extract("(CONNECT |GET )([^ ]*)(:)([0-9]*)",4,SyslogMessage),
@@ -57,5 +56,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/Syslog/squid_tor_proxies.yaml
+++ b/Detections/Syslog/squid_tor_proxies.yaml
@@ -6,7 +6,7 @@ description: |
 severity: Low
 requiredDataConnectors:
   - connectorId: Syslog
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1d
 queryPeriod: 1d
@@ -18,16 +18,15 @@ relevantTechniques:
   - T1090
   - T1008
 query: |
-
-  let DomainList = dynamic(["tor2web.org", "tor2web.com", "torlink.co", "onion.to", "onion.ink", "onion.cab", "onion.nu", "onion.link", 
-  "onion.it", "onion.city", "onion.direct", "onion.top", "onion.casa", "onion.plus", "onion.rip", "onion.dog", "tor2web.fi", 
-  "tor2web.blutmagie.de", "onion.sh", "onion.lu", "onion.pet", "t2w.pw", "tor2web.ae.org", "tor2web.io", "tor2web.xyz", "onion.lt", 
+  let DomainList = dynamic(["tor2web.org", "tor2web.com", "torlink.co", "onion.to", "onion.ink", "onion.cab", "onion.nu", "onion.link",
+  "onion.it", "onion.city", "onion.direct", "onion.top", "onion.casa", "onion.plus", "onion.rip", "onion.dog", "tor2web.fi",
+  "tor2web.blutmagie.de", "onion.sh", "onion.lu", "onion.pet", "t2w.pw", "tor2web.ae.org", "tor2web.io", "tor2web.xyz", "onion.lt",
   "s1.tor-gateways.de", "s2.tor-gateways.de", "s3.tor-gateways.de", "s4.tor-gateways.de", "s5.tor-gateways.de", "hiddenservice.net"]);
   Syslog
   | where ProcessName contains "squid"
-  | extend URL = extract("(([A-Z]+ [a-z]{4,5}:\\/\\/)|[A-Z]+ )([^ :]*)",3,SyslogMessage), 
-          SourceIP = extract("([0-9]+ )(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3}))",2,SyslogMessage), 
-          Status = extract("(TCP_(([A-Z]+)(_[A-Z]+)*)|UDP_(([A-Z]+)(_[A-Z]+)*))",1,SyslogMessage), 
+  | extend URL = extract("(([A-Z]+ [a-z]{4,5}:\\/\\/)|[A-Z]+ )([^ :]*)",3,SyslogMessage),
+          SourceIP = extract("([0-9]+ )(([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3}))",2,SyslogMessage),
+          Status = extract("(TCP_(([A-Z]+)(_[A-Z]+)*)|UDP_(([A-Z]+)(_[A-Z]+)*))",1,SyslogMessage),
           HTTP_Status_Code = extract("(TCP_(([A-Z]+)(_[A-Z]+)*)|UDP_(([A-Z]+)(_[A-Z]+)*))/([0-9]{3})",8,SyslogMessage),
           User = extract("(CONNECT |GET )([^ ]* )([^ ]+)",3,SyslogMessage),
           RemotePort = extract("(CONNECT |GET )([^ ]*)(:)([0-9]*)",4,SyslogMessage),
@@ -52,5 +51,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Detections/Syslog/ssh_potentialBruteForce.yaml
+++ b/Detections/Syslog/ssh_potentialBruteForce.yaml
@@ -16,19 +16,18 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let threshold = 15;
   Syslog
-  | where ProcessName =~ "sshd" 
+  | where ProcessName =~ "sshd"
   | where SyslogMessage contains "Failed password for invalid user"
   | parse kind=relaxed SyslogMessage with * "invalid user" user " from " ip " port" port " ssh2"
   | project user, ip, port, SyslogMessage, EventTime
   | summarize EventTimes = make_list(EventTime), PerHourCount = count() by ip, bin(EventTime, 4h), user
   | where PerHourCount > threshold
   | mvexpand EventTimes
-  | extend EventTimes = tostring(EventTimes) 
+  | extend EventTimes = tostring(EventTimes)
   | summarize StartTimeUtc = min(EventTimes), EndTimeUtc = max(EventTimes), UserList = makeset(user), sum(PerHourCount) by IPAddress = ip
-  | extend UserList = tostring(UserList) 
+  | extend UserList = tostring(UserList)
   | extend timestamp = StartTimeUtc, IPCustomEntity = IPAddress, AccountCustomEntity = UserList
 entityMappings:
   - entityType: Account
@@ -39,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Detections/W3CIISLog/AnomomlousUserAgentConnection.yaml
+++ b/Detections/W3CIISLog/AnomomlousUserAgentConnection.yaml
@@ -16,11 +16,10 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-
   let short_uaLength = 5;
   let long_uaLength = 1000;
   let c_threshold = 100;
-  W3CIISLog 
+  W3CIISLog
   // Exclude local IPs as these create noise
   | where cIP !startswith "192.168." and cIP != "::1"
   | where isnotempty(csUserAgent) and csUserAgent !in~ ("-", "MSRPC") and (string_size(csUserAgent) <= short_uaLength or string_size(csUserAgent) >= long_uaLength)
@@ -41,7 +40,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/W3CIISLog/HighFailedLogonCountByClientIP.yaml
+++ b/Detections/W3CIISLog/HighFailedLogonCountByClientIP.yaml
@@ -3,9 +3,9 @@ name: High count of failed attempts from same client IP
 description: |
   'Identifies when 20 or more failed attempts from a given client IP in 1 minute occur on the IIS server.
   This could be indicative of an attempted brute force. This could also simply indicate a misconfigured service or device.
-  Recommendations: Validate that these are expected connections from the given Client IP.  If the client IP is not recognized, 
+  Recommendations: Validate that these are expected connections from the given Client IP.  If the client IP is not recognized,
   potentially block these connections at the edge device.
-  If these are expected connections, verify the credentials are properly configured on the system, service, application or device 
+  If these are expected connections, verify the credentials are properly configured on the system, service, application or device
   that is associated with the client IP.
   References:
   IIS status code mapping: https://support.microsoft.com/help/943891/the-http-status-code-in-iis-7-0-iis-7-5-and-iis-8-0
@@ -24,13 +24,12 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let timeBin = 1m;
   let failedThreshold = 20;
   W3CIISLog
   | where scStatus in ("401","403")
   | where csUserName != "-"
-  | extend scStatusFull = strcat(scStatus, ".",scSubStatus) 
+  | extend scStatusFull = strcat(scStatus, ".",scSubStatus)
   // Map common IIS codes
   | extend scStatusFull_Friendly = case(
   scStatusFull == "401.0", "Access denied.",
@@ -43,22 +42,22 @@ query: |
   scStatusFull == "403.4", "SSL required.",
   "See - https://support.microsoft.com/help/943891/the-http-status-code-in-iis-7-0-iis-7-5-and-iis-8-0")
   // Mapping to Hex so can be mapped using website in comments above
-  | extend scWin32Status_Hex = tohex(tolong(scWin32Status)) 
+  | extend scWin32Status_Hex = tohex(tolong(scWin32Status))
   // Map common win32 codes
   | extend scWin32Status_Friendly = case(
   scWin32Status_Hex =~ "775", "The referenced account is currently locked out and cannot be logged on to.",
   scWin32Status_Hex =~ "52e", "Logon failure: Unknown user name or bad password.",
   scWin32Status_Hex =~ "532", "Logon failure: The specified account password has expired.",
-  scWin32Status_Hex =~ "533", "Logon failure: Account currently disabled.", 
-  scWin32Status_Hex =~ "2ee2", "The request has timed out.", 
-  scWin32Status_Hex =~ "0", "The operation completed successfully.", 
-  scWin32Status_Hex =~ "1", "Incorrect function.", 
-  scWin32Status_Hex =~ "2", "The system cannot find the file specified.", 
-  scWin32Status_Hex =~ "3", "The system cannot find the path specified.", 
-  scWin32Status_Hex =~ "4", "The system cannot open the file.", 
-  scWin32Status_Hex =~ "5", "Access is denied.", 
-  scWin32Status_Hex =~ "8009030e", "SEC_E_NO_CREDENTIALS", 
-  scWin32Status_Hex =~ "8009030C", "SEC_E_LOGON_DENIED", 
+  scWin32Status_Hex =~ "533", "Logon failure: Account currently disabled.",
+  scWin32Status_Hex =~ "2ee2", "The request has timed out.",
+  scWin32Status_Hex =~ "0", "The operation completed successfully.",
+  scWin32Status_Hex =~ "1", "Incorrect function.",
+  scWin32Status_Hex =~ "2", "The system cannot find the file specified.",
+  scWin32Status_Hex =~ "3", "The system cannot find the path specified.",
+  scWin32Status_Hex =~ "4", "The system cannot open the file.",
+  scWin32Status_Hex =~ "5", "Access is denied.",
+  scWin32Status_Hex =~ "8009030e", "SEC_E_NO_CREDENTIALS",
+  scWin32Status_Hex =~ "8009030C", "SEC_E_LOGON_DENIED",
   "See - https://msdn.microsoft.com/library/cc231199.aspx")
   // decode URI when available
   | extend decodedUriQuery = url_decode(csUriQuery)
@@ -77,7 +76,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/W3CIISLog/HighFailedLogonCountByUser.yaml
+++ b/Detections/W3CIISLog/HighFailedLogonCountByUser.yaml
@@ -3,7 +3,7 @@ name: High count of failed logons by a user
 description: |
   'Identifies when 100 or more failed attempts by a given user in 10 minutes occur on the IIS Server.
   This could be indicative of attempted brute force based on known account information.
-  This could also simply indicate a misconfigured service or device. 
+  This could also simply indicate a misconfigured service or device.
   References:
   IIS status code mapping - https://support.microsoft.com/help/943891/the-http-status-code-in-iis-7-0-iis-7-5-and-iis-8-0
   Win32 Status code mapping - https://msdn.microsoft.com/library/cc231199.aspx'
@@ -21,7 +21,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let timeBin = 10m;
   let failedThreshold = 100;
   W3CIISLog
@@ -30,7 +29,7 @@ query: |
   // Handling Exchange specific items in IIS logs to remove the unique log identifier in the URI
   | extend csUriQuery = iff(csUriQuery startswith "MailboxId=", tostring(split(csUriQuery, "&")[0]) , csUriQuery )
   | extend csUriQuery = iff(csUriQuery startswith "X-ARR-CACHE-HIT=", strcat(tostring(split(csUriQuery, "&")[0]),tostring(split(csUriQuery, "&")[1])) , csUriQuery )
-  | extend scStatusFull = strcat(scStatus, ".",scSubStatus) 
+  | extend scStatusFull = strcat(scStatus, ".",scSubStatus)
   // Map common IIS codes
   | extend scStatusFull_Friendly = case(
   scStatusFull == "401.0", "Access denied.",
@@ -43,22 +42,22 @@ query: |
   scStatusFull == "403.4", "SSL required.",
   "See - https://support.microsoft.com/help/943891/the-http-status-code-in-iis-7-0-iis-7-5-and-iis-8-0")
   // Mapping to Hex so can be mapped using website in comments above
-  | extend scWin32Status_Hex = tohex(tolong(scWin32Status)) 
+  | extend scWin32Status_Hex = tohex(tolong(scWin32Status))
   // Map common win32 codes
   | extend scWin32Status_Friendly = case(
   scWin32Status_Hex =~ "775", "The referenced account is currently locked out and cannot be logged on to.",
   scWin32Status_Hex =~ "52e", "Logon failure: Unknown user name or bad password.",
   scWin32Status_Hex =~ "532", "Logon failure: The specified account password has expired.",
-  scWin32Status_Hex =~ "533", "Logon failure: Account currently disabled.", 
-  scWin32Status_Hex =~ "2ee2", "The request has timed out.", 
-  scWin32Status_Hex =~ "0", "The operation completed successfully.", 
-  scWin32Status_Hex =~ "1", "Incorrect function.", 
-  scWin32Status_Hex =~ "2", "The system cannot find the file specified.", 
-  scWin32Status_Hex =~ "3", "The system cannot find the path specified.", 
-  scWin32Status_Hex =~ "4", "The system cannot open the file.", 
-  scWin32Status_Hex =~ "5", "Access is denied.", 
-  scWin32Status_Hex =~ "8009030e", "SEC_E_NO_CREDENTIALS", 
-  scWin32Status_Hex =~ "8009030C", "SEC_E_LOGON_DENIED", 
+  scWin32Status_Hex =~ "533", "Logon failure: Account currently disabled.",
+  scWin32Status_Hex =~ "2ee2", "The request has timed out.",
+  scWin32Status_Hex =~ "0", "The operation completed successfully.",
+  scWin32Status_Hex =~ "1", "Incorrect function.",
+  scWin32Status_Hex =~ "2", "The system cannot find the file specified.",
+  scWin32Status_Hex =~ "3", "The system cannot find the path specified.",
+  scWin32Status_Hex =~ "4", "The system cannot open the file.",
+  scWin32Status_Hex =~ "5", "Access is denied.",
+  scWin32Status_Hex =~ "8009030e", "SEC_E_NO_CREDENTIALS",
+  scWin32Status_Hex =~ "8009030C", "SEC_E_LOGON_DENIED",
   "See - https://msdn.microsoft.com/library/cc231199.aspx")
   // decode URI when available
   | extend decodedUriQuery = url_decode(csUriQuery)
@@ -77,7 +76,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/W3CIISLog/HighPortCountByClientIP.yaml
+++ b/Detections/W3CIISLog/HighPortCountByClientIP.yaml
@@ -2,7 +2,7 @@ id: 44a555d8-ecee-4a25-95ce-055879b4b14b
 name: High count of connections by client IP on many ports
 description: |
   'Identifies when 30 or more ports are used for a given client IP in 10 minutes occurring on the IIS server.
-  This could be indicative of attempted port scanning or exploit attempt at internet facing web applications.  
+  This could be indicative of attempted port scanning or exploit attempt at internet facing web applications.
   This could also simply indicate a misconfigured service or device.
   References:
   IIS status code mapping - https://support.microsoft.com/help/943891/the-http-status-code-in-iis-7-0-iis-7-5-and-iis-8-0
@@ -21,11 +21,10 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-
   let timeBin = 10m;
   let portThreshold = 30;
   W3CIISLog
-  | extend scStatusFull = strcat(scStatus, ".",scSubStatus) 
+  | extend scStatusFull = strcat(scStatus, ".",scSubStatus)
   // Map common IIS codes
   | extend scStatusFull_Friendly = case(
   scStatusFull == "401.0", "Access denied.",
@@ -38,22 +37,22 @@ query: |
   scStatusFull == "403.4", "SSL required.",
   "See - https://support.microsoft.com/help/943891/the-http-status-code-in-iis-7-0-iis-7-5-and-iis-8-0")
   // Mapping to Hex so can be mapped using website in comments above
-  | extend scWin32Status_Hex = tohex(tolong(scWin32Status)) 
+  | extend scWin32Status_Hex = tohex(tolong(scWin32Status))
   // Map common win32 codes
   | extend scWin32Status_Friendly = case(
   scWin32Status_Hex =~ "775", "The referenced account is currently locked out and cannot be logged on to.",
   scWin32Status_Hex =~ "52e", "Logon failure: Unknown user name or bad password.",
   scWin32Status_Hex =~ "532", "Logon failure: The specified account password has expired.",
-  scWin32Status_Hex =~ "533", "Logon failure: Account currently disabled.", 
-  scWin32Status_Hex =~ "2ee2", "The request has timed out.", 
-  scWin32Status_Hex =~ "0", "The operation completed successfully.", 
-  scWin32Status_Hex =~ "1", "Incorrect function.", 
-  scWin32Status_Hex =~ "2", "The system cannot find the file specified.", 
-  scWin32Status_Hex =~ "3", "The system cannot find the path specified.", 
-  scWin32Status_Hex =~ "4", "The system cannot open the file.", 
-  scWin32Status_Hex =~ "5", "Access is denied.", 
-  scWin32Status_Hex =~ "8009030e", "SEC_E_NO_CREDENTIALS", 
-  scWin32Status_Hex =~ "8009030C", "SEC_E_LOGON_DENIED", 
+  scWin32Status_Hex =~ "533", "Logon failure: Account currently disabled.",
+  scWin32Status_Hex =~ "2ee2", "The request has timed out.",
+  scWin32Status_Hex =~ "0", "The operation completed successfully.",
+  scWin32Status_Hex =~ "1", "Incorrect function.",
+  scWin32Status_Hex =~ "2", "The system cannot find the file specified.",
+  scWin32Status_Hex =~ "3", "The system cannot find the path specified.",
+  scWin32Status_Hex =~ "4", "The system cannot open the file.",
+  scWin32Status_Hex =~ "5", "Access is denied.",
+  scWin32Status_Hex =~ "8009030e", "SEC_E_NO_CREDENTIALS",
+  scWin32Status_Hex =~ "8009030C", "SEC_E_LOGON_DENIED",
   "See - https://msdn.microsoft.com/library/cc231199.aspx")
   // decode URI when available
   | extend decodedUriQuery = url_decode(csUriQuery)
@@ -69,7 +68,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/W3CIISLog/MaliciousAlertLinkedWebRequests.yaml
+++ b/Detections/W3CIISLog/MaliciousAlertLinkedWebRequests.yaml
@@ -12,7 +12,7 @@ requiredDataConnectors:
       - SecurityAlert
   - connectorId: AzureMonitor(IIS)
     dataTypes:
-      - W3CIISLog      
+      - W3CIISLog
 queryFrequency: 1h
 queryPeriod: 7d
 triggerOperator: gt
@@ -22,21 +22,20 @@ tactics:
 relevantTechniques:
   - T1505
 query: |
-
   let alertTimeWindow = 1h;
   let logTimeWindow = 7d;
   // Define script extensions that suit your web application environment - a sample are provided below
-  let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]); 
-  let alertData = materialize(SecurityAlert 
-  | where TimeGenerated > ago(alertTimeWindow) 
-  | where ProviderName == "MDATP" 
-  // Parse and expand the alert JSON 
-  | extend alertData = parse_json(Entities) 
+  let scriptExtensions = dynamic([".php", ".jsp", ".js", ".aspx", ".asmx", ".asax", ".cfm", ".shtml"]);
+  let alertData = materialize(SecurityAlert
+  | where TimeGenerated > ago(alertTimeWindow)
+  | where ProviderName == "MDATP"
+  // Parse and expand the alert JSON
+  | extend alertData = parse_json(Entities)
   | mvexpand alertData);
   let fileData = alertData
   // Extract web script files from MDATP alerts - our malicious web scripts - candidate webshells
-  | where alertData.Type =~ "file" 
-  | where alertData.Name has_any(scriptExtensions) 
+  | where alertData.Type =~ "file"
+  | where alertData.Name has_any(scriptExtensions)
   | extend FileName = tostring(alertData.Name), Directory = tostring(alertData.Directory);
   let hostData = alertData
   // Extract server details from alerts and map to alert id
@@ -45,19 +44,19 @@ query: |
   | distinct HostName, DnsDomain, SystemAlertId;
   // Join the files on their impacted servers
   let webshellData = fileData
-  | join kind=inner (hostData) on SystemAlertId 
+  | join kind=inner (hostData) on SystemAlertId
   | project TimeGenerated, FileName, Directory, HostName, DnsDomain;
   webshellData
-  | join (  
-  // Find requests that were made to this file on the impacted server in the W3CIISLog table 
-  W3CIISLog  
-  | where TimeGenerated > ago(logTimeWindow) 
-  // Restrict to accesses to script extensions 
+  | join (
+  // Find requests that were made to this file on the impacted server in the W3CIISLog table
+  W3CIISLog
+  | where TimeGenerated > ago(logTimeWindow)
+  // Restrict to accesses to script extensions
   | where csUriStem has_any(scriptExtensions)
-  | extend splitUriStem = split(csUriStem, "/")  
+  | extend splitUriStem = split(csUriStem, "/")
   | extend FileName = splitUriStem[-1], HostName = sComputerName
   // Summarize potential attacker activity
-  | summarize count(), StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), RequestUserAgents=make_set(csUserAgent), ReqestMethods=make_set(csMethod), RequestStatusCodes=make_set(scStatus), RequestCookies=make_set(csCookie), RequestReferers=make_set(csReferer), RequestQueryStrings=make_set(csUriQuery) by AttackerIP=cIP, SiteName=sSiteName, ShellLocation=csUriStem, tostring(FileName), HostName  
+  | summarize count(), StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), RequestUserAgents=make_set(csUserAgent), ReqestMethods=make_set(csMethod), RequestStatusCodes=make_set(scStatus), RequestCookies=make_set(csCookie), RequestReferers=make_set(csReferer), RequestQueryStrings=make_set(csUriQuery) by AttackerIP=cIP, SiteName=sSiteName, ShellLocation=csUriStem, tostring(FileName), HostName
   ) on FileName, HostName
   | project StartTime, EndTime, AttackerIP, RequestUserAgents, HostName, SiteName, ShellLocation, ReqestMethods, RequestStatusCodes, RequestCookies, RequestReferers, RequestQueryStrings, RequestCount = count_
   // Expose the attacker ip address as a custom entity
@@ -71,7 +70,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/W3CIISLog/Supernovawebshell.yaml
+++ b/Detections/W3CIISLog/Supernovawebshell.yaml
@@ -1,5 +1,5 @@
 id: 2acc91c3-17c2-4388-938e-4eac2d5894e8
-name: SUPERNOVA webshell 
+name: SUPERNOVA webshell
 description: |
   'Identifies SUPERNOVA webshell based on W3CIISLog data.
    References:
@@ -20,7 +20,6 @@ relevantTechniques:
   - T1505
   - T1071
 query: |
-
   W3CIISLog
   | where csMethod == 'GET'
   | where isnotempty(csUriStem) and isnotempty(csUriQuery)
@@ -41,7 +40,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/ZoomLogs/E2EEDisbaled.yaml
+++ b/Detections/ZoomLogs/E2EEDisbaled.yaml
@@ -14,7 +14,6 @@ tactics:
 relevantTechniques:
   - T1040
 query: |
-
   ZoomLogs
   | where Event =~ "account.settings_updated"
   | extend NewE2ESetting = columnifexists("payload_object_settings_in_meeting_e2e_encryption_b", "")
@@ -26,7 +25,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/ZoomLogs/ExternalUserAccess.yaml
+++ b/Detections/ZoomLogs/ExternalUserAccess.yaml
@@ -15,19 +15,18 @@ relevantTechniques:
   - T1098
   - T1556
 query: |
-
   ZoomLogs
-  | where Event =~ "account.settings_updated" 
-  | extend EnforceLogin = columnifexists("payload_object_settings_schedule_meeting_enfore_login_b", "") 
-  | extend EnforceLoginDomain = columnifexists("payload_object_settings_schedule_meeting_enfore_login_b", "") 
-  | extend GuestAlerts = columnifexists("payload_object_settings_in_meeting_alert_guest_join_b", "") 
-  | where EnforceLogin == 'false' or EnforceLoginDomain == 'false' or GuestAlerts == 'false' 
-  | extend SettingChanged = case(EnforceLogin == 'false' and EnforceLoginDomain == 'false' and GuestAlerts == 'false', "All settings changed", 
-                              EnforceLogin == 'false' and EnforceLoginDomain == 'false', "Enforced Logons and Restricted Domains Changed", 
-                              EnforceLoginDomain == 'false' and GuestAlerts == 'false', "Enforced Domains Changed", 
-                              EnforceLoginDomain == 'false', "Enfored Domains Changed", 
-                              GuestAlerts == 'false', "Guest Join Alerts Changed", 
-                              EnforceLogin == 'false', "Enforced Logins Changed", 
+  | where Event =~ "account.settings_updated"
+  | extend EnforceLogin = columnifexists("payload_object_settings_schedule_meeting_enfore_login_b", "")
+  | extend EnforceLoginDomain = columnifexists("payload_object_settings_schedule_meeting_enfore_login_b", "")
+  | extend GuestAlerts = columnifexists("payload_object_settings_in_meeting_alert_guest_join_b", "")
+  | where EnforceLogin == 'false' or EnforceLoginDomain == 'false' or GuestAlerts == 'false'
+  | extend SettingChanged = case(EnforceLogin == 'false' and EnforceLoginDomain == 'false' and GuestAlerts == 'false', "All settings changed",
+                              EnforceLogin == 'false' and EnforceLoginDomain == 'false', "Enforced Logons and Restricted Domains Changed",
+                              EnforceLoginDomain == 'false' and GuestAlerts == 'false', "Enforced Domains Changed",
+                              EnforceLoginDomain == 'false', "Enfored Domains Changed",
+                              GuestAlerts == 'false', "Guest Join Alerts Changed",
+                              EnforceLogin == 'false', "Enforced Logins Changed",
                               "No Changes")
   | extend timestamp = TimeGenerated, AccountCustomEntity = User
 entityMappings:
@@ -35,7 +34,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/ZoomLogs/JoiningMeetingFromAnotherTimeZone.yaml
+++ b/Detections/ZoomLogs/JoiningMeetingFromAnotherTimeZone.yaml
@@ -15,34 +15,33 @@ tactics:
 relevantTechniques:
   - T1078
 query: |
-
-  let schedule_lookback = 14d; 
-  let join_lookback = 1d; 
+  let schedule_lookback = 14d;
+  let join_lookback = 1d;
   // If you want to whitelist specific timezones include them in a list here
   let tz_whitelist = dynamic([]);
-  let meetings = ( 
-  ZoomLogs 
-  | where TimeGenerated >= ago(schedule_lookback) 
-  | where Event =~ "meeting.created" 
-  | extend MeetingId = tostring(parse_json(MeetingEvents).MeetingId)  
-  | extend SchedTimezone = tostring(parse_json(MeetingEvents).Timezone)); 
-  ZoomLogs 
-  | where TimeGenerated >= ago(join_lookback) 
-  | where Event =~ "meeting.participant_joined" 
-  | extend JoinedTimeZone = tostring(parse_json(MeetingEvents).Timezone) 
-  | extend MeetingName = tostring(parse_json(MeetingEvents).MeetingName) 
-  | extend MeetingId = tostring(parse_json(MeetingEvents).MeetingId) 
+  let meetings = (
+  ZoomLogs
+  | where TimeGenerated >= ago(schedule_lookback)
+  | where Event =~ "meeting.created"
+  | extend MeetingId = tostring(parse_json(MeetingEvents).MeetingId)
+  | extend SchedTimezone = tostring(parse_json(MeetingEvents).Timezone));
+  ZoomLogs
+  | where TimeGenerated >= ago(join_lookback)
+  | where Event =~ "meeting.participant_joined"
+  | extend JoinedTimeZone = tostring(parse_json(MeetingEvents).Timezone)
+  | extend MeetingName = tostring(parse_json(MeetingEvents).MeetingName)
+  | extend MeetingId = tostring(parse_json(MeetingEvents).MeetingId)
   | where JoinedTimeZone !in (tz_whitelist)
-  | join (meetings) on MeetingId 
-  | where SchedTimezone != JoinedTimeZone 
-  | project TimeGenerated, MeetingName, JoiningUser=payload_object_participant_user_name_s, JoinedTimeZone, SchedTimezone, MeetingScheduler=User1 
+  | join (meetings) on MeetingId
+  | where SchedTimezone != JoinedTimeZone
+  | project TimeGenerated, MeetingName, JoiningUser=payload_object_participant_user_name_s, JoinedTimeZone, SchedTimezone, MeetingScheduler=User1
   | extend timestamp = TimeGenerated, AccountCustomEntity = JoiningUser
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:

--- a/Detections/ZoomLogs/SupiciousLinkSharing.yaml
+++ b/Detections/ZoomLogs/SupiciousLinkSharing.yaml
@@ -1,7 +1,7 @@
 id: 1218175f-c534-421c-8070-5dcaabf28067
 name: Suspicious link sharing pattern
 description: |
-  'Alerts in links that have been shared across multiple Zoom chat channels by the same user in a short space if time. 
+  'Alerts in links that have been shared across multiple Zoom chat channels by the same user in a short space if time.
   Adjust the threshold figure to change the number of channels a message needs to be posted in before an alert is raised.'
 severity: Low
 requiredDataConnectors: []
@@ -13,15 +13,14 @@ tactics:
   - CredentialAccess
   - Persistence
 query: |
-
-  let threshold = 3; 
-  ZoomLogs 
-  | where Event =~ "chat_message.sent" 
-  | extend Channel = tostring(parse_json(ChatEvents).Channel)  
-  | extend Message = tostring(parse_json(ChatEvents).Message) 
-  | where Message matches regex "http(s?):\\/\\/" 
+  let threshold = 3;
+  ZoomLogs
+  | where Event =~ "chat_message.sent"
+  | extend Channel = tostring(parse_json(ChatEvents).Channel)
+  | extend Message = tostring(parse_json(ChatEvents).Message)
+  | where Message matches regex "http(s?):\\/\\/"
   | summarize Channels = makeset(Channel), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by Message, User, UserId
-  | extend ChannelCount = arraylength(Channels) 
+  | extend ChannelCount = arraylength(Channels)
   | where ChannelCount > threshold
   | extend timestamp = StartTime, AccountCustomEntity = User
 entityMappings:
@@ -29,7 +28,7 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ChangeToRDSDatabase.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ChangeToRDSDatabase.yaml
@@ -1,9 +1,9 @@
 id: 8c2ef238-67a0-497d-b1dd-5c8a0f533e25
 name: Changes to internet facing AWS RDS Database instances
 description: |
-  'Amazon Relational Database Service (RDS) is scalable relational database in the cloud. 
-  If your organization have one or more AWS RDS Databases running, monitoring changes to especially internet facing AWS RDS (Relational Database Service) 
-  Once alerts triggered, validate if changes observed are authorized and adhere to change control policy. 
+  'Amazon Relational Database Service (RDS) is scalable relational database in the cloud.
+  If your organization have one or more AWS RDS Databases running, monitoring changes to especially internet facing AWS RDS (Relational Database Service)
+  Once alerts triggered, validate if changes observed are authorized and adhere to change control policy.
   More information: https://medium.com/@GorillaStack/the-most-important-aws-cloudtrail-security-events-to-track-a5b9873f8255
   and RDS API Reference Docs: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Operations.html'
 severity: Low
@@ -24,7 +24,6 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
   let EventNameList = dynamic(["AuthorizeDBSecurityGroupIngress","CreateDBSecurityGroup","DeleteDBSecurityGroup","RevokeDBSecurityGroupIngress"]);
   AWSCloudTrail
   | where EventName in~ (EventNameList)
@@ -39,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ChangeToVPC.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ChangeToVPC.yaml
@@ -4,7 +4,7 @@ description: |
   'Amazon Virtual Private Cloud (Amazon VPC) lets you provision a logically isolated section of the AWS Cloud where you can launch AWS resources
   in a virtual network that you define.
   This identifies changes to Amazon VPC (Virtual Private Cloud) settings such as new ACL entries,routes, routetable or Gateways.
-  More information: https://medium.com/@GorillaStack/the-most-important-aws-cloudtrail-security-events-to-track-a5b9873f8255 
+  More information: https://medium.com/@GorillaStack/the-most-important-aws-cloudtrail-security-events-to-track-a5b9873f8255
   and AWS VPC API Docs: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/OperationList-query-vpc.html'
 severity: Low
 status : Available
@@ -26,11 +26,10 @@ relevantTechniques:
   - T1078
   - T1563
 query: |
-
   let EventNameList = dynamic(["CreateNetworkAclEntry","CreateRoute","CreateRouteTable","CreateInternetGateway","CreateNatGateway"]);
   AWSCloudTrail
   | where EventName in~ (EventNameList)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserAgent, 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserAgent,
   UserIdentityUserName, SessionMfaAuthenticated, SourceIpAddress, AWSRegion, EventSource, AdditionalEventData, ResponseElements
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserIdentityUserName, IPCustomEntity = SourceIpAddress
 entityMappings:
@@ -42,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ClearStopChangeTrailLogs.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ClearStopChangeTrailLogs.yaml
@@ -1,7 +1,7 @@
 id: 610d3850-c26f-4f20-8d86-f10fdf2425f5
 name: Changes made to AWS CloudTrail logs
 description: |
-  'Attackers often try to hide their steps by deleting or stopping the collection of logs that could show their activity. 
+  'Attackers often try to hide their steps by deleting or stopping the collection of logs that could show their activity.
   This alert identifies any manipulation of AWS CloudTrail, Cloudwatch/EventBridge or VPC Flow logs.
   More Information: AWS CloudTrail API: https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_Operations.html
   AWS Cloudwatch/Eventbridge API: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Operations.html
@@ -22,11 +22,10 @@ triggerThreshold: 0
 tactics:
   - DefenseEvasion
 query: |
-
   let EventNameList = dynamic(["UpdateTrail","DeleteTrail","StopLogging","DeleteFlowLogs","DeleteEventBus"]);
   AWSCloudTrail
   | where EventName in~ (EventNameList)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserAgent, 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, UserIdentityAccountId, UserIdentityPrincipalid, UserAgent,
   UserIdentityUserName, SessionMfaAuthenticated, SourceIpAddress, AWSRegion, EventSource
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserIdentityUserName, IPCustomEntity = SourceIpAddress
 entityMappings:
@@ -38,5 +37,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ConsoleLogonWithoutMFA.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ConsoleLogonWithoutMFA.yaml
@@ -3,7 +3,7 @@ name: Login to AWS Management Console without MFA
 description: |
   'Multi-Factor Authentication (MFA) helps you to prevent credential compromise. This alert identifies logins to the AWS Management Console without MFA.
   You can limit this detection to trigger for adminsitrative accounts if you do not have MFA enabled on all accounts.
-  This is done by looking at the eventName ConsoleLogin and if the AdditionalEventData field indicates MFA was NOT used 
+  This is done by looking at the eventName ConsoleLogin and if the AdditionalEventData field indicates MFA was NOT used
   and the ResponseElements field indicates NOT a Failure. Thereby indicating that a non-MFA login was successful.'
 severity: Low
 status: Available
@@ -27,11 +27,11 @@ relevantTechniques:
   - T1078
 query: |
   AWSCloudTrail
-  | where EventName =~ "ConsoleLogin" 
+  | where EventName =~ "ConsoleLogin"
   | extend MFAUsed = tostring(parse_json(AdditionalEventData).MFAUsed), LoginResult = tostring(parse_json(ResponseElements).ConsoleLogin), indexId = indexof(tostring(UserIdentityPrincipalid),":")
   | where MFAUsed !~ "Yes" and LoginResult !~ "Failure"
   | where SessionIssuerUserName !contains "AWSReservedSSO"
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, LoginResult, MFAUsed, UserIdentityAccountId,  UserIdentityPrincipalid, UserAgent, 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by EventName, EventTypeName, LoginResult, MFAUsed, UserIdentityAccountId,  UserIdentityPrincipalid, UserAgent,
   UserIdentityUserName, SessionMfaAuthenticated, SourceIpAddress, AWSRegion, indexId
   | extend timestamp = StartTimeUtc, AccountCustomEntity = iif(isempty(UserIdentityUserName),substring(UserIdentityPrincipalid, toint(indexId)+1), UserIdentityUserName), IPCustomEntity = SourceIpAddress
 entityMappings:
@@ -43,5 +43,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CredentialHijack.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CredentialHijack.yaml
@@ -1,7 +1,7 @@
 id: 32555639-b639-4c2b-afda-c0ae0abefa55
 name: Monitor AWS Credential abuse or hijacking
 description: |
-  'Looking for GetCallerIdentity Events where the UserID Type is AssumedRole 
+  'Looking for GetCallerIdentity Events where the UserID Type is AssumedRole
   An attacker who has assumed the role of a legitimate account can call the GetCallerIdentity function to determine what account they are using.
   A legitimate user using legitimate credentials would not need to call GetCallerIdentity since they should already know what account they are using.
   More Information: https://duo.com/decipher/trailblazer-hunts-compromised-credentials-in-aws
@@ -24,13 +24,12 @@ tactics:
 relevantTechniques:
   - T1087
 query: |
-
   AWSCloudTrail
-  | where EventName =~ "GetCallerIdentity" and UserIdentityType =~ "AssumedRole" 
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by SourceIpAddress, EventName, EventTypeName, UserIdentityType, UserIdentityAccountId, UserIdentityPrincipalid, 
+  | where EventName =~ "GetCallerIdentity" and UserIdentityType =~ "AssumedRole"
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by SourceIpAddress, EventName, EventTypeName, UserIdentityType, UserIdentityAccountId, UserIdentityPrincipalid,
   UserAgent, UserIdentityUserName, SessionMfaAuthenticated,AWSRegion, EventSource, AdditionalEventData, ResponseElements
   | extend timestamp = StartTime, AccountCustomEntity = UserIdentityUserName, IPCustomEntity = SourceIpAddress
-  | sort by EndTime desc nulls last 
+  | sort by EndTime desc nulls last
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -40,5 +39,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_IngressEgressSecurityGroupChange.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_IngressEgressSecurityGroupChange.yaml
@@ -1,7 +1,7 @@
 id: 4f19d4e3-ec5f-4abc-9e61-819eb131758c
 name: Changes to AWS Security Group ingress and egress settings
 description: |
-  'A Security Group acts as a virtual firewall of an instance to control inbound and outbound traffic. 
+  'A Security Group acts as a virtual firewall of an instance to control inbound and outbound traffic.
    Hence, ingress and egress settings changes to AWS Security Group should be monitored as these can expose the enviornment to new attack vectors.
   More information: https://medium.com/@GorillaStack/the-most-important-aws-cloudtrail-security-events-to-track-a5b9873f8255.'
 severity: Low
@@ -22,13 +22,12 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
   let EventNameList = dynamic([ "AuthorizeSecurityGroupEgress", "AuthorizeSecurityGroupIngress", "RevokeSecurityGroupEgress", "RevokeSecurityGroupIngress"]);
   AWSCloudTrail
   | where EventName in~ (EventNameList)
   | extend User = iif(isnotempty(UserIdentityUserName), UserIdentityUserName, SessionIssuerUserName)
-  | summarize EventCount=count(), StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) 
-  by EventSource, EventName, UserIdentityType, User, SourceIpAddress, UserAgent, SessionMfaAuthenticated, AWSRegion, 
+  | summarize EventCount=count(), StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated)
+  by EventSource, EventName, UserIdentityType, User, SourceIpAddress, UserAgent, SessionMfaAuthenticated, AWSRegion,
   AdditionalEventData, UserIdentityAccountId, UserIdentityPrincipalid, ResponseElements
   | extend timestamp = StartTimeUtc, AccountCustomEntity = User , IPCustomEntity = SourceIpAddress
 entityMappings:
@@ -40,5 +39,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_LoadBalancerSecGroupChange.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_LoadBalancerSecGroupChange.yaml
@@ -1,9 +1,9 @@
 id: c7bfadd4-34a6-4fa5-82f8-3691a32261e8
 name: Changes to AWS Elastic Load Balancer security groups
 description: |
-  'Elastic Load Balancer distributes incoming traffic across multiple instances in multiple availability Zones. This increases the fault tolerance of your applications. 
+  'Elastic Load Balancer distributes incoming traffic across multiple instances in multiple availability Zones. This increases the fault tolerance of your applications.
    Unwanted changes to Elastic Load Balancer specific security groups could open your environment to attack and  hence needs monitoring.
-   More information: https://medium.com/@GorillaStack/the-most-important-aws-cloudtrail-security-events-to-track-a5b9873f8255 
+   More information: https://medium.com/@GorillaStack/the-most-important-aws-cloudtrail-security-events-to-track-a5b9873f8255
    and https://aws.amazon.com/elasticloadbalancing/.'
 severity: Low
 status: Available
@@ -23,12 +23,11 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
   let EventNameList = dynamic(["ApplySecurityGroupsToLoadBalancer", "SetSecurityGroups"]);
   AWSCloudTrail
   | where EventName in~ (EventNameList)
   | extend User = iif(isnotempty(UserIdentityUserName), UserIdentityUserName, SessionIssuerUserName)
-  | summarize EventCount=count(), StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) 
+  | summarize EventCount=count(), StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated)
   by EventSource, EventName, UserIdentityType, User, SourceIpAddress, UserAgent, SessionMfaAuthenticated, AWSRegion,
   AdditionalEventData, UserIdentityAccountId, UserIdentityPrincipalid, ResponseElements
   | extend timestamp = StartTimeUtc, AccountCustomEntity = User , IPCustomEntity = SourceIpAddress
@@ -41,5 +40,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/Log4J_IPIOC_Dec112021.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/Log4J_IPIOC_Dec112021.yaml
@@ -1,8 +1,8 @@
 id: 6e575295-a7e6-464c-8192-3e1d8fd6a990
 name: Log4j vulnerability exploit aka Log4Shell IP IOC
 description: |
-  'Identifies a match across various data feeds for IP IOCs related to the Log4j vulnerability exploit aka Log4Shell described in CVE-2021-44228.  
-   References: https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228' 
+  'Identifies a match across various data feeds for IP IOCs related to the Log4j vulnerability exploit aka Log4Shell described in CVE-2021-44228.
+   References: https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228'
 severity: High
 status: Available
 tags:
@@ -13,57 +13,56 @@ tags:
     SchemaVersion: 0.1.1
   - Schema: ASIMNetworkSession
     SchemaVersion: 0.2.0
-requiredDataConnectors: 
-  - connectorId: Office365 
-    dataTypes: 
+requiredDataConnectors:
+  - connectorId: Office365
+    dataTypes:
      - OfficeActivity
   - connectorId: DNS
     dataTypes:
       - DnsEvents
-  - connectorId: AzureMonitor(VMInsights) 
-    dataTypes: 
-      - VMConnection 
-  - connectorId: CiscoASA 
-    dataTypes: 
-      - CommonSecurityLog 
-  - connectorId: PaloAltoNetworks 
-    dataTypes: 
-      - CommonSecurityLog 
-  - connectorId: SecurityEvents 
-    dataTypes: 
-      - SecurityEvent 
-  - connectorId: AzureActiveDirectory 
-    dataTypes: 
+  - connectorId: AzureMonitor(VMInsights)
+    dataTypes:
+      - VMConnection
+  - connectorId: CiscoASA
+    dataTypes:
+      - CommonSecurityLog
+  - connectorId: PaloAltoNetworks
+    dataTypes:
+      - CommonSecurityLog
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvent
+  - connectorId: AzureActiveDirectory
+    dataTypes:
       - SigninLogs
   - connectorId: AzureActiveDirectory
     dataTypes:
       - AADNonInteractiveUserSignInLogs
-  - connectorId: AzureMonitor(WireData) 
-    dataTypes: 
-      - WireData 
-  - connectorId: AzureMonitor(IIS) 
-    dataTypes: 
-      - W3CIISLog 
-  - connectorId: AzureActivity 
-    dataTypes: 
-      - AzureActivity 
-  - connectorId: AWS 
-    dataTypes: 
-      - AWSCloudTrail 
+  - connectorId: AzureMonitor(WireData)
+    dataTypes:
+      - WireData
+  - connectorId: AzureMonitor(IIS)
+    dataTypes:
+      - W3CIISLog
+  - connectorId: AzureActivity
+    dataTypes:
+      - AzureActivity
+  - connectorId: AWS
+    dataTypes:
+      - AWSCloudTrail
   - connectorId: MicrosoftThreatProtection
-    dataTypes: 
+    dataTypes:
       - DeviceNetworkEvents
   - connectorId: AzureFirewall
-    dataTypes: 
-      - AzureDiagnostics  
-queryFrequency: 1h 
+    dataTypes:
+      - AzureDiagnostics
+queryFrequency: 1h
 queryPeriod: 1h
-triggerOperator: gt 
-triggerThreshold: 0 
-tactics: 
-  - CommandAndControl 
-query:  | 
-
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CommandAndControl
+query:  |
   let IPList = externaldata(IPAddress:string)[@"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Sample%20Data/Feeds/Log4j_IOC_List.csv"] with (format="csv", ignoreFirstRecord=True);
   let IPRegex = '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}';
   //Network logs
@@ -86,7 +85,7 @@ query:  |
   let iisLogIP = W3CIISLog | summarize by IPAddress = cIP, Type;
   let devNetIP = DeviceNetworkEvents | summarize by IPAddress = RemoteIP, Type;
   //need to parse to get IP
-  let azureDiagIP = AzureDiagnostics | where ResourceType == "AZUREFIREWALLS" | where Category in ("AzureFirewallApplicationRule", "AzureFirewallNetworkRule") 
+  let azureDiagIP = AzureDiagnostics | where ResourceType == "AZUREFIREWALLS" | where Category in ("AzureFirewallApplicationRule", "AzureFirewallNetworkRule")
   | where msg_s has_any (IPList) | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action | summarize by IPAddress = DestinationHost, Type;
   let sysEvtIP = Event | where Source == "Microsoft-Windows-Sysmon" | where EventID == 3 | where EventData has_any (IPList) | extend EvData = parse_xml(EventData)
   | extend EventDetail = EvData.DataItem.EventData.Data
@@ -162,8 +161,8 @@ query:  |
   | where SourceIpAddress in (ipMatch)
   | project TimeGenerated, SourceIpAddress, UserIdentityUserName, Type
   | extend timestamp = TimeGenerated, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
-  ), 
-  ( 
+  ),
+  (
   DeviceNetworkEvents
   | where RemoteIP in (ipMatch)
   | where ActionType == "InboundConnectionAccepted"
@@ -205,5 +204,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.1
+version: 2.0.2
 kind: Scheduled

--- a/Solutions/Attacker Tools Threat Protection Essentials/Analytic Rules/AdFind_Usage.yaml
+++ b/Solutions/Attacker Tools Threat Protection Essentials/Analytic Rules/AdFind_Usage.yaml
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1018
 query: |
-
  let args = dynamic(["objectcategory","domainlist","dcmodes","adinfo","trustdmp","computers_pwdnotreqd","Domain Admins", "objectcategory=person", "objectcategory=computer", "objectcategory=*","dclist"]);
  let parentProcesses = dynamic(["pwsh.exe","powershell.exe","cmd.exe"]);
  DeviceProcessEvents
@@ -50,5 +49,5 @@ entityMappings:
         columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Attacker Tools Threat Protection Essentials/Analytic Rules/powershell_empire.yaml
+++ b/Solutions/Attacker Tools Threat Protection Essentials/Analytic Rules/powershell_empire.yaml
@@ -12,11 +12,11 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
   - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents 
+    dataTypes:
+      - SecurityEvents
   - connectorId: WindowsForwardedEvents
-    dataTypes: 
-      - WindowsEvent 
+    dataTypes:
+      - WindowsEvent
 queryFrequency: 12h
 queryPeriod: 12h
 triggerOperator: gt
@@ -25,7 +25,6 @@ tactics:
   - Execution
   - Persistence
 query: |
-
   let regexEmpire = @"SetDelay|GetDelay|Set-LostLimit|Get-LostLimit|Set-Killdate|Get-Killdate|Set-WorkingHours|Get-WorkingHours|Get-Sysinfo|Add-Servers|Invoke-ShellCommand|Start-AgentJob|Update-Profile|Get-FilePart|Encrypt-Bytes|Decrypt-Bytes|Encode-Packet|Decode-Packet|Send-Message|Process-Packet|Process-Tasking|Get-Task|Start-Negotiate|Invoke-DllInjection|Invoke-ReflectivePEInjection|Invoke-Shellcode|Invoke-ShellcodeMSIL|Get-ChromeDump|Get-ClipboardContents|Get-IndexedItem|Get-Keystrokes|Invoke-Inveigh|Invoke-NetRipper|local:Invoke-PatchDll|Invoke-NinjaCopy|Get-Win32Types|Get-Win32Constants|Get-Win32Functions|Sub-SignedIntAsUnsigned|Add-SignedIntAsUnsigned|Compare-Val1GreaterThanVal2AsUInt|Convert-UIntToInt|Test-MemoryRangeValid|Write-BytesToMemory|Get-DelegateType|Get-ProcAddress|Enable-SeDebugPrivilege|Invoke-CreateRemoteThread|Get-ImageNtHeaders|Get-PEBasicInfo|Get-PEDetailedInfo|Import-DllInRemoteProcess|Get-RemoteProcAddress|Copy-Sections|Update-MemoryAddresses|Import-DllImports|Get-VirtualProtectValue|Update-MemoryProtectionFlags|Update-ExeFunctions|Copy-ArrayOfMemAddresses|Get-MemoryProcAddress|Invoke-MemoryLoadLibrary|Invoke-MemoryFreeLibrary|Out-Minidump|Get-VaultCredential|Invoke-DCSync|Translate-Name|Get-NetDomain|Get-NetForest|Get-NetForestDomain|Get-DomainSearcher|Get-NetComputer|Get-NetGroupMember|Get-NetUser|Invoke-Mimikatz|Invoke-PowerDump|Invoke-TokenManipulation|Exploit-JMXConsole|Exploit-JBoss|Invoke-Thunderstruck|Invoke-VoiceTroll|Set-WallPaper|Invoke-PsExec|Invoke-SSHCommand|Invoke-PSInject|Invoke-RunAs|Invoke-SendMail|Invoke-Rule|Get-OSVersion|Select-EmailItem|View-Email|Get-OutlookFolder|Get-EmailItems|Invoke-MailSearch|Get-SubFolders|Get-GlobalAddressList|Invoke-SearchGAL|Get-SMTPAddress|Disable-SecuritySettings|Reset-SecuritySettings|Get-OutlookInstance|New-HoneyHash|Set-MacAttribute|Invoke-PatchDll|Get-SecurityPackages|Install-SSP|Invoke-BackdoorLNK|New-ElevatedPersistenceOption|New-UserPersistenceOption|Add-Persistence|Invoke-CallbackIEX|Add-PSFirewallRules|Invoke-EventLoop|Invoke-PortBind|Invoke-DNSLoop|Invoke-PacketKnock|Invoke-CallbackLoop|Invoke-BypassUAC|Get-DecryptedCpassword|Get-GPPInnerFields|Invoke-WScriptBypassUAC|Get-ModifiableFile|Get-ServiceUnquoted|Get-ServiceFilePermission|Get-ServicePermission|Invoke-ServiceUserAdd|Invoke-ServiceCMD|Write-UserAddServiceBinary|Write-CMDServiceBinary|Write-ServiceEXE|Write-ServiceEXECMD|Restore-ServiceEXE|Invoke-ServiceStart|Invoke-ServiceStop|Invoke-ServiceEnable|Invoke-ServiceDisable|Get-ServiceDetail|Find-DLLHijack|Find-PathHijack|Write-HijackDll|Get-RegAlwaysInstallElevated|Get-RegAutoLogon|Get-VulnAutoRun|Get-VulnSchTask|Get-UnattendedInstallFile|Get-Webconfig|Get-ApplicationHost|Write-UserAddMSI|Invoke-AllChecks|Invoke-ThreadedFunction|Test-Login|Get-UserAgent|Test-Password|Get-ComputerDetails|Find-4648Logons|Find-4624Logons|Find-AppLockerLogs|Find-PSScriptsInPSAppLog|Find-RDPClientConnections|Get-SystemDNSServer|Invoke-Paranoia|Invoke-WinEnum{|Get-SPN|Invoke-ARPScan|Invoke-Portscan|Invoke-ReverseDNSLookup|Invoke-SMBScanner|New-InMemoryModule|Add-Win32Type|Export-PowerViewCSV|Get-MacAttribute|Copy-ClonedFile|Get-IPAddress|Convert-NameToSid|Convert-SidToName|Convert-NT4toCanonical|Get-Proxy|Get-PathAcl|Get-NameField|Convert-LDAPProperty|Get-NetDomainController|Add-NetUser|Add-NetGroupUser|Get-UserProperty|Find-UserField|Get-UserEvent|Get-ObjectAcl|Add-ObjectAcl|Invoke-ACLScanner|Get-GUIDMap|Get-ADObject|Set-ADObject|Get-ComputerProperty|Find-ComputerField|Get-NetOU|Get-NetSite|Get-NetSubnet|Get-DomainSID|Get-NetGroup|Get-NetFileServer|SplitPath|Get-DFSshare|Get-DFSshareV1|Get-DFSshareV2|Get-GptTmpl|Get-GroupsXML|Get-NetGPO|Get-NetGPOGroup|Find-GPOLocation|Find-GPOComputerAdmin|Get-DomainPolicy|Get-NetLocalGroup|Get-NetShare|Get-NetLoggedon|Get-NetSession|Get-NetRDPSession|Invoke-CheckLocalAdminAccess|Get-LastLoggedOn|Get-NetProcess|Find-InterestingFile|Invoke-CheckWrite|Invoke-UserHunter|Invoke-StealthUserHunter|Invoke-ProcessHunter|Invoke-EventHunter|Invoke-ShareFinder|Invoke-FileFinder|Find-LocalAdminAccess|Get-ExploitableSystem|Invoke-EnumerateLocalAdmin|Get-NetDomainTrust|Get-NetForestTrust|Find-ForeignUser|Find-ForeignGroup|Invoke-MapDomainTrust|Get-Hex|Create-RemoteThread|Get-FoxDump|Decrypt-CipherText|Get-Screenshot|Start-HTTP-Server|Local:Invoke-CreateRemoteThread|Local:Get-Win32Functions|Local:Inject-NetRipper|GetCommandLine|ElevatePrivs|Get-RegKeyClass|Get-BootKey|Get-HBootKey|Get-UserName|Get-UserHashes|DecryptHashes|DecryptSingleHash|Get-UserKeys|DumpHashes|Enable-SeAssignPrimaryTokenPrivilege|Enable-Privilege|Set-DesktopACLs|Set-DesktopACLToAllowEveryone|Get-PrimaryToken|Get-ThreadToken|Get-TokenInformation|Get-UniqueTokens|Find-GPOLocation|Find-GPOComputerAdmin|Get-DomainPolicy|Get-NetLocalGroup|Get-NetShare|Get-NetLoggedon|Get-NetSession|Get-NetRDPSession|Invoke-CheckLocalAdminAccess|Get-LastLoggedOn|Get-NetProcess|Find-InterestingFile|Invoke-CheckWrite|Invoke-UserHunter|Invoke-StealthUserHunter|Invoke-ProcessHunter|Invoke-EventHunter|Invoke-ShareFinder|Invoke-FileFinder|Find-LocalAdminAccess|Get-ExploitableSystem|Invoke-EnumerateLocalAdmin|Get-NetDomainTrust|Get-NetForestTrust|Find-ForeignUser|Find-ForeignGroup|Invoke-MapDomainTrust|Get-Hex|Create-RemoteThread|Get-FoxDump|Decrypt-CipherText|Get-Screenshot|Start-HTTP-Server|Local:Invoke-CreateRemoteThread|Local:Get-Win32Functions|Local:Inject-NetRipper|GetCommandLine|ElevatePrivs|Get-RegKeyClass|Get-BootKey|Get-HBootKey|Get-UserName|Get-UserHashes|DecryptHashes|DecryptSingleHash|Get-UserKeys|DumpHashes|Enable-SeAssignPrimaryTokenPrivilege|Enable-Privilege|Set-DesktopACLs|Set-DesktopACLToAllowEveryone|Get-PrimaryToken|Get-ThreadToken|Get-TokenInformation|Get-UniqueTokens|Invoke-ImpersonateUser|Create-ProcessWithToken|Free-AllTokens|Enum-AllTokens|Invoke-RevertToSelf|Set-Speaker\(\$Volume\){\$wshShell|Local:Get-RandomString|Local:Invoke-PsExecCmd|Get-GPPPassword|Local:Inject-BypassStuff|Local:Invoke-CopyFile\(\$sSource,|ind-Fruit|New-IPv4Range|New-IPv4RangeFromCIDR|Parse-Hosts|Parse-ILHosts|Exclude-Hosts|Get-TopPort|Parse-Ports|Parse-IpPorts|Remove-Ports|Write-PortscanOut|Convert-SwitchtoBool|Get-ForeignUser|Get-ForeignGroup";
   (union isfuzzy=true
    (SecurityEvent
@@ -44,7 +43,7 @@ query: |
   | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer
   ),
   (WindowsEvent
-  | where EventID == 4688 
+  | where EventID == 4688
   | where EventData has_any ("-encodedCommand", "powershell.exe","powershell_ise.exe","pwsh.exe")
   | where not(EventData has_any ('gc_worker.exe', 'gc_service.exe'))
   //consider filtering on filename if perf issues occur
@@ -78,5 +77,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/AnomalousUserAppSigninLocationIncrease-detection.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AnomalousUserAppSigninLocationIncrease-detection.yaml
@@ -1,8 +1,8 @@
 id: 7cb8f77d-c52f-4e46-b82f-3cf2e106224a
 name: Anomalous sign-in location by user account and authenticating application
 description: |
-  'This query over Azure Active Directory sign-in considers all user sign-ins for each Azure Active 
-  Directory application and picks out the most anomalous change in location profile for a user within an 
+  'This query over Azure Active Directory sign-in considers all user sign-ins for each Azure Active
+  Directory application and picks out the most anomalous change in location profile for a user within an
   individual application. An alert is generated for recent sign-ins that have location counts that are anomalous
   over last day but also over the last 3-day and 7-day periods.
   Please note that on workspaces with larger volume of Signin data (~10M+ events a day) may timeout when using this default query time period.
@@ -25,7 +25,6 @@ tactics:
 relevantTechniques:
   - T1078
 query: |
-
   let lookBack_long = 7d;
   let lookBack_med = 3d;
   let lookBack = 1d;
@@ -33,14 +32,14 @@ query: |
   table(tableName)
   | where TimeGenerated >= startofday(ago(lookBack_long))
   | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
-  | extend locationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city), ";") 
-  | project TimeGenerated, AppDisplayName , UserPrincipalName, locationString 
-  // Create time series 
-  | make-series dLocationCount = dcount(locationString) on TimeGenerated in range(startofday(ago(lookBack_long)),now(), 1d) 
-  by UserPrincipalName, AppDisplayName 
-  // Compute best fit line for each entry 
-  | extend (RSquare,Slope,Variance,RVariance,Interception,LineFit)=series_fit_line(dLocationCount) 
-  // Chart the 3 most interesting lines  
+  | extend locationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city), ";")
+  | project TimeGenerated, AppDisplayName , UserPrincipalName, locationString
+  // Create time series
+  | make-series dLocationCount = dcount(locationString) on TimeGenerated in range(startofday(ago(lookBack_long)),now(), 1d)
+  by UserPrincipalName, AppDisplayName
+  // Compute best fit line for each entry
+  | extend (RSquare,Slope,Variance,RVariance,Interception,LineFit)=series_fit_line(dLocationCount)
+  // Chart the 3 most interesting lines
   // A 0-value slope corresponds to an account being completely stable over time for a given Azure Active Directory application
   | where Slope > 0.3
   | top 50 by Slope desc
@@ -48,10 +47,10 @@ query: |
   table(tableName)
   | where TimeGenerated >= startofday(ago(lookBack_med))
   | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
-  | extend locationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city), ";") 
-  | project TimeGenerated, AppDisplayName , UserPrincipalName, locationString 
-  | make-series dLocationCount = dcount(locationString) on TimeGenerated in range(startofday(ago(lookBack_med)) ,now(), 1d) 
-  by UserPrincipalName, AppDisplayName 
+  | extend locationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city), ";")
+  | project TimeGenerated, AppDisplayName , UserPrincipalName, locationString
+  | make-series dLocationCount = dcount(locationString) on TimeGenerated in range(startofday(ago(lookBack_med)) ,now(), 1d)
+  by UserPrincipalName, AppDisplayName
   | extend (RSquare,Slope,Variance,RVariance,Interception,LineFit)=series_fit_line(dLocationCount)
   | where Slope > 0.3
   | top 50 by Slope desc
@@ -60,10 +59,10 @@ query: |
   table(tableName)
   | where TimeGenerated >= startofday(ago(lookBack))
   | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(DeviceDetail), LocationDetails = todynamic(LocationDetails)
-  | extend locationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city), ";") 
-  | project TimeGenerated, AppDisplayName , UserPrincipalName, locationString 
-  | make-series dLocationCount = dcount(locationString) on TimeGenerated in range(startofday(ago(lookBack)) ,now(), 1d) 
-  by UserPrincipalName, AppDisplayName 
+  | extend locationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city), ";")
+  | project TimeGenerated, AppDisplayName , UserPrincipalName, locationString
+  | make-series dLocationCount = dcount(locationString) on TimeGenerated in range(startofday(ago(lookBack)) ,now(), 1d)
+  by UserPrincipalName, AppDisplayName
   | extend (RSquare,Slope,Variance,RVariance,Interception,LineFit)=series_fit_line(dLocationCount)
   | where Slope > 5
   | top 50 by Slope desc
@@ -79,5 +78,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/BypassCondAccessRule.yaml
@@ -4,7 +4,7 @@ description: |
   'Identifies an attempt to Bypass conditional access rule(s) in Azure Active Directory.
   The ConditionalAccessStatus column value details if there was an attempt to bypass Conditional Access
   or if the Conditional access rule was not satisfied (ConditionalAccessStatus == 1).
-  References: 
+  References:
   https://docs.microsoft.com/azure/active-directory/conditional-access/overview
   https://docs.microsoft.com/azure/active-directory/reports-monitoring/concept-sign-ins
   https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-sign-ins-error-codes
@@ -32,7 +32,6 @@ relevantTechniques:
   - T1078
   - T1098
 query: |
-
   let threshold = 1;
   let aadFunc = (tableName:string){
   table(tableName)
@@ -44,9 +43,9 @@ query: |
   )
   | extend DeviceDetail = todynamic(DeviceDetail), Status = todynamic(Status), LocationDetails = todynamic(LocationDetails)
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
-  | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion) 
+  | extend State = tostring(LocationDetails.state), City = tostring(LocationDetails.city), Region = tostring(LocationDetails.countryOrRegion)
   | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
-  | extend Status = strcat(StatusCode, ": ", ResultDescription) 
+  | extend Status = strcat(StatusCode, ": ", ResultDescription)
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Status = make_list(Status), StatusDetails = make_list(StatusDetails), IPAddresses = make_list(IPAddress), IPAddressCount = dcount(IPAddress), CorrelationIds = make_list(CorrelationId), ConditionalAccessPoliciesName = make_list(ConditionalAccessPoliciesName)
   by UserPrincipalName, AppDisplayName, tostring(Browser), tostring(OS), City, State, Region, Type
   | where IPAddressCount > threshold and StatusDetails !has "MFA successfully completed"
@@ -68,5 +67,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/DisabledAccountSigninsAcrossManyApplications.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/DisabledAccountSigninsAcrossManyApplications.yaml
@@ -23,13 +23,12 @@ tactics:
 relevantTechniques:
   - T1078
 query: |
-
   let threshold = 3;
   let aadFunc = (tableName:string){
   table(tableName)
   | where ResultType == "50057"
   | where ResultDescription =~ "User account is disabled. The account has been disabled by an administrator."
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), applicationCount = dcount(AppDisplayName), 
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), applicationCount = dcount(AppDisplayName),
   applicationSet = make_set(AppDisplayName), count() by UserPrincipalName, IPAddress, Type
   | where applicationCount >= threshold
   | extend timestamp = StartTime, AccountCustomEntity = UserPrincipalName, IPCustomEntity = IPAddress
@@ -46,5 +45,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/DistribPassCrackAttempt.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/DistribPassCrackAttempt.yaml
@@ -26,7 +26,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let s_threshold = 30;
   let l_threshold = 3;
   let aadFunc = (tableName:string){
@@ -38,9 +37,9 @@ query: |
   | extend OS = DeviceDetail.operatingSystem, Browser = DeviceDetail.browser
   | extend StatusCode = tostring(Status.errorCode), StatusDetails = tostring(Status.additionalDetails)
   | extend LocationString = strcat(tostring(LocationDetails.countryOrRegion), "/", tostring(LocationDetails.state), "/", tostring(LocationDetails.city))
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), LocationCount=dcount(LocationString), Location = make_set(LocationString), 
-  IPAddress = make_set(IPAddress), IPAddressCount = dcount(IPAddress), AppDisplayName = make_set(AppDisplayName), ResultDescription = make_set(ResultDescription), 
-  Browser = make_set(Browser), OS = make_set(OS), SigninCount = count() by UserPrincipalName, Type                              
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), LocationCount=dcount(LocationString), Location = make_set(LocationString),
+  IPAddress = make_set(IPAddress), IPAddressCount = dcount(IPAddress), AppDisplayName = make_set(AppDisplayName), ResultDescription = make_set(ResultDescription),
+  Browser = make_set(Browser), OS = make_set(OS), SigninCount = count() by UserPrincipalName, Type
   // Setting a generic threshold - Can be different for different environment
   | where SigninCount > s_threshold and LocationCount >= l_threshold
   | extend tostring(Location), tostring(IPAddress), tostring(AppDisplayName), tostring(ResultDescription), tostring(Browser), tostring(OS)
@@ -59,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/FailedLogonToAzurePortal.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/FailedLogonToAzurePortal.yaml
@@ -1,8 +1,8 @@
 id: 223db5c1-1bf8-47d8-8806-bed401b356a4
 name: Failed login attempts to Azure Portal
 description: |
-  'Identifies failed login attempts in the Azure Active Directory SigninLogs to the Azure Portal.  Many failed logon 
-  attempts or some failed logon attempts from multiple IPs could indicate a potential brute force attack.  
+  'Identifies failed login attempts in the Azure Active Directory SigninLogs to the Azure Portal.  Many failed logon
+  attempts or some failed logon attempts from multiple IPs could indicate a potential brute force attack.
   The following are excluded due to success and non-failure results:
   References: https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-sign-ins-error-codes
   0 - successful logon
@@ -26,7 +26,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let timeRange = 1d;
   let lookBack = 7d;
   let threshold_Failed = 5;
@@ -56,7 +55,7 @@ query: |
   ;
   // Verify there is no success for the same connection attempt after the fail
   let failnoSuccess = failPortalSignins | join kind= leftouter (
-     successPortalSignins 
+     successPortalSignins
   ) on UserPrincipalName
   | where TimeGenerated > TimeGenerated1 or isempty(TimeGenerated1)
   | project-away TimeGenerated1, UserPrincipalName1
@@ -68,7 +67,7 @@ query: |
   | summarize by UserId, lu_UserDisplayName = UserDisplayName, lu_UserPrincipalName = UserPrincipalName;
   // Join resolved names to unresolved list from portal signins
   let unresolvedNames = failnoSuccess | where Unresolved == true | join kind= inner (
-     identityLookup 
+     identityLookup
   ) on UserId
   | extend UserDisplayName = lu_UserDisplayName, UserPrincipalName = lu_UserPrincipalName
   | project-away lu_UserDisplayName, lu_UserPrincipalName;
@@ -100,5 +99,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/MailPermissionsAddedToApplication.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/MailPermissionsAddedToApplication.yaml
@@ -20,7 +20,6 @@ tags:
   - Solorigate
   - NOBELIUM
 query: |
-
   AuditLogs
   | where Category =~ "ApplicationManagement"
   | where ActivityDisplayName has_any ("Add delegated permission grant","Add app role assignment to service principal")
@@ -55,5 +54,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/RareApplicationConsent.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/RareApplicationConsent.yaml
@@ -2,8 +2,8 @@ id: 83ba3057-9ea3-4759-bf6a-933f2e5bc7ee
 name: Rare application consent
 description: |
   'This will alert when the "Consent to application" operation occurs by a user that has not done this operation before or rarely does this.
-  This could indicate that permissions to access the listed Azure App were provided to a malicious actor. 
-  Consent to application, Add service principal and Add OAuth2PermissionGrant should typically be rare events. 
+  This could indicate that permissions to access the listed Azure App were provided to a malicious actor.
+  Consent to application, Add service principal and Add OAuth2PermissionGrant should typically be rare events.
   This may help detect the Oauth2 attack that can be initiated by this publicly available tool - https://github.com/fireeye/PwnAuth
   For further information on AuditLogs please see https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities.'
 severity: Medium
@@ -23,18 +23,17 @@ relevantTechniques:
   - T1136
   - T1068
 query: |
-
   let current = 1d;
   let auditLookback = 7d;
-  // Setting threshold to 3 as a default, change as needed.  
+  // Setting threshold to 3 as a default, change as needed.
   // Any operation that has been initiated by a user or app more than 3 times in the past 7 days will be excluded
   let threshold = 3;
   // Gather initial data from lookback period, excluding current, adjust current to more than a single day if no results
   let AuditTrail = AuditLogs | where TimeGenerated >= ago(auditLookback) and TimeGenerated < ago(current)
-  // 2 other operations that can be part of malicious activity in this situation are 
+  // 2 other operations that can be part of malicious activity in this situation are
   // "Add OAuth2PermissionGrant" and "Add service principal", extend the filter below to capture these too
   | where OperationName has "Consent to application"
-  | extend InitiatedBy = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)), 
+  | extend InitiatedBy = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)),
   tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName), tostring(parse_json(tostring(InitiatedBy.app)).displayName))
   | extend TargetResourceName = tolower(tostring(TargetResources.[0].displayName))
   | summarize max(TimeGenerated), OperationCount = count() by OperationName, InitiatedBy, TargetResourceName
@@ -45,10 +44,10 @@ query: |
   let RecentConsent = AuditLogs | where TimeGenerated >= ago(current)
   | where OperationName has "Consent to application"
   | extend IpAddress = case(
-  isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)) and tostring(parse_json(tostring(InitiatedBy.user)).ipAddress) != 'null', tostring(parse_json(tostring(InitiatedBy.user)).ipAddress), 
+  isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)) and tostring(parse_json(tostring(InitiatedBy.user)).ipAddress) != 'null', tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
   isnotempty(tostring(parse_json(tostring(InitiatedBy.app)).ipAddress)) and tostring(parse_json(tostring(InitiatedBy.app)).ipAddress) != 'null', tostring(parse_json(tostring(InitiatedBy.app)).ipAddress),
   'Not Available')
-  | extend InitiatedBy = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)), 
+  | extend InitiatedBy = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)),
   tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName), tostring(parse_json(tostring(InitiatedBy.app)).displayName))
   | extend TargetResourceName = tolower(tostring(TargetResources.[0].displayName))
   | parse TargetResources.[0].modifiedProperties with * "ConsentType: " ConsentType "]" *
@@ -57,7 +56,7 @@ query: |
   | project TimeGenerated, InitiatedBy, IpAddress, TargetResourceName, Category, OperationName, ConsentType, UserAgent, CorrelationId, Type;
   // Exclude previously seen audit activity for "Consent to application" that was seen in the lookback period
   // First for rare InitiatedBy
-  let RareConsentBy = RecentConsent | join kind= leftanti AuditTrail on OperationName, InitiatedBy 
+  let RareConsentBy = RecentConsent | join kind= leftanti AuditTrail on OperationName, InitiatedBy
   | extend Reason = "Previously unseen user consenting";
   // Second for rare TargetResourceName
   let RareConsentApp = RecentConsent | join kind= leftanti AuditTrail on OperationName, TargetResourceName
@@ -78,5 +77,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/SeamlessSSOPasswordSpray.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SeamlessSSOPasswordSpray.yaml
@@ -18,7 +18,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let account_threshold = 5;
   AADNonInteractiveUserSignInLogs
   //| where ResultType == "81016"
@@ -43,5 +42,5 @@ entityMappings:
   fieldMappings:
     - identifier: Address
       columnName: IPAddress
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/SigninAttemptsByIPviaDisabledAccounts.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SigninAttemptsByIPviaDisabledAccounts.yaml
@@ -25,13 +25,12 @@ relevantTechniques:
   - T1078
   - T1098
 query: |
-
   let aadFunc = (tableName:string){
   table(tableName)
-  | where ResultType == "50057" 
-  | where ResultDescription == "User account is disabled. The account has been disabled by an administrator." 
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), disabledAccountLoginAttempts = count(), 
-  disabledAccountsTargeted = dcount(UserPrincipalName), applicationsTargeted = dcount(AppDisplayName), disabledAccountSet = make_set(UserPrincipalName), 
+  | where ResultType == "50057"
+  | where ResultDescription == "User account is disabled. The account has been disabled by an administrator."
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), disabledAccountLoginAttempts = count(),
+  disabledAccountsTargeted = dcount(UserPrincipalName), applicationsTargeted = dcount(AppDisplayName), disabledAccountSet = make_set(UserPrincipalName),
   applicationSet = make_set(AppDisplayName) by IPAddress, Type
   | order by disabledAccountLoginAttempts desc
   | join kind= leftouter (
@@ -41,10 +40,10 @@ query: |
       | summarize successfulAccountSigninCount = dcount(UserPrincipalName), successfulAccountSigninSet = make_set(UserPrincipalName, 15) by IPAddress, Type
       // Assume IPs associated with sign-ins from 100+ distinct user accounts are safe
       | where successfulAccountSigninCount < 100
-  ) on IPAddress  
+  ) on IPAddress
   // IPs from which attempts to authenticate as disabled user accounts originated, and had a non-zero success rate for some other account
   | where isnotempty(successfulAccountSigninCount)
-  | project StartTime, EndTime, IPAddress, disabledAccountLoginAttempts, disabledAccountsTargeted, disabledAccountSet, applicationSet, 
+  | project StartTime, EndTime, IPAddress, disabledAccountLoginAttempts, disabledAccountsTargeted, disabledAccountSet, applicationSet,
   successfulAccountSigninCount, successfulAccountSigninSet, Type
   | order by disabledAccountLoginAttempts
   | extend timestamp = StartTime, IPCustomEntity = IPAddress
@@ -57,5 +56,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/SigninPasswordSpray.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SigninPasswordSpray.yaml
@@ -26,7 +26,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
     let timeRange = 3d;
     let lookBack = 7d;
     let authenticationWindow = 20m;
@@ -59,7 +58,7 @@ query: |
     // lookup any unresolved identities
     | extend UnresolvedUserId = iff(Identity matches regex isGUID, UserId, "")
     | join kind= leftouter (
-     identityLookup 
+     identityLookup
     ) on $left.UnresolvedUserId==$right.UserId
     | extend UserDisplayName=iff(isempty(lu_UserDisplayName), UserDisplayName, lu_UserDisplayName)
     | extend UserPrincipalName=iff(isempty(lu_UserPrincipalName), UserPrincipalName, lu_UserPrincipalName)
@@ -85,5 +84,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
@@ -23,20 +23,19 @@ relevantTechniques:
   - T1110
   - T1078
 query: |
-
   let logonDiff = 10m;
   let aadFunc = (tableName:string){
-  table(tableName) 
-  | where ResultType == "0" 
+  table(tableName)
+  | where ResultType == "0"
   | where AppDisplayName !in ("Office 365 Exchange Online", "Skype for Business Online")
   | project SuccessLogonTime = TimeGenerated, UserPrincipalName, SuccessIPAddress = IPAddress, AppDisplayName, SuccessIPBlock = strcat(split(IPAddress, ".")[0], ".", split(IPAddress, ".")[1]), Type
   | join kind= inner (
       table(tableName)
-      | where ResultType !in ("0", "50140") 
-      | where ResultDescription !~ "Other"  
+      | where ResultType !in ("0", "50140")
+      | where ResultDescription !~ "Other"
       | where AppDisplayName !in ("Office 365 Exchange Online", "Skype for Business Online")
       | project FailedLogonTime = TimeGenerated, UserPrincipalName, FailedIPAddress = IPAddress, AppDisplayName, ResultType, ResultDescription, Type
-  ) on UserPrincipalName, AppDisplayName 
+  ) on UserPrincipalName, AppDisplayName
   | where SuccessLogonTime < FailedLogonTime and FailedLogonTime - SuccessLogonTime <= logonDiff and FailedIPAddress !startswith SuccessIPBlock
   | summarize FailedLogonTime = max(FailedLogonTime), SuccessLogonTime = max(SuccessLogonTime) by UserPrincipalName, SuccessIPAddress, AppDisplayName, FailedIPAddress, ResultType, ResultDescription, Type
   | extend timestamp = SuccessLogonTime
@@ -57,5 +56,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: FailedIPAddress
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled

--- a/Solutions/Azure Activity/Analytic Rules/Creating_Anomalous_Number_Of_Resources_detection.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/Creating_Anomalous_Number_Of_Resources_detection.yaml
@@ -5,7 +5,7 @@ description: |
   The anomaly detection identifies activities that have occurred both since the start of the day 1 day ago and the start of the day 7 days ago.
   The start of the day is considered 12am UTC time.'
 severity: Medium
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: AzureActivity
     dataTypes:
@@ -19,19 +19,18 @@ tactics:
 relevantTechniques:
   - T1496
 query: |
-
   let szOperationNames = dynamic(["microsoft.compute/virtualMachines/write", "microsoft.resources/deployments/write"]);
   let starttime = 7d;
   let endtime = 1d;
   AzureActivity
   | where TimeGenerated between (startofday(ago(starttime)) .. startofday(ago(endtime)))
   | where OperationNameValue  in~ (szOperationNames)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ActivityTimeStamp = makelist(TimeGenerated), ActivityStatusValue = makelist(ActivityStatusValue), 
-  OperationIds = makelist(OperationId), CallerIpAddress = makelist(CallerIpAddress), CorrelationId = makelist(CorrelationId) 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ActivityTimeStamp = makelist(TimeGenerated), ActivityStatusValue = makelist(ActivityStatusValue),
+  OperationIds = makelist(OperationId), CallerIpAddress = makelist(CallerIpAddress), CorrelationId = makelist(CorrelationId)
   by ResourceId, Caller, OperationNameValue, Resource, ResourceGroup
   | mvexpand CallerIpAddress
   | where isnotempty(CallerIpAddress)
-  | make-series dResourceCount=dcount(ResourceId)  default=0 on StartTimeUtc in range(startofday(ago(7d)), now(), 1d) 
+  | make-series dResourceCount=dcount(ResourceId)  default=0 on StartTimeUtc in range(startofday(ago(7d)), now(), 1d)
   by Caller, tostring(ActivityTimeStamp), tostring(ActivityStatusValue), tostring(OperationIds), tostring(CallerIpAddress), tostring(CorrelationId), ResourceId, OperationNameValue , Resource, ResourceGroup
   | extend (RSquare,Slope,Variance,RVariance,Interception,LineFit)=series_fit_line(dResourceCount)
   | where Slope > 0.2
@@ -40,16 +39,16 @@ query: |
   AzureActivity
   | where TimeGenerated >= startofday(ago(endtime))
   | where OperationNameValue in~ (szOperationNames)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ActivityTimeStamp = makelist(TimeGenerated), ActivityStatusValue = makelist(ActivityStatusValue), 
-  OperationIds = makelist(OperationId), CallerIpAddress = makelist(CallerIpAddress), CorrelationId = makelist(CorrelationId) 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ActivityTimeStamp = makelist(TimeGenerated), ActivityStatusValue = makelist(ActivityStatusValue),
+  OperationIds = makelist(OperationId), CallerIpAddress = makelist(CallerIpAddress), CorrelationId = makelist(CorrelationId)
   by ResourceId, Caller, OperationNameValue, Resource, ResourceGroup
   | mvexpand CallerIpAddress
   | where isnotempty(CallerIpAddress)
-  | make-series dResourceCount=dcount(ResourceId)  default=0 on StartTimeUtc in range(startofday(ago(1d)), now(), 1d) 
+  | make-series dResourceCount=dcount(ResourceId)  default=0 on StartTimeUtc in range(startofday(ago(1d)), now(), 1d)
   by Caller, tostring(ActivityTimeStamp), tostring(ActivityStatusValue), tostring(OperationIds), tostring(CallerIpAddress), tostring(CorrelationId), ResourceId, OperationNameValue , Resource, ResourceGroup
   | extend (RSquare,Slope,Variance,RVariance,Interception,LineFit)=series_fit_line(dResourceCount)
-  | where Slope > 0.2    
-  ) on Caller, CallerIpAddress        
+  | where Slope > 0.2
+  ) on Caller, CallerIpAddress
   | mvexpand todynamic(ActivityTimeStamp), todynamic(ActivityStatusValue), todynamic(OperationIds), todynamic(CorrelationId)
   | extend timestamp = ActivityTimeStamp, AccountCustomEntity = Caller, IPCustomEntity = CallerIpAddress
 entityMappings:
@@ -61,5 +60,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Azure Activity/Analytic Rules/New-CloudShell-User.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/New-CloudShell-User.yaml
@@ -4,7 +4,7 @@ description: |
   'Identifies when a user creates an Azure CloudShell for the first time.
   Monitor this activity to ensure only expected user are using CloudShell'
 severity: Low
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: AzureActivity
     dataTypes:
@@ -18,17 +18,16 @@ tactics:
 relevantTechniques:
   - T1059
 query: |
-
   let match_window = 3m;
   AzureActivity
   | where ResourceGroup has "cloud-shell"
-  | where (OperationNameValue =~ "Microsoft.Storage/storageAccounts/listKeys/action") 
+  | where (OperationNameValue =~ "Microsoft.Storage/storageAccounts/listKeys/action")
   | where ActivityStatusValue == "Success"
   | extend TimeKey = bin(TimeGenerated, match_window), AzureIP = CallerIpAddress
   | join kind = inner
   (AzureActivity
   | where ResourceGroup has "cloud-shell"
-  | where (OperationNameValue =~ "Microsoft.Storage/storageAccounts/write") 
+  | where (OperationNameValue =~ "Microsoft.Storage/storageAccounts/write")
   | extend TimeKey = bin(TimeGenerated, match_window), UserIP = CallerIpAddress
   ) on Caller, TimeKey
   | summarize count() by TimeKey, Caller, ResourceGroup, SubscriptionId, TenantId, AzureIP, UserIP, HTTPRequest, Type, Properties, CategoryValue, OperationList = strcat(OperationNameValue, ' , ', OperationNameValue1)
@@ -42,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: UserIP
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Azure Activity/Analytic Rules/RareOperations.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/RareOperations.yaml
@@ -1,11 +1,11 @@
 id: 23de46ea-c425-4a77-b456-511ae4855d69
 name: Rare subscription-level operations in Azure
 description: |
-  'This query looks for a few sensitive subscription-level events based on Azure Activity Logs. 
-   For example this monitors for the operation name 'Create or Update Snapshot' which is used for creating backups but could be misused by attackers 
+  'This query looks for a few sensitive subscription-level events based on Azure Activity Logs.
+   For example this monitors for the operation name 'Create or Update Snapshot' which is used for creating backups but could be misused by attackers
    to dump hashes or extract sensitive information from the disk.'
 severity: Low
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: AzureActivity
     dataTypes:
@@ -21,7 +21,6 @@ relevantTechniques:
   - T1003
   - T1098
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   // The number of operations below which an IP address is considered an unusual source of role assignment operations
@@ -34,11 +33,11 @@ query: |
   | where TimeGenerated between (ago(starttime) .. ago(endtime))
   | summarize count() by CallerIpAddress, Caller, OperationNameValue
   | where count_ >= alertOperationThreshold
-  | join kind = rightanti ( 
+  | join kind = rightanti (
   SensitiveActivity
   | where TimeGenerated >= ago(endtime)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ActivityTimeStamp = makelist(TimeGenerated), ActivityStatusValue = makelist(ActivityStatusValue), 
-  OperationIds = makelist(OperationId), CorrelationIds = makelist(CorrelationId), Resources = makelist(Resource), ResourceGroups = makelist(ResourceGroup), ResourceIds = makelist(ResourceId), ActivityCountByCallerIPAddress = count()  
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), ActivityTimeStamp = makelist(TimeGenerated), ActivityStatusValue = makelist(ActivityStatusValue),
+  OperationIds = makelist(OperationId), CorrelationIds = makelist(CorrelationId), Resources = makelist(Resource), ResourceGroups = makelist(ResourceGroup), ResourceIds = makelist(ResourceId), ActivityCountByCallerIPAddress = count()
   by CallerIpAddress, Caller, OperationNameValue
   ) on CallerIpAddress, Caller, OperationNameValue
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Caller, IPCustomEntity = CallerIpAddress
@@ -51,5 +50,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Azure Firewall/Analytic Rules/SeveralDenyActionsRegistered.yaml
+++ b/Solutions/Azure Firewall/Analytic Rules/SeveralDenyActionsRegistered.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: AzureFirewall
-    dataTypes: 
+    dataTypes:
       - AzureDiagnostics
 queryFrequency: 1h
 queryPeriod: 1h
@@ -21,7 +21,6 @@ relevantTechniques:
   - T1071
   - T1210
 query: |
-
   let threshold = 1;
   AzureDiagnostics
       | where OperationName in ("AzureFirewallApplicationRuleLog","AzureFirewallNetworkRuleLog")
@@ -44,5 +43,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Azure Key Vault/Analytic Rules/KeyVaultSensitiveOperations.yaml
+++ b/Solutions/Azure Key Vault/Analytic Rules/KeyVaultSensitiveOperations.yaml
@@ -1,7 +1,7 @@
 id: d6491be0-ab2d-439d-95d6-ad8ea39277c5
 name: Sensitive Azure Key Vault operations
 description: |
-  'Identifies when sensitive Azure Key Vault operations are used. This includes: VaultDelete, KeyDelete, SecretDelete, SecretPurge, KeyPurge, SecretBackup, KeyBackup. 
+  'Identifies when sensitive Azure Key Vault operations are used. This includes: VaultDelete, KeyDelete, SecretDelete, SecretPurge, KeyPurge, SecretBackup, KeyBackup.
   Any Backup operations should match with expected scheduled backup activity.'
 severity: Low
 status: Available
@@ -18,7 +18,6 @@ tactics:
 relevantTechniques:
   - T1485
 query: |
-
   let SensitiveOperationList = dynamic(
   ["VaultDelete", "KeyDelete", "SecretDelete", "SecretPurge", "KeyPurge", "SecretBackup", "KeyBackup"]);
   AzureDiagnostics
@@ -31,8 +30,8 @@ query: |
   | where CallerIPAddress !~ "None" and isnotempty(CallerIPAddress)
   | where clientInfo_s !~ "None" and isnotempty(clientInfo_s)
   | where requestUri_s !~ "None" and isnotempty(requestUri_s)
-  | where ResourceType =~ "VAULTS" and ResultType =~ "Success" 
-  | where OperationName in~ (SensitiveOperationList)  
+  | where ResourceType =~ "VAULTS" and ResultType =~ "Success"
+  | where OperationName in~ (SensitiveOperationList)
   | summarize EventCount=count(), StartTimeUtc=min(TimeGenerated), EndTimeUtc=max(TimeGenerated), TimeTriggered=makelist(TimeGenerated),OperationNameList=make_set(OperationName), RequestURLList=make_set(requestUri_s), CallerIPList = make_set(CallerIPAddress),  CallerIPMax= arg_max(CallerIPAddress,*) by ResourceType, ResultType, Resource, id_s, identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g, clientInfo_s
   | extend timestamp = StartTimeUtc, IPCustomEntity = CallerIPMax, AccountCustomEntity = identity_claim_http_schemas_microsoft_com_identity_claims_objectidentifier_g
 entityMappings:
@@ -44,5 +43,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Azure Key Vault/Analytic Rules/TimeSeriesKeyvaultAccessAnomaly.yaml
+++ b/Solutions/Azure Key Vault/Analytic Rules/TimeSeriesKeyvaultAccessAnomaly.yaml
@@ -20,12 +20,11 @@ tactics:
 relevantTechniques:
   - T1003
 query: |
-
   let starttime = 14d;
   let timeframe = 1d;
   let scorethreshold = 3;
   let baselinethreshold = 5;
-  // To avoid any False Positives, filtering using AppId is recommended. For example the AppId 509e4652-da8d-478d-a730-e9d4a1996ca4 has been added in the query as it corresponds 
+  // To avoid any False Positives, filtering using AppId is recommended. For example the AppId 509e4652-da8d-478d-a730-e9d4a1996ca4 has been added in the query as it corresponds
   // to Azure Resource Graph performing VaultGet operations for indexing and syncing all tracked resources across Azure.
   let Allowedappid = dynamic(["509e4652-da8d-478d-a730-e9d4a1996ca4"]);
   let OperationList = dynamic(
@@ -82,5 +81,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOAdminGroupAdditions.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOAdminGroupAdditions.yaml
@@ -14,7 +14,6 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
   // Change to true to monitor for Project Administrator adds to *any* project
   let MonitorAllProjects = false;
   // If MonitorAllProjects is false, trigger only on Project Administrator add for the following projects
@@ -27,7 +26,7 @@ query: |
   | extend Level = iif(GroupName == 'Project Collection Administrators', 'Organization', 'Project'), AddedIdentityId = Data.MemberId
   | extend Severity = iif(Level == 'Organization', 'High', 'Medium'), AlertDetails = strcat('At ', TimeGenerated, ' UTC ', ActorUPN, '/', ActorDisplayName, ' added ', AddedIdentity, ' to the ', EntityName, ' ', Level)
   | where MonitorAllProjects == true or EntityName in (ProjectsToMonitor) or Level == 'Organization'
-  | project TimeGenerated, Severity, Adder = ActorUPN, AddedIdentity, AddedIdentityId, AlertDetails, Level, EntityName, GroupName, ActorAuthType = AuthenticationMechanism, 
+  | project TimeGenerated, Severity, Adder = ActorUPN, AddedIdentity, AddedIdentityId, AlertDetails, Level, EntityName, GroupName, ActorAuthType = AuthenticationMechanism,
     ActorIpAddress = IpAddress, ActorUserAgent = UserAgent, RawDetails = Details
   | extend timestamp = TimeGenerated, AccountCustomEntity = Adder, IPCustomEntity = ActorIpAddress
 entityMappings:
@@ -39,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricPrPolicyBypassing.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricPrPolicyBypassing.yaml
@@ -14,7 +14,6 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
   let starttime = 14d;
   let endtime = 3h;
   // Add full UPN (user@domain.com) to Authorized Bypassers to ignore policy bypasses by certain authorized users
@@ -28,7 +27,7 @@ query: |
   | where OperationName == 'Git.RefUpdatePoliciesBypassed'
   | where ActorUPN !in (historicBypassers) and ActorUPN !in (AuthorizedBypassers)
   | parse ScopeDisplayName with OrganizationName '(Organization)'
-  | project TimeGenerated, ActorUPN, IpAddress, UserAgent, OrganizationName, ProjectName, RepoName = Data.RepoName, AlertDetails = Details, Branch = Data.Name, 
+  | project TimeGenerated, ActorUPN, IpAddress, UserAgent, OrganizationName, ProjectName, RepoName = Data.RepoName, AlertDetails = Details, Branch = Data.Name,
     BypassReason = Data.BypassReason, PRLink = strcat('https://dev.azure.com/', OrganizationName, '/', ProjectName, '/_git/', Data.RepoName, '/pullrequest/', Data.PullRequestId)
   | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
 entityMappings:
@@ -40,5 +39,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricServiceConnectionAdds.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricServiceConnectionAdds.yaml
@@ -1,7 +1,7 @@
 id: 5efb0cfd-063d-417a-803b-562eae5b0301
 name: Azure DevOps Service Connection Addition/Abuse - Historic allow list
 description: |
-  'This detection builds an allow list of historic service connection use by Builds and Releases and compares to recent history, flagging growth of service connection use which are not manually included in the allow list and 
+  'This detection builds an allow list of historic service connection use by Builds and Releases and compares to recent history, flagging growth of service connection use which are not manually included in the allow list and
   not historically included in the allow list Build/Release runs.  This is to determine if someone is hijacking a build/release and adding many service connections in order to abuse or dump credentials from service connections.'
 severity: Medium
 status: Available
@@ -17,7 +17,6 @@ relevantTechniques:
   - T1098
   - T1496
 query: |
-
   let starttime = 14d;
   let endtime = 6h;
   // Ignore Build/Releases with less/equal this number
@@ -33,16 +32,16 @@ query: |
   ];
   let HistoricDefs = AzureDevOpsAuditing
   | where TimeGenerated between (ago(starttime) .. ago(endtime))
-  | where OperationName == "Library.ServiceConnectionExecuted" 
+  | where OperationName == "Library.ServiceConnectionExecuted"
   | extend DefId = tostring(Data.DefinitionId), Type = tostring(Data.PlanType), ConnectionId = tostring(Data.ConnectionId)
-  | summarize HistoricCount = dcount(tostring(ConnectionId)), ConnectionNames = make_set(tostring(Data.ConnectionName)) 
+  | summarize HistoricCount = dcount(tostring(ConnectionId)), ConnectionNames = make_set(tostring(Data.ConnectionName))
     by DefId = tostring(DefId), Type = tostring(Type), ProjectId, ProjectName, ActorUPN;
   AzureDevOpsAuditing
   | where TimeGenerated >= ago(endtime)
-  | where OperationName == "Library.ServiceConnectionExecuted" 
+  | where OperationName == "Library.ServiceConnectionExecuted"
   | extend DefId = tostring(Data.DefinitionId), Type = tostring(Data.PlanType), ConnectionId = tostring(Data.ConnectionId)
   | parse ScopeDisplayName with OrganizationName ' (Organization)'
-  | summarize CurrentCount = dcount(tostring(ConnectionId)), ConnectionNames = make_set(tostring(Data.ConnectionName)), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) 
+  | summarize CurrentCount = dcount(tostring(ConnectionId)), ConnectionNames = make_set(tostring(Data.ConnectionName)), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated)
     by OrganizationName, DefId = tostring(DefId), Type = tostring(Type), ProjectId, ProjectName, ActorUPN
   | where CurrentCount > ServiceConnectionThreshold
   | join (HistoricDefs) on ProjectId, DefId, Type, ActorUPN
@@ -51,7 +50,7 @@ query: |
   Type == "Build", strcat('https://dev.azure.com/', OrganizationName, '/', ProjectName, '/_build?definitionId=', DefId),
   strcat('https://dev.azure.com/', OrganizationName, '/', ProjectName, '/_release?_a=releases&view=mine&definitionId=', DefId))
   | where CurrentCount >= HistoricCount + NewConnectionThreshold
-  | project StartTime, OrganizationName, ProjectName, DefId, link, RecentDistinctServiceConnections = CurrentCount, HistoricDistinctServiceConnections = HistoricCount, 
+  | project StartTime, OrganizationName, ProjectName, DefId, link, RecentDistinctServiceConnections = CurrentCount, HistoricDistinctServiceConnections = HistoricCount,
     RecentConnections = ConnectionNames, HistoricConnections = ConnectionNames1, ActorUPN
   | extend timestamp = StartTime, AccountCustomEntity = ActorUPN
 entityMappings:
@@ -59,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPatSessionMisuse.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPatSessionMisuse.yaml
@@ -20,7 +20,6 @@ relevantTechniques:
   - T1496
   - T1559
 query: |
-
   // Allowlisted UPNs should likely stay empty
   let AllowlistedUpns = datatable(UPN:string)['foo@bar.com', 'test@foo.com'];
   // Operation Name parts that will alert
@@ -42,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOServiceConnectionUsage.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOServiceConnectionUsage.yaml
@@ -2,7 +2,7 @@ id: d564ff12-8f53-41b8-8649-44f76b37b99f
 name: Azure DevOps Service Connection Abuse
 description: |
   'Flags builds/releases that use a large number of service connections if they aren't manually in the allow list.
-  This is to determine if someone is hijacking a build/release and adding many service connections in order to abuse 
+  This is to determine if someone is hijacking a build/release and adding many service connections in order to abuse
   or dump credentials from service connections.'
 severity: Medium
 status: Available
@@ -18,7 +18,6 @@ relevantTechniques:
   - T1098
   - T1496
 query: |
-
   // How many greater than Service Connections you want to view per build/release
   let ServiceConnectionThreshold = 4;
   let BypassDefIds = datatable(DefId:string, Type:string, ProjectName:string)
@@ -28,10 +27,10 @@ query: |
   //"122", "Build", "ProjectB"
   ];
   AzureDevOpsAuditing
-  | where OperationName == "Library.ServiceConnectionExecuted" 
+  | where OperationName == "Library.ServiceConnectionExecuted"
   | extend DefId = tostring(Data.DefinitionId), Type = tostring(Data.PlanType), ConnectionId = tostring(Data.ConnectionId)
   | parse ScopeDisplayName with OrganizationName ' (Organization)'
-  | summarize CurrentCount = dcount(tostring(ConnectionId)), ConnectionNames = make_set(tostring(Data.ConnectionName)), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) 
+  | summarize CurrentCount = dcount(tostring(ConnectionId)), ConnectionNames = make_set(tostring(Data.ConnectionName)), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated)
     by OrganizationName, tostring(DefId), tostring(Type), ProjectId, ProjectName
   | where CurrentCount > ServiceConnectionThreshold
   | join kind=anti BypassDefIds on $left.DefId==$right.DefId and $left.Type == $right.Type and $left.ProjectName == $right.ProjectName
@@ -39,5 +38,5 @@ query: |
     Type == "Build", strcat('https://dev.azure.com/', OrganizationName, '/', ProjectName, '/_build?definitionId=', DefId),
     strcat('https://dev.azure.com/', OrganizationName, '/', ProjectName, '/_release?_a=releases&view=mine&definitionId=', DefId))
   | extend timestamp = StartTime
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/CiscoASA/Analytic Rules/CiscoASA-AvgAttackDetectRateIncrease.yaml
+++ b/Solutions/CiscoASA/Analytic Rules/CiscoASA-AvgAttackDetectRateIncrease.yaml
@@ -21,11 +21,10 @@ relevantTechniques:
   - T1046
   - T1498
 query: |
-
   let timeframe = 1h;
-  let last1h = CommonSecurityLog 
+  let last1h = CommonSecurityLog
   | where TimeGenerated >= ago(timeframe)
-  | where isempty(CommunicationDirection) 
+  | where isempty(CommunicationDirection)
   | where DeviceEventClassID == "733100"
   | extend SourceOfDropRateCount = tostring(split(tostring(split(Message, "]")[0]),"[ ")[1])
   | extend splitMessage = split(Message, ".")
@@ -38,9 +37,9 @@ query: |
   | extend MaxConfiguredAvgRate = toint(CurrentAvgRate[2])
   | extend CumulativeTotal = toint(split(tostring(split(tostring(splitMessage[1]),"  ")[2]),"is ")[1])
   | summarize last1hCumTotal = sum(CumulativeTotal), last1hAvgRatePerSec = avg(CurrentAvgRatePerSec), last1hAvgBurstRatePerSec = avg(CurrentBurstRatePerSec) by DeviceName, DeviceEventClassID, SourceIP, SourceOfDropRateCount, DropRate;
-  let prev6h = CommonSecurityLog 
+  let prev6h = CommonSecurityLog
   | where TimeGenerated between (ago(6h) .. ago(1h))
-  | where isempty(CommunicationDirection) 
+  | where isempty(CommunicationDirection)
   | where DeviceEventClassID == "733100"
   | extend SourceOfDropRateCount = tostring(split(tostring(split(Message, "]")[0]),"[ ")[1])
   | extend splitMessage = split(Message, ".")
@@ -52,10 +51,10 @@ query: |
   | extend prevCurrentAvgRatePerSec = toint(split(tostring(CurrentAvgRate[1])," ")[0])
   | extend prevMaxConfiguredAvgRate = toint(CurrentAvgRate[2])
   | extend prevCumulativeTotal = toint(split(tostring(split(tostring(splitMessage[1]),"  ")[2]),"is ")[1])
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), prev6hCumTotal = sum(prevCumulativeTotal), prev6hAvgRatePerSec = avg(prevCurrentAvgRatePerSec), prev6hAvgBurstRatePerSec = avg(prevCurrentBurstRatePerSec) 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), prev6hCumTotal = sum(prevCumulativeTotal), prev6hAvgRatePerSec = avg(prevCurrentAvgRatePerSec), prev6hAvgBurstRatePerSec = avg(prevCurrentBurstRatePerSec)
   by DeviceName, DeviceEventClassID, SourceIP, SourceOfDropRateCount, DropRate;
   last1h | join (
-    prev6h 
+    prev6h
   ) on DeviceName, DeviceEventClassID, SourceIP, SourceOfDropRateCount, DropRate
   | project StartTimeUtc, EndTimeUtc, DeviceName, DeviceEventClassID, SourceIP, SourceOfDropRateCount, DropRate, last1hCumTotal, prev6hCumTotal, prev6hAvgCumTotal = prev6hCumTotal/6, last1hAvgRatePerSec, prev6hAvgRatePerSec, last1hAvgBurstRatePerSec, prev6hAvgBurstRatePerSec
   // Select only events that indicate a doubling of the expected rate in the last hour over the previous 6 hours
@@ -70,5 +69,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/CiscoASA/Analytic Rules/CiscoASA-ThreatDetectionMessage.yaml
+++ b/Solutions/CiscoASA/Analytic Rules/CiscoASA-ThreatDetectionMessage.yaml
@@ -21,9 +21,8 @@ relevantTechniques:
   - T1046
   - T1498
 query: |
-
-  CommonSecurityLog 
-  | where isempty(CommunicationDirection) 
+  CommonSecurityLog
+  | where isempty(CommunicationDirection)
   | where DeviceEventClassID in ("733101","733102","733103","733104","733105")
   | extend timestamp = TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName
 entityMappings:
@@ -35,5 +34,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Cloud Identity Threat Protection Essentials/Analytic Rules/MFADisable.yaml
+++ b/Solutions/Cloud Identity Threat Protection Essentials/Analytic Rules/MFADisable.yaml
@@ -21,19 +21,18 @@ relevantTechniques:
   - T1098
   - T1556
 query: |
-
  (union isfuzzy=true
- (AuditLogs 
+ (AuditLogs
  | where OperationName =~ "Disable Strong Authentication"
- | extend IPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress) 
- | extend InitiatedByUser = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)), 
+ | extend IPAddress = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+ | extend InitiatedByUser = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)),
   tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName), tostring(parse_json(tostring(InitiatedBy.app)).displayName))
  | extend Targetprop = todynamic(TargetResources)
- | extend TargetUser = tostring(Targetprop[0].userPrincipalName) 
+ | extend TargetUser = tostring(Targetprop[0].userPrincipalName)
  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by User = TargetUser, InitiatedByUser , Operation = OperationName , CorrelationId, IPAddress, Category, Source = SourceSystem , AADTenantId, Type
  ),
  (AWSCloudTrail
- | where EventName in~ ("DeactivateMFADevice", "DeleteVirtualMFADevice") 
+ | where EventName in~ ("DeactivateMFADevice", "DeleteVirtualMFADevice")
  | extend InstanceProfileName = tostring(parse_json(RequestParameters).InstanceProfileName)
  | extend TargetUser = tostring(parse_json(RequestParameters).userName)
  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by User = TargetUser, Source = EventSource , Operation = EventName , TenantorInstance_Detail = InstanceProfileName, IPAddress = SourceIpAddress
@@ -49,5 +48,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Endpoint Threat Protection Essentials/Analytic Rules/SecurityEventLogCleared.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Analytic Rules/SecurityEventLogCleared.yaml
@@ -1,7 +1,7 @@
 id: 80da0a8f-cfe1-4cd0-a895-8bc1771a720e
 name: Security Event log cleared
 description: |
-  'Checks for event id 1102 which indicates the security event log was cleared. 
+  'Checks for event id 1102 which indicates the security event log was cleared.
   It uses Event Source Name "Microsoft-Windows-Eventlog" to avoid generating false positives from other sources, like AD FS servers for instance.'
 severity: Medium
 status: Available
@@ -24,17 +24,16 @@ tactics:
 relevantTechniques:
   - T1070
 query: |
-
   (union isfuzzy=true
   (
   SecurityEvent
-  | where EventID == 1102 and EventSourceName == "Microsoft-Windows-Eventlog" 
+  | where EventID == 1102 and EventSourceName == "Microsoft-Windows-Eventlog"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), EventCount = count() by Computer, Account, EventID, Activity
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Account, HostCustomEntity = Computer
   ),
   (
   WindowsEvent
-  | where EventID == 1102 and Provider == "Microsoft-Windows-Eventlog"  
+  | where EventID == 1102 and Provider == "Microsoft-Windows-Eventlog"
   | extend Account =  strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
   | extend Activity= "1102 - The audit log was cleared."
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), EventCount = count() by Computer, Account, EventID, Activity
@@ -50,5 +49,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Solutions/Endpoint Threat Protection Essentials/Analytic Rules/base64_encoded_pefile.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Analytic Rules/base64_encoded_pefile.yaml
@@ -12,11 +12,11 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
   - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents 
+    dataTypes:
+      - SecurityEvents
   - connectorId: WindowsForwardedEvents
-    dataTypes: 
-      - WindowsEvent 
+    dataTypes:
+      - WindowsEvent
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -29,8 +29,6 @@ relevantTechniques:
   - T1027
   - T1140
 query: |
-
-
   let ProcessCreationEvents=() {
   let processEvents=(union isfuzzy=true
   (SecurityEvent
@@ -55,7 +53,6 @@ query: |
   ProcessCreationEvents
   | where CommandLine contains "TVqQAAMAAAAEAAA"
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Account, HostCustomEntity = Computer
-  
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -65,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled

--- a/Solutions/GitHub/Analytic Rules/(Preview) GitHub - Two Factor Authentication Disabled in GitHub.yaml
+++ b/Solutions/GitHub/Analytic Rules/(Preview) GitHub - Two Factor Authentication Disabled in GitHub.yaml
@@ -14,7 +14,6 @@ tactics:
 relevantTechniques:
   - T1562
 query: |
-
   GitHubAuditData
   | where Action == "org.disable_two_factor_requirement"
   | project TimeGenerated, Action, Actor, Country, Repository
@@ -24,5 +23,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Infoblox Cloud Data Connector/Analytic Rules/Infoblox-HighNumberOfHighThreatLevelQueriesDetected.yaml
+++ b/Solutions/Infoblox Cloud Data Connector/Analytic Rules/Infoblox-HighNumberOfHighThreatLevelQueriesDetected.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: InfobloxCloudDataConnector
-    dataTypes: 
+    dataTypes:
       - CommonSecurityLog (InfobloxCDC)
 queryFrequency: 1h
 queryPeriod: 1h
@@ -18,7 +18,6 @@ relevantTechniques:
   - T1498
   - T1565
 query: |
-
   let threshold = 200;
   InfobloxCDC
   | where DeviceEventClassID has_cs "RPZ"
@@ -39,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Infoblox Cloud Data Connector/Analytic Rules/Infoblox-HighNumberOfNXDOMAINDNSResponsesDetected.yaml
+++ b/Solutions/Infoblox Cloud Data Connector/Analytic Rules/Infoblox-HighNumberOfNXDOMAINDNSResponsesDetected.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: InfobloxCloudDataConnector
-    dataTypes: 
+    dataTypes:
       - CommonSecurityLog (InfobloxCDC)
 queryFrequency: 1h
 queryPeriod: 1h
@@ -18,7 +18,6 @@ relevantTechniques:
   - T1498
   - T1565
 query: |
-
   let threshold = 200;
   InfobloxCDC
   | where DeviceEventClassID == "DNS Response"
@@ -39,6 +38,6 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled
 

--- a/Solutions/Infoblox Cloud Data Connector/Analytic Rules/Infoblox-HighThreatLevelQueryNotBlockedDetected.yaml
+++ b/Solutions/Infoblox Cloud Data Connector/Analytic Rules/Infoblox-HighThreatLevelQueryNotBlockedDetected.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: InfobloxCloudDataConnector
-    dataTypes: 
+    dataTypes:
       - CommonSecurityLog (InfobloxCDC)
 queryFrequency: 1h
 queryPeriod: 1h
@@ -18,7 +18,6 @@ relevantTechniques:
   - T1498
   - T1565
 query: |
-
   let threshold = 1;
   InfobloxCDC
   | where DeviceEventClassID has_cs "RPZ"
@@ -41,5 +40,5 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Infoblox NIOS/Analytic Rules/ExcessiveNXDOMAINDNSQueries.yaml
+++ b/Solutions/Infoblox NIOS/Analytic Rules/ExcessiveNXDOMAINDNSQueries.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: InfobloxNIOS
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -18,7 +18,6 @@ relevantTechniques:
   - T1568
   - T1008
 query: |
-
   let threshold = 200;
   Infoblox_dnsclient
   | where isnotempty(DnsResponseCode)
@@ -35,5 +34,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Infoblox NIOS/Analytic Rules/PotentialDHCPStarvationAttack.yaml
+++ b/Solutions/Infoblox NIOS/Analytic Rules/PotentialDHCPStarvationAttack.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: InfobloxNIOS
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1200
 query: |
-
   let threshold = 1000;
   Infoblox
   | where ProcessName =~ "dhcpd" and Log_Type =~ "DHCPREQUEST"
@@ -32,5 +31,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Microsoft 365 Defender/Analytic Rules/SolarWinds_SUNBURST_&_SUPERNOVA_File-IOCs.yaml
+++ b/Solutions/Microsoft 365 Defender/Analytic Rules/SolarWinds_SUNBURST_&_SUPERNOVA_File-IOCs.yaml
@@ -24,7 +24,6 @@ relevantTechniques:
   - T1059
   - T1546
 query:  |
-
   let SunburstMD5=dynamic(["b91ce2fa41029f6955bff20079468448","02af7cec58b9a5da1c542b5a32151ba1","2c4a910a1299cdae2a4e55988a2f102e","846e27a652a5e1bfbd0ddd38a16dc865","4f2eb62fa529c0283b28d05ddd311fae"]);
   let SupernovaMD5="56ceb6d0011d87b6e4d7023d7ef85676";
   DeviceFileEvents
@@ -50,5 +49,5 @@ entityMappings:
         columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/Microsoft 365 Defender/Analytic Rules/SolarWinds_SUNBURST_Network-IOCs.yaml
+++ b/Solutions/Microsoft 365 Defender/Analytic Rules/SolarWinds_SUNBURST_Network-IOCs.yaml
@@ -24,7 +24,6 @@ relevantTechniques:
   - T1059
   - T1546
 query:  |
-
   let SunburstURL=dynamic(["panhardware.com","databasegalore.com","avsvmcloud.com","freescanonline.com","thedoccloud.com","deftsecurity.com"]);
   DeviceNetworkEvents
   | where ActionType == "ConnectionSuccess"
@@ -33,7 +32,7 @@ query:  |
       timestamp = TimeGenerated,
       AccountCustomEntity = iff(isnotempty(InitiatingProcessAccountUpn), InitiatingProcessAccountUpn, InitiatingProcessAccountName),
       HostCustomEntity = DeviceName,
-      FileHashCustomEntity = InitiatingProcessMD5, 
+      FileHashCustomEntity = InitiatingProcessMD5,
       HashAlgorithm = 'MD5',
       URLCustomEntity = RemoteUrl,
       IPCustomEntity = RemoteIP
@@ -60,5 +59,5 @@ entityMappings:
         columnName: HashAlgorithm
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Microsoft 365 Defender/Analytic Rules/SolarWinds_TEARDROP_Process-IOCs.yaml
+++ b/Solutions/Microsoft 365 Defender/Analytic Rules/SolarWinds_TEARDROP_Process-IOCs.yaml
@@ -28,7 +28,6 @@ tags:
   - Solorigate
   - NOBELIUM
 query:  |
-
   DeviceEvents
   | where ActionType has "ExploitGuardNonMicrosoftSignedBlocked"
   | where InitiatingProcessFileName contains "svchost.exe" and FileName contains "NetSetupSvc.dll"
@@ -50,5 +49,5 @@ entityMappings:
         columnName: FileHashType
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/MailItemsAccessedTimeSeries.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/MailItemsAccessedTimeSeries.yaml
@@ -7,7 +7,7 @@ description: |
   Manually change scorethreshold from 1.5 to 3 or higher to reduce the noise based on outliers flagged from the query criteria.
   Read more about MailItemsAccessed- https://docs.microsoft.com/microsoft-365/compliance/advanced-audit?view=o365-worldwide#mailitemsaccessed'
 severity: Medium
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -24,7 +24,6 @@ tags:
   - Solorigate
   - NOBELIUM
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   let timeframe = 1h;
@@ -51,13 +50,13 @@ query: |
       | where TimeGenerated > ago(2d)
       | extend DateHour = bin(TimeGenerated, 1h)
       | where OfficeWorkload=~ "Exchange" and Operation =~ "MailItemsAccessed" and ResultStatus =~ "Succeeded"
-      | summarize HourlyCount=count(), TimeGeneratedMax = arg_max(TimeGenerated, *), IPAdressList = make_set(Client_IPAddress), SourceIPMax= arg_max(Client_IPAddress, *), ClientInfoStringList= make_set(ClientInfoString) by MailboxOwnerUPN, Logon_Type, TenantId, UserType, TimeGenerated = bin(TimeGenerated, 1h) 
+      | summarize HourlyCount=count(), TimeGeneratedMax = arg_max(TimeGenerated, *), IPAdressList = make_set(Client_IPAddress), SourceIPMax= arg_max(Client_IPAddress, *), ClientInfoStringList= make_set(ClientInfoString) by MailboxOwnerUPN, Logon_Type, TenantId, UserType, TimeGenerated = bin(TimeGenerated, 1h)
       | where HourlyCount > 25 // Only considering operations with more than 25 hourly count to reduce False Positivies
-      | order by HourlyCount desc 
+      | order by HourlyCount desc
   ) on TimeGenerated
-  | extend PercentofTotal = round(HourlyCount/Total, 2) * 100 
+  | extend PercentofTotal = round(HourlyCount/Total, 2) * 100
   | where PercentofTotal > percentthreshold // Filter Users with count of less than 5 percent of TotalEvents per Hour to remove FPs/ users with very low count of MailItemsAccessed events
-  | order by PercentofTotal desc 
+  | order by PercentofTotal desc
   | project-reorder TimeGeneratedMax, Type, OfficeWorkload, Operation, UserId,SourceIPMax ,IPAdressList, ClientInfoStringList, HourlyCount, PercentofTotal, Total, baseline, score, anomalies
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId
 entityMappings:
@@ -65,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/Malicious_Inbox_Rule.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/Malicious_Inbox_Rule.yaml
@@ -1,11 +1,11 @@
 id: 7b907bf7-77d4-41d0-a208-5643ff75bf9a
 name: Malicious Inbox Rule
 description: |
-  'Often times after the initial compromise the attackers create inbox rules to delete emails that contain certain keywords. 
+  'Often times after the initial compromise the attackers create inbox rules to delete emails that contain certain keywords.
    This is done so as to limit ability to warn compromised users that they've been compromised. Below is a sample query that tries to detect this.
   Reference: https://www.reddit.com/r/sysadmin/comments/7kyp0a/recent_phishing_attempts_my_experience_and_what/'
 severity: Medium
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -21,7 +21,6 @@ relevantTechniques:
   - T1098
   - T1078
 query: |
-
  let Keywords = dynamic(["helpdesk", " alert", " suspicious", "fake", "malicious", "phishing", "spam", "do not click", "do not open", "hijacked", "Fatal"]);
  OfficeActivity
  | where Operation =~ "New-InboxRule"
@@ -51,5 +50,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/MultipleTeamsDeletes.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/MultipleTeamsDeletes.yaml
@@ -4,7 +4,7 @@ description: |
   'This detection flags the occurrences of deleting multiple teams within an hour.
   This data is a part of Office 365 Connector in Microsoft Sentinel.'
 severity: Low
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -19,12 +19,11 @@ relevantTechniques:
   - T1485
   - T1489
 query: |
-
   // Adjust this value to change how many Teams should be deleted before including
   let max_delete_count = 3;
   // Adjust this value to change the timewindow the query runs over
     OfficeActivity
-  | where OfficeWorkload =~ "MicrosoftTeams" 
+  | where OfficeWorkload =~ "MicrosoftTeams"
   | where Operation =~ "TeamDeleted"
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), DeletedTeams = make_set(TeamName) by UserId
   | where array_length(DeletedTeams) > max_delete_count
@@ -34,5 +33,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
@@ -6,7 +6,7 @@ description: |
   Additionally, identifies when a given user is uploading these files to another users workspace.
   This may be indication of a staging location for malware or other malicious activity.'
 severity: Low
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -20,7 +20,6 @@ tactics:
 relevantTechniques:
   - T1105
 query: |
-
   // a threshold can be enabled, see commented line below for PrevSeenCount
   let threshold = 2;
   let uploadOp = 'FileUploaded';
@@ -43,16 +42,16 @@ query: |
   //| where PrevSeenCount > threshold
   | mvexpand SourceRelativeUrl, UserId
   | extend SourceRelativeUrl = tostring(SourceRelativeUrl), UserId = tostring(UserId)
-  ) on SourceFileName, SourceRelativeUrl, UserId 
+  ) on SourceFileName, SourceRelativeUrl, UserId
   | extend SiteUrlUserFolder = tolower(split(Site_Url, '/')[-2])
   | extend UserIdUserFolderFormat = tolower(replace('@|\\.', '_',UserId))
   // identify when UserId is not a match to the specific site url personal folder reference
-  | extend UserIdDiffThanUserFolder = iff(Site_Url has '/personal/' and SiteUrlUserFolder != UserIdUserFolderFormat, true , false ) 
-  | summarize TimeGenerated = make_list(TimeGenerated), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), 
+  | extend UserIdDiffThanUserFolder = iff(Site_Url has '/personal/' and SiteUrlUserFolder != UserIdUserFolderFormat, true , false )
+  | summarize TimeGenerated = make_list(TimeGenerated), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),
   UserAgents = make_list(UserAgent), OfficeIds = make_list(OfficeId), SourceRelativeUrls = make_list(SourceRelativeUrl), FileNames = make_list(SourceFileName)
   by OfficeWorkload, RecordType, Operation, UserType, UserKey, UserId, ClientIP, Site_Url, SiteUrlUserFolder, UserIdUserFolderFormat, UserIdDiffThanUserFolder
   | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
-  
+
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -66,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -3,7 +3,7 @@ name: Rare and potentially high-risk Office operations
 description: |
   'Identifies Office operations that are typically rare and can provide capabilities useful to attackers.'
 severity: Low
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -19,7 +19,6 @@ relevantTechniques:
   - T1098
   - T1114
 query: |
-
   OfficeActivity
   | where Operation in~ ( "Add-MailboxPermission", "Add-MailboxFolderPermission", "Set-Mailbox", "New-ManagementRoleAssignment", "New-InboxRule", "Set-InboxRule", "Set-TransportRule")
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
@@ -35,5 +34,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
@@ -4,7 +4,7 @@ description: |
   'Identifies when the volume of documents uploaded to or downloaded from Sharepoint by new IP addresses
   exceeds a threshold (default is 50).'
 severity: Medium
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -18,7 +18,6 @@ tactics:
 relevantTechniques:
   - T1030
 query: |
-
   let threshold = 50;
   let szSharePointFileOperation = "SharePointFileOperation";
   let szOperations = dynamic(["FileDownloaded", "FileUploaded"]);
@@ -38,8 +37,8 @@ query: |
   let RareIP = recentActivity | join kind= leftanti ( historicalActivity ) on ClientIP, RecordType, Operation
   // More than 50 downloads/uploads from a new IP
   | where recentCount > threshold;
-  OfficeActivity 
-  | where TimeGenerated >= ago(endtime) 
+  OfficeActivity
+  | where TimeGenerated >= ago(endtime)
   | where RecordType =~ szSharePointFileOperation
   | where Operation in~ (szOperations)
   | join kind= inner (RareIP) on ClientIP, RecordType, Operation
@@ -61,5 +60,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewUserAgent.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewUserAgent.yaml
@@ -4,7 +4,7 @@ description: |
   'Identifies if the number of documents uploaded or downloaded from device(s) associated
   with a previously unseen user agent exceeds a threshold (default is 5).'
 severity: Medium
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -18,7 +18,6 @@ tactics:
 relevantTechniques:
   - T1030
 query: |
-
   let threshold = 5;
   let szSharePointFileOperation = "SharePointFileOperation";
   let szOperations = dynamic(["FileDownloaded", "FileUploaded"]);
@@ -41,13 +40,13 @@ query: |
   | order by recentCount desc, UserAgent
   // More than 5 downloads/uploads from a new user agent today
   | where recentCount > threshold;
-  OfficeActivity 
-  | where TimeGenerated > ago(endtime) 
-  | where RecordType =~ szSharePointFileOperation 
+  OfficeActivity
+  | where TimeGenerated > ago(endtime)
+  | where RecordType =~ szSharePointFileOperation
   | where Operation in~ (szOperations)
   | where isnotempty(UserAgent)
   | join kind= inner (RareUserAgent)
-  on UserAgent, RecordType, Operation    
+  on UserAgent, RecordType, Operation
   | where Start_Time between(min_Start_Time .. max_Start_Time)
   | summarize StartTimeUtc = min(min_Start_Time), EndTimeUtc = max(max_Start_Time) by RecordType, Operation, UserAgent, UserType, UserId, ClientIP, OfficeWorkload, Site_Url, OfficeObjectId, UserAgentSeenCount = recentCount
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
@@ -66,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
@@ -4,7 +4,7 @@ description: |
   'Identifies when the exchange audit logging has been disabled which may be an adversary attempt
   to evade detection or avoid other defenses.'
 severity: Medium
-status: Available 
+status: Available
 requiredDataConnectors:
   - connectorId: Office365
     dataTypes:
@@ -18,15 +18,14 @@ tactics:
 relevantTechniques:
   - T1562
 query: |
-
   OfficeActivity
-  | where UserType in~ ("Admin","DcAdmin") 
+  | where UserType in~ ("Admin","DcAdmin")
   // Only admin or global-admin can disable audit logging
-  | where Operation =~ "Set-AdminAuditLogConfig" 
+  | where Operation =~ "Set-AdminAuditLogConfig"
   | extend AdminAuditLogEnabledValue = tostring(parse_json(tostring(parse_json(tostring(array_slice(parse_json(Parameters),3,3)))[0])).Value)
-  | where AdminAuditLogEnabledValue =~ "False" 
+  | where AdminAuditLogEnabledValue =~ "False"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP, ResultStatus, Parameters, AdminAuditLogEnabledValue
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP 
+  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -36,5 +35,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft Defender for Cloud Apps/Analytic Rules/AdditionalFilesUploadedByActor.yaml
+++ b/Solutions/Microsoft Defender for Cloud Apps/Analytic Rules/AdditionalFilesUploadedByActor.yaml
@@ -19,64 +19,63 @@ relevantTechniques:
   - T1071
   - T1567
 query: |
-
   //Collect the alert events
-  let alertData = SecurityAlert 
-  | where DisplayName has "Potential malware uploaded to" 
-  | extend Entities = parse_json(Entities) 
+  let alertData = SecurityAlert
+  | where DisplayName has "Potential malware uploaded to"
+  | extend Entities = parse_json(Entities)
   | mv-expand Entities;
   //Parse the IP address data
-  let ipData = alertData 
-  | where Entities['Type'] =~ "ip" 
+  let ipData = alertData
+  | where Entities['Type'] =~ "ip"
   | extend AttackerIP = tostring(Entities['Address']), AttackerCountry = tostring(Entities['Location']['CountryName']);
   //Parse the file data
-  let FileData = alertData 
-  | where Entities['Type'] =~ "file" 
+  let FileData = alertData
+  | where Entities['Type'] =~ "file"
   | extend MaliciousFileDirectory = tostring(Entities['Directory']), MaliciousFileName = tostring(Entities['Name']), MaliciousFileHashes = tostring(Entities['FileHashes']);
   //Combine the File and IP data together
-  ipData 
-  | join (FileData) on VendorOriginalId 
+  ipData
+  | join (FileData) on VendorOriginalId
   | summarize by TimeGenerated, AttackerIP, AttackerCountry, DisplayName, ResourceId, AlertType, MaliciousFileDirectory, MaliciousFileName, MaliciousFileHashes
-  //Create a type column so we can track if it was a File storage or blobl storage upload 
-  | extend type = iff(DisplayName has "file", "File", "Blob") 
+  //Create a type column so we can track if it was a File storage or blobl storage upload
+  | extend type = iff(DisplayName has "file", "File", "Blob")
   | join (
     union
-    StorageFileLogs, 
-    StorageBlobLogs 
-    //File upload operations 
+    StorageFileLogs,
+    StorageBlobLogs
+    //File upload operations
     | where OperationName =~ "PutBlob" or OperationName =~ "PutRange"
-    //Parse out the uploader IP 
+    //Parse out the uploader IP
     | extend ClientIP = tostring(split(CallerIpAddress, ":", 0)[0])
-    //Extract the filename from the Uri 
+    //Extract the filename from the Uri
     | extend FileName = extract(@"\/([\w\-. ]+)\?", 1, Uri)
     //Base64 decode the MD5 filehash, we will encounter non-ascii hex so string operations don't work
-    //We can work around this by making it an array then converting it to hex from an int 
-    | extend base64Char = base64_decode_toarray(ResponseMd5) 
-    | mv-expand base64Char 
+    //We can work around this by making it an array then converting it to hex from an int
+    | extend base64Char = base64_decode_toarray(ResponseMd5)
+    | mv-expand base64Char
     | extend hexChar = tohex(toint(base64Char))
-    | extend hexChar = iff(strlen(hexChar) < 2, strcat("0", hexChar), hexChar) 
-    | extend SourceTable = iff(OperationName has "range", "StorageFileLogs", "StorageBlobLogs") 
-    | summarize make_list(hexChar) by CorrelationId, ResponseMd5, FileName, AccountName, TimeGenerated, RequestBodySize, ClientIP, SourceTable 
+    | extend hexChar = iff(strlen(hexChar) < 2, strcat("0", hexChar), hexChar)
+    | extend SourceTable = iff(OperationName has "range", "StorageFileLogs", "StorageBlobLogs")
+    | summarize make_list(hexChar) by CorrelationId, ResponseMd5, FileName, AccountName, TimeGenerated, RequestBodySize, ClientIP, SourceTable
     | extend Md5Hash = strcat_array(list_hexChar, "")
-    //Pack the file information the summarise into a ClientIP row 
-    | extend p = pack("FileName", FileName, "FileSize", RequestBodySize, "Md5Hash", Md5Hash, "Time", TimeGenerated, "SourceTable", SourceTable) 
-    | summarize UploadedFileInfo=make_list(p), FilesUploaded=count() by ClientIP 
+    //Pack the file information the summarise into a ClientIP row
+    | extend p = pack("FileName", FileName, "FileSize", RequestBodySize, "Md5Hash", Md5Hash, "Time", TimeGenerated, "SourceTable", SourceTable)
+    | summarize UploadedFileInfo=make_list(p), FilesUploaded=count() by ClientIP
         | join kind=leftouter (
           union
           StorageFileLogs,
-          StorageBlobLogs               
-          | where OperationName =~ "DeleteFile" or OperationName =~ "DeleteBlob"         
-          | extend ClientIP = tostring(split(CallerIpAddress, ":", 0)[0])         
-          | extend FileName = extract(@"\/([\w\-. ]+)\?", 1, Uri)         
-          | extend SourceTable = iff(OperationName has "range", "StorageFileLogs", "StorageBlobLogs")         
-          | extend p = pack("FileName", FileName, "Time", TimeGenerated, "SourceTable", SourceTable)         
+          StorageBlobLogs
+          | where OperationName =~ "DeleteFile" or OperationName =~ "DeleteBlob"
+          | extend ClientIP = tostring(split(CallerIpAddress, ":", 0)[0])
+          | extend FileName = extract(@"\/([\w\-. ]+)\?", 1, Uri)
+          | extend SourceTable = iff(OperationName has "range", "StorageFileLogs", "StorageBlobLogs")
+          | extend p = pack("FileName", FileName, "Time", TimeGenerated, "SourceTable", SourceTable)
           | summarize DeletedFileInfo=make_list(p), FilesDeleted=count() by ClientIP
           ) on ClientIP
-    ) on $left.AttackerIP == $right.ClientIP 
-  | mvexpand UploadedFileInfo 
-  | extend LinkedMaliciousFileName = UploadedFileInfo.FileName 
-  | extend LinkedMaliciousFileHash = UploadedFileInfo.Md5Hash     
-  | project AlertTimeGenerated = TimeGenerated, tostring(LinkedMaliciousFileName), tostring(LinkedMaliciousFileHash), AlertType, AttackerIP, AttackerCountry, MaliciousFileDirectory, MaliciousFileName, FilesUploaded, UploadedFileInfo 
+    ) on $left.AttackerIP == $right.ClientIP
+  | mvexpand UploadedFileInfo
+  | extend LinkedMaliciousFileName = UploadedFileInfo.FileName
+  | extend LinkedMaliciousFileHash = UploadedFileInfo.Md5Hash
+  | project AlertTimeGenerated = TimeGenerated, tostring(LinkedMaliciousFileName), tostring(LinkedMaliciousFileHash), AlertType, AttackerIP, AttackerCountry, MaliciousFileDirectory, MaliciousFileName, FilesUploaded, UploadedFileInfo
   | extend FileHashCustomEntity = LinkedMaliciousFileName, HashAlgorithm = "MD5", IPCustomEntity = AttackerIP
 entityMappings:
   - entityType: IP
@@ -89,5 +88,5 @@ entityMappings:
         columnName: HashAlgorithm
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Network Threat Protection Essentials/Analytic Rules/NewUserAgentLast24h.yaml
+++ b/Solutions/Network Threat Protection Essentials/Analytic Rules/NewUserAgentLast24h.yaml
@@ -33,7 +33,6 @@ relevantTechniques:
   - T1071
   - T1203
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   let UserAgentAll =
@@ -82,7 +81,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Solutions/Okta Single Sign-On/Analytic Rules/FailedLoginsFromUnknownOrInvalidUser.yaml
+++ b/Solutions/Okta Single Sign-On/Analytic Rules/FailedLoginsFromUnknownOrInvalidUser.yaml
@@ -6,18 +6,17 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: OktaSSO
-    dataTypes: 
+    dataTypes:
       - Okta_CL
 queryFrequency: 1h
 queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - CredentialAccess 
+  - CredentialAccess
 relevantTechniques:
   - T1110
 query: |
-
   let FailureThreshold = 15;
   let FailedLogins = Okta_CL
   | where eventType_s =~ "user.session.start" and outcome_reason_s =~ "VERIFICATION_ERROR"
@@ -30,7 +29,7 @@ query: |
   | summarize count() by actor_alternateId_s, ClientIP = client_ipAddress_s, City = client_geographicalContext_city_s, Country = client_geographicalContext_country_s, column_ifexists('published_t', now())
   | sort by column_ifexists('published_t', now()) desc
   | extend timestamp = column_ifexists('published_t', now()), IPCustomEntity = ClientIP, AccountCustomEntity = actor_alternateId_s
- 
+
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -40,5 +39,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Okta Single Sign-On/Analytic Rules/LoginfromUsersfromDifferentCountrieswithin3hours.yaml
+++ b/Solutions/Okta Single Sign-On/Analytic Rules/LoginfromUsersfromDifferentCountrieswithin3hours.yaml
@@ -6,18 +6,17 @@ severity: High
 status: Available
 requiredDataConnectors:
   - connectorId: OktaSSO
-    dataTypes: 
+    dataTypes:
       - Okta_CL
 queryFrequency: 3h
 queryPeriod: 3h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - InitialAccess 
+  - InitialAccess
 relevantTechniques:
   - T1078
 query: |
-
   let timeframe = ago(3h);
   let threshold = 2;
   Okta_CL
@@ -32,5 +31,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AccountCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Okta Single Sign-On/Analytic Rules/PasswordSpray.yaml
+++ b/Solutions/Okta Single Sign-On/Analytic Rules/PasswordSpray.yaml
@@ -6,18 +6,17 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: OktaSSO
-    dataTypes: 
+    dataTypes:
       - Okta_CL
 queryFrequency: 1h
 queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - CredentialAccess 
+  - CredentialAccess
 relevantTechniques:
   - T1110
 query: |
-
   let FailureThreshold = 15;
   let FailedEvents = Okta_CL
   | where eventType_s =~ "user.session.start"and outcome_reason_s in ("VERIFICATION_ERROR","INVALID_CREDENTIALS")
@@ -36,5 +35,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/PaloAlto-PAN-OS/Analytic Rules/FileHashEntity_Covid19_CommonSecurityLog.yaml
+++ b/Solutions/PaloAlto-PAN-OS/Analytic Rules/FileHashEntity_Covid19_CommonSecurityLog.yaml
@@ -15,7 +15,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let covidIndicators = (externaldata(TimeGenerated:datetime, FileHashValue:string, FileHashType: string, TlpLevel: string, Product: string, ThreatType: string, Description: string )
   [@"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Sample%20Data/Feeds/Microsoft.Covid19.Indicators.csv"] with (format="csv"));
@@ -26,14 +25,14 @@ query: |
   | union (fileHashIndicators | extend FileHashValue = toupper(FileHashValue)))
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   |  join kind=innerunique (
-     CommonSecurityLog | where TimeGenerated >= ago(dt_lookBack) 
+     CommonSecurityLog | where TimeGenerated >= ago(dt_lookBack)
      | where isnotempty(FileHash)
      | extend CommonSecurityLog_TimeGenerated = TimeGenerated
      )
   on $left.FileHashValue == $right.FileHash
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by FileHashValue
-  | project CommonSecurityLog_TimeGenerated, FileHashValue, FileHashType, Description, ThreatType,  
-  SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction, 
+  | project CommonSecurityLog_TimeGenerated, FileHashValue, FileHashType, Description, ThreatType,
+  SourceIP, SourcePort, DestinationIP, DestinationPort, SourceUserID, SourceUserName, DeviceName, DeviceAction,
   RequestURL, DestinationUserName, DestinationUserID, ApplicationProtocol, Activity
   | extend timestamp = CommonSecurityLog_TimeGenerated, IPCustomEntity = SourceIP, HostCustomEntity = DeviceName, AccountCustomEntity = SourceUserName
 entityMappings:
@@ -55,5 +54,5 @@ entityMappings:
         columnName: FileHashValue
       - identifier: Algorithm
         columnName: FileHashType
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Solutions/PaloAlto-PAN-OS/Analytic Rules/PaloAlto-NetworkBeaconing.yaml
+++ b/Solutions/PaloAlto-PAN-OS/Analytic Rules/PaloAlto-NetworkBeaconing.yaml
@@ -1,8 +1,8 @@
 id: f0be259a-34ac-4946-aa15-ca2b115d5feb
 name: Palo Alto - potential beaconing detected
 description: |
-  'Identifies beaconing patterns from Palo Alto Network traffic logs based on recurrent timedelta patterns. 
-  The query leverages various KQL functions to calculate time deltas and then compares it with total events observed in a day to find percentage of beaconing. 
+  'Identifies beaconing patterns from Palo Alto Network traffic logs based on recurrent timedelta patterns.
+  The query leverages various KQL functions to calculate time deltas and then compares it with total events observed in a day to find percentage of beaconing.
   This outbound beaconing pattern to untrusted public networks should be investigated for any malware callbacks or data exfiltration attempts.
   Reference Blog:
   http://www.austintaylor.io/detect/beaconing/intrusion/detection/system/command/control/flare/elastic/stack/2017/06/10/detect-beaconing-with-flare-elasticsearch-and-intrusion-detection-systems/
@@ -23,7 +23,6 @@ relevantTechniques:
   - T1071
   - T1571
 query: |
-
   let starttime = 2d;
   let endtime = 1d;
   let TimeDeltaThreshold = 25;
@@ -41,15 +40,15 @@ query: |
   | extend TimeDeltainSeconds = datetime_diff('second',nextTimeGenerated,TimeGenerated)
   | where SourceIP == nextSourceIP
   //Whitelisting criteria/ threshold criteria
-  | where TimeDeltainSeconds > TimeDeltaThreshold 
+  | where TimeDeltainSeconds > TimeDeltaThreshold
   | summarize count(), sum(ReceivedBytes), sum(SentBytes)
   by TimeDeltainSeconds, bin(TimeGenerated, 1h), DeviceName, SourceUserID, SourceIP, DestinationIP, DestinationPort
-  | summarize (MostFrequentTimeDeltaCount, MostFrequentTimeDeltainSeconds) = arg_max(count_, TimeDeltainSeconds), TotalEvents=sum(count_), TotalSentBytes = sum(sum_SentBytes), TotalReceivedBytes = sum(sum_ReceivedBytes) 
+  | summarize (MostFrequentTimeDeltaCount, MostFrequentTimeDeltainSeconds) = arg_max(count_, TimeDeltainSeconds), TotalEvents=sum(count_), TotalSentBytes = sum(sum_SentBytes), TotalReceivedBytes = sum(sum_ReceivedBytes)
   by bin(TimeGenerated, 1h), DeviceName, SourceUserID, SourceIP, DestinationIP, DestinationPort
   | where TotalEvents > TotalEventsThreshold and MostFrequentTimeDeltaCount > MostFrequentTimeDeltaThreshold
   | extend BeaconPercent = MostFrequentTimeDeltaCount/toreal(TotalEvents) * 100
   | where BeaconPercent > PercentBeaconThreshold
-  | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIP, AccountCustomEntity = SourceUserID, HostCustomEntity = DeviceName 
+  | extend timestamp = TimeGenerated, IPCustomEntity = DestinationIP, AccountCustomEntity = SourceUserID, HostCustomEntity = DeviceName
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -63,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/PaloAlto-PAN-OS/Analytic Rules/PaloAlto-PortScanning.yaml
+++ b/Solutions/PaloAlto-PAN-OS/Analytic Rules/PaloAlto-PortScanning.yaml
@@ -1,9 +1,9 @@
 id: 5b72f527-e3f6-4a00-9908-8e4fee14da9f
 name: Palo Alto - possible internal to external port scanning
 description: |
-  'Identifies a list of internal Source IPs (10.x.x.x Hosts) that have triggered 10 or more non-graceful tcp server resets from one or more Destination IPs which 
-  results in an "ApplicationProtocol = incomplete" designation. The server resets coupled with an "Incomplete" ApplicationProtocol designation can be an indication 
-  of internal to external port scanning or probing attack. 
+  'Identifies a list of internal Source IPs (10.x.x.x Hosts) that have triggered 10 or more non-graceful tcp server resets from one or more Destination IPs which
+  results in an "ApplicationProtocol = incomplete" designation. The server resets coupled with an "Incomplete" ApplicationProtocol designation can be an indication
+  of internal to external port scanning or probing attack.
   References: https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClUvCAK and
   https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClTaCAK'
 severity: Low
@@ -21,37 +21,36 @@ tactics:
 relevantTechniques:
   - T1046
 query: |
-
   CommonSecurityLog
-  | where isnotempty(DestinationPort) and DeviceAction !in ("reset-both", "deny") 
+  | where isnotempty(DestinationPort) and DeviceAction !in ("reset-both", "deny")
   // filter out common usage ports. Add ports that are legitimate for your environment
   | where DestinationPort !in ("443", "53", "389", "80", "0", "880", "8888", "8080")
-  | where ApplicationProtocol == "incomplete" 
+  | where ApplicationProtocol == "incomplete"
   // filter out IANA ephemeral or negotiated ports as per https://en.wikipedia.org/wiki/Ephemeral_port
-  | where DestinationPort !between (toint(49512) .. toint(65535)) 
-  | where Computer != "" 
+  | where DestinationPort !between (toint(49512) .. toint(65535))
+  | where Computer != ""
   | where DestinationIP !startswith "10."
   | extend Reason = coalesce(
-                                column_ifexists("Reason", ""), 
+                                column_ifexists("Reason", ""),
                                 extract("reason=(.+?)(;|$)", 1, AdditionalExtensions),
                                 ""
                             )
-  // Filter out any graceful reset reasons of AGED OUT which occurs when a TCP session closes with a FIN due to aging out. 
-  | where Reason !has "aged-out" 
+  // Filter out any graceful reset reasons of AGED OUT which occurs when a TCP session closes with a FIN due to aging out.
+  | where Reason !has "aged-out"
   // Filter out any TCP FIN which occurs when a TCP FIN is used to gracefully close half or both sides of a connection.
-  | where Reason !has "tcp-fin" 
+  | where Reason !has "tcp-fin"
   // Uncomment one of the following where clauses to trigger on specific TCP reset reasons
   // See Palo Alto article for details - https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClUvCAK
   // TCP RST-server - Occurs when the server sends a TCP reset to the client
-  // | where AdditionalExtensions has "reason=tcp-rst-from-server"  
+  // | where AdditionalExtensions has "reason=tcp-rst-from-server"
   // TCP RST-client - Occurs when the client sends a TCP reset to the server
-  // | where AdditionalExtensions has "reason=tcp-rst-from-client"  
+  // | where AdditionalExtensions has "reason=tcp-rst-from-client"
   // Already performed
   //| extend reason = tostring(split(AdditionalExtensions, ";")[3])
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count() by DeviceName, SourceUserID, SourceIP, ApplicationProtocol, Reason, DestinationPort, Protocol, DeviceVendor, DeviceProduct, DeviceAction, DestinationIP
   | where count_ >= 10
   | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), makeset(DestinationIP), totalcount = sum(count_) by DeviceName, SourceUserID, SourceIP, ApplicationProtocol, Reason, DestinationPort, Protocol, DeviceVendor, DeviceProduct, DeviceAction
-  | extend timestamp = StartTimeUtc, IPCustomEntity = SourceIP, AccountCustomEntity = SourceUserID, HostCustomEntity = DeviceName 
+  | extend timestamp = StartTimeUtc, IPCustomEntity = SourceIP, AccountCustomEntity = SourceUserID, HostCustomEntity = DeviceName
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -65,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/ProofPointTap/Analytic Rules/MalwareAttachmentDelivered.yaml
+++ b/Solutions/ProofPointTap/Analytic Rules/MalwareAttachmentDelivered.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: ProofpointTAP
-    dataTypes: 
+    dataTypes:
       - ProofPointTAPMessagesDelivered_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -15,7 +15,6 @@ triggerThreshold: 0
 tactics:
   - InitialAccess
 query: |
-
   ProofPointTAPMessagesDelivered_CL
   | mv-expand todynamic(threatsInfoMap_s)
   | mv-expand todynamic(messageParts_s)
@@ -33,5 +32,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/ProofPointTap/Analytic Rules/MalwareLinkClicked.yaml
+++ b/Solutions/ProofPointTap/Analytic Rules/MalwareLinkClicked.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: ProofpointTAP
-    dataTypes: 
+    dataTypes:
       - ProofPointTAPClicksPermitted_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -15,7 +15,6 @@ triggerThreshold: 0
 tactics:
   - InitialAccess
 query: |
-
   ProofPointTAPClicksPermitted_CL
   | where classification_s =~ "malware"
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), count() by TimeGenerated, Sender = sender_s, SenderIPAddress = senderIP_s, Recipient = recipient_s, TimeClicked = clickTime_t, URLClicked = url_s
@@ -33,5 +32,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Pulse Connect Secure/Analytic Rules/PulseConnectSecureVPN-BruteForce.yaml
+++ b/Solutions/Pulse Connect Secure/Analytic Rules/PulseConnectSecureVPN-BruteForce.yaml
@@ -6,18 +6,17 @@ severity: Low
 status: Available
 requiredDataConnectors:
   - connectorId: PulseConnectSecure
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - CredentialAccess 
+  - CredentialAccess
 relevantTechniques:
   - T1110
 query: |
-
   let threshold = 20;
   PulseConnectSecure
   | where Messages contains "Login failed"
@@ -33,5 +32,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Pulse Connect Secure/Analytic Rules/PulseConnectSecureVPN-DistinctFailedUserLogin.yaml
+++ b/Solutions/Pulse Connect Secure/Analytic Rules/PulseConnectSecureVPN-DistinctFailedUserLogin.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: PulseConnectSecure
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -15,9 +15,8 @@ triggerThreshold: 0
 tactics:
   - CredentialAccess
 relevantTechniques:
-  - T1110  
+  - T1110
 query: |
-
   let threshold = 100;
   PulseConnectSecure
   | where Messages startswith "Login failed"
@@ -29,5 +28,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/QualysVM/Analytic Rules/HighNumberofVulnDetectedV2.yaml
+++ b/Solutions/QualysVM/Analytic Rules/HighNumberofVulnDetectedV2.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: QualysVulnerabilityManagement
-    dataTypes: 
+    dataTypes:
       - QualysHostDetection_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-
   let threshold = 10;
   QualysHostDetectionV2_CL
   | where Severity_s == "5"
@@ -33,5 +32,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/QualysVM/Analytic Rules/NewHighSeverityVulnDetectedAcrossMulitpleHostsV2.yaml
+++ b/Solutions/QualysVM/Analytic Rules/NewHighSeverityVulnDetectedAcrossMulitpleHostsV2.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: QualysVulnerabilityManagement
-    dataTypes: 
+    dataTypes:
       - QualysHostDetection_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1190
 query: |
-
   let threshold = 10;
   QualysHostDetectionV2_CL
   | extend Status = tostring(Status_s), Vulnerability = tostring(QID_s), Severity = tostring(Severity_s)
@@ -25,5 +24,5 @@ query: |
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), dcount(NetBios_s) by tostring(QID_s)
   | where dcount_NetBios_s >= threshold
   | extend timestamp = StartTime
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/SecurityThreatEssentialSolution/Analytic Rules/Threat_Essentials_Mail_redirect_via_ExO_transport_rule.yaml
+++ b/Solutions/SecurityThreatEssentialSolution/Analytic Rules/Threat_Essentials_Mail_redirect_via_ExO_transport_rule.yaml
@@ -20,7 +20,6 @@ relevantTechniques:
   - T1114
   - T1020
 query: |
-
   OfficeActivity
   | where OfficeWorkload == "Exchange"
   | where Operation in~ ("New-TransportRule", "Set-TransportRule")
@@ -29,16 +28,16 @@ query: |
     Operation =~ "Set-TransportRule", tostring(OfficeObjectId),
     Operation =~ "New-TransportRule", tostring(p[1].Value),
     "Unknown"
-    ) 
+    )
   | mvexpand p
   | where (p.Name =~ "BlindCopyTo" or p.Name =~ "RedirectMessageTo") and isnotempty(p.Value)
   | extend RedirectTo = p.Value
-  | extend ClientIPOnly = case( 
-    ClientIP has "." and ClientIP has ":", tostring(split(ClientIP,":")[0]), 
-    ClientIP has "." and ClientIP has "-", tostring(split(ClientIP,"-")[0]), 
+  | extend ClientIPOnly = case(
+    ClientIP has "." and ClientIP has ":", tostring(split(ClientIP,":")[0]),
+    ClientIP has "." and ClientIP has "-", tostring(split(ClientIP,"-")[0]),
     ClientIP has "[", tostring(trim_start(@'[[]',tostring(split(ClientIP,"]")[0]))),
     ClientIP
-    )  
+    )
   | extend Port = case(
     ClientIP has "." and ClientIP has ":", (split(ClientIP,":")[1]),
     ClientIP has "." and ClientIP has "-", (split(ClientIP,"-")[1]),
@@ -48,7 +47,7 @@ query: |
     )
   | extend ClientIP = ClientIPOnly
   | project TimeGenerated, RedirectTo, ClientIP, Port, UserId, Operation, RuleName
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP 
+  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -58,5 +57,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/SecurityThreatEssentialSolution/Analytic Rules/Threat_Essentials_TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
+++ b/Solutions/SecurityThreatEssentialSolution/Analytic Rules/Threat_Essentials_TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
@@ -30,7 +30,6 @@ relevantTechniques:
 tags:
   - DEV-0537
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   let timeframe = 1h;
@@ -117,5 +116,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Sophos XG Firewall/Analytic Rules/ExcessiveAmountofDeniedConnectionsfromASingleSource.yaml
+++ b/Solutions/Sophos XG Firewall/Analytic Rules/ExcessiveAmountofDeniedConnectionsfromASingleSource.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: SophosXGFirewall
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1499
 query: |
-
   let threshold = 5000;
   SophosXGFirewall
   | where Log_Type =~ "Firewall" and Status =~ "Deny"
@@ -29,5 +28,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Sophos XG Firewall/Analytic Rules/PortScanDetected.yaml
+++ b/Solutions/Sophos XG Firewall/Analytic Rules/PortScanDetected.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: SophosXGFirewall
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1046
 query: |
-
   let threshold = 50;
   SophosXGFirewall
   | where Log_Type =~ "Firewall"
@@ -30,5 +29,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Symantec Endpoint Protection/Analytic Rules/ExcessiveBlockedTrafficGeneratedbyUser.yaml
+++ b/Solutions/Symantec Endpoint Protection/Analytic Rules/ExcessiveBlockedTrafficGeneratedbyUser.yaml
@@ -6,14 +6,13 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: SymantecEndpointProtection
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 query: |
-
   let threshold = 15;
   let NoteableEvents = SymantecEndpointProtection
   | where LogType == "Agent Traffic Logs"
@@ -39,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Symantec Endpoint Protection/Analytic Rules/MalwareDetected.yaml
+++ b/Solutions/Symantec Endpoint Protection/Analytic Rules/MalwareDetected.yaml
@@ -6,21 +6,20 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: SymantecEndpointProtection
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - Execution 
+  - Execution
 query: |
-
   SymantecEndpointProtection
   | where LogType == "Agent Risk Logs"
   | where CategorySet == "Malware"
   | where ActualAction !contains "Cleaned"
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by SrcIpAddr, SrcHostName, UserName, FilePath, ActualAction, CategorySet, CategoryType 
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated) by SrcIpAddr, SrcHostName, UserName, FilePath, ActualAction, CategorySet, CategoryType
   | extend timestamp = StartTimeUtc, IPCustomEntity = SrcIpAddr, HostCustomEntity = SrcHostName, AccountCustomEntity = UserName
 entityMappings:
   - entityType: Account
@@ -35,5 +34,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/SymantecProxySG/Analytic Rules/ExcessiveDeniedProxyTraffic.yaml
+++ b/Solutions/SymantecProxySG/Analytic Rules/ExcessiveDeniedProxyTraffic.yaml
@@ -6,7 +6,7 @@ severity: Low
 status: Available
 requiredDataConnectors:
   - connectorId: SymantecProxySG
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -15,9 +15,8 @@ triggerThreshold: 0
 tactics:
   - DefenseEvasion
 query: |
-
   let threshold = 100;
-  SymantecProxySG 
+  SymantecProxySG
   | where sc_filter_result =~ "DENIED"
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), count() by c_ip, cs_host
   | where count_ > threshold
@@ -31,5 +30,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/SymantecProxySG/Analytic Rules/UserAccessedSuspiciousURLCategories.yaml
+++ b/Solutions/SymantecProxySG/Analytic Rules/UserAccessedSuspiciousURLCategories.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: SymantecProxySG
-    dataTypes: 
+    dataTypes:
       - Syslog
 queryFrequency: 1h
 queryPeriod: 1h
@@ -15,7 +15,6 @@ triggerThreshold: 0
 tactics:
   - DefenseEvasion
 query: |
-
   SymantecProxySG
   | mv-expand cs_categories
   | where cs_categories has_any ("Suspicious","phishing", "hacking")
@@ -34,5 +33,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_AzureActivity.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_AzureActivity.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let emailregex = @'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$';
@@ -40,8 +39,8 @@ query: |
   on $left.EmailSenderAddress == $right.Caller
   | where AzureActivity_TimeGenerated < ExpirationDateTime
   | summarize AzureActivity_TimeGenerated = arg_max(AzureActivity_TimeGenerated, *) by IndicatorId, Caller
-  | project AzureActivity_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Url, EmailSenderName, EmailRecipient, 
-  EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Caller, Level, CallerIpAddress, CategoryValue, OperationNameValue, ActivityStatusValue, 
+  | project AzureActivity_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Url, EmailSenderName, EmailRecipient,
+  EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, Caller, Level, CallerIpAddress, CategoryValue, OperationNameValue, ActivityStatusValue,
   ResourceGroup, SubscriptionId
   | extend timestamp = AzureActivity_TimeGenerated, AccountCustomEntity = Caller, IPCustomEntity = CallerIpAddress, URLCustomEntity = Url
 entityMappings:
@@ -57,5 +56,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_OfficeActivity.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_OfficeActivity.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let emailregex = @'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$';
@@ -55,5 +54,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_PaloAlto.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_PaloAlto.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let emailregex = @'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$';
@@ -42,8 +41,8 @@ query: |
   on $left.EmailSenderAddress == $right.DestinationUserID
   | where CommonSecurityLog_TimeGenerated < ExpirationDateTime
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId, DestinationUserID
-  | project CommonSecurityLog_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, EmailSenderName, EmailRecipient, 
-  EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, DestinationUserID, DeviceEventClassID, LogSeverity, DeviceAction, SourceIP, SourcePort, 
+  | project CommonSecurityLog_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, EmailSenderName, EmailRecipient,
+  EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, DestinationUserID, DeviceEventClassID, LogSeverity, DeviceAction, SourceIP, SourcePort,
   DestinationIP, DestinationPort, Protocol, ApplicationProtocol
   | extend timestamp = CommonSecurityLog_TimeGenerated, AccountCustomEntity = DestinationUserID, IPCustomEntity = SourceIP, URLCustomEntity = Url
 entityMappings:
@@ -59,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_SecurityAlert.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_SecurityAlert.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let emailregex = @'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$';
@@ -32,7 +31,7 @@ query: |
   | where isnotempty(EmailSenderAddress)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
   | join kind=innerunique (
-      SecurityAlert 
+      SecurityAlert
       | where TimeGenerated >= ago(dt_lookBack)
       | extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
       | where MSTI == false
@@ -49,7 +48,7 @@ query: |
   on $left.EmailSenderAddress == $right.EntityEmail
   | where Alert_TimeGenerated < ExpirationDateTime
   | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId, AlertName
-  | project Alert_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, 
+  | project Alert_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore,
   EmailSenderName, EmailRecipient, EmailSourceDomain, EmailSourceIpAddress, EmailSubject, FileHashValue, FileHashType, EntityEmail, AlertName, AlertType,
   AlertSeverity, Entities, ProviderName, VendorName
   | extend timestamp = Alert_TimeGenerated, AccountCustomEntity = EntityEmail, URLCustomEntity = Url
@@ -62,5 +61,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_SecurityEvent.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_SecurityEvent.yaml
@@ -14,11 +14,11 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
   - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents 
+    dataTypes:
+      - SecurityEvents
   - connectorId: WindowsForwardedEvents
-    dataTypes: 
-      - WindowsEvent 
+    dataTypes:
+      - WindowsEvent
 queryFrequency: 1h
 queryPeriod: 14d
 triggerOperator: gt
@@ -26,7 +26,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let emailregex = @'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$';
@@ -37,7 +36,7 @@ query: |
   //Filtering the table for Email related IOCs
   | where isnotempty(EmailSenderAddress)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
-  | join kind=innerunique ( 
+  | join kind=innerunique (
   (union isfuzzy=true
   (SecurityEvent
   | where TimeGenerated >= ago(dt_lookBack) and isnotempty(TargetUserName)
@@ -47,8 +46,8 @@ query: |
   | extend SecurityEvent_TimeGenerated = TimeGenerated
   ),
   (WindowsEvent
-  | where TimeGenerated >= ago(dt_lookBack) 
-  | extend TargetUserName = tostring(EventData.TargetUserName) 
+  | where TimeGenerated >= ago(dt_lookBack)
+  | extend TargetUserName = tostring(EventData.TargetUserName)
   | where isnotempty(TargetUserName)
   //Normalizing the column to lower case for exact match with EmailSenderAddress column
   | extend TargetUserName = tolower(TargetUserName)
@@ -86,5 +85,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.3.1
+version: 1.3.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_SigninLogs.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/EmailEntity_SigninLogs.yaml
@@ -23,7 +23,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let emailregex = @'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$';
@@ -70,5 +69,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/FileHashEntity_CommonSecurityLog.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/FileHashEntity_CommonSecurityLog.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let fileHashIndicators = ThreatIntelligenceIndicator
@@ -67,5 +66,5 @@ entityMappings:
         columnName: FileHashValue
       - identifier: Algorithm
         columnName: FileHashType
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/FileHashEntity_SecurityEvent.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/FileHashEntity_SecurityEvent.yaml
@@ -8,11 +8,11 @@ requiredDataConnectors:
     dataTypes:
       - SecurityEvent
   - connectorId: WindowsSecurityEvents
-    dataTypes: 
-      - SecurityEvents 
+    dataTypes:
+      - SecurityEvents
   - connectorId: WindowsForwardedEvents
-    dataTypes: 
-      - WindowsEvent     
+    dataTypes:
+      - WindowsEvent
   - connectorId: ThreatIntelligence
     dataTypes:
       - ThreatIntelligenceIndicator
@@ -26,7 +26,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
  let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -36,7 +35,7 @@ query: |
   | where isnotempty(FileHashValue)
   | extend FileHashValue = toupper(FileHashValue)
   // using innerunique to keep perf fast and result set low, we only need one match to indicate potential malicious activity that needs to be investigated
-  | join kind=innerunique ( union isfuzzy=true 
+  | join kind=innerunique ( union isfuzzy=true
     (SecurityEvent | where TimeGenerated >= ago(dt_lookBack)
         | where EventID in ("8003","8002","8005")
         | where isnotempty(FileHash)
@@ -73,5 +72,5 @@ entityMappings:
         columnName: FileHashValue
       - identifier: Algorithm
         columnName: FileHashType
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_DuoSecurity.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_DuoSecurity.yaml
@@ -17,7 +17,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -51,5 +50,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_OfficeActivity.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_OfficeActivity.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let IoCList = materialize(externaldata(TimeGenerated:datetime,IoC:string,IoC_Type:string,ExpirationDateTime:datetime,Description:string,Action:string, ConfidenceScore:real, ThreatType:string, Active:string,Type:string, TrafficLightProtocolLevel:string, ActivityGroupNames:string)[@"https://raw.githubusercontent.com/microsoft/mstic/master/RapidReleaseTI/Indicators.csv"] with(format="csv", ignoreFirstRecord=True));
@@ -78,5 +77,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.3.2
+version: 1.3.3
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/IPentity_SigninLogs.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPentity_SigninLogs.yaml
@@ -23,7 +23,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   let aadFunc = (tableName:string){
@@ -70,5 +69,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/URLEntity_AuditLogs.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/URLEntity_AuditLogs.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -58,5 +57,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/URLEntity_OfficeActivity.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/URLEntity_OfficeActivity.yaml
@@ -17,7 +17,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -41,7 +40,7 @@ query: |
   ) on Url
   | where OfficeActivity_TimeGenerated < ExpirationDateTime
   | summarize OfficeActivity_TimeGenerated = arg_max(OfficeActivity_TimeGenerated, *) by IndicatorId, Url
-  | project OfficeActivity_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Operation, 
+  | project OfficeActivity_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, Operation,
   UserType, OfficeWorkload, Parameters, Url, User
   | extend timestamp = OfficeActivity_TimeGenerated, AccountCustomEntity = User, URLCustomEntity = Url
 entityMappings:
@@ -53,5 +52,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/URLEntity_PaloAlto.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/URLEntity_PaloAlto.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -63,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.0
+version: 1.2.1
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/URLEntity_SecurityAlerts.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/URLEntity_SecurityAlerts.yaml
@@ -23,7 +23,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -59,5 +58,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.2
+version: 1.2.3
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/URLEntity_Syslog.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/URLEntity_Syslog.yaml
@@ -20,7 +20,6 @@ triggerThreshold: 0
 tactics:
   - Impact
 query: |
-
   let dt_lookBack = 1h;
   let ioc_lookBack = 14d;
   ThreatIntelligenceIndicator
@@ -55,5 +54,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled

--- a/Solutions/VMware Carbon Black Cloud/Analytic Rules/CriticalThreatDetected.yaml
+++ b/Solutions/VMware Carbon Black Cloud/Analytic Rules/CriticalThreatDetected.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: VMwareCarbonBlack
-    dataTypes: 
+    dataTypes:
       - CarbonBlackNotifications_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1210
 query: |
-
   let threshold = 8;
   CarbonBlackNotifications_CL
   | where threatHunterInfo_score_d >= threshold
@@ -34,5 +33,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/VMware Carbon Black Cloud/Analytic Rules/KnownMalwareDetected.yaml
+++ b/Solutions/VMware Carbon Black Cloud/Analytic Rules/KnownMalwareDetected.yaml
@@ -6,7 +6,7 @@ severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: VMwareCarbonBlack
-    dataTypes: 
+    dataTypes:
       - CarbonBlackEvents_CL
 queryFrequency: 1h
 queryPeriod: 1h
@@ -15,9 +15,8 @@ triggerThreshold: 0
 tactics:
   - Execution
 relevantTechniques:
-  - T1204 
+  - T1204
 query: |
-
   CarbonBlackEvents_CL
   | extend eventTime = datetime(1970-01-01) + tolong(eventTime_d/1000) * 1sec
   | where targetApp_effectiveReputation_s =~ "KNOWN_MALWARE"
@@ -36,5 +35,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/ExcessiveLogonFailures.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/ExcessiveLogonFailures.yaml
@@ -20,7 +20,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let starttime = 8d;
   let endtime = 1d;
   let threshold = 0.333;
@@ -31,7 +30,7 @@ query: |
   | where IpAddress !in ("127.0.0.1", "::1")
   | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), CountToday = count() by EventID, Account, LogonTypeName, SubStatus, AccountType, Computer, WorkstationName, IpAddress, Process
   | join kind=leftouter (
-      SecurityEvent 
+      SecurityEvent
       | where TimeGenerated between (ago(starttime) .. ago(endtime))
       | where EventID == 4625 and AccountType =~ "User"
       | where IpAddress !in ("127.0.0.1", "::1")
@@ -42,14 +41,14 @@ query: |
   | extend Reason = case(
   SubStatus =~ '0xC000005E', 'There are currently no logon servers available to service the logon request.',
   SubStatus =~ '0xC0000064', 'User logon with misspelled or bad user account',
-  SubStatus =~ '0xC000006A', 'User logon with misspelled or bad password',    
+  SubStatus =~ '0xC000006A', 'User logon with misspelled or bad password',
   SubStatus =~ '0xC000006D', 'Bad user name or password',
   SubStatus =~ '0xC000006E', 'Unknown user name or bad password',
   SubStatus =~ '0xC000006F', 'User logon outside authorized hours',
   SubStatus =~ '0xC0000070', 'User logon from unauthorized workstation',
   SubStatus =~ '0xC0000071', 'User logon with expired password',
   SubStatus =~ '0xC0000072', 'User logon to account disabled by administrator',
-  SubStatus =~ '0xC00000DC', 'Indicates the Sam Server was in the wrong state to perform the desired operation',  
+  SubStatus =~ '0xC00000DC', 'Indicates the Sam Server was in the wrong state to perform the desired operation',
   SubStatus =~ '0xC0000133', 'Clocks between DC and other computer too far out of sync',
   SubStatus =~ '0xC000015B', 'The user has not been granted the requested logon type (aka logon right) at this machine',
   SubStatus =~ '0xC000018C', 'The logon request failed because the trust relationship between the primary domain and the trusted domain failed',
@@ -61,11 +60,11 @@ query: |
   SubStatus =~ '0xC00002EE', 'Failure Reason: An Error occurred during Logon',
   SubStatus =~ '0xC0000413', 'Logon Failure: The machine you are logging onto is protected by an authentication firewall. The specified account is not allowed to authenticate to the machine',
   strcat('Unknown reason substatus: ', SubStatus))
-  | extend WorkstationName = iff(WorkstationName == "-" or isempty(WorkstationName), Computer , WorkstationName) 
+  | extend WorkstationName = iff(WorkstationName == "-" or isempty(WorkstationName), Computer , WorkstationName)
   | project StartTime, EndTime, EventID, Account, LogonTypeName, SubStatus, Reason, AccountType, Computer, WorkstationName, IpAddress, CountToday, CountPrev7day, Avg7Day = round(CountPrev7day*1.00/7,2), Process
-  | summarize StartTime = min(StartTime), EndTime = max(EndTime), Computer = make_set(Computer,128), IpAddressList = make_set(IpAddress,128), sum(CountToday), sum(CountPrev7day), avg(Avg7Day) 
+  | summarize StartTime = min(StartTime), EndTime = max(EndTime), Computer = make_set(Computer,128), IpAddressList = make_set(IpAddress,128), sum(CountToday), sum(CountPrev7day), avg(Avg7Day)
   by EventID, Account, LogonTypeName, SubStatus, Reason, AccountType, WorkstationName, Process
-  | order by sum_CountToday desc nulls last 
+  | order by sum_CountToday desc nulls last
   | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = WorkstationName
 entityMappings:
   - entityType: Account
@@ -80,5 +79,5 @@ entityMappings:
     fieldMappings:
       - identifier: CommandLine
         columnName: Process
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/MultipleFailedFollowedBySuccess.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/MultipleFailedFollowedBySuccess.yaml
@@ -24,7 +24,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
     let timeRange = 6h;
     let authenticationWindow = 1h;
     let authenticationThreshold = 5;
@@ -38,7 +37,7 @@ query: |
     | project TimeGenerated, Account, IpAddress, Computer, Outcome, OutcomeCount
     // sort ready for sessionizing - by account and time of the authentication outcome
     | sort by Account asc, TimeGenerated asc
-    | serialize 
+    | serialize
     // sessionize into failure groupings until either the account changes or there is a success
     | extend SessionStartedUtc = row_window_session(TimeGenerated, timeRange, authenticationWindow, Account != prev(Account) or prev(Outcome) == "Success")
     // count the failures in each session
@@ -46,8 +45,8 @@ query: |
     // the session must not start with a success, and must end with one
     | where array_index_of(list_Outcome, "Success") != 0
     | where array_index_of(list_Outcome, "Success") == array_length(list_Outcome) - 1
-    | project-away SessionStartedUtc, list_Outcome 
-    // where the number of failures before the success is above the threshold 
+    | project-away SessionStartedUtc, list_Outcome
+    // where the number of failures before the success is above the threshold
     | where FailureCountBeforeSuccess >= authenticationThreshold
     // expand out ip and computer for customer entity assignment
     | mvexpand set_IpAddress, set_Computer
@@ -66,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/TimeSeriesAnomaly-ProcessExecutions.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/TimeSeriesAnomaly-ProcessExecutions.yaml
@@ -23,7 +23,6 @@ tactics:
 relevantTechniques:
   - T1059
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   let timeframe = 1h;
@@ -55,7 +54,7 @@ query: |
   ) on Process, TimeGenerated
   | project AnomalyHour = TimeGenerated, Computer, Account, Process, CommandLine, CommandlineCount, Total, baseline, anomalies, score
   | extend timestamp = AnomalyHour, AccountCustomEntity = Account, HostCustomEntity = Computer
-  
+
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -65,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/password_not_set.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/password_not_set.yaml
@@ -2,8 +2,8 @@ id: 62085097-d113-459f-9ea7-30216f2ee6af
 name: AD user enabled and password not set within 48 hours
 description: |
   'Identifies when an account is enabled with a default password and the password is not set by the user within 48 hours.
-  Effectively, there is an event 4722 indicating an account was enabled and within 48 hours, no event 4723 occurs which 
-  indicates there was no attempt by the user to set the password. This will show any attempts (success or fail) that occur 
+  Effectively, there is an event 4722 indicating an account was enabled and within 48 hours, no event 4723 occurs which
+  indicates there was no attempt by the user to set the password. This will show any attempts (success or fail) that occur
   after 48 hours, which can indicate too long of a time period in setting the password to something that only the user knows.
   It is recommended that this time period is adjusted per your internal company policy.'
 severity: Low
@@ -24,7 +24,6 @@ tactics:
 relevantTechniques:
   - T1098
 query: |
-
   let starttime = 3d;
   let SecEvents = materialize ( SecurityEvent | where TimeGenerated >= ago(starttime)
   | where EventID in (4722,4723) | where TargetUserName !endswith "$"
@@ -43,7 +42,7 @@ query: |
   | where PasswordSetAttemptDelta_Min > 2880 or isempty(PasswordSetAttemptDelta_Min)
   | project-away TargetAccount1, TargetSid1
   | extend Reason = @"User either has not yet attempted to set the initial password after account was enabled or it occurred after 48 hours"
-  | order by Time_Event4722 asc 
+  | order by Time_Event4722 asc
   | extend timestamp = Time_Event4722, AccountCustomEntity = TargetAccount, HostCustomEntity = Computer_4722
   | project-reorder Time_Event4722, Time_Event4723, PasswordSetAttemptDelta_Min, TargetAccount, TargetSid
 entityMappings:
@@ -57,5 +56,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Server DNS/Analytic Rules/DNS_HighNXDomainCount_detection.yaml
+++ b/Solutions/Windows Server DNS/Analytic Rules/DNS_HighNXDomainCount_detection.yaml
@@ -2,7 +2,7 @@ id: a0907abe-6925-4d90-af2b-c7e89dc201a6
 name: Potential DGA detected
 description: |
   'Identifies clients with a high NXDomain count which could be indicative of a DGA (cycling through possible C2 domains
-  where most C2s are not live). Alert is generated when a new IP address is seen (based on not being seen associated with 
+  where most C2s are not live). Alert is generated when a new IP address is seen (based on not being seen associated with
   NXDomain records in prior 10-day baseline period).'
 severity: Medium
 status: Available
@@ -20,12 +20,11 @@ relevantTechniques:
   - T1568
   - T1008
 query: |
-
   let starttime = 10d;
   let endtime = 1d;
   let threshold = 100;
-  let nxDomainDnsEvents = DnsEvents 
-  | where ResultCode == 3 
+  let nxDomainDnsEvents = DnsEvents
+  | where ResultCode == 3
   | where QueryType in ("A", "AAAA")
   | where ipv4_is_match("127.0.0.1", ClientIP) == False
   | where Name !contains "/"
@@ -50,5 +49,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Server DNS/Analytic Rules/DNS_HighReverseDNSCount_detection.yaml
+++ b/Solutions/Windows Server DNS/Analytic Rules/DNS_HighReverseDNSCount_detection.yaml
@@ -18,22 +18,21 @@ tactics:
 relevantTechniques:
   - T1046
 query: |
-
   let starttime = 8d;
   let endtime = 1d;
   let threshold = 10;
-  DnsEvents 
+  DnsEvents
   | where TimeGenerated > ago(endtime)
-  | where Name contains "in-addr.arpa" 
+  | where Name contains "in-addr.arpa"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), dcount(Name) by ClientIP
   | where dcount_Name > threshold
-  | project StartTimeUtc, EndTimeUtc, ClientIP , dcount_Name 
-  | join kind=leftanti (DnsEvents 
+  | project StartTimeUtc, EndTimeUtc, ClientIP , dcount_Name
+  | join kind=leftanti (DnsEvents
       | where TimeGenerated between(ago(starttime)..ago(endtime))
-      | where Name contains "in-addr.arpa" 
+      | where Name contains "in-addr.arpa"
       | summarize dcount(Name) by ClientIP, bin(TimeGenerated, 1d)
       | where dcount_Name > threshold
-      | project ClientIP , dcount_Name 
+      | project ClientIP , dcount_Name
   ) on ClientIP
   | extend timestamp = StartTimeUtc, IPCustomEntity = ClientIP
 entityMappings:
@@ -41,5 +40,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Server DNS/Analytic Rules/DNS_Miners.yaml
+++ b/Solutions/Windows Server DNS/Analytic Rules/DNS_Miners.yaml
@@ -17,17 +17,16 @@ tactics:
 relevantTechniques:
   - T1496
 query: |
-
   DnsEvents
   | where Name contains "."
-  | where Name has_any ("monerohash.com", "do-dear.com", "xmrminerpro.com", "secumine.net", "xmrpool.com", "minexmr.org", "hashanywhere.com", 
-  "xmrget.com", "mininglottery.eu", "minergate.com", "moriaxmr.com", "multipooler.com", "moneropools.com", "xmrpool.eu", "coolmining.club", 
-  "supportxmr.com", "minexmr.com", "hashvault.pro", "xmrpool.net", "crypto-pool.fr", "xmr.pt", "miner.rocks", "walpool.com", "herominers.com", 
-  "gntl.co.uk", "semipool.com", "coinfoundry.org", "cryptoknight.cc", "fairhash.org", "baikalmine.com", "tubepool.xyz", "fairpool.xyz", "asiapool.io", 
-  "coinpoolit.webhop.me", "nanopool.org", "moneropool.com", "miner.center", "prohash.net", "poolto.be", "cryptoescrow.eu", "monerominers.net", "cryptonotepool.org", 
-  "extrmepool.org", "webcoin.me", "kippo.eu", "hashinvest.ws", "monero.farm", "supportxmr.com", "xmrpool.eu", "linux-repository-updates.com", "1gh.com", 
-  "dwarfpool.com", "hash-to-coins.com", "hashvault.pro", "pool-proxy.com", "hashfor.cash", "fairpool.cloud", "litecoinpool.org", "mineshaft.ml", "abcxyz.stream", 
-  "moneropool.ru", "cryptonotepool.org.uk", "extremepool.org", "extremehash.com", "hashinvest.net", "unipool.pro", "crypto-pools.org", "monero.net", 
+  | where Name has_any ("monerohash.com", "do-dear.com", "xmrminerpro.com", "secumine.net", "xmrpool.com", "minexmr.org", "hashanywhere.com",
+  "xmrget.com", "mininglottery.eu", "minergate.com", "moriaxmr.com", "multipooler.com", "moneropools.com", "xmrpool.eu", "coolmining.club",
+  "supportxmr.com", "minexmr.com", "hashvault.pro", "xmrpool.net", "crypto-pool.fr", "xmr.pt", "miner.rocks", "walpool.com", "herominers.com",
+  "gntl.co.uk", "semipool.com", "coinfoundry.org", "cryptoknight.cc", "fairhash.org", "baikalmine.com", "tubepool.xyz", "fairpool.xyz", "asiapool.io",
+  "coinpoolit.webhop.me", "nanopool.org", "moneropool.com", "miner.center", "prohash.net", "poolto.be", "cryptoescrow.eu", "monerominers.net", "cryptonotepool.org",
+  "extrmepool.org", "webcoin.me", "kippo.eu", "hashinvest.ws", "monero.farm", "supportxmr.com", "xmrpool.eu", "linux-repository-updates.com", "1gh.com",
+  "dwarfpool.com", "hash-to-coins.com", "hashvault.pro", "pool-proxy.com", "hashfor.cash", "fairpool.cloud", "litecoinpool.org", "mineshaft.ml", "abcxyz.stream",
+  "moneropool.ru", "cryptonotepool.org.uk", "extremepool.org", "extremehash.com", "hashinvest.net", "unipool.pro", "crypto-pools.org", "monero.net",
   "backup-pool.com", "mooo.com", "freeyy.me", "cryptonight.net", "shscrypto.net")
   | extend timestamp = TimeGenerated, IPCustomEntity = ClientIP, HostCustomEntity = Computer
 entityMappings:
@@ -39,5 +38,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Server DNS/Analytic Rules/DNS_TorProxies.yaml
+++ b/Solutions/Windows Server DNS/Analytic Rules/DNS_TorProxies.yaml
@@ -17,12 +17,11 @@ tactics:
 relevantTechniques:
   - T1048
 query: |
-
   DnsEvents
   | where Name contains "."
-  | where Name has_any ("tor2web.org", "tor2web.com", "torlink.co", "onion.to", "onion.ink", "onion.cab", "onion.nu", "onion.link", 
-  "onion.it", "onion.city", "onion.direct", "onion.top", "onion.casa", "onion.plus", "onion.rip", "onion.dog", "tor2web.fi", 
-  "tor2web.blutmagie.de", "onion.sh", "onion.lu", "onion.pet", "t2w.pw", "tor2web.ae.org", "tor2web.io", "tor2web.xyz", "onion.lt", 
+  | where Name has_any ("tor2web.org", "tor2web.com", "torlink.co", "onion.to", "onion.ink", "onion.cab", "onion.nu", "onion.link",
+  "onion.it", "onion.city", "onion.direct", "onion.top", "onion.casa", "onion.plus", "onion.rip", "onion.dog", "tor2web.fi",
+  "tor2web.blutmagie.de", "onion.sh", "onion.lu", "onion.pet", "t2w.pw", "tor2web.ae.org", "tor2web.io", "tor2web.xyz", "onion.lt",
   "s1.tor-gateways.de", "s2.tor-gateways.de", "s3.tor-gateways.de", "s4.tor-gateways.de", "s5.tor-gateways.de", "hiddenservice.net")
   | extend timestamp = TimeGenerated, IPCustomEntity = ClientIP, HostCustomEntity = Computer
 entityMappings:
@@ -34,5 +33,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/ZeroNetworks/Analytic Rules/ZNSegmentRareJITRuleCreation.yaml
+++ b/Solutions/ZeroNetworks/Analytic Rules/ZNSegmentRareJITRuleCreation.yaml
@@ -21,7 +21,6 @@ tactics:
 relevantTechniques:
   - T1021
 query: |
-
   let starttime = 14d;
   let endtime = 1d;
   ZNSegmentAudit
@@ -48,5 +47,5 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: DestinationEntityName
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Zscaler Internet Access/Analytic Rules/Zscaler-LowVolumeDomainRequests.yaml
+++ b/Solutions/Zscaler Internet Access/Analytic Rules/Zscaler-LowVolumeDomainRequests.yaml
@@ -18,7 +18,6 @@ relevantTechniques:
   - T1102
   - T1071
 query: |
-
   let scriptExtensions = dynamic([".php", ".aspx", ".asp", ".cfml"]);
   //The number of URI's seen to be suspicious, higher = less likely to be suspicious
   let uriThreshold = 1;
@@ -51,5 +50,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
### Change(s)
I've removed the preceding new lines from all queries in `Detections` and `Solutions/*/Analytic Rules`

### Reason for Changes:
This PR addresses the incredibly frustrating behaviour where during an incident investigation, clicking on the events creates a query that fails:
<img width="260" alt="SCR-20221205-n9d-2" src="https://user-images.githubusercontent.com/939704/205693728-34ff9cdc-6236-4002-9101-286167b8692f.png">
![SCR-20221205-naw](https://user-images.githubusercontent.com/939704/205694039-fe4a6755-2679-438b-91dc-55d7f62837e0.png)
This is due to the preceding newline that breaks the query into two.

### Versions updated:
   - Yes

I've painstakingly updated the version numbers, however if this isn't significant enough to warrant a version update I'm more than happy to resubmit with just the newlines removed from queries.
