### PR TITLE
Update Office365.JSON

### DIFF
--- a/Solutions/Microsoft 365/Data Connectors/Office365.JSON
+++ b/Solutions/Microsoft 365/Data Connectors/Office365.JSON
@@ -2,7 +2,7 @@
     "id": "Office365",
     "title": "Office 365",
     "publisher": "Microsoft",
-    "descriptionMarkdown": "The Office 365 activity log connector provides insight into ongoing user activities. You will get details of operations such as file downloads, access requests sent, changes to group events, set-mailbox and details of the user who performed the actions.​ By connecting Office 365 logs into Microsoft Sentinel you can use this data to view dashboards, create custom alerts, and improve your investigation process.​",
+    "descriptionMarkdown": "The Office 365 activity log connector provides insight into ongoing user activities. You will get details of operations such as file downloads, access requests sent, changes to group events, set-mailbox and details of the user who performed the actions. By connecting Office 365 logs into Microsoft Sentinel you can use this data to view dashboards, create custom alerts, and improve your investigation process. For more information, see the [Microsoft Sentinel documentation >](https://go.microsoft.com/fwlink/p/?linkid=2219943&wt.mc_id=sentinel_dataconnectordocs_content_cnl_csasci).",
     "logo": "Office365Logo.svg",
     "graphQueries": [
       {


### PR DESCRIPTION
Add link to documentation for installation info w/in the data connector description markdown in solution @prtanej

Required items, please complete

Change(s):

Add link to documentation for installation info w/in the data connector description markdown
Reason for Change(s):

Need link so autogenerated Docs page will have cross-link to connection install article.
Version updated:

No
Testing Completed:

No
Checked that the validations are passing and have addressed any issues that are present:

No