### PR TITLE
Update to add `where` IP find/search

### DIFF
--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -29,13 +29,16 @@ query: |
     | where TimeGenerated > ago(1d)
     | where ProductName == "Azure Active Directory Identity Protection"
     | where AlertName == "Sign-in from an infected device"
-    | mv-expand EntityAccount = todynamic(Entities)
-    | where EntityAccount .Type == "account"
-    | extend AadTenantId = tostring(EntityAccount.AadTenantId)
-    | extend AadUserId = tostring(EntityAccount.AadUserId)
-    | mv-expand EntityIp = todynamic(Entities)
-    | where EntityIp.Type == "ip"
+    | mv-apply EntityAccount=todynamic(Entities) on
+    (
+    where EntityAccount.Type == "account"
+    | extend AadTenantId = tostring(EntityAccount.AadTenantId), AadUserId = tostring(EntityAccount.AadUserId)
+    )
+    | mv-apply EntityIp=todynamic(Entities) on
+    (
+    where EntityIp.Type == "ip"
     | extend IpAddress = tostring(EntityIp.Address)
+    )
     | join kind=inner (
     IdentityInfo
     | distinct AccountTenantId, AccountObjectId, AccountUPN, AccountDisplayName
@@ -66,7 +69,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -29,11 +29,13 @@ query: |
     | where TimeGenerated > ago(1d)
     | where ProductName == "Azure Active Directory Identity Protection"
     | where AlertName == "Sign-in from an infected device"
-    | mv-expand Entity = todynamic(Entities)
-    | where Entity.Type == "account"
-    | extend AadTenantId = tostring(Entity.AadTenantId)
-    | extend AadUserId = tostring(Entity.AadUserId)
-    | extend IpAddress = tostring(parse_json(Entities)[2].Address)
+    | mv-expand EntityAccount = todynamic(Entities)
+    | where EntityAccount .Type == "account"
+    | extend AadTenantId = tostring(EntityAccount.AadTenantId)
+    | extend AadUserId = tostring(EntityAccount.AadUserId)
+    | mv-expand EntityIp = todynamic(Entities)
+    | where EntityIp.Type == "ip"
+    | extend IpAddress = tostring(EntityIp.Address)
     | join kind=inner (
     IdentityInfo
     | distinct AccountTenantId, AccountObjectId, AccountUPN, AccountDisplayName

--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -69,6 +69,10 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
+  - entityType: AzureResource
+    fieldMappings:
+      - identifier: ResourceId
+        columnName: _ResourceId
 version: 1.0.6
 kind: Scheduled
 metadata:


### PR DESCRIPTION


   Required items, please complete
   
   Change(s):
   - Create specific search for `type: ip` to prevent an empty value which will cause detection to not fire and potentially not capture a real event.

   Reason for Change(s):
   - Something has changed around Feb 6th or 7th (from some of my tenants) and now many AAD-IP (Azure Active Directory Identity Protection) events have a different data structure that causes LN36 `| extend IpAddress = tostring(parse_json(Entities)[2].Address)` to be moved to `| extend IpAddress = tostring(parse_json(Entities)[3].Address)`
   - There is a new value with `Type: cloud-logon-request` at `| extend IpAddress = tostring(parse_json(Entities)[2].Address)` 
   - To work around this, the simplest fix seems to be another mv-expand with where for type of `ip` as suggested here.

   Version Updated:
   - No, request PR to branch pending PR by @gitj121 [https://github.com/Azure/Azure-Sentinel/pull/7360](https://github.com/Azure/Azure-Sentinel/pull/7360)

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes