### PR TITLE
Enhancement:Identify targetProduct change With Azure Sentinel

### DIFF
--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -9,12 +9,22 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
     {
         const fileContent = fs.readFileSync(filePath, "utf8");
         const searchText = "Azure Sentinel"
-        const hasAzureSentinelText = fileContent.toLowerCase().includes(searchText.toLowerCase());
-        const hasTargetProductAzureSentinel = fileContent.includes('"targetProduct": "Azure Sentinel"')
+        const replaceText = '"targetProduct": "Azure Sentinel"';
 
-        if (hasAzureSentinelText && !hasTargetProductAzureSentinel)
+        const hasTargetProductAzureSentinel = fileContent.includes(replaceText);
+        const replacedFileContent = fileContent.replace(replaceText, "");
+        const hasAzureSentinelText = replacedFileContent.toLowerCase().includes(searchText.toLowerCase());
+
+        if (hasAzureSentinelText)
         {
-            throw new Error(`Please update text from 'Azure Sentinel' to 'Microsoft Sentinel' in file '${filePath}'`);
+            if (hasTargetProductAzureSentinel)
+            {
+                throw new Error(`Please update text from 'Azure Sentinel' to 'Microsoft Sentinel' except 'targetProduct' key-value pair in file '${filePath}'`);
+            }
+            else
+            {
+                throw new Error(`Please update text from 'Azure Sentinel' to 'Microsoft Sentinel' in file '${filePath}'`);
+            }
         }
     }
     return ExitCode.SUCCESS;

--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -10,7 +10,7 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
         const fileContent = fs.readFileSync(filePath, "utf8");
         const searchText = "Azure Sentinel"
         const hasAzureSentinelText = fileContent.toLowerCase().includes(searchText.toLowerCase());
-        const hasTargetProductAzureSentinel = fileContent.includes("''targetProduct'': ''Azure Sentinel''")
+        const hasTargetProductAzureSentinel = fileContent.includes('"targetProduct": "Azure Sentinel"')
 
         if (hasAzureSentinelText && !hasTargetProductAzureSentinel)
         {

--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -10,8 +10,9 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
         const fileContent = fs.readFileSync(filePath, "utf8");
         const searchText = "Azure Sentinel"
         const hasAzureSentinelText = fileContent.toLowerCase().includes(searchText.toLowerCase());
-        
-        if (hasAzureSentinelText)
+        const hasTargetProductAzureSentinel = fileContent.includes("''targetProduct'': ''Azure Sentinel''")
+
+        if (hasAzureSentinelText && !hasTargetProductAzureSentinel)
         {
             throw new Error(`Please update text from 'Azure Sentinel' to 'Microsoft Sentinel' in file '${filePath}'`);
         }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - When a Playbook file or mainTemplate.json file has "targetProduct": "Azure Sentinel" then we should skip the tag key value pair only. If there are Azure Sentinel in the same file at other places then we should fail the build.

   Reason for Change(s):
   - We are using "targetProduct": "Azure Sentinel" in Playbooks and we need to keep it intact so we should support skip for such cases of tag not complete file.

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Scenarios I tested are as below and are passing:**
targetproduct = yes and value AS, azure sentinel in file yes ==> fail the build
targetproduct = yes and value AS, no azure sentinel in file ==> pass
targetproduct = yes and value Not AS, has azure sentinel in file ==> fail 
targetproduct = not present, no azure sentinel in file ==> pass
targetproduct = not present, azure sentinel in file ==> fail

**Screenshot while testing PR:**
![image](https://user-images.githubusercontent.com/107389644/212872441-4af42d97-7815-4e16-9146-160ba74985e7.png)
