### PR TITLE
Update vimAuthenticationPostgreSQL.yaml

### DIFF
--- a/Parsers/ASimAuthentication/Parsers/vimAuthenticationPostgreSQL.yaml
+++ b/Parsers/ASimAuthentication/Parsers/vimAuthenticationPostgreSQL.yaml
@@ -36,7 +36,7 @@ ParserQuery: |
   // *************************************************************************
   | where 
     (isnull(starttime) or TimeGenerated >= starttime)
-    and (isnull(endtime) or TimeGenerated <= starttime)
+    and (isnull(endtime) or TimeGenerated <= endtime)
     and (targetusername_has=='*' or RawData has targetusername_has)
   // ************************************************************************* 
   //      </Prefilterring>
@@ -78,7 +78,7 @@ ParserQuery: |
   // *************************************************************************
   | where 
     (isnull(starttime) or TimeGenerated >= starttime)
-    and (isnull(endtime) or TimeGenerated <= starttime)
+    and (isnull(endtime) or TimeGenerated <= endtime)
     and (targetusername_has=='*' or RawData has targetusername_has)
   // ************************************************************************* 
   //      </Prefilterring>
@@ -121,7 +121,7 @@ ParserQuery: |
   // *************************************************************************
   | where 
     (isnull(starttime) or TimeGenerated >= starttime)
-    and (isnull(endtime) or TimeGenerated <= starttime)
+    and (isnull(endtime) or TimeGenerated <= endtime)
     and (targetusername_has=='*' or RawData has targetusername_has)
   // ************************************************************************* 
   //      </Prefilterring>
@@ -165,7 +165,7 @@ ParserQuery: |
   // *************************************************************************
   | where 
     (isnull(starttime) or TimeGenerated >= starttime)
-    and (isnull(endtime) or TimeGenerated <= starttime)
+    and (isnull(endtime) or TimeGenerated <= endtime)
     and (targetusername_has=='*' or RawData has targetusername_has)
   // ************************************************************************* 
   //      </Prefilterring>
@@ -209,7 +209,7 @@ ParserQuery: |
   // *************************************************************************
   | where 
     (isnull(starttime) or TimeGenerated >= starttime)
-    and (isnull(endtime) or TimeGenerated <= starttime)
+    and (isnull(endtime) or TimeGenerated <= endtime)
     and (targetusername_has=='*' or RawData has targetusername_has)
   // ************************************************************************* 
   //      </Prefilterring>


### PR DESCRIPTION
Change(s):
   - Update vimAuthenticationPostgreSQL.yaml

Reason for Change(s):
   - Parser would not return records without the endtime being set to endtime instead of starttime.
   - I used this parser as template for building a different parser and the parser that I built contained the mistakes from the current version of this parser. Changing the starttime to endtime allows my parser to work and other parsers on the github also use endtime instead of starttime.

Version Updated:
   - No

Testing Completed:
   - No

Checked that the validations are passing and have addressed any issues that are present:
   - No