### PR TITLE
updated incorrect versions

### DIFF
--- a/Parsers/ASimAuditEvent/Parsers/vimAuditEventEmpty.yaml
+++ b/Parsers/ASimAuditEvent/Parsers/vimAuditEventEmpty.yaml
@@ -1,6 +1,6 @@
 Parser:
   Title: Audit event ASIM schema function
-  Version: '0.1'
+  Version: '0.2'
   LastUpdated: Dec 19 2022
 Product:
   Name: Microsoft

--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionCheckPointFirewall.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionCheckPointFirewall.yaml
@@ -1,6 +1,6 @@
 Parser:
   Title: Network Session ASIM parser for Check Point Firewall
-  Version: '2.0'
+  Version: '1.1'
   LastUpdated: Dec 11, 2022
 Product:
   Name: CheckPointFirewall

--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionMicrosoftSysmon.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionMicrosoftSysmon.yaml
@@ -1,6 +1,6 @@
 Parser:
   Title: Network Session Event ASIM parser for Sysmon (Event 3)
-  Version: '0.0.2'
+  Version: '0.1'
   LastUpdated: Jan 11, 2023
 Product:
   Name: Windows Sysmon

--- a/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionCheckPointFirewall.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionCheckPointFirewall.yaml
@@ -1,6 +1,6 @@
 Parser:
   Title: Network Session ASIM parser for Check Point Firewall
-  Version: '2.0'
+  Version: '1.1'
   LastUpdated: Dec 11, 2022
 Product:
   Name: CheckPointFirewall


### PR DESCRIPTION
   
   Change(s):
   - Updated incorrect versions for the following parsers: vimAuditEventEmpty , ASimNetworkSessionCheckPointFirewall, ASimNetworkSessionMicrosoftSysmon , vimNetworkSessionCheckPointFirewall .


   Reason for Change(s):
   - The version of ASimNetworkSessionMicrosoftSysmon should have been updated as the parser was updated.
   - The versions of the other Three parsers were incorrect. 

