### PR TITLE
Fix to handle multiple replacement of targetProduct tag in Content Validation

### DIFF
--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -9,10 +9,11 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
     {
         const fileContent = fs.readFileSync(filePath, "utf8");
         const searchText = "Azure Sentinel"
-        const replaceText = '"targetProduct": "Azure Sentinel"';
+        const searchTargetProductAzureSentinelTag = '"targetProduct": "Azure Sentinel"';
+        const replaceTextTargetProductTag = /"targetProduct": "Azure Sentinel"/gi
 
-        const hasTargetProductAzureSentinel = fileContent.includes(replaceText);
-        const replacedFileContent = fileContent.replace(replaceText, "");
+        const hasTargetProductAzureSentinel = fileContent.includes(searchTargetProductAzureSentinelTag);
+        const replacedFileContent = fileContent.replace(replaceTextTargetProductTag, "");
         const hasAzureSentinelText = replacedFileContent.toLowerCase().includes(searchText.toLowerCase());
 
         if (hasAzureSentinelText)


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - When having multiple tags of "targetProduct" with value "Azure Sentinel" then it fails in current case. Javascript ".replace" function only replaces first occurance of the text not all matching text. So this new changes will handle all matching text. Here "/g" is for global and "i" is for ignore case insensitivity.

   Reason for Change(s):
   - Fix issue of single targetProduct as there can be multiple targetProduct tags.

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

