### PR TITLE
Fix condition in Analytic rule Dev-0270PowershellSep2022.yaml

### DIFF
--- a/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270PowershellSep2022.yaml
+++ b/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270PowershellSep2022.yaml
@@ -26,7 +26,7 @@ query: |
   (union isfuzzy=true
   (SecurityEvent
   | where EventID==4688
-  | extend FileName=tostring(split(NewProcessName, @'')[(-1)]),  ProcessCommandLine = CommandLine, InitiatingProcessFileName=ParentProcessName
+  | extend FileName=tostring(split(NewProcessName, @'\')[(-1)]),  ProcessCommandLine = CommandLine
   | where (FileName =~ "powershell.exe" and ProcessCommandLine has_all("try", "Add-MpPreference", "-ExclusionPath", "ProgramData", "catch")) or (FileName =~ 'powershell.exe' and ProcessCommandLine has_all('Add-PSSnapin', 'Get-Recipient', '-ExpandProperty', 'EmailAddresses', 'SmtpAddress', '-hidetableheaders') )
   | project TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = Account, AccountDomain, ProcessName, ProcessNameFullPath = NewProcessName, EventID, Activity, CommandLine, EventSourceName, Type
   ),
@@ -45,5 +45,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270PowershellSep2022.yaml
+++ b/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270PowershellSep2022.yaml
@@ -26,9 +26,9 @@ query: |
   (union isfuzzy=true
   (SecurityEvent
   | where EventID==4688
-  | extend FileName=tostring(split(NewProcessName, @'\')[(-1)]),  ProcessCommandLine = CommandLine
+  | extend FileName=tostring(split(NewProcessName, @'\')[(-1)]),  ProcessCommandLine = CommandLine, InitiatingProcessFileName=ParentProcessName
   | where (FileName =~ "powershell.exe" and ProcessCommandLine has_all("try", "Add-MpPreference", "-ExclusionPath", "ProgramData", "catch")) or (FileName =~ 'powershell.exe' and ProcessCommandLine has_all('Add-PSSnapin', 'Get-Recipient', '-ExpandProperty', 'EmailAddresses', 'SmtpAddress', '-hidetableheaders') )
-  | project TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = Account, AccountDomain, ProcessName, ProcessNameFullPath = NewProcessName, EventID, Activity, CommandLine, EventSourceName, Type
+  | project TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = Account, AccountDomain, ProcessName, ProcessNameFullPath = NewProcessName, InitiatingProcessFileName, EventID, Activity, CommandLine, EventSourceName, Type
   ),
   (DeviceProcessEvents 
   | where (FileName =~ "powershell.exe" and ((ProcessCommandLine has_all("try", "Add-MpPreference", "-ExclusionPath", "ProgramData", "catch"))  or (ProcessCommandLine has_all('Add-PSSnapin', 'Get-Recipient', '-ExpandProperty', 'EmailAddresses', 'SmtpAddress', '-hidetableheaders'))))


### PR DESCRIPTION
   Change(s):
   - Split ```NewProcessName``` by a character, specifically ```\```.
   - Remove ```InitiatingProcessFileName``` in SecurityEvent table part.

   Reason for Change(s):
   - It was not split by any character, so ```FileName``` column was still equal to ```NewProcessName```, it was not matching ```=~ "powershell.exe"```, nothing was achieved in this step.
   - It was not being used, or projected.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

Additionally, it should be considered to use default column ```Process``` instead of creating the custom column ```FileName``` in SecurityEvent table part.