### PR TITLE
add ASimAuthentication Parsers for syslog sshd, su and sudo

### DIFF
--- a/Parsers/ASimAuthentication/ARM/ASimAuthenticationSshd/ASimAuthenticationSshd.json
+++ b/Parsers/ASimAuthentication/ARM/ASimAuthenticationSshd/ASimAuthenticationSshd.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "Workspace": {
+            "type": "string",
+            "metadata": {
+                "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
+            }
+        },
+        "WorkspaceRegion": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "The region of the selected workspace. The default value will use the Region selection above."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2017-03-15-preview",
+            "name": "[parameters('Workspace')]",
+            "location": "[parameters('WorkspaceRegion')]",
+            "resources": [
+                {
+                    "type": "savedSearches",
+                    "apiVersion": "2020-08-01",
+                    "name": "ASimAuthenticationSshd",
+                    "dependsOn": [
+                        "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+                    ],
+                    "properties": {
+                        "etag": "*",
+                        "displayName": "Authentication ASIM parser for Syslog sshd",
+                        "category": "ASIM",
+                        "FunctionAlias": "ASimAuthenticationSshd",
+                        "query": "let SSHDSignInAuthorized=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"sshd\" and SyslogMessage has 'Accepted '\n  | extend\n  EventVendor = 'OpenBSD'\n  , EventProduct = 'sshd'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Success'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logon'\n  , DvcHostname = Computer\n  //, DvcIpAddr = extract(@'\\d{1,3}\\.\\d{1.3}\\.\\d{1,3}\\.\\d{1,3}', 1, SyslogMessage)\n  , DvcIpAddr = extract(\"from (([0-9]{1,3})\\\\.([0-9]{1,3})\\\\.([0-9]{1,3})\\\\.(([0-9]{1,3}))) port\",1,SyslogMessage)\n  , TargetUsernameType = 'Simple'\n  , TargetUsername = extract(@'for (.*?) from', 1, SyslogMessage)\n  , EventResultDetails = 'Other'\n  , EventOriginalRestultDetails = 'Connection authorized'\n// ************************\n//      <Aliases>\n// ************************\n| extend\n        User=TargetUsername\n      , Dvc=Computer\n// ************************\n//      </Aliases>\n// ************************\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nlet SSHDAuthFailure1=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"sshd\" and SyslogMessage has 'Failed '\n  | extend\n  EventVendor = 'OpenBSD'\n  , EventProduct = 'sshd'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Failure'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logon'\n  , DvcHostname = Computer\n  //, DvcIpAddr = extract(@'from \\d{1,3}\\.\\d{1.3}\\.\\d{1,3}\\.\\d{1,3} port', 1, SyslogMessage)\n  , DvcIpAddr = extract(\"from (([0-9]{1,3})\\\\.([0-9]{1,3})\\\\.([0-9]{1,3})\\\\.(([0-9]{1,3}))) port\",1,SyslogMessage)\n  , TargetUsernameType = 'Simple'\n  , TargetUsername = extract(@'for (invalid user )?(.*?) from', 2, SyslogMessage)\n  , EventResultDetails = 'No such user or password'\n  , EventOriginalRestultDetails = 'User authentication failed'\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nlet SSHDDisconnect=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"sshd\" and SyslogMessage has 'session closed for user '\n  | extend\n  EventVendor = 'OpenBSD'\n  , EventProduct = 'sshd'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Success'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logoff'\n  , DvcHostname = Computer\n  , TargetUsernameType = 'Simple'\n  , TargetUsername = extract('for user (.*?)$', 1, SyslogMessage)\n  , EventResultDetails = 'Other'\n  , EventOriginalRestultDetails = 'User session closed'\n// ************************\n//      <Aliases>\n// ************************\n| extend\n        User=TargetUsername\n      , Dvc=Computer\n// ************************\n//      </Aliases>\n// ************************\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nunion isfuzzy=false SSHDSignInAuthorized(disabled), SSHDAuthFailure1(disabled), SSHDDisconnect(disabled)\n",
+                        "version": 1,
+                        "functionParameters": "disabled:bool=False"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/Parsers/ASimAuthentication/ARM/ASimAuthenticationSshd/README.md
+++ b/Parsers/ASimAuthentication/ARM/ASimAuthenticationSshd/README.md
@@ -1,0 +1,18 @@
+# Syslog sshd ASIM Authentication Normalization Parser
+
+ARM template for ASIM Authentication schema parser for sshd (via Syslog).
+
+This ASIM parser supports filtering and normalizing sshd sign in logs to the ASIM Authentication schema.
+
+
+The Advanced Security Information Model (ASIM) enables you to use and create source-agnostic content, simplifying your analysis of the data in your Microsoft Sentinel workspace.
+
+For more information, see:
+
+- [Normalization and the Advanced Security Information Model (ASIM)](https://aka.ms/AboutASIM)
+- [Deploy all of ASIM](https://aka.ms/DeployASIM)
+- [ASIM Authentication normalization schema reference](https://aka.ms/ASimAuthenticationDoc)
+
+<br>
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FParsers%2FASimAuthentication%2FARM%2FASimAuthenticationSshd%2FASimAuthenticationSshd.json) [![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FParsers%2FASimAuthentication%2FARM%2FASimAuthenticationSshd%2FASimAuthenticationSshd.json)

--- a/Parsers/ASimAuthentication/ARM/ASimAuthenticationSu/ASimAuthenticationSu.json
+++ b/Parsers/ASimAuthentication/ARM/ASimAuthenticationSu/ASimAuthenticationSu.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "Workspace": {
+            "type": "string",
+            "metadata": {
+                "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
+            }
+        },
+        "WorkspaceRegion": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "The region of the selected workspace. The default value will use the Region selection above."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2017-03-15-preview",
+            "name": "[parameters('Workspace')]",
+            "location": "[parameters('WorkspaceRegion')]",
+            "resources": [
+                {
+                    "type": "savedSearches",
+                    "apiVersion": "2020-08-01",
+                    "name": "ASimAuthenticationSu",
+                    "dependsOn": [
+                        "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+                    ],
+                    "properties": {
+                        "etag": "*",
+                        "displayName": "Authentication ASIM parser for Syslog su",
+                        "category": "ASIM",
+                        "FunctionAlias": "ASimAuthenticationSu",
+                        "query": "let SuSignInAuthorized=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"su\" and (SyslogMessage has 'pam_unix(su:session): session opened' or SyslogMessage has 'pam_unix(su-l:session): session opened')\n  | parse SyslogMessage with \"for user \" TargetUsername \" by \" ActorUsername\n  | extend\n  EventVendor = 'su'\n  , EventProduct = 'su'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Success'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logon'\n  , DvcHostname = Computer\n  , ActorUsernameType = 'Simple'\n  , EventResultDetails = 'Other'\n  , EventOriginalRestultDetails = 'Connection authorized'\n// ************************\n//      <Aliases>\n// ************************\n| extend\n        User=TargetUsername\n      , Dvc=Computer\n// ************************\n//      </Aliases>\n// ************************\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nlet SuDisconnect=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"su\" and (SyslogMessage has 'pam_unix(su:session): session closed' or SyslogMessage has 'pam_unix(su-l:session): session closed')\n  | parse SyslogMessage with \"for user \" TargetUsername\n  | extend\n  EventVendor = 'su'\n  , EventProduct = 'su'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Success'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logoff'\n  , DvcHostname = Computer\n  , TargetUsernameType = 'Simple'\n  , EventResultDetails = 'Other'\n  , EventOriginalRestultDetails = 'User session closed'\n// ************************\n//      <Aliases>\n// ************************\n| extend\n        User=TargetUsername\n      , Dvc=Computer\n// ************************\n//      </Aliases>\n// ************************\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nunion isfuzzy=false SuSignInAuthorized(disabled), SuDisconnect(disabled)\n",
+                        "version": 1,
+                        "functionParameters": "disabled:bool=False"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/Parsers/ASimAuthentication/ARM/ASimAuthenticationSu/README.md
+++ b/Parsers/ASimAuthentication/ARM/ASimAuthenticationSu/README.md
@@ -1,0 +1,18 @@
+# Syslog su ASIM Authentication Normalization Parser
+
+ARM template for ASIM Authentication schema parser for su (via Syslog).
+
+This ASIM parser supports filtering and normalizing su sign in logs to the ASIM Authentication schema.
+
+
+The Advanced Security Information Model (ASIM) enables you to use and create source-agnostic content, simplifying your analysis of the data in your Microsoft Sentinel workspace.
+
+For more information, see:
+
+- [Normalization and the Advanced Security Information Model (ASIM)](https://aka.ms/AboutASIM)
+- [Deploy all of ASIM](https://aka.ms/DeployASIM)
+- [ASIM Authentication normalization schema reference](https://aka.ms/ASimAuthenticationDoc)
+
+<br>
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FParsers%2FASimAuthentication%2FARM%2FASimAuthenticationSu%2FASimAuthenticationSu.json) [![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FParsers%2FASimAuthentication%2FARM%2FASimAuthenticationSu%2FASimAuthenticationSu.json)

--- a/Parsers/ASimAuthentication/ARM/ASimAuthenticationSudo/ASimAuthenticationSudo.json
+++ b/Parsers/ASimAuthentication/ARM/ASimAuthenticationSudo/ASimAuthenticationSudo.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "Workspace": {
+            "type": "string",
+            "metadata": {
+                "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
+            }
+        },
+        "WorkspaceRegion": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "The region of the selected workspace. The default value will use the Region selection above."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2017-03-15-preview",
+            "name": "[parameters('Workspace')]",
+            "location": "[parameters('WorkspaceRegion')]",
+            "resources": [
+                {
+                    "type": "savedSearches",
+                    "apiVersion": "2020-08-01",
+                    "name": "ASimAuthenticationSudo",
+                    "dependsOn": [
+                        "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+                    ],
+                    "properties": {
+                        "etag": "*",
+                        "displayName": "Authentication ASIM parser for Syslog sudo",
+                        "category": "ASIM",
+                        "FunctionAlias": "ASimAuthenticationSudo",
+                        "query": "let SudoSignInAuthorized=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"sudo\" and SyslogMessage has 'TTY=' and SyslogMessage has 'USER='and SyslogMessage has 'COMMAND='\n  | parse-kv SyslogMessage as (TTY: string, PWD: string, USER: string, COMMAND: string) with (pair_delimiter=' ', kv_delimiter='=')\n  | extend\n  EventVendor = 'sudo'\n  , EventProduct = 'sudo'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Success'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logon'\n  , DvcHostname = Computer\n  , ActorUsernameType = 'Simple'\n  , ActorUsername = extract(@'^(.*?):', 1, SyslogMessage)\n  , TargetUsername = USER\n  , EventResultDetails = 'Other'\n  , EventOriginalRestultDetails = 'Connection authorized'\n// ************************\n//      <Aliases>\n// ************************\n| extend\n        User=TargetUsername\n      , Dvc=Computer\n// ************************\n//      </Aliases>\n// ************************\n  | project-away Computer, MG, SourceSystem, TenantId,USER\n  };\nlet SudoAuthFailure1=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"sudo\" and (SyslogMessage has 'user NOT in sudoers' or SyslogMessage has 'incorrect password attempts')\n  | parse-kv SyslogMessage as (TTY: string, PWD: string, USER: string, COMMAND: string) with  (pair_delimiter=' ', kv_delimiter='=')\n  | extend\n  EventVendor = 'sudo'\n  , EventProduct = 'sudo'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Failure'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logon'\n  , DvcHostname = Computer\n  , ActorUsernameType = 'Simple'\n  , ActorUsername = extract(@'^(.*?):', 1, SyslogMessage)\n  , TargetUsernameType = 'Simple'\n  , TargetUsername = USER\n  , EventResultDetails = 'No such user or password'\n  , EventOriginalRestultDetails = 'User authentication failed'\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nlet SudoDisconnect=(disabled:bool=false){\nSyslog | where not(disabled)\n  | where ProcessName == \"sudo\" and SyslogMessage has 'session closed for user '\n  | extend\n  EventVendor = 'sudo'\n  , EventProduct = 'sudo'\n  , EventCount = int(1)\n  , EventSchema = 'Authentication'\n  , EventSchemaVersion = '0.1.1'\n  , EventResult = 'Success'\n  , EventStartTime = TimeGenerated\n  , EventEndTime = TimeGenerated\n  , EventType = 'Logoff'\n  , DvcHostname = Computer\n  , TargetUsernameType = 'Simple'\n  , TargetUsername = extract('for user (.*?)$', 1, SyslogMessage)\n  , EventResultDetails = 'Other'\n  , EventOriginalRestultDetails = 'User session closed'\n// ************************\n//      <Aliases>\n// ************************\n| extend\n        User=TargetUsername\n      , Dvc=Computer\n// ************************\n//      </Aliases>\n// ************************\n  | project-away Computer, MG, SourceSystem, TenantId\n  };\nunion isfuzzy=false SudoSignInAuthorized(disabled), SudoAuthFailure1(disabled), SudoDisconnect(disabled)\n",
+                        "version": 1,
+                        "functionParameters": "disabled:bool=False"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/Parsers/ASimAuthentication/ARM/ASimAuthenticationSudo/README.md
+++ b/Parsers/ASimAuthentication/ARM/ASimAuthenticationSudo/README.md
@@ -1,0 +1,18 @@
+# Syslog sudo ASIM Authentication Normalization Parser
+
+ARM template for ASIM Authentication schema parser for sudo (via Syslog).
+
+This ASIM parser supports filtering and normalizing sudo sign in logs to the ASIM Authentication schema.
+
+
+The Advanced Security Information Model (ASIM) enables you to use and create source-agnostic content, simplifying your analysis of the data in your Microsoft Sentinel workspace.
+
+For more information, see:
+
+- [Normalization and the Advanced Security Information Model (ASIM)](https://aka.ms/AboutASIM)
+- [Deploy all of ASIM](https://aka.ms/DeployASIM)
+- [ASIM Authentication normalization schema reference](https://aka.ms/ASimAuthenticationDoc)
+
+<br>
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FParsers%2FASimAuthentication%2FARM%2FASimAuthenticationSu%2FASimAuthenticationSudo.json) [![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FParsers%2FASimAuthentication%2FARM%2FASimAuthenticationSu%2FASimAuthenticationSudo.json)

--- a/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSshd.yaml
+++ b/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSshd.yaml
@@ -23,6 +23,8 @@ ParserQuery: |
   let SSHDSignInAuthorized=(disabled:bool=false){
   Syslog | where not(disabled)
     | where ProcessName == "sshd" and SyslogMessage has 'Accepted '
+    | parse SyslogMessage with * "for " TargetUsername " from " SrcIpAddr " port"
+    | parse SyslogMessage with * " message repeated " EventCount " times:" *
     | extend
     EventVendor = 'OpenBSD'
     , EventProduct = 'sshd'
@@ -34,12 +36,7 @@ ParserQuery: |
     , EventEndTime = TimeGenerated
     , EventType = 'Logon'
     , DvcHostname = Computer
-    //, DvcIpAddr = extract(@'\d{1,3}\.\d{1.3}\.\d{1,3}\.\d{1,3}', 1, SyslogMessage)
-    , DvcIpAddr = extract("from (([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3}))) port",1,SyslogMessage)
     , TargetUsernameType = 'Simple'
-    , TargetUsername = extract(@'for (.*?) from', 1, SyslogMessage)
-    , EventResultDetails = 'Other'
-    , EventOriginalRestultDetails = 'Connection authorized'
   // ************************
   //      <Aliases>
   // ************************
@@ -53,7 +50,9 @@ ParserQuery: |
     };
   let SSHDAuthFailure1=(disabled:bool=false){
   Syslog | where not(disabled)
-    | where ProcessName == "sshd" and SyslogMessage has 'Failed '
+    | where ProcessName == "sshd" and SyslogMessage has_any ('Failed password ', 'Failed publickey ', 'Invalid user ')
+    | parse SyslogMessage with * " from " SrcIpAddr " port"
+    | parse SyslogMessage with * " message repeated " EventCount " times:" *
     | extend
     EventVendor = 'OpenBSD'
     , EventProduct = 'sshd'
@@ -65,8 +64,6 @@ ParserQuery: |
     , EventEndTime = TimeGenerated
     , EventType = 'Logon'
     , DvcHostname = Computer
-    //, DvcIpAddr = extract(@'from \d{1,3}\.\d{1.3}\.\d{1,3}\.\d{1,3} port', 1, SyslogMessage)
-    , DvcIpAddr = extract("from (([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3}))) port",1,SyslogMessage)
     , TargetUsernameType = 'Simple'
     , TargetUsername = extract(@'for (invalid user )?(.*?) from', 2, SyslogMessage)
     , EventResultDetails = 'No such user or password'
@@ -75,7 +72,10 @@ ParserQuery: |
     };
   let SSHDDisconnect=(disabled:bool=false){
   Syslog | where not(disabled)
-    | where ProcessName == "sshd" and SyslogMessage has 'session closed for user '
+    | where ProcessName == "sshd" and SyslogMessage has_any ('session closed for user ', 'Connection closed by ')
+    | parse SyslogMessage with * "for user " TargetUsername
+    | parse SyslogMessage with "Connection closed by " SrcIpAddr " port "
+    | parse SyslogMessage with * " message repeated " EventCount " times:" *
     | extend
     EventVendor = 'OpenBSD'
     , EventProduct = 'sshd'
@@ -88,7 +88,6 @@ ParserQuery: |
     , EventType = 'Logoff'
     , DvcHostname = Computer
     , TargetUsernameType = 'Simple'
-    , TargetUsername = extract('for user (.*?)$', 1, SyslogMessage)
     , EventResultDetails = 'Other'
     , EventOriginalRestultDetails = 'User session closed'
   // ************************

--- a/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSshd.yaml
+++ b/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSshd.yaml
@@ -1,0 +1,105 @@
+Parser:
+  Title: Authentication ASIM parser for Syslog sshd
+  Version: '0.1.1'
+  LastUpdated: November 21, 2022
+Product:
+  Name: sshd
+Normalization:
+  Schema: Authentication
+  Version: '0.1.1'
+References:
+- Title: ASIM Authentication Schema
+  Link: https://aka.ms/ASimAuthenticationDoc
+- Title: ASIM
+  Link: https:/aka.ms/AboutASIM
+Description: |
+  This ASIM parser supports normalizing Syslog opensshd sign in logs to the ASIM Authentication schema.
+ParserName: ASimAuthenticationSshd
+ParserParams:
+  - Name: disabled
+    Type: bool
+    Default: false
+ParserQuery: |
+  let SSHDSignInAuthorized=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "sshd" and SyslogMessage has 'Accepted '
+    | extend
+    EventVendor = 'OpenBSD'
+    , EventProduct = 'sshd'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Success'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logon'
+    , DvcHostname = Computer
+    //, DvcIpAddr = extract(@'\d{1,3}\.\d{1.3}\.\d{1,3}\.\d{1,3}', 1, SyslogMessage)
+    , DvcIpAddr = extract("from (([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3}))) port",1,SyslogMessage)
+    , TargetUsernameType = 'Simple'
+    , TargetUsername = extract(@'for (.*?) from', 1, SyslogMessage)
+    , EventResultDetails = 'Other'
+    , EventOriginalRestultDetails = 'Connection authorized'
+  // ************************
+  //      <Aliases>
+  // ************************
+  | extend
+          User=TargetUsername
+        , Dvc=Computer
+  // ************************
+  //      </Aliases>
+  // ************************
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  let SSHDAuthFailure1=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "sshd" and SyslogMessage has 'Failed '
+    | extend
+    EventVendor = 'OpenBSD'
+    , EventProduct = 'sshd'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Failure'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logon'
+    , DvcHostname = Computer
+    //, DvcIpAddr = extract(@'from \d{1,3}\.\d{1.3}\.\d{1,3}\.\d{1,3} port', 1, SyslogMessage)
+    , DvcIpAddr = extract("from (([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.(([0-9]{1,3}))) port",1,SyslogMessage)
+    , TargetUsernameType = 'Simple'
+    , TargetUsername = extract(@'for (invalid user )?(.*?) from', 2, SyslogMessage)
+    , EventResultDetails = 'No such user or password'
+    , EventOriginalRestultDetails = 'User authentication failed'
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  let SSHDDisconnect=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "sshd" and SyslogMessage has 'session closed for user '
+    | extend
+    EventVendor = 'OpenBSD'
+    , EventProduct = 'sshd'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Success'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logoff'
+    , DvcHostname = Computer
+    , TargetUsernameType = 'Simple'
+    , TargetUsername = extract('for user (.*?)$', 1, SyslogMessage)
+    , EventResultDetails = 'Other'
+    , EventOriginalRestultDetails = 'User session closed'
+  // ************************
+  //      <Aliases>
+  // ************************
+  | extend
+          User=TargetUsername
+        , Dvc=Computer
+  // ************************
+  //      </Aliases>
+  // ************************
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  union isfuzzy=false SSHDSignInAuthorized(disabled), SSHDAuthFailure1(disabled), SSHDDisconnect(disabled)

--- a/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSu.yaml
+++ b/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSu.yaml
@@ -22,8 +22,11 @@ ParserParams:
 ParserQuery: |
   let SuSignInAuthorized=(disabled:bool=false){
   Syslog | where not(disabled)
-    | where ProcessName == "su" and (SyslogMessage has 'pam_unix(su:session): session opened' or SyslogMessage has 'pam_unix(su-l:session): session opened')
-    | parse SyslogMessage with "for user " TargetUsername " by " ActorUsername
+    | where ProcessName == "su" and SyslogMessage has_any ('pam_unix(su:session): session opened', 'pam_unix(su-l:session): session opened')
+    // if ActorUserName is empty, need two parse statements
+    | parse SyslogMessage with * "for user " TargetUsername:string " by "
+    | parse SyslogMessage with * "for user " TargetUsername:string " by " ActorUsername
+    | parse SyslogMessage with * "for user " TargetUsername:string "(uid=" TargetUserId:long ") by " ActorUsername "(uid=" ActorUserId:long ")"
     | extend
     EventVendor = 'su'
     , EventProduct = 'su'
@@ -33,11 +36,10 @@ ParserQuery: |
     , EventResult = 'Success'
     , EventStartTime = TimeGenerated
     , EventEndTime = TimeGenerated
-    , EventType = 'Logon'
+    , EventType = 'Elevation'
     , DvcHostname = Computer
     , ActorUsernameType = 'Simple'
-    , EventResultDetails = 'Other'
-    , EventOriginalRestultDetails = 'Connection authorized'
+    , TargetUsernameType = 'Simple'
   // ************************
   //      <Aliases>
   // ************************
@@ -51,8 +53,8 @@ ParserQuery: |
     };
   let SuDisconnect=(disabled:bool=false){
   Syslog | where not(disabled)
-    | where ProcessName == "su" and (SyslogMessage has 'pam_unix(su:session): session closed' or SyslogMessage has 'pam_unix(su-l:session): session closed')
-    | parse SyslogMessage with "for user " TargetUsername
+    | where ProcessName == "su" and SyslogMessage has_any ('pam_unix(su:session): session closed', 'pam_unix(su-l:session): session closed')
+    | parse SyslogMessage with * "for user " TargetUsername:string
     | extend
     EventVendor = 'su'
     , EventProduct = 'su'
@@ -65,8 +67,6 @@ ParserQuery: |
     , EventType = 'Logoff'
     , DvcHostname = Computer
     , TargetUsernameType = 'Simple'
-    , EventResultDetails = 'Other'
-    , EventOriginalRestultDetails = 'User session closed'
   // ************************
   //      <Aliases>
   // ************************

--- a/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSu.yaml
+++ b/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSu.yaml
@@ -1,0 +1,81 @@
+Parser:
+  Title: Authentication ASIM parser for Syslog su
+  Version: '0.1.1'
+  LastUpdated: November 21, 2022
+Product:
+  Name: su
+Normalization:
+  Schema: Authentication
+  Version: '0.1.1'
+References:
+- Title: ASIM Authentication Schema
+  Link: https://aka.ms/ASimAuthenticationDoc
+- Title: ASIM
+  Link: https:/aka.ms/AboutASIM
+Description: |
+  This ASIM parser supports normalizing Syslog su sign in logs to the ASIM Authentication schema.
+ParserName: ASimAuthenticationSu
+ParserParams:
+  - Name: disabled
+    Type: bool
+    Default: false
+ParserQuery: |
+  let SuSignInAuthorized=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "su" and (SyslogMessage has 'pam_unix(su:session): session opened' or SyslogMessage has 'pam_unix(su-l:session): session opened')
+    | parse SyslogMessage with "for user " TargetUsername " by " ActorUsername
+    | extend
+    EventVendor = 'su'
+    , EventProduct = 'su'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Success'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logon'
+    , DvcHostname = Computer
+    , ActorUsernameType = 'Simple'
+    , EventResultDetails = 'Other'
+    , EventOriginalRestultDetails = 'Connection authorized'
+  // ************************
+  //      <Aliases>
+  // ************************
+  | extend
+          User=TargetUsername
+        , Dvc=Computer
+  // ************************
+  //      </Aliases>
+  // ************************
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  let SuDisconnect=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "su" and (SyslogMessage has 'pam_unix(su:session): session closed' or SyslogMessage has 'pam_unix(su-l:session): session closed')
+    | parse SyslogMessage with "for user " TargetUsername
+    | extend
+    EventVendor = 'su'
+    , EventProduct = 'su'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Success'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logoff'
+    , DvcHostname = Computer
+    , TargetUsernameType = 'Simple'
+    , EventResultDetails = 'Other'
+    , EventOriginalRestultDetails = 'User session closed'
+  // ************************
+  //      <Aliases>
+  // ************************
+  | extend
+          User=TargetUsername
+        , Dvc=Computer
+  // ************************
+  //      </Aliases>
+  // ************************
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  union isfuzzy=false SuSignInAuthorized(disabled), SuDisconnect(disabled)

--- a/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSudo.yaml
+++ b/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSudo.yaml
@@ -24,6 +24,7 @@ ParserQuery: |
   Syslog | where not(disabled)
     | where ProcessName == "sudo" and SyslogMessage has 'TTY=' and SyslogMessage has 'USER='and SyslogMessage has 'COMMAND='
     | parse-kv SyslogMessage as (TTY: string, PWD: string, USER: string, COMMAND: string) with (pair_delimiter=' ', kv_delimiter='=')
+    | project-rename TargetUsername = USER
     | extend
     EventVendor = 'sudo'
     , EventProduct = 'sudo'
@@ -37,7 +38,7 @@ ParserQuery: |
     , DvcHostname = Computer
     , ActorUsernameType = 'Simple'
     , ActorUsername = extract(@'^(.*?):', 1, SyslogMessage)
-    , TargetUsername = USER
+    , TargetUsernameType = 'Simple'
     , EventResultDetails = 'Other'
     , EventOriginalRestultDetails = 'Connection authorized'
   // ************************
@@ -55,6 +56,7 @@ ParserQuery: |
   Syslog | where not(disabled)
     | where ProcessName == "sudo" and (SyslogMessage has 'user NOT in sudoers' or SyslogMessage has 'incorrect password attempts')
     | parse-kv SyslogMessage as (TTY: string, PWD: string, USER: string, COMMAND: string) with  (pair_delimiter=' ', kv_delimiter='=')
+    | project-rename TargetUsername = USER
     | extend
     EventVendor = 'sudo'
     , EventProduct = 'sudo'
@@ -69,7 +71,6 @@ ParserQuery: |
     , ActorUsernameType = 'Simple'
     , ActorUsername = extract(@'^(.*?):', 1, SyslogMessage)
     , TargetUsernameType = 'Simple'
-    , TargetUsername = USER
     , EventResultDetails = 'No such user or password'
     , EventOriginalRestultDetails = 'User authentication failed'
     | project-away Computer, MG, SourceSystem, TenantId
@@ -77,6 +78,7 @@ ParserQuery: |
   let SudoDisconnect=(disabled:bool=false){
   Syslog | where not(disabled)
     | where ProcessName == "sudo" and SyslogMessage has 'session closed for user '
+    | parse SyslogMessage with * "for user " TargetUsername:string
     | extend
     EventVendor = 'sudo'
     , EventProduct = 'sudo'
@@ -89,7 +91,6 @@ ParserQuery: |
     , EventType = 'Logoff'
     , DvcHostname = Computer
     , TargetUsernameType = 'Simple'
-    , TargetUsername = extract('for user (.*?)$', 1, SyslogMessage)
     , EventResultDetails = 'Other'
     , EventOriginalRestultDetails = 'User session closed'
   // ************************

--- a/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSudo.yaml
+++ b/Parsers/ASimAuthentication/Parsers/ASimAuthenticationSudo.yaml
@@ -1,0 +1,106 @@
+Parser:
+  Title: Authentication ASIM parser for Syslog sudo
+  Version: '0.1.1'
+  LastUpdated: November 21, 2022
+Product:
+  Name: sudo
+Normalization:
+  Schema: Authentication
+  Version: '0.1.1'
+References:
+- Title: ASIM Authentication Schema
+  Link: https://aka.ms/ASimAuthenticationDoc
+- Title: ASIM
+  Link: https:/aka.ms/AboutASIM
+Description: |
+  This ASIM parser supports normalizing Syslog sudo sign in logs to the ASIM Authentication schema.
+ParserName: ASimAuthenticationSudo
+ParserParams:
+  - Name: disabled
+    Type: bool
+    Default: false
+ParserQuery: |
+  let SudoSignInAuthorized=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "sudo" and SyslogMessage has 'TTY=' and SyslogMessage has 'USER='and SyslogMessage has 'COMMAND='
+    | parse-kv SyslogMessage as (TTY: string, PWD: string, USER: string, COMMAND: string) with (pair_delimiter=' ', kv_delimiter='=')
+    | extend
+    EventVendor = 'sudo'
+    , EventProduct = 'sudo'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Success'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logon'
+    , DvcHostname = Computer
+    , ActorUsernameType = 'Simple'
+    , ActorUsername = extract(@'^(.*?):', 1, SyslogMessage)
+    , TargetUsername = USER
+    , EventResultDetails = 'Other'
+    , EventOriginalRestultDetails = 'Connection authorized'
+  // ************************
+  //      <Aliases>
+  // ************************
+  | extend
+          User=TargetUsername
+        , Dvc=Computer
+  // ************************
+  //      </Aliases>
+  // ************************
+    | project-away Computer, MG, SourceSystem, TenantId,USER
+    };
+  let SudoAuthFailure1=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "sudo" and (SyslogMessage has 'user NOT in sudoers' or SyslogMessage has 'incorrect password attempts')
+    | parse-kv SyslogMessage as (TTY: string, PWD: string, USER: string, COMMAND: string) with  (pair_delimiter=' ', kv_delimiter='=')
+    | extend
+    EventVendor = 'sudo'
+    , EventProduct = 'sudo'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Failure'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logon'
+    , DvcHostname = Computer
+    , ActorUsernameType = 'Simple'
+    , ActorUsername = extract(@'^(.*?):', 1, SyslogMessage)
+    , TargetUsernameType = 'Simple'
+    , TargetUsername = USER
+    , EventResultDetails = 'No such user or password'
+    , EventOriginalRestultDetails = 'User authentication failed'
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  let SudoDisconnect=(disabled:bool=false){
+  Syslog | where not(disabled)
+    | where ProcessName == "sudo" and SyslogMessage has 'session closed for user '
+    | extend
+    EventVendor = 'sudo'
+    , EventProduct = 'sudo'
+    , EventCount = int(1)
+    , EventSchema = 'Authentication'
+    , EventSchemaVersion = '0.1.1'
+    , EventResult = 'Success'
+    , EventStartTime = TimeGenerated
+    , EventEndTime = TimeGenerated
+    , EventType = 'Logoff'
+    , DvcHostname = Computer
+    , TargetUsernameType = 'Simple'
+    , TargetUsername = extract('for user (.*?)$', 1, SyslogMessage)
+    , EventResultDetails = 'Other'
+    , EventOriginalRestultDetails = 'User session closed'
+  // ************************
+  //      <Aliases>
+  // ************************
+  | extend
+          User=TargetUsername
+        , Dvc=Computer
+  // ************************
+  //      </Aliases>
+  // ************************
+    | project-away Computer, MG, SourceSystem, TenantId
+    };
+  union isfuzzy=false SudoSignInAuthorized(disabled), SudoAuthFailure1(disabled), SudoDisconnect(disabled)


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - add ASimAuthentication Parsers for syslog sshd, su and sudo that can be used with Linux and other Un*x logging.

   Reason for Change(s):
   - Extend ASimAuthentication to usual authentication systems on Linux

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   - Need help to finalize: extend product table as enumerated and those are new, add vim* files and include in imAuthentication.yaml
