### PR TITLE
Update Dynamics 365 md desc to add Docs link

### DIFF
--- a/Solutions/Dynamics 365/Data Connectors/template_Dynamics365.json
+++ b/Solutions/Dynamics 365/Data Connectors/template_Dynamics365.json
@@ -2,7 +2,7 @@
     "id": "Dynamics365",
     "title": "Dynamics365",
     "publisher": "Microsoft",
-    "descriptionMarkdown": "The Dynamics 365 Common Data Service (CDS) activities connector provides insight into admin, user, and support activities, as well as Microsoft Social Engagement logging events. By connecting Dynamics 365 CRM logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process.",
+    "descriptionMarkdown": "The Dynamics 365 Common Data Service (CDS) activities connector provides insight into admin, user, and support activities, as well as Microsoft Social Engagement logging events. By connecting Dynamics 365 CRM logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. For more information, see the [Microsoft Sentinel documentation](https://go.microsoft.com//fwlink/p/?linkid=2226719&wt.mc_id=sentinel_dataconnectordocs_content_cnl_csasci).",
     "logo": "DynamicsLogo.svg",
     "graphQueries": [
         {


### PR DESCRIPTION
@prtanej

   Required items, please complete
   
Change(s):

Added fwlink to Microsoft Docs for setup instructions in the data connector description.

Reason for Change(s):

This link is for the Microsoft Docs data connector automation project to cross-link to the setup instructions. On the Microsoft Docs side we're pulling description info from the mainTemplate.JSON and autogenerating pages like: https://review.learn.microsoft.com/en-us/azure/sentinel/data-connectors/windows-dns-events-via-ama-preview?branch=release-sentinel-auto-gen-data-connectors.
Version Updated:
N/A

Testing Completed:
No

Checked that the validations are passing and have addressed any issues that are present:
No / N/A