### PR TITLE
Update Union parser to include Sysmon 3 Windows

### DIFF
--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSession.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSession.yaml
@@ -69,7 +69,7 @@ ParserQuery: |
     , ASimNetworkSessionCheckPointFirewall            (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionCheckPointFirewall'      in (DisabledParsers) ))
     , ASimNetworkSessionCiscoASA                      (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionCiscoASA'      in (DisabledParsers) ))
     , ASimNetworkSessionWatchGuardFirewareOS          (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionWatchGuardFirewareOS'      in (DisabledParsers) ))
-    , ASimNetworkSessionMicrosoftSysmon               (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionWatchGuardFirewareOS'      in (DisabledParsers) ))
+    , ASimNetworkSessionMicrosoftSysmon               (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionMicrosoftSysmon'      in (DisabledParsers) ))
     , ASimNetworkSessionNative                        (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionNative'      in (DisabledParsers) ))
   };
   NetworkSessionsGeneric (pack=pack)

--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSession.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSession.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Network Session ASIM parser
-  Version: '0.5'
-  LastUpdated: Feb 21, 2021
+  Version: '0.6'
+  LastUpdated: Jan 17, 2023
 Product:
   Name: Source agnostic
 Normalization:
@@ -37,6 +37,7 @@ Parsers:
   - _ASim_NetworkSession_CheckPointFirewall
   - _ASim_NetworkSession_CiscoASA
   - _ASim_NetworkSession_WatchGuardFirewareOS
+  - _ASim_NetworkSession_MicrosoftSysmon
   - _ASim_NetworkSession_Native
 
 ParserParams:
@@ -68,6 +69,7 @@ ParserQuery: |
     , ASimNetworkSessionCheckPointFirewall            (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionCheckPointFirewall'      in (DisabledParsers) ))
     , ASimNetworkSessionCiscoASA                      (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionCiscoASA'      in (DisabledParsers) ))
     , ASimNetworkSessionWatchGuardFirewareOS          (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionWatchGuardFirewareOS'      in (DisabledParsers) ))
+    , ASimNetworkSessionMicrosoftSysmon               (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionWatchGuardFirewareOS'      in (DisabledParsers) ))
     , ASimNetworkSessionNative                        (ASimBuiltInDisabled or ('ExcludeASimNetworkSessionNative'      in (DisabledParsers) ))
   };
   NetworkSessionsGeneric (pack=pack)


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
Include Sysmon 3 Windows in the union parser.

