### PR TITLE
Fixed Entity mapping on line 48

### DIFF
--- a/Detections/SigninLogs/PrivilegedUserLogonfromnewASN.yaml
+++ b/Detections/SigninLogs/PrivilegedUserLogonfromnewASN.yaml
@@ -45,6 +45,6 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.3
+        columnName: IPAddress
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
Changed Entity mapping on line 48 - It was populated with an empty value

   Required items, please complete
   
   Change(s):
   - Changed line 48 entity mapping from "IPCustomEntity" to "IPAddress"
   

   Reason for Change(s):
   - Template Error

   Version Updated:
   - New version 1.0.4




