### PR TITLE
Hyperlink validation to skip "&&sudo" in URL

### DIFF
--- a/.script/hyperLinkValidator.ts
+++ b/.script/hyperLinkValidator.ts
@@ -41,10 +41,13 @@ export async function ValidateHyperlinks(filePath: string): Promise<ExitCode>
                     var isGithubLink = false;
                     if (link.includes('https://raw.githubusercontent.com') || link.includes('https://github.com'))
                     {
-                        if (!link.includes('&&sudo'))
-                        {
-                            isGithubLink = true;
-                        }
+                        isGithubLink = true;
+                    }
+
+                    if (link.includes('&&sudo'))
+                    {
+                        //IGNORE HYPERLINKS WHICH HAS &&SUDO IN IT
+                        isGithubLink = false;
                     }
 
                     if (isGithubLink)

--- a/.script/hyperLinkValidator.ts
+++ b/.script/hyperLinkValidator.ts
@@ -41,7 +41,10 @@ export async function ValidateHyperlinks(filePath: string): Promise<ExitCode>
                     var isGithubLink = false;
                     if (link.includes('https://raw.githubusercontent.com') || link.includes('https://github.com'))
                     {
-                        isGithubLink = true;
+                        if (!link.includes('&&sudo'))
+                        {
+                            isGithubLink = true;
+                        }
                     }
 
                     if (isGithubLink)
@@ -66,6 +69,10 @@ export async function ValidateHyperlinks(filePath: string): Promise<ExitCode>
                         {
                             console.log(`Skipping Hyperlink validation for '${link}' in file path : '${filePath}'`);
                         }
+                    }
+                    else
+                    {
+                        console.log(`Skipping Hyperlink validation for '${link}' in file path : '${filePath}'`);
                     }
                 }
             }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Skip validation if link contains &&sudo

   Reason for Change(s):
   - We have to skip validation in 1 scenario

   Version Updated:
   - No

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Screentshot while testing:**
![image](https://user-images.githubusercontent.com/107389644/212828975-0bef32e9-4684-47c5-8a9a-c6218af93b36.png)

