### PR TITLE
Remove arm-ttk validations for dataconnector and playbooks

### DIFF
--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -9,30 +9,10 @@ ENV mainTemplateChanged ${mainTemplateChanged}
 ARG createUiChanged
 ENV createUiChanged ${createUiChanged}
 
-ARG hasPlaybooksChanged
-ENV playbooksChanged ${hasPlaybooksChanged}
-
-ARG playbookFilesList
-ENV playbookFilesList ${playbookFilesList}
-
-ARG isDataConnectorFolderNameWithSpace
-ENV isDataConnectorFolderNameWithSpace ${isDataConnectorFolderNameWithSpace}
-
-ARG dataConnectorFileNames
-ENV dataConnectorFileNames ${dataConnectorFileNames}
-
-ARG hasDataConnectorFileChanged
-ENV hasDataConnectorFileChanged ${hasDataConnectorFileChanged}
-
 ENV sname ${SolutionName}
 ENV sname1 $SolutionName
-RUN echo "playbooksChanged ${playbooksChanged}"
 RUN echo "mainTemplateChanged ${mainTemplateChanged}"
 RUN echo "createUiChanged ${createUiChanged}"
-
-RUN echo "isDataConnectorFolderNameWithSpace ${isDataConnectorFolderNameWithSpace}"
-RUN echo "dataConnectorFileNames ${dataConnectorFileNames}"
-RUN echo "hasDataConnectorFileChanged ${hasDataConnectorFileChanged}"
 
 LABEL version="v1.0"
 

--- a/.github/actions/entrypoint.ps1
+++ b/.github/actions/entrypoint.ps1
@@ -1,15 +1,8 @@
 
-$playbooksChanged = (Get-Item env:playbooksChanged).value
-$playbookFilesList = (Get-Item env:playbookFilesList).value
 $mainTemplateChanged = (Get-Item env:mainTemplateChanged).value
 $createUiChanged = (Get-Item env:createUiChanged).value
 
-$isDataConnectorFolderNameWithSpace = (Get-Item env:isDataConnectorFolderNameWithSpace).value
-$dataConnectorFileNames = (Get-Item env:dataConnectorFileNames).value
-$hasDataConnectorFileChanged = (Get-Item env:hasDataConnectorFileChanged).value
-
 Import-Module '/dist/armttk/arm-ttk/arm-ttk.psd1' 
-$BasePath = './dist'
 $PackageFolderPath = './dist/Package'
 
 # RUN FOR MAINTEMPLATE.JSON FILE
@@ -47,76 +40,6 @@ if ($createUiChanged -eq $true)
     }
     else {
         Write-Host "All tests passed for the 'CreateUiDefinition.json' file!"
-    }
-}
-
-# Data Connector file change
-if ($hasDataConnectorFileChanged -eq $true)
-{
-    Write-Host "Running ARM-TTK on Data Connectors Folder, '$dataConnectorFileNames' files!"
-    $dataConnectorFolderName = "Data Connectors"
-    if($isDataConnectorFolderNameWithSpace -ne $true)
-    {
-        $dataConnectorFolderName = "DataConnectors"
-    }
-
-    $dataConnectorFilesList = $dataConnectorFileNames.Split(" ")
-    foreach($dataConnectorFileItem in $dataConnectorFilesList)
-    {
-        Write-Host "Running ARM-TTK on file '$dataConnectorFileItem'"
-        $dataConnectorTestResults = Test-AzTemplate -TemplatePath "$BasePath/$dataConnectorFolderName/$dataConnectorFileItem"
-
-        $dataConnectorTestPassed =  $dataConnectorTestResults | Where-Object { -not $_.Failed }
-        Write-Output $dataConnectorTestPassed
-
-        $dataConnectorFailures =  $dataConnectorTestResults | Where-Object { -not $_.Passed }
-
-        if ($dataConnectorFailures) {
-            Write-Host "Please review and rectify the Data Connectors Folder, '$dataConnectorFileItem' file as some of the ARM-TTK tests did not pass!"
-            exit 1
-        } 
-        else {
-            Write-Host "All files passed for Data Connectors Folder!"
-        }
-    }
-}
-
-# RUN FOR PLAYBOOKS JSON FILE
-if ($playbooksChanged -eq $true)
-{
-    $playbookFilesListObj = $playbookFilesList.Split(" ")
-    Write-Host "Running ARM-TTK on Playbooks Folder, '$playbookFilesListObj' files!"
-    foreach($playbookFile in $playbookFilesListObj)
-    {
-        if($playbookFile.Contains(".json"))
-        {
-            Write-Host "Running ARM-TTK on file '$playbookFile'"
-            $folderEndIndex = $playbookFile.LastIndexOf('/')
-            if ($folderEndIndex -eq 0)
-            {
-                $folderPath = $playbookFile.substring(0)
-            }
-            else 
-            {
-                $folderPath = $playbookFile
-            }
-            
-            $folderFilePath = "$BasePath/Playbooks/$folderPath"
-            $playbooksTestResults = Test-AzTemplate -TemplatePath $folderFilePath
-            
-            $playbooksTestPassed =  $playbooksTestResults | Where-Object { -not $_.Failed }
-            Write-Output $playbooksTestPassed
-
-            $playbooksTestFailures =  $playbooksTestResults | Where-Object { -not $_.Passed }
-
-            if ($playbooksTestFailures) {
-                Write-Host "Please review and rectify Playbooks Folder '$folderPath' json file as some of the ARM-TTK tests did not pass!"
-                exit 1
-            } 
-            else {
-                Write-Host "All files passed for Playbooks Folder!"
-            }
-        }
     }
 }
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Remove validation for data connectos and playbooks

   Reason for Change(s):
   - After discusssion with Anki we have to remove this validations and keep only for maintemplate and createUI.

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
