### PR TITLE
Skip Azure Sentinel Community Github text from validations

### DIFF
--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -9,11 +9,14 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
     {
         const fileContent = fs.readFileSync(filePath, "utf8");
         const searchText = "Azure Sentinel"
+
         const searchTargetProductAzureSentinelTag = '"targetProduct": "Azure Sentinel"';
         const replaceTextTargetProductTag = /"targetProduct": "Azure Sentinel"/gi
+        const replaceAzureSentinelCommunityGithubText = /Azure Sentinel Community Github/gi;
 
         const hasTargetProductAzureSentinel = fileContent.includes(searchTargetProductAzureSentinelTag);
-        const replacedFileContent = fileContent.replace(replaceTextTargetProductTag, "");
+        var replacedFileContent = fileContent.replace(replaceTextTargetProductTag, "");
+        replacedFileContent = fileContent.replace(replaceAzureSentinelCommunityGithubText, "");
         const hasAzureSentinelText = replacedFileContent.toLowerCase().includes(searchText.toLowerCase());
 
         if (hasAzureSentinelText)

--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -8,30 +8,39 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
     if (!filePath.includes("azure-pipelines"))
     {
         const fileContent = fs.readFileSync(filePath, "utf8");
-        const searchText = "Azure Sentinel"
+        const searchText = "Azure Sentinel";
 
+        // DEFINE SKIP TEXT TO BE SEARCHED
         const searchTargetProductAzureSentinelTag = '"targetProduct": "Azure Sentinel"';
-        const replaceTextTargetProductTag = /"targetProduct": "Azure Sentinel"/gi
-        const replaceAzureSentinelCommunityGithubText = /Azure Sentinel Community Github/gi;
+        const searchAzureSentinelCommunityGithubText = 'Azure Sentinel Community Github';
 
+        // SEARCH & CHECK IF SKIP TEXT EXIST IN THE FILE
         const hasTargetProductAzureSentinel = fileContent.includes(searchTargetProductAzureSentinelTag);
-        var replacedFileContent = fileContent.replace(replaceTextTargetProductTag, "");
-        replacedFileContent = fileContent.replace(replaceAzureSentinelCommunityGithubText, "");
-        const hasAzureSentinelText = replacedFileContent.toLowerCase().includes(searchText.toLowerCase());
+        const hasAzureSentinelCommunityGithubText = fileContent.includes(searchAzureSentinelCommunityGithubText);
 
+        // REPLACE ALL SKIP TEXT WITH BLANK
+        const skipText = [searchAzureSentinelCommunityGithubText, searchTargetProductAzureSentinelTag];
+        let replacedFileContent = fileContent.replace(new RegExp(skipText.join('|'), 'gi'), '');
+
+        // FIND IF AZURE SENTINEL TEXT PRESENT
+        let hasAzureSentinelText = replacedFileContent.toLowerCase().includes(searchText.toLowerCase());
         if (hasAzureSentinelText)
         {
-            if (hasTargetProductAzureSentinel)
-            {
-                throw new Error(`Please update text from 'Azure Sentinel' to 'Microsoft Sentinel' except 'targetProduct' key-value pair in file '${filePath}'`);
-            }
-            else
-            {
-                throw new Error(`Please update text from 'Azure Sentinel' to 'Microsoft Sentinel' in file '${filePath}'`);
-            }
+            // VALIDATE AND THROW ERROR
+            CustomizedException(hasTargetProductAzureSentinel, searchTargetProductAzureSentinelTag, searchText);
+            CustomizedException(hasAzureSentinelCommunityGithubText, searchAzureSentinelCommunityGithubText, searchText);
+
+            throw new Error(`Please update text from '${searchText}' to 'Microsoft Sentinel' in file '${filePath}'`);
         }
     }
     return ExitCode.SUCCESS;
+
+    function CustomizedException(hasSkipText: any, exceptText: any, searchText: any): void
+    {
+        if (hasSkipText) {
+            throw new Error(`Please update text from '${searchText}' to 'Microsoft Sentinel' except '${exceptText}' text in file '${filePath}'`);
+        }
+    }
 }
 
 let fileTypeSuffixes = ["json", "txt", "md", "yaml", "yml", "py"];

--- a/.script/skip-text.txt
+++ b/.script/skip-text.txt
@@ -1,0 +1,2 @@
+"targetProduct": "Azure Sentinel"
+Azure Sentinel Community Github


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - We should skip any text "Azure Sentinel Community Github" from file and should not fail in content validation build.

   Reason for Change(s):
   - In some files "Azure Sentinel Community Github" text is used as a "DetectionService" where this data is coming from a url and this looks for the text from the url response. If we make this as "Microsoft Sentinel Community Github" then it will not work as the url response from client data also needs to be updated which is not possible so we are skipping this text.
   Below is the screenshot page in which url has the data and query filters data by "Azure Sentinel Community Github" text:
![image](https://user-images.githubusercontent.com/107389644/216339334-dd956564-dab1-470f-811c-a8e1895950ce.png)

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Testing Result screenshots:**
**1. Failed image:**
![image](https://user-images.githubusercontent.com/107389644/216235352-0e5b61ad-55d6-43a4-b4a6-b00a289bc036.png)

**2. Success image:**
![image](https://user-images.githubusercontent.com/107389644/216237617-1d197280-6ab2-4deb-aa88-9443c209b2f5.png)
