### PR TITLE
Fix rule scheduling in Analytic Rule GuestAccountsAddedinAADGroupsOtherThanTheOnesSpecified.yaml

### DIFF
--- a/Detections/AuditLogs/GuestAccountsAddedinAADGroupsOtherThanTheOnesSpecified.yaml
+++ b/Detections/AuditLogs/GuestAccountsAddedinAADGroupsOtherThanTheOnesSpecified.yaml
@@ -7,7 +7,7 @@ requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
       - AuditLogs
-queryFrequency: 5m
+queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
 triggerThreshold: 0
@@ -22,10 +22,8 @@ relevantTechniques:
   - T1087.004
 query: |
   // OBJECT ID of AAD Groups can be found by navigating to Azure Active Directory then from menu on the left, select Groups and from the list shown of AAD Groups, the Second Column shows the ObjectID of each
-  let queryperiod= 1d;
   let GroupIDs = dynamic(["List with Custom AAD GROUP OBJECT ID 1","Custom AAD GROUP OBJECT ID 2"]);
   AuditLogs
-  | where TimeGenerated > ago(queryperiod)
   | where OperationName in ('Add member to group', 'Add owner to group')
   | extend InitiatedByActionUserInformation = iff(isnotempty(InitiatedBy.user.userPrincipalName), InitiatedBy.user.userPrincipalName, InitiatedBy.app.displayName)
   | extend InitiatedByIPAdress = InitiatedBy.user.ipAddress 
@@ -34,8 +32,8 @@ query: |
   | extend InvitedUser = TargetResources[0].userPrincipalName
   | extend AADGroup = TargetResources[0].modifiedProperties[1].newValue
   | where InvitedUser has_any ("CUSTOM DOMAIN NAME#", "#EXT#")
-  | mv-expand AADGroup = TargetResources[1].id to typeof(string)
-  | where AADGroup !in (GroupIDs)
+  | mv-expand AADGroupId = TargetResources[1].id to typeof(string)
+  | where AADGroupId !in (GroupIDs)
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -49,5 +47,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatedByIPAdress
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Check events of the last day (once a day), instead of check events of the last day (every 5 min).
   - Use another column for AAD group id.

   Reason for Change(s):
   - If only one event matches this detection, this rule would have generated 288 alerts over a day (for the very same event, thus repeated alerts), and each alert would have generated an incident, because the alerts were not being grouped by default.
   - The column ```AADGroup``` with the name of the group was being substituted with the group id (UUID) values.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes