### PR TITLE
GCP IAM instruction update.

### DIFF
--- a/Solutions/GoogleCloudPlatformIAM/Data Connectors/azuredeploy_GCP_IAM_API_FunctionApp.json
+++ b/Solutions/GoogleCloudPlatformIAM/Data Connectors/azuredeploy_GCP_IAM_API_FunctionApp.json
@@ -12,7 +12,7 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "Comma separated list of GCP resources to get logs from (organizations, folders, projects). For example: projects/PROJECT_ID_1,projects/PROJECT_ID_2"
+                "description": "Comma separated list of GCP resources to get logs from (projects). For example: projects/PROJECT_ID_1,projects/PROJECT_ID_2"
             }
         },
         "GoogleCloudPlatformCredentialsFileContent": {


### PR DESCRIPTION
Updating the instruction for Google cloud platform IAM as right now we only support project IDs and not organization ids and others.