### PR TITLE
Adding analytics rule for subscription migration

### DIFF
--- a/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
@@ -1,0 +1,62 @@
+id: 48c026d8-7f36-4a95-9568-6f1420d66e37
+kind: scheduled
+name: Subscription moved to another tenant
+description: |
+  Detects when a subscription is moved to another tenant. This may indicate a subscription hijacking event.
+severity: High
+requiredDataConnectors:
+  - connectorId: AzureActivity
+    dataTypes:
+      - AzureActivity
+queryPeriod: 10m
+queryFrequency: 5m
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - Impact
+relevantTechniques:
+  - T1496
+query: |
+  let eventCapture = "moved from tenant ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) to tenant ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
+  AzureActivity
+  | where OperationNameValue == "Microsoft.Subscription/updateTenant/action"
+  | extend EventCapture = extract_all(eventCapture, tostring(Properties_d.message))
+  | extend SourceTenant = iff(isnotempty(EventCapture), EventCapture[0][0], "")
+  | extend DestinationTenant = iff(isnotempty(EventCapture), EventCapture[0][1], "")
+  | extend UserParts = split(Caller, "@")
+  | extend UserName = iff(array_length(UserParts)==2, UserParts[0], Caller)
+  | extend UserUPNSuffix = iff(array_length(UserParts)==2, UserParts[1], "")
+  | extend Summary=Properties_d.message
+eventGroupingSettings:
+  aggregationKind: SingleAlert
+entityMappings:
+  - entityType: AzureResource
+    fieldMappings: 
+      - identifier: ResourceId,
+        columnName: SubscriptionId                 
+  - entityType: Account
+    fieldMappings: 
+      - identifier: Name
+        columnName: UserName
+      - identifier: UPNSuffix
+        columnName: UserUPNSuffix
+customDetails:
+  DestinationTenant: DestinationTenant,
+  SourceTenant: SourceTenant,
+  SubscriptionId: SubscriptionId
+alertDetailsOverride:
+  alertDescriptionFormat: |
+    The user {{Caller}} migrated a subscription:
+    {{Summary}}
+incidentConfiguration:
+  createIncident: true
+  groupingConfiguration:
+    enabled: true
+    groupByAlertDetails: []
+    groupByCustomDetails: []
+    groupByEntities:
+      - Account
+    lookbackDuration: 5h
+    matchingMethod: Selected
+    reopenClosedIncident: false
+version: 1.0.0

--- a/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
@@ -1,5 +1,5 @@
 id: 48c026d8-7f36-4a95-9568-6f1420d66e37
-kind: scheduled
+kind: Scheduled
 name: Subscription moved to another tenant
 description: |
   Detects when a subscription is moved to another tenant. This may indicate a subscription hijacking event.
@@ -32,7 +32,7 @@ eventGroupingSettings:
 entityMappings:
   - entityType: AzureResource
     fieldMappings: 
-      - identifier: ResourceId,
+      - identifier: ResourceId
         columnName: SubscriptionId                 
   - entityType: Account
     fieldMappings: 
@@ -41,8 +41,8 @@ entityMappings:
       - identifier: UPNSuffix
         columnName: UserUPNSuffix
 customDetails:
-  DestinationTenant: DestinationTenant,
-  SourceTenant: SourceTenant,
+  DestinationTenant: DestinationTenant
+  SourceTenant: SourceTenant
   SubscriptionId: SubscriptionId
 alertDetailsOverride:
   alertDescriptionFormat: |

--- a/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
@@ -52,8 +52,6 @@ incidentConfiguration:
   createIncident: true
   groupingConfiguration:
     enabled: true
-    groupByAlertDetails: []
-    groupByCustomDetails: []
     groupByEntities:
       - Account
     lookbackDuration: 5h

--- a/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
@@ -3,12 +3,12 @@ kind: Scheduled
 name: Subscription moved to another tenant
 description: |
   Detects when a subscription is moved to another tenant. This may indicate a subscription hijacking event.
-severity: High
+severity: Low
 requiredDataConnectors:
   - connectorId: AzureActivity
     dataTypes:
       - AzureActivity
-queryPeriod: 10m
+queryPeriod: 20m
 queryFrequency: 5m
 triggerOperator: gt
 triggerThreshold: 0
@@ -17,16 +17,19 @@ tactics:
 relevantTechniques:
   - T1496
 query: |
+  let queryFrequency = 5m;
   let eventCapture = "moved from tenant ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) to tenant ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
   AzureActivity
+  | where ingestion_time() > ago(queryFrequency)
   | where OperationNameValue == "Microsoft.Subscription/updateTenant/action"
-  | extend EventCapture = extract_all(eventCapture, tostring(Properties_d.message))
-  | extend SourceTenant = iff(isnotempty(EventCapture), EventCapture[0][0], "")
-  | extend DestinationTenant = iff(isnotempty(EventCapture), EventCapture[0][1], "")
+  | where isnotempty(Properties_d)
+  | extend Summary = tostring(Properties_d.message)
+  | extend EventCapture = extract_all(eventCapture, Summary)
+  | extend SourceTenantId = iff(isnotempty(EventCapture), EventCapture[0][0], "")
+  | extend DestinationTenantId = iff(isnotempty(EventCapture), EventCapture[0][1], "")
   | extend UserParts = split(Caller, "@")
-  | extend UserName = iff(array_length(UserParts)==2, UserParts[0], Caller)
-  | extend UserUPNSuffix = iff(array_length(UserParts)==2, UserParts[1], "")
-  | extend Summary=Properties_d.message
+  | extend UserName = iff(array_length(UserParts) == 2, UserParts[0], Caller)
+  | extend UserUPNSuffix = iff(array_length(UserParts) == 2, UserParts[1], "")
 eventGroupingSettings:
   aggregationKind: SingleAlert
 entityMappings:
@@ -41,20 +44,16 @@ entityMappings:
       - identifier: UPNSuffix
         columnName: UserUPNSuffix
 customDetails:
-  DestinationTenant: DestinationTenant
-  SourceTenant: SourceTenant
+  DestinationTenantId: DestinationTenantId
+  SourceTenantId: SourceTenantId
   SubscriptionId: SubscriptionId
 alertDetailsOverride:
   alertDescriptionFormat: |
-    The user {{Caller}} migrated a subscription:
+    The user {{Caller}} moved a subscription:
+    
     {{Summary}}
-incidentConfiguration:
-  createIncident: true
-  groupingConfiguration:
-    enabled: true
-    groupByEntities:
-      - Account
-    lookbackDuration: 5h
-    matchingMethod: Selected
-    reopenClosedIncident: false
+    
+    If this was not expected, it may indicate a subscription hijacking event.
+  alertDisplayNameFormat: |
+    Subscription {{SubscriptionId}} changed tenants
 version: 1.0.0

--- a/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
@@ -26,6 +26,7 @@ query: |
   | where ingestion_time() > ago(queryFrequency)
   | where CategoryValue =~ "Security"
   | where OperationNameValue =~ "Microsoft.Subscription/updateTenant/action"
+  | extend Properties_d = coalesce(parse_json(Properties), Properties_d)
   | where isnotempty(Properties_d)
   | extend Summary = tostring(Properties_d.message)
   | extend EventCapture = extract_all(eventCapture, Summary)

--- a/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/SubscriptionMigration.yaml
@@ -2,7 +2,10 @@ id: 48c026d8-7f36-4a95-9568-6f1420d66e37
 kind: Scheduled
 name: Subscription moved to another tenant
 description: |
-  Detects when a subscription is moved to another tenant. This may indicate a subscription hijacking event.
+  'This detection uses AzureActivity logs (Security category) to identify when a subscription is moved to another tenant.
+  A threat actor may move a subscription into their own tenant to circumvent local resource deployment and logging policies.
+  Once moved, threat actors may deploy resources and perform malicious activities such as crypto mining.
+  This is a technique known as "subscription hijacking". More information can be found here: https://techcommunity.microsoft.com/t5/microsoft-365-defender-blog/hunt-for-compromised-azure-subscriptions-using-microsoft/ba-p/3607121'
 severity: Low
 requiredDataConnectors:
   - connectorId: AzureActivity
@@ -21,32 +24,32 @@ query: |
   let eventCapture = "moved from tenant ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) to tenant ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
   AzureActivity
   | where ingestion_time() > ago(queryFrequency)
-  | where OperationNameValue == "Microsoft.Subscription/updateTenant/action"
+  | where CategoryValue =~ "Security"
+  | where OperationNameValue =~ "Microsoft.Subscription/updateTenant/action"
   | where isnotempty(Properties_d)
   | extend Summary = tostring(Properties_d.message)
   | extend EventCapture = extract_all(eventCapture, Summary)
   | extend SourceTenantId = iff(isnotempty(EventCapture), EventCapture[0][0], "")
   | extend DestinationTenantId = iff(isnotempty(EventCapture), EventCapture[0][1], "")
-  | extend UserParts = split(Caller, "@")
-  | extend UserName = iff(array_length(UserParts) == 2, UserParts[0], Caller)
-  | extend UserUPNSuffix = iff(array_length(UserParts) == 2, UserParts[1], "")
+  | extend 
+      Name = split(Caller, "@", 0)[0],
+      UPNSuffix = split(Caller, "@", 1)[0]
 eventGroupingSettings:
   aggregationKind: SingleAlert
 entityMappings:
   - entityType: AzureResource
     fieldMappings: 
       - identifier: ResourceId
-        columnName: SubscriptionId                 
+        columnName: _ResourceId                 
   - entityType: Account
     fieldMappings: 
       - identifier: Name
-        columnName: UserName
+        columnName: Name
       - identifier: UPNSuffix
-        columnName: UserUPNSuffix
+        columnName: UPNSuffix
 customDetails:
   DestinationTenantId: DestinationTenantId
   SourceTenantId: SourceTenantId
-  SubscriptionId: SubscriptionId
 alertDetailsOverride:
   alertDescriptionFormat: |
     The user {{Caller}} moved a subscription:


### PR DESCRIPTION
   Change(s):
   - Adding an analytics rule to detect when a subscription is moved to another tenant.

   Reason for Change(s):
   - New rule.

   Version Updated:
   - Adding version 1.0.0

   Testing Completed:
   - Tested on local tenants by moving subscriptions between them.

   Checked that the validations are passing and have addressed any issues that are present:
   - Validated yaml.