### PR TITLE
🐛 Fix incorrect case for IPAddress column

### DIFF
--- a/Detections/SigninLogs/AnomolousSingleFactorSignin.yaml
+++ b/Detections/SigninLogs/AnomolousSingleFactorSignin.yaml
@@ -44,8 +44,8 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IpAddress
-version: 1.0.1
+        columnName: IPAddress
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
   Change(s):
   - Fix case of `IPAddress` column in analytic entity mapping

   Reason for Change(s):
   - Mapping was referencing a non-existent column `IpAddress`, the actual column is `IPAddress`

   Version Updated:
   - ✅

   Details:

While deploying rules via the REST API we came across this error. Updating the analytic's entity references to use the correct case fixed this issue:
```ruby
ERROR:__main__:ERROR: to deploy Anomolous Single Factor Signin: 400 - {"error":{"code":"BadRequest","message":"Error in EntityMappings: The given column 'IpAddress' does not exist."}}
```

