### PR TITLE
ActivityStatusValue appears to be changed/updated

### DIFF
--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -51,7 +51,7 @@ query: |
     (
     AzureActivity
     | where OperationNameValue hassuffix ("/workspaces/computes/delete")
-    | where ActivityStatusValue =~ "Succeeded"
+    | where ActivityStatusValue has_any ("Succeeded", "Success")
     | project TimeGenerated, _ResourceId, SubscriptionId, UserAccount=Caller, IpAddress=CallerIpAddress, CorrelationId, OperationId, ResourceGroup, TenantId
     ) on IpAddress, UserAccount
     | extend timestamp = TimeGenerated, AccountCustomEntity = UserAccount, IPCustomEntity = IpAddress
@@ -64,7 +64,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
Required items, please complete
   
Change(s):
   - Update search from `Succeeded` list with both `Succeeded` and `Success`. 
   - This proposed solution matches on both values and is case-insensitive.


 Reason for Change(s):
   - Having issues testing this rule in an environment; found that the `ActivityStatusValue` from table AzureActivity regarding workspaces/computes/delete appears to be formatted as `Success` instead of `Succeeded`
   - screenshot example:
   <img width="1742" alt="Screenshot 2023-02-02 at 2 57 42 PM" src="https://user-images.githubusercontent.com/20403061/216442956-4f347b1e-28e0-492f-91e8-00ae27ab318c.png">


Version Updated:
   - Yes

Testing Completed:
   - Yes