### PR TITLE
Add more cases to RareRunCommandPowerShellScript.yaml

### DIFF
--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -98,7 +98,7 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
-version: 1.0.4
+version: 1.0.5
 kind: Scheduled
 metadata:
     source:

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -27,13 +27,13 @@ relevantTechniques:
 query: |
   let RunCommandData = materialize ( AzureActivity
   // Isolate run command actions
-  | where OperationNameValue == "MICROSOFT.COMPUTE/VIRTUALMACHINES/RUNCOMMAND/ACTION"
+  | where OperationNameValue =~ "Microsoft.Compute/virtualMachines/runCommand/action"
   // Confirm that the operation impacted a virtual machine
   | where Authorization has "virtualMachines"
   // Each runcommand operation consists of three events when successful, StartTimeed, Accepted (or Rejected), Successful (or Failed).
   | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
   // Limit to Run Command executions that Succeeded
-  | where list_ActivityStatusValue has "Success"
+  | where ActivityStatusValueList has_any ("Succeeded", "Success")
   // Extract data from the Authorization field, allowing us to later extract the Caller (UPN) and CallerIpAddress
   | extend Authorization_d = parse_json(Authorization)
   | extend Scope = Authorization_d.scope

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -31,9 +31,9 @@ query: |
   // Confirm that the operation impacted a virtual machine
   | where Authorization has "virtualMachines"
   // Each runcommand operation consists of three events when successful, StartTimeed, Accepted (or Rejected), Successful (or Failed).
-  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), ActivityStatusValueList = make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
+  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
   // Limit to Run Command executions that Succeeded
-  | where ActivityStatusValueList has_any ("Succeeded", "Success")
+  | where list_ActivityStatusValu has_any ("Succeeded", "Success")
   // Extract data from the Authorization field, allowing us to later extract the Caller (UPN) and CallerIpAddress
   | extend Authorization_d = parse_json(Authorization)
   | extend Scope = Authorization_d.scope

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -31,7 +31,7 @@ query: |
   // Confirm that the operation impacted a virtual machine
   | where Authorization has "virtualMachines"
   // Each runcommand operation consists of three events when successful, StartTimeed, Accepted (or Rejected), Successful (or Failed).
-  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
+  | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), ActivityStatusValueList = make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
   // Limit to Run Command executions that Succeeded
   | where ActivityStatusValueList has_any ("Succeeded", "Success")
   // Extract data from the Authorization field, allowing us to later extract the Caller (UPN) and CallerIpAddress

--- a/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
+++ b/Detections/AzureActivity/RareRunCommandPowerShellScript.yaml
@@ -33,7 +33,7 @@ query: |
   // Each runcommand operation consists of three events when successful, StartTimeed, Accepted (or Rejected), Successful (or Failed).
   | summarize StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), max(CallerIpAddress), make_list(ActivityStatusValue) by CorrelationId, Authorization, Caller
   // Limit to Run Command executions that Succeeded
-  | where list_ActivityStatusValu has_any ("Succeeded", "Success")
+  | where list_ActivityStatusValue has_any ("Succeeded", "Success")
   // Extract data from the Authorization field, allowing us to later extract the Caller (UPN) and CallerIpAddress
   | extend Authorization_d = parse_json(Authorization)
   | extend Scope = Authorization_d.scope


### PR DESCRIPTION
   Change(s):
   - Add case where OperationNameValue is not uppercase, and ActivityStatusValue can have other value for successful operation.

   Reason for Change(s):
   - AzureActivity events with the same OperationNameValues can have different parsings, so the rules must contemplate both possible parsings.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes