### PR TITLE
Add more cases and fix join key in Analytic Rule AzDiagSettingsDeleted.yaml

### DIFF
--- a/Detections/AzureActivity/AzDiagSettingsDeleted.yaml
+++ b/Detections/AzureActivity/AzDiagSettingsDeleted.yaml
@@ -19,17 +19,20 @@ relevantTechniques:
   - T1562.008
 query: |
   AzureActivity
-    | where OperationNameValue == 'MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE' and ActivityStatusValue == "Start"
-    | extend ParentResource_a = split(_ResourceId,"/")
-    | extend ParentResourceLength = array_length(ParentResource_a)-4
-    | extend ParentResourceSplit = array_split(ParentResource_a,ParentResourceLength)
-    | extend resource = strcat_array(ParentResourceSplit[0],"/")
-    | project Diagdelete = TimeGenerated, Caller, ResourceProviderValue, _ResourceId, SubscriptionId, ResourceGroup, OperationNameValue, ActivityStatusValue, ActivitySubstatusValue, Start=TimeGenerated, resource, CallerIpAddress
-    | join kind=leftanti  ( AzureActivity
-    | where OperationNameValue != 'MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE' and OperationNameValue endswith "/DELETE"
-    | where ActivityStatusValue == 'Start'
-    | project Caller, ResourceProviderValue, resource = tostring(parse_json(Properties).resource), SubscriptionId, ResourceGroup, OperationNameValue, ActivityStatusValue, ActivitySubstatusValue, Start=TimeGenerated) on $left.resource == $right.resource
-    | project Caller, ResourceProviderValue, resource, SubscriptionId, ResourceGroup, OperationNameValue, ActivityStatusValue, ActivitySubstatusValue, Start, CallerIpAddress
+  | where OperationNameValue =~ "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE"
+  | summarize
+      TimeGenerated = arg_max(TimeGenerated, Properties),
+      ActivityStatusValue = make_list(ActivityStatusValue),
+      take_any(Caller, CallerIpAddress, OperationName, ResourceGroup, Resource)
+      by CorrelationId, _ResourceId, OperationNameValue
+  | extend ResourceHierarchy = split(_ResourceId, "/")
+  | extend MonitoredResourcePath = strcat_array(array_slice(ResourceHierarchy, 0, array_length(ResourceHierarchy)-5), "/")
+  | join kind=leftanti (
+      AzureActivity
+      | where OperationNameValue !~ "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE" and OperationNameValue endswith "/DELETE"
+      | project _ResourceId
+  ) on $left.MonitoredResourcePath == $right._ResourceId
+  | project TimeGenerated, Caller, CallerIpAddress, OperationNameValue, OperationName, ActivityStatusValue, ResourceGroup, MonitoredResourcePath, Resource,  Properties, _ResourceId, CorrelationId
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -39,7 +42,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: CallerIpAddress
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/AzureActivity/AzDiagSettingsDeleted.yaml
+++ b/Detections/AzureActivity/AzDiagSettingsDeleted.yaml
@@ -29,7 +29,7 @@ query: |
   | extend MonitoredResourcePath = strcat_array(array_slice(ResourceHierarchy, 0, array_length(ResourceHierarchy)-5), "/")
   | join kind=leftanti (
       AzureActivity
-      | where OperationNameValue !~ "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE" and OperationNameValue endswith "/DELETE"
+      | where OperationNameValue !~ "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE" and OperationNameValue endswith "/DELETE" and ActivityStatusValue has_any ("Success", "Succeeded")
       | project _ResourceId
   ) on $left.MonitoredResourcePath == $right._ResourceId
   | project TimeGenerated, Caller, CallerIpAddress, OperationNameValue, OperationName, ActivityStatusValue, ResourceGroup, MonitoredResourcePath, Resource,  Properties, _ResourceId, CorrelationId

--- a/Detections/AzureActivity/AzDiagSettingsDeleted.yaml
+++ b/Detections/AzureActivity/AzDiagSettingsDeleted.yaml
@@ -22,7 +22,7 @@ query: |
   | where OperationNameValue =~ "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE"
   | summarize
       TimeGenerated = arg_max(TimeGenerated, Properties),
-      ActivityStatusValue = make_list(ActivityStatusValue),
+      ActivityStatusValue = make_set(ActivityStatusValue, 5),
       take_any(Caller, CallerIpAddress, OperationName, ResourceGroup, Resource)
       by CorrelationId, _ResourceId, OperationNameValue
   | extend ResourceHierarchy = split(_ResourceId, "/")
@@ -32,12 +32,20 @@ query: |
       | where OperationNameValue !~ "MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/DELETE" and OperationNameValue endswith "/DELETE" and ActivityStatusValue has_any ("Success", "Succeeded")
       | project _ResourceId
   ) on $left.MonitoredResourcePath == $right._ResourceId
-  | project TimeGenerated, Caller, CallerIpAddress, OperationNameValue, OperationName, ActivityStatusValue, ResourceGroup, MonitoredResourcePath, Resource,  Properties, _ResourceId, CorrelationId
+  | extend
+      Name = iif(Caller has "@", tostring(split(Caller, "@")[0]), ""),
+      UPNSuffix = iif(Caller has "@", tostring(split(Caller, "@")[1]), ""),
+      AadUserId = iif(Caller has "@", "", Caller)
+  | project TimeGenerated, Caller, CallerIpAddress, OperationNameValue, OperationName, ActivityStatusValue, ResourceGroup, MonitoredResourcePath, Resource, Properties, Name, UPNSuffix, AadUserId, _ResourceId, CorrelationId
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Caller
+        columnName: Name
+      - identifier: UPNSuffix
+        columnName: UPNSuffix
+      - identifier: AadUserId
+        columnName: AadUserId
   - entityType: IP
     fieldMappings:
       - identifier: Address


### PR DESCRIPTION
   Change(s):
   - Add case where OperationNameValue is not uppercase (thus ```microsoft.insights/diagnosticSettings/delete```).
   - Fix join key on the right side of the join.

   Reason for Change(s):
   - AzureActivity events with the same OperationNameValues can have different parsings, so the rules must contemplate both possible parsings.
   - The ```resource``` column in the right side of the join was returning just the resource name like ```exampleresourcename```, while the ```resource``` column in the left side was returning the resource path, like ```/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-exampleresourcegroup/providers/microsoft.sql/servers/exampleresourcename```

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes