### PR TITLE
Update TimeSeriesAnomaly-ProcessExecutions.yaml

### DIFF
--- a/Solutions/Windows Security Events/Analytic Rules/TimeSeriesAnomaly-ProcessExecutions.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/TimeSeriesAnomaly-ProcessExecutions.yaml
@@ -64,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/TimeSeriesAnomaly-ProcessExecutions.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/TimeSeriesAnomaly-ProcessExecutions.yaml
@@ -27,7 +27,7 @@ query: |
   let endtime = 1d;
   let timeframe = 1h;
   let TotalEventsThreshold = 5;
-  let ExeList = dynamic(["powershell.exe","cmd.exe","wmic.exe","psexec.exe","cacls.exe","rundll.exe"]);
+  let ExeList = dynamic(["powershell.exe","cmd.exe","wmic.exe","psexec.exe","cacls.exe","rundll32.exe"]);
   let TimeSeriesData =
   SecurityEvent
   | where EventID == 4688 | extend Process = tolower(Process)


### PR DESCRIPTION
Changing rundll.exe to rundll32.exe, which is the actual process name of the dll loader.

   Required items, please complete
   
   Change(s):
   - Changing "rundll.exe" to "rundll32.exe"

   Reason for Change(s):
   -  rundll32.exe  is the actual name of the process used to load dll.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes