### PR TITLE
Add more cases in detection RunCommandUEBABreach.yaml

### DIFF
--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -21,13 +21,13 @@ relevantTechniques:
 query: |
   AzureActivity
   // Isolate run command actions
-  | where OperationNameValue == "MICROSOFT.COMPUTE/VIRTUALMACHINES/RUNCOMMAND/ACTION"
+  | where OperationNameValue =~ "MICROSOFT.COMPUTE/VIRTUALMACHINES/RUNCOMMAND/ACTION"
   // Confirm that the operation impacted a virtual machine
   | where Authorization has "virtualMachines"
   // Each runcommand operation consists of three events when successful, Started, Accepted (or Rejected), Successful (or Failed).
   | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
   // Limit to Run Command executions that Succeeded
-  | where list_ActivityStatusValue has "Success"
+  | where list_ActivityStatusValue has_any ("Success", "Succeeded")
   // Extract data from the Authorization field
   | extend Authorization_d = parse_json(Authorization)
   | extend Scope = Authorization_d.scope

--- a/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
+++ b/Detections/MultipleDataSources/RunCommandUEBABreach.yaml
@@ -60,7 +60,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.6
+version: 1.0.7
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
   Change(s):
   - Add more cases to consider, depending on ```OperationNameValue``` and ```ActivityStatus```.

   Reason for Change(s):
   - It seems there can be two parsed versions of the same type of operation in ```AzureActivity```

![image](https://user-images.githubusercontent.com/2527990/210613009-33541466-df29-46a4-90b8-bf1d2fed4d11.png)

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes