### PR TITLE
Create detect-av-edr-privileged-delete-vulnerability.yaml

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
@@ -13,8 +13,8 @@ requiredDataConnectors:
   dataTypes:
   - DeviceFileEvents
 tactics:
-- Privilege escalation
-- Lateral movement
+- PrivilegeEscalation
+- LateralMovement
 relevantTechniques:
 - t1574
 query: |

--- a/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
@@ -22,4 +22,4 @@ query: |
   | where Timestamp > ago(7d)
   | where ActionType == "FileCreated"
   | where FileName endswith "ndis.sys"
-  | where FolderPath startswith "C:\\\temp\\Windows\\System32\\drivers\\"
+  | where FolderPath startswith "C:\\temp\\Windows\\System32\\drivers\\"

--- a/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
@@ -2,12 +2,12 @@ id: a9eb9b06-4345-47f2-abe6-29f7200ddf83
 name: Windows Anitivirus and EDR Elevation of Privilege Vulnerability
 description: |
   The query for malicious file creations via TOCTOU Vulnerability in Leading Endpoint Detection and Response (EDR) and Antivirus (AV) Solutions.
-▪ Microsoft Defender (CVE-2022-37971)
-▪ Defender for Endpoint (CVE-2022-37971)
-▪ SentinelOne EDR
-▪ TrendMicro Apex One (CVE-2022-45797)
-▪ Avast Antivirus (CVE-2022-4173)
-▪ AVG Antivirus (CVE-2022-4173)
+  - Microsoft Defender (CVE-2022-37971)
+  - Defender for Endpoint (CVE-2022-37971)
+  - SentinelOne EDR
+  - TrendMicro Apex One (CVE-2022-45797)
+  - Avast Antivirus (CVE-2022-4173)
+  - AVG Antivirus (CVE-2022-4173)
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:

--- a/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Privilege escalation/detect-av-edr-privileged-delete-vulnerability.yaml
@@ -1,0 +1,25 @@
+id: a9eb9b06-4345-47f2-abe6-29f7200ddf83
+name: Windows Anitivirus and EDR Elevation of Privilege Vulnerability
+description: |
+  The query for malicious file creations via TOCTOU Vulnerability in Leading Endpoint Detection and Response (EDR) and Antivirus (AV) Solutions.
+▪ Microsoft Defender (CVE-2022-37971)
+▪ Defender for Endpoint (CVE-2022-37971)
+▪ SentinelOne EDR
+▪ TrendMicro Apex One (CVE-2022-45797)
+▪ Avast Antivirus (CVE-2022-4173)
+▪ AVG Antivirus (CVE-2022-4173)
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceFileEvents
+tactics:
+- Privilege escalation
+- Lateral movement
+relevantTechniques:
+- t1574
+query: |
+  DeviceFileEvents
+  | where Timestamp > ago(7d)
+  | where ActionType == "FileCreated"
+  | where FileName endswith "ndis.sys"
+  | where FolderPath startswith "C:\\\temp\\Windows\\System32\\drivers\\"


### PR DESCRIPTION
   Required items, please complete
   
    Change(s):
   - Create a New rule to detect malicious files via Antivirus and EDR Elevation of Privilege Vulnerability

   Reason for Change(s):
   - New rule for detection of Privileged Delete Vulnerability in AV/EDR

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

   References: 
   - https://i.blackhat.com/EU-22/Wednesday-Briefings/EU-22-Yair-Aikido-Turning-EDRs-to-Malicious-Wipers.pdf
   - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-37971