### PR TITLE
Remove trailing spaces in SEABORGIUMIOC.csv

### DIFF
--- a/Sample Data/Feeds/SEABORGIUMIOC.csv
+++ b/Sample Data/Feeds/SEABORGIUMIOC.csv
@@ -1,70 +1,70 @@
 ﻿DateAdded,IoC,Type
-8/15/2022,cache-dns.com ,domainname
-8/15/2022,cache-dns-forwarding.com ,domainname
-8/15/2022,cache-dns-preview.com ,domainname
-8/15/2022,cache-docs.com ,domainname
-8/15/2022,cache-pdf.com ,domainname
-8/15/2022,cache-pdf.online ,domainname
-8/15/2022,cache-services.live ,domainname
-8/15/2022,cloud-docs.com ,domainname
-8/15/2022,cloud-drive.live ,domainname
-8/15/2022,cloud-storage.live ,domainname
-8/15/2022,docs-cache.com ,domainname
-8/15/2022,docs-forwarding.online ,domainname
-8/15/2022,docs-info.com ,domainname
-8/15/2022,docs-shared.com ,domainname
-8/15/2022,docs-shared.online ,domainname
-8/15/2022,docs-view.online ,domainname
-8/15/2022,document-forwarding.com ,domainname
-8/15/2022,document-online.live ,domainname
-8/15/2022,document-preview.com ,domainname
-8/15/2022,documents-cloud.com ,domainname
-8/15/2022,documents-cloud.online ,domainname
-8/15/2022,documents-forwarding.com ,domainname
-8/15/2022,document-share.live ,domainname
-8/15/2022,documents-online.live ,domainname
-8/15/2022,documents-pdf.online ,domainname
-8/15/2022,documents-preview.com ,domainname
-8/15/2022,documents-view.live ,domainname
-8/15/2022,document-view.live ,domainname
-8/15/2022,drive-docs.com ,domainname
-8/15/2022,drive-share.live ,domainname
-8/15/2022,goo-link.online ,domainname
-8/15/2022,hypertextteches.com ,domainname
-8/15/2022,mail-docs.online ,domainname
-8/15/2022,officeonline365.live ,domainname
-8/15/2022,online365-office.com ,domainname
-8/15/2022,online-document.live ,domainname
-8/15/2022,online-storage.live ,domainname
-8/15/2022,pdf-cache.com ,domainname
-8/15/2022,pdf-cache.online ,domainname
-8/15/2022,pdf-docs.online ,domainname
-8/15/2022,pdf-forwarding.online ,domainname
-8/15/2022,protection-checklinks.xyz ,domainname
-8/15/2022,protection-link.online ,domainname
-8/15/2022,protectionmail.online ,domainname
-8/15/2022,protection-office.live ,domainname
-8/15/2022,protect-link.online ,domainname
-8/15/2022,proton-docs.com ,domainname
-8/15/2022,proton-reader.com ,domainname
-8/15/2022,proton-viewer.com ,domainname
-8/15/2022,relogin-dashboard.online ,domainname
-8/15/2022,safe-connection.online ,domainname
-8/15/2022,safelinks-protect.live ,domainname
-8/15/2022,secureoffice.live ,domainname
-8/15/2022,webresources.live ,domainname
-8/15/2022,word-yand.live ,domainname
-8/15/2022,yandx-online.cloud ,domainname
-8/15/2022,y-ml.co ,domainname
-8/15/2022,docs-drive.online ,domainname
-8/15/2022,docs-info.online ,domainname
-8/15/2022,cloud-mail.online ,domainname
-8/15/2022,onlinecloud365.live ,domainname
-8/15/2022,pdf-cloud.online ,domainname
-8/15/2022,pdf-shared.online ,domainname
-8/15/2022,proton-pdf.online ,domainname
-8/15/2022,proton-view.online ,domainname
-8/15/2022,office365-online.live ,domainname
-8/15/2022,doc-viewer.com ,domainname
-8/15/2022,file-milgov.systems ,domainname
-8/15/2022,office-protection.online ,domainname
+8/15/2022,cache-dns.com,domainname
+8/15/2022,cache-dns-forwarding.com,domainname
+8/15/2022,cache-dns-preview.com,domainname
+8/15/2022,cache-docs.com,domainname
+8/15/2022,cache-pdf.com,domainname
+8/15/2022,cache-pdf.online,domainname
+8/15/2022,cache-services.live,domainname
+8/15/2022,cloud-docs.com,domainname
+8/15/2022,cloud-drive.live,domainname
+8/15/2022,cloud-storage.live,domainname
+8/15/2022,docs-cache.com,domainname
+8/15/2022,docs-forwarding.online,domainname
+8/15/2022,docs-info.com,domainname
+8/15/2022,docs-shared.com,domainname
+8/15/2022,docs-shared.online,domainname
+8/15/2022,docs-view.online,domainname
+8/15/2022,document-forwarding.com,domainname
+8/15/2022,document-online.live,domainname
+8/15/2022,document-preview.com,domainname
+8/15/2022,documents-cloud.com,domainname
+8/15/2022,documents-cloud.online,domainname
+8/15/2022,documents-forwarding.com,domainname
+8/15/2022,document-share.live,domainname
+8/15/2022,documents-online.live,domainname
+8/15/2022,documents-pdf.online,domainname
+8/15/2022,documents-preview.com,domainname
+8/15/2022,documents-view.live,domainname
+8/15/2022,document-view.live,domainname
+8/15/2022,drive-docs.com,domainname
+8/15/2022,drive-share.live,domainname
+8/15/2022,goo-link.online,domainname
+8/15/2022,hypertextteches.com,domainname
+8/15/2022,mail-docs.online,domainname
+8/15/2022,officeonline365.live,domainname
+8/15/2022,online365-office.com,domainname
+8/15/2022,online-document.live,domainname
+8/15/2022,online-storage.live,domainname
+8/15/2022,pdf-cache.com,domainname
+8/15/2022,pdf-cache.online,domainname
+8/15/2022,pdf-docs.online,domainname
+8/15/2022,pdf-forwarding.online,domainname
+8/15/2022,protection-checklinks.xyz,domainname
+8/15/2022,protection-link.online,domainname
+8/15/2022,protectionmail.online,domainname
+8/15/2022,protection-office.live,domainname
+8/15/2022,protect-link.online,domainname
+8/15/2022,proton-docs.com,domainname
+8/15/2022,proton-reader.com,domainname
+8/15/2022,proton-viewer.com,domainname
+8/15/2022,relogin-dashboard.online,domainname
+8/15/2022,safe-connection.online,domainname
+8/15/2022,safelinks-protect.live,domainname
+8/15/2022,secureoffice.live,domainname
+8/15/2022,webresources.live,domainname
+8/15/2022,word-yand.live,domainname
+8/15/2022,yandx-online.cloud,domainname
+8/15/2022,y-ml.co,domainname
+8/15/2022,docs-drive.online,domainname
+8/15/2022,docs-info.online,domainname
+8/15/2022,cloud-mail.online,domainname
+8/15/2022,onlinecloud365.live,domainname
+8/15/2022,pdf-cloud.online,domainname
+8/15/2022,pdf-shared.online,domainname
+8/15/2022,proton-pdf.online,domainname
+8/15/2022,proton-view.online,domainname
+8/15/2022,office365-online.live,domainname
+8/15/2022,doc-viewer.com,domainname
+8/15/2022,file-milgov.systems,domainname
+8/15/2022,office-protection.online,domainname


### PR DESCRIPTION
   Change(s):
   - Remove trailing spaces of domain IOCs

   Reason for Change(s):
   - They will not match events with the trailing space [See images]

![image](https://user-images.githubusercontent.com/2527990/217777592-b4745c59-45f3-4d08-be3a-c1b7fce1e3e3.png)
![image](https://user-images.githubusercontent.com/2527990/217777673-8d86f855-9fcb-44b4-bde5-fe0e59061914.png)
![image](https://user-images.githubusercontent.com/2527990/217777920-6abc23bd-b373-40c0-8163-92ff2cb09a62.png)


   Checked that the validations are passing and have addressed any issues that are present:
   - Yes