### PR TITLE
Fixed Arm-ttk issue when solution name has space

### DIFF
--- a/.github/workflows/arm-ttk-validations.yaml
+++ b/.github/workflows/arm-ttk-validations.yaml
@@ -41,20 +41,18 @@ jobs:
             {
               $hasCreateUiDefinitionTemplateChanged = $true
             }
-
-            $filePaths = $filteredFiles -split ' '
-            if ($null -ne $filePaths[0])
+            
+            if ($filteredFiles.Count -eq 1)
             {
-              $solutionNameWithOtherPath = $filePaths[0].SubString(10)
-              if ($solutionNameWithOtherPath -ne '' -and $solutionNameWithOtherPath -ne $null)
-              {
-                $headers = $solutionNameWithOtherPath -split '/', 3
-                if ($null -ne $headers[0])
-                {
-                  $sName = $headers[0]
-                }
-              }
+              $packageIndex = $filteredFiles.IndexOf("/Package")
+              $sName = $filteredFiles.SubString(10, $packageIndex - 10)
             }
+            else
+            {
+              $packageIndex = $filteredFiles[0].IndexOf("/Package")
+              $sName = $filteredFiles[0].SubString(10, $packageIndex - 10)
+            }
+            Write-Host "SolutionName: $sName"
           }
 
           Write-Output "::set-output name=solutionName::$sName"


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Fixed issue when a solution name has space in it. eg:`Solutions/Jamf Protect/Package/createUiDefinition.json` where `Jamf Protect` solution name has space in it and it failed. So this PR fixes this issue.

   Reason for Change(s):
   - Fix issue on space in solution name

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
