### PR TITLE
Update Dvc in Dns Native parameters

### DIFF
--- a/Parsers/ASimDns/Parsers/ASimDnsNative.yaml
+++ b/Parsers/ASimDns/Parsers/ASimDnsNative.yaml
@@ -30,7 +30,7 @@ ParserQuery: |
       | extend
           EventEndTime = TimeGenerated,
           EventStartTime = TimeGenerated,
-          Dvc = iff (isempty(Dvc), coalesce (DvcFQDN, DvcHostname, SrcIpAddr, DvcId, _ResourceId), Dvc),
+          Dvc = coalesce (Dvc, DvcFQDN, DvcHostname, DvcIpAddr, DvcId, _ResourceId, strcat (EventVendor,'/', EventProduct)),
           Dst = coalesce (DstFQDN, DstHostname, DstIpAddr, DstDvcId),
           Src = coalesce (SrcFQDN, SrcHostname, SrcIpAddr, SrcDvcId),
           EventSchema = "Dns"

--- a/Parsers/ASimDns/Parsers/ASimDnsNative.yaml
+++ b/Parsers/ASimDns/Parsers/ASimDnsNative.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: DNS activity ASIM parser for Microsoft Sentinel native DNS table
-  Version: '0.5'
-  LastUpdated: Jan 5 2023
+  Version: '0.6'
+  LastUpdated: Feb 2 2023
 Product:
   Name: Native
 Normalization:

--- a/Parsers/ASimDns/Parsers/vimDnsNative.yaml
+++ b/Parsers/ASimDns/Parsers/vimDnsNative.yaml
@@ -76,7 +76,7 @@ ParserQuery: |
     | extend
         EventStartTime = TimeGenerated,
         EventEndTime = TimeGenerated,
-        Dvc = iff (isempty(Dvc), coalesce (DvcFQDN, DvcHostname, SrcIpAddr, DvcId, _ResourceId), Dvc),
+        Dvc = coalesce (Dvc, DvcFQDN, DvcHostname, DvcIpAddr, DvcId, _ResourceId, strcat (EventVendor,'/', EventProduct)),
         Dst = coalesce (DstFQDN, DstHostname, DstIpAddr, DstDvcId),
         Src = coalesce (SrcFQDN, SrcHostname, SrcIpAddr, SrcDvcId),
         EventSchema = "Dns"

--- a/Parsers/ASimDns/Parsers/vimDnsNative.yaml
+++ b/Parsers/ASimDns/Parsers/vimDnsNative.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: DNS activity ASIM filtering parser for Microsoft Sentinel native DNS table
-  Version: '0.5'
-  LastUpdated: Jan 5 2023
+  Version: '0.6'
+  LastUpdated: Feb 2 2023
 Product:
   Name: Native
 Normalization:


### PR DESCRIPTION
   
   Change(s):
   - Updated logic of Dvc in Dns Native parser

   Reason for Change(s):
   - Dvc value is required to map data from multiple sources.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes