### PR TITLE
Changing Device Filter - Line 6

### DIFF
--- a/Solutions/Trend Micro Apex One/Parsers/TMApexOneEvent.txt
+++ b/Solutions/Trend Micro Apex One/Parsers/TMApexOneEvent.txt
@@ -4,6 +4,7 @@
 // Reference : Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 CommonSecurityLog
 | where DeviceVendor == "Trend Micro"
+| where DeviceProduct == "Apex Central"
 | extend DeviceCustomNumber1 = coalesce(column_ifexists("FieldDeviceCustomNumber1", long(null)),DeviceCustomNumber1),
          DeviceCustomNumber2 = coalesce(column_ifexists("FieldDeviceCustomNumber2", long(null)),DeviceCustomNumber2),
          DeviceCustomNumber3 = coalesce(column_ifexists("FieldDeviceCustomNumber3", long(null)),DeviceCustomNumber3),


### PR DESCRIPTION
Currently the parser checks the CEF table for logs that have DeviceVendor as "Trend Micro" This logic would have been correct if ApexOne was the only source of Trend Micro logs. However we have more Trend Micro connectors like "Deep Security" with very similar parsers "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Trend%20Micro%20Deep%20Security/Parsers/TrendMicroDeepSecurity"

The fact that the "Deep Security" parser also checks for "| where DeviceVendor has_any ("TrendMicro", "Trend Micro")" creates confusion since when customers integrate both Deep Security and ApexOne, the function of each connector also returns the logs of the other. With the change I am making here I ensure that the parser of the ApexOne connector will only return results forwarded by the ApexOne API - The information in which my change is based can be seen here: https://docs.trendmicro.com/en-us/enterprise/apex-central-as-a-service-online-help/appendices/syslog-mapping-cef/cef-cc-callback-logs.aspx

Similar change can be argued for the Deep Security connector, since its parser will also return ApexOne logs

   Required items, please complete
   
   Change(s):
   - Added "| where DeviceProduct == "Apex Central"" in line 7

   Reason for Change(s):
   - Because of multible Trend Micro connectors, parsers need to be specific to the Trend Micro product in which the table the dedicated to

   Version Updated:
   -N/A there is no version in the parser 

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

