### PR TITLE
Update Endpoint Agent Health Status Report.yaml

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
@@ -68,39 +68,39 @@ query: |
     | extend packed = pack(Test, Result)
     | summarize Tests = make_bag(packed), DeviceName = any(DeviceName) by DeviceId, OSPlatform
     | evaluate bag_unpack(Tests)
-    | extend CloudProtection = case(
-        OSPlatform contains "Windows", CloudProtectionWin,
-        OSPlatform contains "macOS",   CloudProtectionMac,
-        OSPlatform contains "Linux",   CloudProtectionLin,
-        "N/A")
+  | extend CloudProtection = case(
+        OSPlatform has "Windows", CloudProtectionWin,
+        OSPlatform has "macOS",   CloudProtectionMac,
+        OSPlatform has "Linux",   CloudProtectionLin,
+        "NULL")
     | extend PUAProtection = case(
-        OSPlatform contains "Windows", PUAProtectionWin,
-        OSPlatform contains "macOS",   PUAProtectionMac,
-        OSPlatform contains "Linux",   PUAProtectionLin,
-        "N/A")
+        OSPlatform has "Windows", PUAProtectionWin,
+        OSPlatform has "macOS",   PUAProtectionMac,
+        OSPlatform has "Linux",   PUAProtectionLin,
+        "NULL")
     | extend TamperProtection = case(
-        OSPlatform contains "Windows", TamperProtectionWin,
-        OSPlatform contains "macOS",   TamperProtectionMac,
-        //OSPlatform contains "Linux",   TamperProtectionLin,
-        "N/A")
+        OSPlatform has "Windows", TamperProtectionWin,
+        OSPlatform has "macOS",   TamperProtectionMac,
+        //OSPlatform has "Linux",   TamperProtectionLin,
+        "NULL")
     | extend SensorDataCollection = case(
-        OSPlatform contains "Windows", SensorDataCollectionWin,
-        OSPlatform contains "macOS",   SensorDataCollectionMac,
-        OSPlatform contains "Linux",   SensorDataCollectionLin,
-        "N/A")
+        OSPlatform has "Windows", SensorDataCollectionWin,
+        OSPlatform has "macOS",   SensorDataCollectionMac,
+        OSPlatform has "Linux",   SensorDataCollectionLin,
+        "NULL")
     | extend ImpairedCommunications = case(
-        OSPlatform contains "Windows", ImpairedCommunicationsWin,
-        OSPlatform contains "macOS",   ImpairedCommunicationsMac,
-        OSPlatform contains "Linux",   ImpairedCommunicationsLin,
-        "N/A")
+        OSPlatform has "Windows", ImpairedCommunicationsWin,
+        OSPlatform has "macOS",   ImpairedCommunicationsMac,
+        OSPlatform has "Linux",   ImpairedCommunicationsLin,
+        "NULL")
     | extend RealtimeProtection = case(
-        OSPlatform contains "Windows", RealtimeProtectionWin,
-        OSPlatform contains "macOS",   RealtimeProtectionMac,
-        OSPlatform contains "Linux",   RealtimeProtectionLin,
-        "N/A")
+        OSPlatform has "Windows", RealtimeProtectionWin,
+        OSPlatform has "macOS",   RealtimeProtectionMac,
+        OSPlatform has "Linux",   RealtimeProtectionLin,
+        "NULL")
     | extend AntivirusSignatureVersion = case(
-        OSPlatform contains "Windows", AntivirusSignatureVersionWin,
-        OSPlatform contains "macOS",   AntivirusSignatureVersionMac,
-        OSPlatform contains "Linux",   AntivirusSignatureVersionLin,
-        "N/A")
+        OSPlatform has "Windows", AntivirusSignatureVersionWin,
+        OSPlatform has "macOS",   AntivirusSignatureVersionMac,
+        OSPlatform has "Linux",   AntivirusSignatureVersionLin,
+        "NULL")
     | project-away *Win, *Mac, *Lin

--- a/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
@@ -68,7 +68,7 @@ query: |
     | extend packed = pack(Test, Result)
     | summarize Tests = make_bag(packed), DeviceName = any(DeviceName) by DeviceId, OSPlatform
     | evaluate bag_unpack(Tests)
-  | extend CloudProtection = case(
+    | extend CloudProtection = case(
         OSPlatform has "Windows", CloudProtectionWin,
         OSPlatform has "macOS",   CloudProtectionMac,
         OSPlatform has "Linux",   CloudProtectionLin,

--- a/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
@@ -72,35 +72,35 @@ query: |
         OSPlatform contains "Windows", CloudProtectionWin,
         OSPlatform contains "macOS",   CloudProtectionMac,
         OSPlatform contains "Linux",   CloudProtectionLin,
-        "NULL")
+        "N/A")
     | extend PUAProtection = case(
         OSPlatform contains "Windows", PUAProtectionWin,
         OSPlatform contains "macOS",   PUAProtectionMac,
         OSPlatform contains "Linux",   PUAProtectionLin,
-        "NULL")
+        "N/A")
     | extend TamperProtection = case(
         OSPlatform contains "Windows", TamperProtectionWin,
         OSPlatform contains "macOS",   TamperProtectionMac,
         //OSPlatform contains "Linux",   TamperProtectionLin,
-        "NULL")
+        "N/A")
     | extend SensorDataCollection = case(
         OSPlatform contains "Windows", SensorDataCollectionWin,
         OSPlatform contains "macOS",   SensorDataCollectionMac,
         OSPlatform contains "Linux",   SensorDataCollectionLin,
-        "NULL")
+        "N/A")
     | extend ImpairedCommunications = case(
         OSPlatform contains "Windows", ImpairedCommunicationsWin,
         OSPlatform contains "macOS",   ImpairedCommunicationsMac,
         OSPlatform contains "Linux",   ImpairedCommunicationsLin,
-        "NULL")
+        "N/A")
     | extend RealtimeProtection = case(
         OSPlatform contains "Windows", RealtimeProtectionWin,
         OSPlatform contains "macOS",   RealtimeProtectionMac,
         OSPlatform contains "Linux",   RealtimeProtectionLin,
-        "NULL")
+        "N/A")
     | extend AntivirusSignatureVersion = case(
         OSPlatform contains "Windows", AntivirusSignatureVersionWin,
         OSPlatform contains "macOS",   AntivirusSignatureVersionMac,
         OSPlatform contains "Linux",   AntivirusSignatureVersionLin,
-        "NULL")
+        "N/A")
     | project-away *Win, *Mac, *Lin

--- a/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
@@ -10,22 +10,97 @@ requiredDataConnectors:
 tactics:
 - Misconfiguration
 query: |
-  DeviceTvmSecureConfigurationAssessment
-  | where ConfigurationId in ('scid-91', 'scid-2000', 'scid-2001', 'scid-2002', 'scid-2003', 'scid-2010', 'scid-2011', 'scid-2012', 'scid-2013', 'scid-2014', 'scid-2016')
-  | extend Test = case(
-      ConfigurationId == "scid-2000", "SensorEnabled",
-      ConfigurationId == "scid-2001", "SensorDataCollection",
-      ConfigurationId == "scid-2002", "ImpairedCommunications",
-      ConfigurationId == "scid-2003", "TamperProtection",
-      ConfigurationId == "scid-2010", "AntivirusEnabled",
-      ConfigurationId == "scid-2011", "AntivirusSignatureVersion",
-      ConfigurationId == "scid-2012", "RealtimeProtection",
-      ConfigurationId == "scid-91", "BehaviorMonitoring",
-      ConfigurationId == "scid-2013", "PUAProtection",
-      ConfigurationId == "scid-2014", "AntivirusReporting",
-      ConfigurationId == "scid-2016", "CloudProtection",
-      "N/A"),
-      Result = case(IsApplicable == 0, "N/A", IsCompliant == 1, "GOOD", "BAD")
-  | extend packed = pack(Test, Result)
-  | summarize Tests = make_bag(packed), DeviceName = any(DeviceName) by DeviceId
-  | evaluate bag_unpack(Tests)
+    let configurationIDs = dynamic([
+        "scid-2000", 
+        "scid-2001", 
+        "scid-5001", 
+        "scid-6001", 
+        "scid-2002", 
+        "scid-5002", 
+        "scid-6002", 
+        "scid-2003", 
+        "scid-5092", 
+        "scid-2010", 
+        "scid-2011", 
+        "scid-5095", 
+        "scid-6095", 
+        "scid-2012", 
+        "scid-5090", 
+        "scid-6090", 
+        "scid-91",
+        "scid-2013", 
+        "scid-5091", 
+        "scid-6091", 
+        "scid-2014", 
+        "scid-2016", 
+        "scid-5094", 
+        "scid-6094"
+    ]);
+    DeviceTvmSecureConfigurationAssessment
+    | where ConfigurationId in (configurationIDs)
+    | extend Test = case(
+        ConfigurationId == "scid-2000", "SensorEnabled",
+        ConfigurationId == "scid-2001", "SensorDataCollectionWin", //windows
+        ConfigurationId == "scid-5001", "SensorDataCollectionMac", //macOS
+        ConfigurationId == "scid-6001", "SensorDataCollectionLin", //linux
+        ConfigurationId == "scid-2002", "ImpairedCommunicationsWin", //windows
+        ConfigurationId == "scid-5002", "ImpairedCommunicationsMac", //macOS
+        ConfigurationId == "scid-6002", "ImpairedCommunicationsLin", //linux
+        ConfigurationId == "scid-2003", "TamperProtectionWin", //windows
+        ConfigurationId == "scid-5092", "TamperProtectionMac", //macOS
+        ConfigurationId == "scid-2010", "AntivirusEnabled",
+        ConfigurationId == "scid-2011", "AntivirusSignatureVersionWin", //windows
+        ConfigurationId == "scid-5095", "AntivirusSignatureVersionMac", //macOS
+        ConfigurationId == "scid-6095", "AntivirusSignatureVersionLin", //linux
+        ConfigurationId == "scid-2012", "RealtimeProtectionWin", //windows
+        ConfigurationId == "scid-5090", "RealtimeProtectionMac", //macOS
+        ConfigurationId == "scid-6090", "RealtimeProtectionLin", //linux
+        ConfigurationId == "scid-91"  , "BehaviorMonitoring",
+        ConfigurationId == "scid-2013", "PUAProtectionWin", // windows
+        ConfigurationId == "scid-5091", "PUAProtectionMac", //macOS
+        ConfigurationId == "scid-6091", "PUAProtectionLin", //linux
+        ConfigurationId == "scid-2014", "AntivirusReporting",
+        ConfigurationId == "scid-2016", "CloudProtectionWin", //windows
+        ConfigurationId == "scid-5094", "CloudProtectionMac", //macOS
+        ConfigurationId == "scid-6094", "CloudProtectionLin", //linux
+        "N/A"),
+        Result = case(IsApplicable == 0, "N/A", IsCompliant == 1, "GOOD", "BAD")
+    | extend packed = pack(Test, Result)
+    | summarize Tests = make_bag(packed), DeviceName = any(DeviceName) by DeviceId, OSPlatform
+    | evaluate bag_unpack(Tests)
+    | extend CloudProtection = case(
+        OSPlatform contains "Windows", CloudProtectionWin,
+        OSPlatform contains "macOS",   CloudProtectionMac,
+        OSPlatform contains "Linux",   CloudProtectionLin,
+        "NULL")
+    | extend PUAProtection = case(
+        OSPlatform contains "Windows", PUAProtectionWin,
+        OSPlatform contains "macOS",   PUAProtectionMac,
+        OSPlatform contains "Linux",   PUAProtectionLin,
+        "NULL")
+    | extend TamperProtection = case(
+        OSPlatform contains "Windows", TamperProtectionWin,
+        OSPlatform contains "macOS",   TamperProtectionMac,
+        //OSPlatform contains "Linux",   TamperProtectionLin,
+        "NULL")
+    | extend SensorDataCollection = case(
+        OSPlatform contains "Windows", SensorDataCollectionWin,
+        OSPlatform contains "macOS",   SensorDataCollectionMac,
+        OSPlatform contains "Linux",   SensorDataCollectionLin,
+        "NULL")
+    | extend ImpairedCommunications = case(
+        OSPlatform contains "Windows", ImpairedCommunicationsWin,
+        OSPlatform contains "macOS",   ImpairedCommunicationsMac,
+        OSPlatform contains "Linux",   ImpairedCommunicationsLin,
+        "NULL")
+    | extend RealtimeProtection = case(
+        OSPlatform contains "Windows", RealtimeProtectionWin,
+        OSPlatform contains "macOS",   RealtimeProtectionMac,
+        OSPlatform contains "Linux",   RealtimeProtectionLin,
+        "NULL")
+    | extend AntivirusSignatureVersion = case(
+        OSPlatform contains "Windows", AntivirusSignatureVersionWin,
+        OSPlatform contains "macOS",   AntivirusSignatureVersionMac,
+        OSPlatform contains "Linux",   AntivirusSignatureVersionLin,
+        "NULL")
+    | project-away *Win, *Mac, *Lin


### PR DESCRIPTION
Extened query to include Linux and macOS evaluations where applicable.

   Required items, please complete
   
   Change(s):
   - Updated `Update Endpoint Agent Health Status Report.yaml.yaml`

   Reason for Change(s):
   - Extended Endpoint Agent Health Status Report query to include Linux and macOS (all in one)

   Version Updated:
   - No

   Testing Completed:
   - Yes
