### PR TITLE
Fix incorrect fields in detection AdminPromoAfterRoleMgmtAppPermissionGrant.yaml

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -55,7 +55,7 @@ query: |
       | where Category == "ApplicationManagement" and LoggedByService == "Core Directory"
       | where OperationName == "Add app role assignment to service principal"
       | mv-expand TargetResource = TargetResources
-      //| where TargetResource["displayName"] == "Microsoft Graph"
+      //| where tostring(TargetResource["displayName"]) == "Microsoft Graph"
       | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
       | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
       | extend PermissionGrant = tostring(modifiedProperty["newValue"])

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -60,7 +60,7 @@ query: |
       | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
       | extend PermissionGrant = tostring(modifiedProperty["newValue"])
       | where PermissionGrant has "RoleManagement.ReadWrite.Directory"
-      | mv-apply modifiedProperty = TargetResource.modifiedProperties on (
+      | mv-apply modifiedProperty = TargetResource["modifiedProperties"] on (
           summarize modifiedProperties = make_bag(
               pack(tostring(modifiedProperty["displayName"]),
                   pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -2,7 +2,7 @@ id: f80d951a-eddc-4171-b9d0-d616bb83efdc
 name: Admin promotion after Role Management Application Permission Grant
 description: |
   'This rule looks for a service principal being granted the Microsoft Graph RoleManagement.ReadWrite.Directory (application) permission before being used to add an Azure AD object or user account to an Admin directory role (i.e. Global Administrators).
-  This is a known attack path that is usually abused when a service principal already has the AppRoleAssignment.ReadWrite.All permission granted. This permission Allows an app to manage permission grants for application permissions to any API.
+  This is a known attack path that is usually abused when a service principal already has the AppRoleAssignment.ReadWrite.All permission granted. This permission allows an app to manage permission grants for application permissions to any API.
   A service principal can promote itself or other service principals to admin roles (i.e. Global Administrators). This would be considered a privilege escalation technique.
   Ref : https://docs.microsoft.com/graph/permissions-reference#role-management-permissions, https://docs.microsoft.com/graph/api/directoryrole-post-members?view=graph-rest-1.0&tabs=http'
 severity: High
@@ -10,7 +10,7 @@ requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
       - AuditLogs
-queryFrequency: 2h
+queryFrequency: 1h
 queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0
@@ -24,54 +24,68 @@ relevantTechniques:
 tags:
   - SimuLand
 query: |
+  let query_frequency = 1h;
+  let query_period = 2h;
   AuditLogs
-  | where LoggedByService =~ "Core Directory"
-  | where Category =~ "ApplicationManagement"
-  | where AADOperationType =~ "Assign"
-  | where ActivityDisplayName =~ "Add app role assignment to service principal"
-  | mv-expand TargetResources
-  | mv-expand TargetResources.modifiedProperties
-  | extend displayName_ = tostring(TargetResources_modifiedProperties.displayName)
-  | where displayName_ =~ "AppRole.Value"
-  | extend AppRole = tostring(parse_json(tostring(TargetResources_modifiedProperties.newValue)))
-  | where AppRole has "RoleManagement.ReadWrite.Directory"
-  | extend InitiatingApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
-  | extend Initiator = iif(isnotempty(InitiatingApp), InitiatingApp, tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
-  | extend Target = tostring(parse_json(tostring(TargetResources.modifiedProperties[4].newValue)))
-  | extend TargetId = tostring(parse_json(tostring(TargetResources.modifiedProperties[3].newValue)))
-  | project TimeGenerated, OperationName, Initiator, Target, TargetId, Result
-  | join kind=innerunique (
-    AuditLogs
-    | where LoggedByService =~ "Core Directory"
-    | where Category =~ "RoleManagement"
-    | where AADOperationType in ("Assign", "AssignEligibleRole")
-    | where ActivityDisplayName has_any ("Add eligible member to role", "Add member to role")
-    | mv-expand TargetResources
-    | mv-expand TargetResources.modifiedProperties
-    | extend displayName_ = tostring(TargetResources_modifiedProperties.displayName)
-    | where displayName_ =~ "Role.DisplayName"
-    | extend RoleName = tostring(parse_json(tostring(TargetResources_modifiedProperties.newValue)))
-    | where RoleName contains "Admin"
-    | extend Initiator = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
-    | extend InitiatorId = tostring(parse_json(tostring(InitiatedBy.app)).servicePrincipalId)
-    | extend TargetUser = tostring(TargetResources.userPrincipalName)
-    | extend Target = iif(isnotempty(TargetUser), TargetUser, tostring(TargetResources.displayName))
-    | extend TargetType = tostring(TargetResources.type)
-    | extend TargetId = tostring(TargetResources.id)
-    | project TimeGenerated, OperationName,  RoleName, Initiator, InitiatorId, Target, TargetId, TargetType, Result
-  ) on $left.TargetId == $right.InitiatorId
-  | extend TimeRoleMgGrant = TimeGenerated, TimeAdminPromo = TimeGenerated1, ServicePrincipal = Initiator1, ServicePrincipalId = InitiatorId,
-    TargetObject = Target1, TargetObjectId = TargetId1, TargetObjectType = TargetType
-  | where TimeRoleMgGrant < TimeAdminPromo
-  | project TimeRoleMgGrant, TimeAdminPromo, RoleName, ServicePrincipal, ServicePrincipalId, TargetObject, TargetObjectId, TargetObjectType
+  | where TimeGenerated > ago(query_frequency)
+  | where Category == "RoleManagement" and LoggedByService == "Core Directory" and AADOperationType == "Assign"
+  | where isnotempty(InitiatedBy["app"])
+  | mv-expand TargetResource = TargetResources
+  | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
+  | where tostring(modifiedProperty["displayName"]) in ("Role.DisplayName", "RoleDefinition.DisplayName")
+  | extend RoleAssignment = tostring(modifiedProperty["newValue"])
+  | where RoleAssignment contains "Admin"
+  | project
+      RoleAssignment_TimeGenerated = TimeGenerated,
+      RoleAssignment_OperationName = OperationName,
+      RoleAssignment_Result = Result,
+      RoleAssignment,
+      TargetType = tostring(TargetResources[0]["type"]),
+      Target = iff(isnotempty(TargetResources[0]["displayName"]), tostring(TargetResources[0]["displayName"]), tolower(TargetResources[0]["userPrincipalName"])),
+      TargetId = tostring(TargetResources[0]["id"]),
+      RoleAssignment_InitiatedBy = InitiatedBy,
+      RoleAssignment_TargetResources = TargetResources,
+      RoleAssignment_AdditionalDetails = AdditionalDetails,
+      RoleAssignment_CorrelationId = CorrelationId,
+      AppServicePrincipalId = tostring(InitiatedBy["app"]["servicePrincipalId"])
+  | join kind=inner (
+      AuditLogs
+      | where TimeGenerated > ago(query_period)
+      | where Category == "ApplicationManagement" and LoggedByService == "Core Directory"
+      | where OperationName == "Add app role assignment to service principal"
+      | mv-expand TargetResource = TargetResources
+      | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
+      | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
+      | extend PermissionGrant = tostring(modifiedProperty["newValue"])
+      | where PermissionGrant has "RoleManagement.ReadWrite.Directory"
+      | mv-apply modifiedProperty = TargetResource.modifiedProperties on (
+          summarize modifiedProperties = make_bag(
+              pack(tostring(modifiedProperty["displayName"]),
+                  pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),
+                      "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
+      )
+      | project
+          PermissionGrant_TimeGenerated = TimeGenerated,
+          PermissionGrant_OperationName = OperationName,
+          PermissionGrant_Result = Result,
+          PermissionGrant,
+          AppDisplayName = tostring(modifiedProperties["ServicePrincipal.DisplayName"]["newValue"]),
+          AppServicePrincipalId = tostring(modifiedProperties["ServicePrincipal.ObjectID"]["newValue"]),
+          PermissionGrant_InitiatedBy = InitiatedBy,
+          PermissionGrant_TargetResources = TargetResources,
+          PermissionGrant_AdditionalDetails = AdditionalDetails,
+          PermissionGrant_CorrelationId = CorrelationId
+  ) on AppServicePrincipalId
+  | where PermissionGrant_TimeGenerated < RoleAssignment_TimeGenerated
+  | project PermissionGrant_TimeGenerated, PermissionGrant_OperationName, PermissionGrant_Result, PermissionGrant, AppDisplayName, AppServicePrincipalId, PermissionGrant_InitiatedBy, PermissionGrant_TargetResources, PermissionGrant_AdditionalDetails, PermissionGrant_CorrelationId, RoleAssignment_TimeGenerated, RoleAssignment_OperationName, RoleAssignment_Result, RoleAssignment, TargetType, Target, TargetId, RoleAssignment_InitiatedBy, RoleAssignment_TargetResources, RoleAssignment_AdditionalDetails, RoleAssignment_CorrelationId
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: ServicePrincipal
+        columnName: AppDisplayName
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: TargetObject
-version: 1.0.2
+        columnName: Target
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -55,6 +55,7 @@ query: |
       | where Category == "ApplicationManagement" and LoggedByService == "Core Directory"
       | where OperationName == "Add app role assignment to service principal"
       | mv-expand TargetResource = TargetResources
+      //| where TargetResource["displayName"] == "Microsoft Graph"
       | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
       | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
       | extend PermissionGrant = tostring(modifiedProperty["newValue"])

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -29,6 +29,7 @@ query: |
   AuditLogs
   | where TimeGenerated > ago(query_frequency)
   | where Category == "RoleManagement" and LoggedByService == "Core Directory" and AADOperationType == "Assign"
+  //| where OperationName in ("Add eligible member to role", "Add member to role")
   | where isnotempty(InitiatedBy["app"])
   | mv-expand TargetResource = TargetResources
   | mv-expand modifiedProperty = TargetResource["modifiedProperties"]

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -28,7 +28,7 @@ query: |
   let query_period = 2h;
   AuditLogs
   | where TimeGenerated > ago(query_frequency)
-  | where Category == "RoleManagement" and LoggedByService == "Core Directory" and AADOperationType == "Assign"
+  | where Category =~ "RoleManagement" and LoggedByService =~ "Core Directory" and AADOperationType =~ "Assign"
   //| where OperationName in ("Add eligible member to role", "Add member to role")
   | where isnotempty(InitiatedBy["app"])
   | mv-expand TargetResource = TargetResources

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -27,57 +27,57 @@ query: |
   let query_frequency = 1h;
   let query_period = 2h;
   AuditLogs
-  | where TimeGenerated > ago(query_frequency)
-  | where Category =~ "RoleManagement" and LoggedByService =~ "Core Directory" and AADOperationType =~ "Assign"
-  //| where OperationName in ("Add eligible member to role", "Add member to role")
-  | where isnotempty(InitiatedBy["app"])
+  | where TimeGenerated > ago(query_period)
+  | where Category =~ "ApplicationManagement" and LoggedByService =~ "Core Directory"
+  | where OperationName =~ "Add app role assignment to service principal"
   | mv-expand TargetResource = TargetResources
+  //| where tostring(TargetResource["displayName"]) == "Microsoft Graph"
   | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
-  | where tostring(modifiedProperty["displayName"]) in ("Role.DisplayName", "RoleDefinition.DisplayName")
-  | extend RoleAssignment = tostring(modifiedProperty["newValue"])
-  | where RoleAssignment contains "Admin"
+  | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
+  | extend PermissionGrant = tostring(modifiedProperty["newValue"])
+  | where PermissionGrant has "RoleManagement.ReadWrite.Directory"
+  | mv-apply modifiedProperty = TargetResource["modifiedProperties"] on (
+      summarize modifiedProperties = make_bag(
+          pack(tostring(modifiedProperty["displayName"]),
+              pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),
+                  "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
+  )
   | project
-      RoleAssignment_TimeGenerated = TimeGenerated,
-      RoleAssignment_OperationName = OperationName,
-      RoleAssignment_Result = Result,
-      RoleAssignment,
-      TargetType = tostring(TargetResources[0]["type"]),
-      Target = iff(isnotempty(TargetResources[0]["displayName"]), tostring(TargetResources[0]["displayName"]), tolower(TargetResources[0]["userPrincipalName"])),
-      TargetId = tostring(TargetResources[0]["id"]),
-      RoleAssignment_InitiatedBy = InitiatedBy,
-      RoleAssignment_TargetResources = TargetResources,
-      RoleAssignment_AdditionalDetails = AdditionalDetails,
-      RoleAssignment_CorrelationId = CorrelationId,
-      AppServicePrincipalId = tostring(InitiatedBy["app"]["servicePrincipalId"])
+      PermissionGrant_TimeGenerated = TimeGenerated,
+      PermissionGrant_OperationName = OperationName,
+      PermissionGrant_Result = Result,
+      PermissionGrant,
+      AppDisplayName = tostring(modifiedProperties["ServicePrincipal.DisplayName"]["newValue"]),
+      AppServicePrincipalId = tostring(modifiedProperties["ServicePrincipal.ObjectID"]["newValue"]),
+      PermissionGrant_InitiatedBy = InitiatedBy,
+      PermissionGrant_TargetResources = TargetResources,
+      PermissionGrant_AdditionalDetails = AdditionalDetails,
+      PermissionGrant_CorrelationId = CorrelationId
   | join kind=inner (
       AuditLogs
-      | where TimeGenerated > ago(query_period)
-      | where Category == "ApplicationManagement" and LoggedByService == "Core Directory"
-      | where OperationName == "Add app role assignment to service principal"
+      | where TimeGenerated > ago(query_frequency)
+      | where Category =~ "RoleManagement" and LoggedByService =~ "Core Directory" and AADOperationType =~ "Assign"
+      //| where OperationName in ("Add eligible member to role", "Add member to role")
+      | where isnotempty(InitiatedBy["app"])
       | mv-expand TargetResource = TargetResources
-      //| where tostring(TargetResource["displayName"]) == "Microsoft Graph"
       | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
-      | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
-      | extend PermissionGrant = tostring(modifiedProperty["newValue"])
-      | where PermissionGrant has "RoleManagement.ReadWrite.Directory"
-      | mv-apply modifiedProperty = TargetResource["modifiedProperties"] on (
-          summarize modifiedProperties = make_bag(
-              pack(tostring(modifiedProperty["displayName"]),
-                  pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),
-                      "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
-      )
+      | where tostring(modifiedProperty["displayName"]) in ("Role.DisplayName", "RoleDefinition.DisplayName")
+      | extend RoleAssignment = tostring(modifiedProperty["newValue"])
+      | where RoleAssignment contains "Admin"
       | project
-          PermissionGrant_TimeGenerated = TimeGenerated,
-          PermissionGrant_OperationName = OperationName,
-          PermissionGrant_Result = Result,
-          PermissionGrant,
-          AppDisplayName = tostring(modifiedProperties["ServicePrincipal.DisplayName"]["newValue"]),
-          AppServicePrincipalId = tostring(modifiedProperties["ServicePrincipal.ObjectID"]["newValue"]),
-          PermissionGrant_InitiatedBy = InitiatedBy,
-          PermissionGrant_TargetResources = TargetResources,
-          PermissionGrant_AdditionalDetails = AdditionalDetails,
-          PermissionGrant_CorrelationId = CorrelationId
-  ) on AppServicePrincipalId
+          RoleAssignment_TimeGenerated = TimeGenerated,
+          RoleAssignment_OperationName = OperationName,
+          RoleAssignment_Result = Result,
+          RoleAssignment,
+          TargetType = tostring(TargetResources[0]["type"]),
+          Target = iff(isnotempty(TargetResources[0]["displayName"]), tostring(TargetResources[0]["displayName"]), tolower(TargetResources[0]["userPrincipalName"])),
+          TargetId = tostring(TargetResources[0]["id"]),
+          RoleAssignment_InitiatedBy = InitiatedBy,
+          RoleAssignment_TargetResources = TargetResources,
+          RoleAssignment_AdditionalDetails = AdditionalDetails,
+          RoleAssignment_CorrelationId = CorrelationId,
+          AppServicePrincipalId = tostring(InitiatedBy["app"]["servicePrincipalId"])
+      ) on AppServicePrincipalId
   | where PermissionGrant_TimeGenerated < RoleAssignment_TimeGenerated
   | project PermissionGrant_TimeGenerated, PermissionGrant_OperationName, PermissionGrant_Result, PermissionGrant, AppDisplayName, AppServicePrincipalId, PermissionGrant_InitiatedBy, PermissionGrant_TargetResources, PermissionGrant_AdditionalDetails, PermissionGrant_CorrelationId, RoleAssignment_TimeGenerated, RoleAssignment_OperationName, RoleAssignment_Result, RoleAssignment, TargetType, Target, TargetId, RoleAssignment_InitiatedBy, RoleAssignment_TargetResources, RoleAssignment_AdditionalDetails, RoleAssignment_CorrelationId
 entityMappings:

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -37,9 +37,9 @@ query: |
   | where PermissionGrant has "RoleManagement.ReadWrite.Directory"
   | mv-apply modifiedProperty = TargetResource["modifiedProperties"] on (
       summarize modifiedProperties = make_bag(
-          pack(tostring(modifiedProperty["displayName"]),
-              pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),
-                  "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
+          bag_pack(tostring(modifiedProperty["displayName"]),
+              bag_pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),
+                  "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))), 100)
   )
   | project
       PermissionGrant_TimeGenerated = TimeGenerated,

--- a/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/AdminPromoAfterRoleMgmtAppPermissionGrant.yaml
@@ -31,7 +31,6 @@ query: |
   | where Category =~ "ApplicationManagement" and LoggedByService =~ "Core Directory"
   | where OperationName =~ "Add app role assignment to service principal"
   | mv-expand TargetResource = TargetResources
-  //| where tostring(TargetResource["displayName"]) == "Microsoft Graph"
   | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
   | where tostring(modifiedProperty["displayName"]) == "AppRole.Value"
   | extend PermissionGrant = tostring(modifiedProperty["newValue"])
@@ -57,7 +56,6 @@ query: |
       AuditLogs
       | where TimeGenerated > ago(query_frequency)
       | where Category =~ "RoleManagement" and LoggedByService =~ "Core Directory" and AADOperationType =~ "Assign"
-      //| where OperationName in ("Add eligible member to role", "Add member to role")
       | where isnotempty(InitiatedBy["app"])
       | mv-expand TargetResource = TargetResources
       | mv-expand modifiedProperty = TargetResource["modifiedProperties"]
@@ -79,15 +77,20 @@ query: |
           AppServicePrincipalId = tostring(InitiatedBy["app"]["servicePrincipalId"])
       ) on AppServicePrincipalId
   | where PermissionGrant_TimeGenerated < RoleAssignment_TimeGenerated
-  | project PermissionGrant_TimeGenerated, PermissionGrant_OperationName, PermissionGrant_Result, PermissionGrant, AppDisplayName, AppServicePrincipalId, PermissionGrant_InitiatedBy, PermissionGrant_TargetResources, PermissionGrant_AdditionalDetails, PermissionGrant_CorrelationId, RoleAssignment_TimeGenerated, RoleAssignment_OperationName, RoleAssignment_Result, RoleAssignment, TargetType, Target, TargetId, RoleAssignment_InitiatedBy, RoleAssignment_TargetResources, RoleAssignment_AdditionalDetails, RoleAssignment_CorrelationId
+  | extend
+      TargetName = tostring(split(Target, "@")[0]),
+      TargetUPNSuffix = tostring(split(Target, "@")[1])
+  | project PermissionGrant_TimeGenerated, PermissionGrant_OperationName, PermissionGrant_Result, PermissionGrant, AppDisplayName, AppServicePrincipalId, PermissionGrant_InitiatedBy, PermissionGrant_TargetResources, PermissionGrant_AdditionalDetails, PermissionGrant_CorrelationId, RoleAssignment_TimeGenerated, RoleAssignment_OperationName, RoleAssignment_Result, RoleAssignment, TargetType, Target, TargetName, TargetUPNSuffix, TargetId, RoleAssignment_InitiatedBy, RoleAssignment_TargetResources, RoleAssignment_AdditionalDetails, RoleAssignment_CorrelationId
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
+      - identifier: Name
         columnName: AppDisplayName
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: Target
+      - identifier: Name
+        columnName: TargetName
+      - identifier: UPNSuffix
+        columnName: TargetUPNSuffix
 version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   1. Use distinct query_frequency and query_period parameters.
   2. ~~Interchange left and right join sides.~~
   3. Use join kind inner instead of innerunique.
   4. Parse ```ServicePrincipal.ObjectID``` by name instead of position ```modifiedProperties[3]```.
   5. Remove the ```AADOperationType == "AssignEligibleRole"```.
   6. Take into account any ```"RoleManagement"``` and ```"Assign"``` operation.

   Reason for Change(s):
   1. If the permission grant operation happened 2h10m before the query execution, and the role assignment operation happened 1h50m before the query execution, this detection would have not triggered any alert, thus the detection was not working in some cases.
   2. ~~This detection should trigger only if a ```"RoleManagement"``` and ```"Assign"``` operation happens, it should be the first thing to check as it has the lower timescope.~~
   3. ```innerunique``` kind deduplicates left side instead of the right side, so there could have been (very improbable) cases were the condition ```TimeRoleMgGrant < TimeAdminPromo``` does not evaluate to ```true```, thus the detection was not working in some cases.
   4. Not every event or environment has ```ServicePrincipal.ObjectID``` in position 3 of ```modifiedProperties```, thus the detection was not working in some cases.
   5. Operation ```Add eligible member to role``` in ```Core Directory``` has ```AADOperationType == "Assign"```, not ```"AssignEligibleRole"```.
   6. Custom role definition assignments could be considered by this detection too if the custom role contains ```Admin```.

   Version Updated:
   - Yes

   Testing Completed:
   - Need help, because I don't have available events of this privilege escalation. I have tried this query by adding some columns so the join works.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
