### PR TITLE
Fix possible mistake in condition in Nobelium_FoggyWeb.yaml

### DIFF
--- a/Solutions/Legacy IOC based Threat Protection/Analytic Rules/Nobelium_FoggyWeb.yaml
+++ b/Solutions/Legacy IOC based Threat Protection/Analytic Rules/Nobelium_FoggyWeb.yaml
@@ -79,7 +79,7 @@ query: |
   | distinct Computer
   ),
   ( WindowsEvent
-  | where EventID == 4688 and EventData has "Microsoft.IdentityServer.ServiceHost.exe" and EventData has "0x3e4"
+  | where EventID == 4688 and EventData has "Microsoft.IdentityServer.ServiceHost.exe"// and not(EventData has "0x3e4")
   | extend ProcessName = tostring(EventData.ProcessName)
   | where ProcessName == "Microsoft.IdentityServer.ServiceHost.exe"
   | extend SubjectLogonId = tostring(EventData.SubjectLogonId)
@@ -202,5 +202,5 @@ entityMappings:
     fieldMappings:
       - identifier: ProcessId
         columnName: ProcessCustomEntity
-version: 2.1.1
+version: 2.1.2
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Remove condition about SubjectLogonId being a hardcoded value.

   Reason for Change(s):
   - It is strange to look for events whose EventData column contains "0x3e4" and then exclude the events whose SubjectLogonId is "0x3e4". In the other tables events whose SubjectLogonId is "0x3e4" are excluded too.
  
   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes