### PR TITLE
Show the actual Role and Fix InitiatingUser

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
@@ -21,7 +21,7 @@ tags:
   - AADSecOpsGuide
 query: |
   AuditLogs
-  | where TimeGenerated >= ago(queryPeriod)
+  | where TimeGenerated >= ago(2h)
   | where ActivityDisplayName =~'Add member to role completed (PIM activation)'
   | where Result == "failure"
   | extend Role = tostring(TargetResources[3].displayName)

--- a/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
@@ -21,13 +21,14 @@ tags:
   - AADSecOpsGuide
 query: |
   AuditLogs
+  | where TimeGenerated >= ago(queryPeriod)
   | where ActivityDisplayName =~'Add member to role completed (PIM activation)'
   | where Result == "failure"
   | extend Role = tostring(TargetResources[3].displayName)
   | extend User = tostring(TargetResources[2].displayName)
-  | project-reorder TimeGenerated, User, Role, OperationName, Result, ResultDescription
-  | extend InitiatingUser = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-  | extend AccountCustomEntity = User, IPCustomEntity = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend InitiatingUser = tostring(coalesce(parse_json(tostring(InitiatedBy.user)).userPrincipalName,parse_json(tostring(InitiatedBy.app)).displayName))
+  | project-reorder TimeGenerated, InitiatingUser, User, Role, OperationName, Result, ResultDescription
+  | extend AccountCustomEntity = User, IPCustomEntity = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress), Role = tostring(TargetResources[0].displayName)
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -41,5 +42,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
@@ -44,5 +44,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
@@ -24,11 +24,13 @@ query: |
   | where TimeGenerated >= ago(2h)
   | where ActivityDisplayName =~'Add member to role completed (PIM activation)'
   | where Result == "failure"
-  | extend Role = tostring(TargetResources[3].displayName)
+  | extend Role = tostring(TargetResources[0].displayName)
   | extend User = tostring(TargetResources[2].displayName)
-  | extend InitiatingUser = tostring(coalesce(parse_json(tostring(InitiatedBy.user)).userPrincipalName,parse_json(tostring(InitiatedBy.app)).displayName))
+  | extend InitiatedUserDetail = parse_json(tostring(InitiatedBy.user)), InitiatedAppDetail = parse_json(tostring(InitiatedBy.app))
+  | extend InitiatingUser = tostring(coalesce(InitiatedUserDetail.userPrincipalName, InitiatedAppDetail.displayName))
   | project-reorder TimeGenerated, InitiatingUser, User, Role, OperationName, Result, ResultDescription
-  | extend AccountCustomEntity = User, IPCustomEntity = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress), Role = tostring(TargetResources[0].displayName)
+  | extend AccountCustomEntity = User, IPCustomEntity = tostring(InitiatedUserDetail.ipAddress)
+  | project-away InitiatedUserDetail, InitiatedAppDetail
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/PIMElevationRequestRejected.yaml
@@ -21,7 +21,6 @@ tags:
   - AADSecOpsGuide
 query: |
   AuditLogs
-  | where TimeGenerated >= ago(2h)
   | where ActivityDisplayName =~'Add member to role completed (PIM activation)'
   | where Result == "failure"
   | extend Role = tostring(TargetResources[0].displayName)


### PR DESCRIPTION
Get the actual role being assigned and get InitiatingUser from User or App that triggered. Also added Time constrain for performance improvement.

   Required items, please complete
   
   Change(s):
   - Role shows the role being assigned. IntitiatingUser now shows app triggered name like Azure AD PIM. Use time constrains to improve performance.

   Reason for Change(s):
   - Role wasn't showing the role being assigned. Also InitiatingUser was only showing if user, not app triggered like Azure AD PIM. Added time constrains in the beginning to improve performance and don't get older results.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
