### PR TITLE
Fix condition in Analytic Rule Dev-0270WMICDiscoverySep2022.yaml

### DIFF
--- a/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270WMICDiscoverySep2022.yaml
+++ b/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270WMICDiscoverySep2022.yaml
@@ -24,12 +24,11 @@ query: |
   (union isfuzzy=true
   (SecurityEvent
   | where EventID==4688
-  | where CommandLine has "wmic computersystem get domain" and tostring(split(ParentProcessName, @'\')[-1]) =~ "dllhost.exe"
+  | where CommandLine has "wmic computersystem get domain" and ParentProcessName has "dllhost.exe"
   | project TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = Account, AccountDomain, ProcessName, ProcessNameFullPath = NewProcessName, EventID, Activity, CommandLine, EventSourceName, Type
   ),
   (DeviceProcessEvents 
-  | where InitiatingProcessFileName =~ "dllhost.exe" and InitiatingProcessCommandLine == "dllhost.exe" 
-  | where ProcessCommandLine has "wmic computersystem get domain" 
+  | where ProcessCommandLine has "wmic computersystem get domain" and InitiatingProcessFileName =~ "dllhost.exe" and InitiatingProcessCommandLine has "dllhost.exe"
   | extend timestamp = TimeGenerated, AccountCustomEntity =  InitiatingProcessAccountName, HostCustomEntity = DeviceName
   )
   )

--- a/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270WMICDiscoverySep2022.yaml
+++ b/Solutions/Dev 0270 Detection and Hunting/Analytic Rules/Dev-0270WMICDiscoverySep2022.yaml
@@ -24,7 +24,7 @@ query: |
   (union isfuzzy=true
   (SecurityEvent
   | where EventID==4688
-  | where CommandLine has "wmic computersystem get domain" and ParentProcessName =~ "dllhost.exe"
+  | where CommandLine has "wmic computersystem get domain" and tostring(split(ParentProcessName, @'\')[-1]) =~ "dllhost.exe"
   | project TimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = Account, AccountDomain, ProcessName, ProcessNameFullPath = NewProcessName, EventID, Activity, CommandLine, EventSourceName, Type
   ),
   (DeviceProcessEvents 
@@ -42,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Check "dllhost.exe" string against the last part of ```ParentProcessName```.

   Reason for Change(s):
   - It was checking against the full column of ```ParentProcessName``` (eg ```C:\Windows\System32\dllhost.exe``` instead of ```dllhost.exe```)

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
   Moreover, the title contains 2 consecutive spaces.