### PR TITLE
Rename Auth0 custom table to match documentation

### DIFF
--- a/Solutions/Auth0/Data Connectors/Auth0Connector/main.py
+++ b/Solutions/Auth0/Data Connectors/Auth0Connector/main.py
@@ -17,7 +17,7 @@ WORKSPACE_ID = os.environ['WorkspaceID']
 SHARED_KEY = os.environ['WorkspaceKey']
 
 FILE_SHARE_CONNECTION_STRING = os.environ['AzureWebJobsStorage']
-LOG_TYPE = 'Auth0'
+LOG_TYPE = 'Auth0AM'
 
 MAX_SCRIPT_EXEC_TIME_MINUTES = 5
 logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.ERROR)

--- a/Solutions/Auth0/Parsers/Auth0.txt
+++ b/Solutions/Auth0/Parsers/Auth0.txt
@@ -2,7 +2,7 @@
 // Paste below query in log analytics, click on Save button and select as Function from drop down by specifying function name and alias as Auth0.
 // Function usually takes 10-15 minutes to activate. You can then use function alias from any other queries (e.g. Auth0 | take 10).
 // Reference : Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
-Auth0AM_CL
+union isfuzzy=true Auth0AM_CL, Auth0_CL
 | project-rename EventType = type_s,
     HttpRequestMethod = details_request_method_s,
     ActorSessionId = _id_s,


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated log type for Auth0Connector/main.py

   Reason for Change(s):
   - The Function App creates an invalid table named `Auth0_CL`, which doesn't match with the settings and documentation.

   Testing Completed:
   - ..

   Checked that the validations are passing and have addressed any issues that are present:
   -..