### PR TITLE
Azure ddos ar fixes

### DIFF
--- a/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPPSThreshold.yaml
+++ b/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPPSThreshold.yaml
@@ -27,4 +27,8 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: sourcePublicIpAddress_s
+tactics:
+  - Impact
+relevantTechniques:
+  - T1498
 version: 1.0.1

--- a/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPPSThreshold.yaml
+++ b/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPPSThreshold.yaml
@@ -20,7 +20,8 @@ query: |
   | summarize maxPPS = max(PPS) by destPublicIpAddress_s, sourcePublicIpAddress_s
   | order by destPublicIpAddress_s, maxPPS desc
   | where maxPPS > 10000
-aggergationKind: SingleAlert
+eventGroupingSettings:
+  aggregationKind: SingleAlert
 entityMappings:
   - entityType: IP
     fieldMappings:

--- a/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPPSThreshold.yaml
+++ b/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPPSThreshold.yaml
@@ -27,4 +27,4 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: sourcePublicIpAddress_s
-version: 1.0.0
+version: 1.0.1

--- a/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPercentThreshold.yaml
+++ b/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPercentThreshold.yaml
@@ -31,4 +31,4 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: sourcePublicIpAddress_s
-version: 1.0.0
+version: 1.0.1

--- a/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPercentThreshold.yaml
+++ b/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPercentThreshold.yaml
@@ -24,8 +24,8 @@ query: |
     | project destPublicIpAddress_s, sourcePublicIpAddress_s, percent_of_traffic = 100*rows_count/rows_total
     | order by percent_of_traffic desc
     | where percent_of_traffic > 5
-eventGroupSettings:
-  aggergationKind: SingleAlert
+eventGroupingSettings:
+  aggregationKind: SingleAlert
 entityMappings:
   - entityType: IP
     fieldMappings:

--- a/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPercentThreshold.yaml
+++ b/Solutions/Azure DDoS Protection/Analytic Rules/AttackSourcesPercentThreshold.yaml
@@ -31,4 +31,8 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: sourcePublicIpAddress_s
+tactics:
+  - Impact
+relevantTechniques:
+  - T1498
 version: 1.0.1


### PR DESCRIPTION
   Change(s):
   - Fixed eventGroupingSettings in the following Azure DDOS Protection analytic rules:
     - AttackSourcesPercentThreshold.yaml
     - AttackSourcesPPSThreshold.yaml
   - Added MITRE technique 1498 (network ddos) to pass validation

   Reason for Change(s):
   - The Azure DDOS solution had incorrect `eventGroupingSettings` in the analytic rules and no MITRE techniques.

   Version Updated:
   - Yes, bumped patch version. Since the incorrect aggregationKind fields were set to the default value, they weren't breaking anything.

   Testing Completed:
   - No change to rule logic. 

   Checked that the validations are passing and have addressed any issues that are present:
   - Ran Pester tests on the two rules: Tests Passed: 54, Failed: 0, Skipped: 0 NotRun: 0
