### PR TITLE
Content Validation to check only Specific tag in Data,DataConnectors and CreateUiDefinition folder file

### DIFF
--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -22,23 +22,29 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
 
     if (!isExcludedFile && isIncludedFolderFile)
     {
-        const fileContent = fs.readFileSync(filePath, "utf8");
         const searchText = "Azure Sentinel";
         const expectedText = "Microsoft Sentinel";
 
-        // Read skip text from a file
-        const skipTextFile = fs.readFileSync('./.script/validate-tag-text.txt', "utf8");
-        const validTags = skipTextFile.split("\n").filter(tag => tag.length > 0);
+        const tagsList = fs.readFileSync('./.script/validate-tag-text.txt', "utf8");
+        const validTags = tagsList.split("\n").filter(tag => tag.length > 0);
 
-        // SEARCH & CHECK IF SKIP TEXT EXIST IN THE FILE
-        var fileContentObj = JSON.parse(fileContent.replace(/\\/g, '\\\\'));
+        const fileContent = fs.readFileSync(filePath, "utf8");
+        var fileContentObj = JSON.parse(fileContent);
+
         for (const tagName of validTags) 
         {
-            let hasDescriptionTag = fileContentObj[tagName];
-            if (hasDescriptionTag)
+            if (filePath.includes("createUiDefinition.json"))
             {
-                let hasAzureSentinelText = hasDescriptionTag.toLowerCase().includes(searchText.toLowerCase());
+                var tagContent = fileContentObj["parameters"]["config"]["basics"][tagName];
+            }
+            else
+            {
+                var tagContent = fileContentObj[tagName];
+            }
 
+            if (tagContent)
+            {
+                let hasAzureSentinelText = tagContent.toLowerCase().includes(searchText.toLowerCase());
                 if (hasAzureSentinelText) {
                     throw new Error(`Please update text from '${searchText}' to '${expectedText}' in '${tagName}' tag in the file '${filePath}'`);
                 }

--- a/.script/contentValidator.ts
+++ b/.script/contentValidator.ts
@@ -5,22 +5,13 @@ import * as logger from "./utils/logger";
 
 export async function ValidateFileContent(filePath: string): Promise<ExitCode> 
 {
-    // WE SHOULD SKIP ANY FILE WHICH IS LISTED BELOW
-    const isExcludedFile = (filePath.includes("azure-pipelines")
-        || filePath.includes("azureDeploy")
-        || filePath.includes("host.json")
-        || filePath.includes("proxies.json")
-        || filePath.includes("azuredeploy")
-        || filePath.includes("function.json"));
+    const ignoreFiles = ["azure-pipelines", "azureDeploy", "host.json", "proxies.json", "azuredeploy", "function.json"]
+    const requiredFolderFiles = ["/Data/", "/data/", "/DataConnectors/", "/Data Connectors/", "createUiDefinition.json"]
 
-    // WE SHOULD CHECK ONLY IN BELOW FOLDERS
-    const isIncludedFolderFile = (filePath.includes("/Data/") 
-        || filePath.includes("/data/")
-        || filePath.includes("/Data Connectors/") 
-        || filePath.includes("/DataConnectors/")
-        || filePath.includes("createUiDefinition.json"));
+    const hasIgnoredFile = ignoreFiles.filter(item => { return filePath.includes(item)}).length > 0
+    const hasRequiredFolderFiles = requiredFolderFiles.filter(item => { return filePath.includes(item)}).length > 0
 
-    if (!isExcludedFile && isIncludedFolderFile)
+    if (!hasIgnoredFile && hasRequiredFolderFiles)
     {
         const searchText = "Azure Sentinel";
         const expectedText = "Microsoft Sentinel";
@@ -33,14 +24,7 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
 
         for (const tagName of validTags) 
         {
-            if (filePath.includes("createUiDefinition.json"))
-            {
-                var tagContent = fileContentObj["parameters"]["config"]["basics"][tagName];
-            }
-            else
-            {
-                var tagContent = fileContentObj[tagName];
-            }
+            var tagContent = GetTagContent(tagName);
 
             if (tagContent)
             {
@@ -52,6 +36,26 @@ export async function ValidateFileContent(filePath: string): Promise<ExitCode>
         }
     }
     return ExitCode.SUCCESS;
+
+    function GetTagContent(tagName: any) {
+        if (filePath.includes("createUiDefinition.json")) {
+            var tagContent = fileContentObj["parameters"]["config"]["basics"][tagName];
+            if (tagContent == undefined) {
+                //MAKE FIRST LETTER OF THE WORD CAPS
+                const firstLetterCapsInTagName = tagName.charAt(0).toUpperCase() + tagName.slice(1)
+                var tagContent = fileContentObj["parameters"]["config"]["basics"][firstLetterCapsInTagName];
+            }
+        }
+        else {
+            var tagContent = fileContentObj[tagName];
+            if (tagContent == undefined) {
+                //MAKE FIRST LETTER OF THE WORD CAPS
+                const firstLetterCapsInTagName = tagName.charAt(0).toUpperCase() + tagName.slice(1)
+                var tagContent = fileContentObj[firstLetterCapsInTagName];
+            }
+        }
+        return tagContent;
+    }
 }
 
 let fileTypeSuffixes = ["json"];

--- a/.script/skip-text.txt
+++ b/.script/skip-text.txt
@@ -1,2 +1,0 @@
-"targetProduct": "Azure Sentinel"
-Azure Sentinel Community Github

--- a/.script/validate-tag-text.txt
+++ b/.script/validate-tag-text.txt
@@ -1,0 +1,2 @@
+description
+descriptionMarkdown

--- a/.script/validate-tag-text.txt
+++ b/.script/validate-tag-text.txt
@@ -1,2 +1,0 @@
-description
-descriptionMarkdown

--- a/.script/validate-tag.json
+++ b/.script/validate-tag.json
@@ -1,0 +1,5 @@
+{
+    "createUiDefinition": "description",
+    "data": "description",
+    "dataConnectors" : "descriptionMarkdown"
+}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - We will check only specific tag specified i.e. description and descriptionMarkdown tag text value which are visible to endusers. We will eventually grow this once we are sure on which tags we have to target.

   Reason for Change(s):
   - Due to dependency of Azure Sentinel in many cases we cannot change the text from Azure Sentinel to Microsoft Sentinel in lot of cases so we have kept the scope limited.

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Testing Screenshots**
**1. Failure Result:**
![MicrosoftTeams-image](https://user-images.githubusercontent.com/107389644/220917093-a96d0cd5-2e38-43a8-b479-f52cd114b864.png)

**2. Success Result:**
![image](https://user-images.githubusercontent.com/107389644/220926632-4c9d7e22-78a8-4db9-b7d3-a0c20c5f6f59.png)
