### PR TITLE
hide table only available to private preview

### DIFF
--- a/Workbooks/AcscEssential8.json
+++ b/Workbooks/AcscEssential8.json
@@ -3227,7 +3227,7 @@
           {
             "type": 1,
             "content": {
-              "json": "### Restrict Admin Privileges ###"
+              "json": "### Multi-factor Authentication ###"
             },
             "customWidth": "50",
             "name": "text - 14"
@@ -3235,7 +3235,7 @@
           {
             "type": 1,
             "content": {
-              "json": "### Multi-factor Authentication ###"
+              "json": "### Restrict Admin Privileges ###"
             },
             "customWidth": "50",
             "name": "text - 15"

--- a/Workbooks/AcscEssential8.json
+++ b/Workbooks/AcscEssential8.json
@@ -3584,6 +3584,6 @@
     }
   ],
   "fallbackResourceIds": [],
-  "fromTemplateId": "sentinel-AcscEssential8",
+  "fromTemplateId": "sentinel-AcscEssential8Workbook",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/AcscEssential8.json
+++ b/Workbooks/AcscEssential8.json
@@ -206,6 +206,38 @@
       "name": "parameters - 8"
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "e1e2cd0c-519c-44af-887b-3c44866296d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "tvmExists",
+            "type": 1,
+            "isRequired": true,
+            "query": "datatable(Count:long)[0] | union isfuzzy = true (table(\"DeviceTvmSecureConfigurationAssessment\") | take 1 | summarize Count = count())\r\n| summarize sum(Count)\r\n| project tvmExists = iff(sum_Count > 0, \"True\", \"False\")",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 13"
+    },
+    {
       "type": 12,
       "content": {
         "version": "NotebookGroup/1.0",
@@ -2334,283 +2366,298 @@
             "name": "text - 0"
           },
           {
-            "type": 1,
+            "type": 12,
             "content": {
-              "json": "## Health Legend\r\n\r\n#### Healthy:\r\nHealthy Virtual Machines have all the following ASR rules configured in 'block' mode:\r\n- Email Threats - Block executable content from email client and webmail.\r\n- Office Threats - Block Win32 API calls from Office macros.\r\n\r\nHealthy Virtual Machines have antimalware with automatically updated signatures.\r\n\r\nIf the control is not applicable (e.g. Linux OS), the health state is reported as Healthy.\r\n\r\n#### Unhealthy:\r\nUnhealthy Virtual machines do not have at least one of the above ASR rules configured in 'block' mode or do not have antimalware with automatically updated signatures.",
-              "style": "success"
-            },
-            "name": "text - 1"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "## Virtual Machines Health: Summary"
-            },
-            "name": "text - 5"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "DeviceTvmSecureConfigurationAssessment\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // ASR: Block executable content from email client and webmail\r\n    \"scid-2506\",    // ASR: Block Win32 API calls from Office macros\r\n    \"scid-2010\",    // AV: Defender AV mode: 0 == active, 1 == passive, 4 == EDR block mode\r\n    \"scid-2011\",    // AV: Defender AV signature (Windows)\r\n//    \"scid-2012\",    // AV: Defender enable RTP (Widows)\r\n//    \"scid-2016\",    // AV: Defender enable cloud protection (Windows)\r\n//    \"scid-6090\",    // AV: Defender enable RTP (Linux)\r\n//    \"scid-6094\",    // AV: Defender enable cloud protection (Linux)\r\n    \"scid-6095\"     // AV: Defender AV signature (Linux)\r\n)\r\n| extend Setting = case(\r\n    ConfigurationId == \"scid-2500\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2506\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2010\", tostring(Context[0].AntiVirusMode),\r\n    ConfigurationId == \"scid-2011\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    ConfigurationId == \"scid-6095\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    \"Error\"\r\n)\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| extend AvSignatureUpdateTime = iff([\"scid-2011\"] == \"NA\", [\"scid-6095\"], [\"scid-2011\"])\r\n| project-away [\"scid-2011\"], [\"scid-6095\"]\r\n| project-rename ExecutableEmailContent = [\"scid-2500\"], OfficeMacroWin32ApiCalls = [\"scid-2506\"], AvMode = [\"scid-2010\"]\r\n| extend TimeSinceAvSignatureUpdate = max_Timestamp - todatetime(AvSignatureUpdateTime)\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeMacroWin32ApiCalls in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AvMode in (\"0\", \"1\", \"4\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(TimeSinceAvSignatureUpdate < 7d and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| where not(AvMode in~ (\"\", \"Unknown\") and ExecutableEmailContent in~ (\"\", \"Unknown\") and AvSignatureUpdateTime == \"\")\r\n| summarize count = dcount(DeviceId) by Compliant",
-              "size": 3,
-              "timeContextFromParameter": "TimeRange",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
-              "visualization": "piechart",
-              "chartSettings": {
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "Unhealthy",
-                    "color": "red"
-                  },
-                  {
-                    "seriesName": "Healthy",
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "name": "query - 6"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "## Virtual Machines Health: Details"
-            },
-            "name": "text - 6"
-          },
-          {
-            "type": 9,
-            "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
                 {
-                  "id": "19582757-cbb9-4e41-8e76-252f56b52506",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "HealthState",
-                  "label": "Health State",
-                  "type": 2,
-                  "isRequired": true,
-                  "multiSelect": true,
-                  "quote": "'",
-                  "delimiter": ",",
-                  "typeSettings": {
-                    "additionalResourceOptions": [
-                      "value::all"
+                  "type": 1,
+                  "content": {
+                    "json": "## Health Legend\r\n\r\n#### Healthy:\r\nHealthy Virtual Machines have all the following ASR rules configured in 'block' mode:\r\n- Email Threats - Block executable content from email client and webmail.\r\n- Office Threats - Block Win32 API calls from Office macros.\r\n\r\nHealthy Virtual Machines have antimalware with automatically updated signatures.\r\n\r\nIf the control is not applicable (e.g. Linux OS), the health state is reported as Healthy.\r\n\r\n#### Unhealthy:\r\nUnhealthy Virtual machines do not have at least one of the above ASR rules configured in 'block' mode or do not have antimalware with automatically updated signatures.",
+                    "style": "success"
+                  },
+                  "name": "text - 1"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "## Virtual Machines Health: Summary"
+                  },
+                  "name": "text - 5"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "DeviceTvmSecureConfigurationAssessment\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // ASR: Block executable content from email client and webmail\r\n    \"scid-2506\",    // ASR: Block Win32 API calls from Office macros\r\n    \"scid-2010\",    // AV: Defender AV mode: 0 == active, 1 == passive, 4 == EDR block mode\r\n    \"scid-2011\",    // AV: Defender AV signature (Windows)\r\n//    \"scid-2012\",    // AV: Defender enable RTP (Widows)\r\n//    \"scid-2016\",    // AV: Defender enable cloud protection (Windows)\r\n//    \"scid-6090\",    // AV: Defender enable RTP (Linux)\r\n//    \"scid-6094\",    // AV: Defender enable cloud protection (Linux)\r\n    \"scid-6095\"     // AV: Defender AV signature (Linux)\r\n)\r\n| extend Setting = case(\r\n    ConfigurationId == \"scid-2500\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2506\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2010\", tostring(Context[0].AntiVirusMode),\r\n    ConfigurationId == \"scid-2011\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    ConfigurationId == \"scid-6095\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    \"Error\"\r\n)\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| extend AvSignatureUpdateTime = iff([\"scid-2011\"] == \"NA\", [\"scid-6095\"], [\"scid-2011\"])\r\n| project-away [\"scid-2011\"], [\"scid-6095\"]\r\n| project-rename ExecutableEmailContent = [\"scid-2500\"], OfficeMacroWin32ApiCalls = [\"scid-2506\"], AvMode = [\"scid-2010\"]\r\n| extend TimeSinceAvSignatureUpdate = max_Timestamp - todatetime(AvSignatureUpdateTime)\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeMacroWin32ApiCalls in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AvMode in (\"0\", \"1\", \"4\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(TimeSinceAvSignatureUpdate < 7d and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| where not(AvMode in~ (\"\", \"Unknown\") and ExecutableEmailContent in~ (\"\", \"Unknown\") and AvSignatureUpdateTime == \"\")\r\n| summarize count = dcount(DeviceId) by Compliant",
+                    "size": 3,
+                    "timeContextFromParameter": "TimeRange",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "crossComponentResources": [
+                      "{Workspace}"
                     ],
-                    "showDefault": false
+                    "visualization": "piechart",
+                    "chartSettings": {
+                      "seriesLabelSettings": [
+                        {
+                          "seriesName": "Unhealthy",
+                          "color": "red"
+                        },
+                        {
+                          "seriesName": "Healthy",
+                          "color": "green"
+                        }
+                      ]
+                    }
                   },
-                  "jsonData": "[\"Healthy\", \"Unhealthy\"]",
-                  "timeContext": {
-                    "durationMs": 86400000
+                  "name": "query - 6"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "## Virtual Machines Health: Details"
                   },
-                  "defaultValue": "value::all",
-                  "value": [
-                    "Healthy"
-                  ]
+                  "name": "text - 6"
+                },
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "19582757-cbb9-4e41-8e76-252f56b52506",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "HealthState",
+                        "label": "Health State",
+                        "type": 2,
+                        "isRequired": true,
+                        "multiSelect": true,
+                        "quote": "'",
+                        "delimiter": ",",
+                        "typeSettings": {
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
+                          "showDefault": false
+                        },
+                        "jsonData": "[\"Healthy\", \"Unhealthy\"]",
+                        "timeContext": {
+                          "durationMs": 86400000
+                        },
+                        "defaultValue": "value::all",
+                        "value": [
+                          "Unhealthy"
+                        ]
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces"
+                  },
+                  "name": "parameters - 4"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "DeviceTvmSecureConfigurationAssessment\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // ASR: Block executable content from email client and webmail\r\n    \"scid-2506\",    // ASR: Block Win32 API calls from Office macros\r\n    \"scid-2010\",    // AV: Defender AV mode: 0 == active, 1 == passive, 4 == EDR block mode\r\n    \"scid-2011\",    // AV: Defender AV signature (Windows)\r\n//    \"scid-2012\",    // AV: Defender enable RTP (Widows)\r\n//    \"scid-2016\",    // AV: Defender enable cloud protection (Windows)\r\n//    \"scid-6090\",    // AV: Defender enable RTP (Linux)\r\n//    \"scid-6094\",    // AV: Defender enable cloud protection (Linux)\r\n    \"scid-6095\"     // AV: Defender AV signature (Linux)\r\n)\r\n| extend Setting = case(\r\n    ConfigurationId == \"scid-2500\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2506\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2010\", tostring(Context[0].AntiVirusMode),\r\n    ConfigurationId == \"scid-2011\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    ConfigurationId == \"scid-6095\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    \"Error\"\r\n)\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| extend AvSignatureUpdateTime = iff([\"scid-2011\"] == \"NA\", [\"scid-6095\"], [\"scid-2011\"])\r\n| project-away [\"scid-2011\"], [\"scid-6095\"]\r\n| project-rename ExecutableEmailContent = [\"scid-2500\"], OfficeMacroWin32ApiCalls = [\"scid-2506\"], AvMode = [\"scid-2010\"]\r\n| extend TimeSinceAvSignatureUpdate = max_Timestamp - todatetime(AvSignatureUpdateTime)\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeMacroWin32ApiCalls in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AvMode in (\"0\", \"1\", \"4\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(TimeSinceAvSignatureUpdate < 7d and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| where not(AvMode in~ (\"\", \"Unknown\") and ExecutableEmailContent in~ (\"\", \"Unknown\") and AvSignatureUpdateTime == \"\")\r\n| where Compliant in~ ({HealthState})\r\n| extend AvMode = case(\r\n    AvMode == \"0\", \"Active\",\r\n    AvMode == \"1\", \"Passive\",\r\n    AvMode == \"4\", \"EDR Block\",\r\n    AvMode\r\n)\r\n| project-reorder DeviceName, DeviceId, Compliant, max_Timestamp\r\n| order by DeviceName asc, DeviceId asc",
+                    "size": 2,
+                    "timeContextFromParameter": "TimeRange",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "crossComponentResources": [
+                      "{Workspace}"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Compliant",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Healthy",
+                                "representation": "green",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Unhealthy",
+                                "representation": "red",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "gray",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "AvMode",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Active",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Passive",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "EDR Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "4",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ExecutableEmailContent",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "4",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OfficeMacroWin32ApiCalls",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "TimeSinceAvSignatureUpdate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "HealthState",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Healthy",
+                                "representation": "green",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Unhealthy",
+                                "representation": "red",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "gray",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "labelSettings": [
+                        {
+                          "columnId": "DeviceName",
+                          "label": "Resource"
+                        },
+                        {
+                          "columnId": "Compliant",
+                          "label": "Health State"
+                        },
+                        {
+                          "columnId": "max_Timestamp",
+                          "label": "Timestamp"
+                        },
+                        {
+                          "columnId": "OSPlatform",
+                          "label": "OS Platform"
+                        },
+                        {
+                          "columnId": "AvMode",
+                          "label": "AV Mode"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "query - 5"
                 }
-              ],
-              "style": "pills",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces"
+              ]
             },
-            "name": "parameters - 4"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "DeviceTvmSecureConfigurationAssessment\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // ASR: Block executable content from email client and webmail\r\n    \"scid-2506\",    // ASR: Block Win32 API calls from Office macros\r\n    \"scid-2010\",    // AV: Defender AV mode: 0 == active, 1 == passive, 4 == EDR block mode\r\n    \"scid-2011\",    // AV: Defender AV signature (Windows)\r\n//    \"scid-2012\",    // AV: Defender enable RTP (Widows)\r\n//    \"scid-2016\",    // AV: Defender enable cloud protection (Windows)\r\n//    \"scid-6090\",    // AV: Defender enable RTP (Linux)\r\n//    \"scid-6094\",    // AV: Defender enable cloud protection (Linux)\r\n    \"scid-6095\"     // AV: Defender AV signature (Linux)\r\n)\r\n| extend Setting = case(\r\n    ConfigurationId == \"scid-2500\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2506\", tostring(Context[0].Unknown1),\r\n    ConfigurationId == \"scid-2010\", tostring(Context[0].AntiVirusMode),\r\n    ConfigurationId == \"scid-2011\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    ConfigurationId == \"scid-6095\", tostring(Context[0].AntiVirusSignatureLastUpdateTime),\r\n    \"Error\"\r\n)\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| extend AvSignatureUpdateTime = iff([\"scid-2011\"] == \"NA\", [\"scid-6095\"], [\"scid-2011\"])\r\n| project-away [\"scid-2011\"], [\"scid-6095\"]\r\n| project-rename ExecutableEmailContent = [\"scid-2500\"], OfficeMacroWin32ApiCalls = [\"scid-2506\"], AvMode = [\"scid-2010\"]\r\n| extend TimeSinceAvSignatureUpdate = max_Timestamp - todatetime(AvSignatureUpdateTime)\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeMacroWin32ApiCalls in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AvMode in (\"0\", \"1\", \"4\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(TimeSinceAvSignatureUpdate < 7d and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| where not(AvMode in~ (\"\", \"Unknown\") and ExecutableEmailContent in~ (\"\", \"Unknown\") and AvSignatureUpdateTime == \"\")\r\n| where Compliant in~ ({HealthState})\r\n| extend AvMode = case(\r\n    AvMode == \"0\", \"Active\",\r\n    AvMode == \"1\", \"Passive\",\r\n    AvMode == \"4\", \"EDR Block\",\r\n    AvMode\r\n)\r\n| project-reorder DeviceName, DeviceId, Compliant, max_Timestamp\r\n| order by DeviceName asc, DeviceId asc",
-              "size": 2,
-              "timeContextFromParameter": "TimeRange",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
-              "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "Compliant",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "colors",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Healthy",
-                          "representation": "green",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Unhealthy",
-                          "representation": "red",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "gray",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "AvMode",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Active",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Passive",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "EDR Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "4",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "ExecutableEmailContent",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "4",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "OfficeMacroWin32ApiCalls",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "TimeSinceAvSignatureUpdate",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "HealthState",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "colors",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Healthy",
-                          "representation": "green",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Unhealthy",
-                          "representation": "red",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "gray",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "labelSettings": [
-                  {
-                    "columnId": "DeviceName",
-                    "label": "Resource"
-                  },
-                  {
-                    "columnId": "Compliant",
-                    "label": "Health State"
-                  },
-                  {
-                    "columnId": "max_Timestamp",
-                    "label": "Timestamp"
-                  },
-                  {
-                    "columnId": "OSPlatform",
-                    "label": "OS Platform"
-                  },
-                  {
-                    "columnId": "AvMode",
-                    "label": "AV Mode"
-                  }
-                ]
-              }
+            "conditionalVisibility": {
+              "parameterName": "tvmExists",
+              "comparison": "isEqualTo",
+              "value": "True"
             },
-            "name": "query - 5"
+            "name": "group - 7"
           }
         ]
       },
@@ -2620,6 +2667,26 @@
         "value": "macros"
       },
       "name": "group - 9"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Please make sure that you have selected the appropriate Sentinel workspace from the drop-down parameter above.\r\n\r\n### If you still see this message, it is because this strategy relies on data only available through a Microsoft Sentinel private preview feature.  \r\n### To see this strategy, and to provide feedback on this and other private preview features for Microsoft Sentinel and other Microsoft security products, join our Customer Connection Program.  \r\n### [Learn more here](https://techcommunity.microsoft.com/t5/security-compliance-and-identity/how-microsoft-security-wants-to-help-you-take-your-fandom-and/ba-p/3745057) or fill out the [form](https://www.aka.ms/JoinCCP) to join.",
+        "style": "warning"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "tvmExists",
+          "comparison": "isEqualTo",
+          "value": "False"
+        },
+        {
+          "parameterName": "Tab",
+          "comparison": "isEqualTo",
+          "value": "macros"
+        }
+      ],
+      "name": "text - 14"
     },
     {
       "type": 12,
@@ -2635,454 +2702,489 @@
             "name": "text - 0"
           },
           {
-            "type": 1,
+            "type": 12,
             "content": {
-              "json": "## Health Legend\r\n#### Healthy:\r\nHealthy Virtual Machines have **all of the following** ASR rules configured in 'block' mode:\r\n\r\nScripting Threats:\r\n- Block JavaScript or VBScript from launching downloaded executable content.\r\n- Block execution of potentially obfuscated scripts.\r\n\r\nEmail Threats:\r\n- Block executable content from email client and webmail.\r\n\r\nOffice Threats:\r\n- Block Office application from creating child processes.\r\n- Block Office applications from creating executable content.\r\n- Block Office applications from injecting code into other processes.\r\n- Block Adobe Reader from creating child processes.\r\n\r\n#### Unhealthy:\r\nUnhealthy Virtual Machines have **at least one** of the above ASR rules not configured in 'block' mode.",
-              "style": "success"
-            },
-            "name": "text - 1"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "## Virtual Machines Health: Summary"
-            },
-            "name": "text - 8"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "DeviceTvmSecureConfigurationAssessment\r\n//| where OSPlatform != \"Linux\" //exclude Linux machines\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // Block executable content from email client and webmail\r\n    \"scid-2501\",    // Block Office applications from creating child processes\r\n    \"scid-2502\",    // Block Office applications from creating executable content\r\n    \"scid-2503\",    // Block Office applications from injecting code into other processes\r\n    \"scid-2504\",    // Block JavaScript or VBScript from launching downloaded executable content\r\n    \"scid-2505\",    // Block execution of potentially obfuscated scripts\r\n    \"scid-2513\"    // Block Adobe Reader from creating child processes\r\n)\r\n| extend Setting = tostring(Context[0].Unknown1)\r\n| where Setting != \"Unknown\"\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| project-rename\r\n    ExecutableEmailContent = [\"scid-2500\"],\r\n    OfficeChildProcess = [\"scid-2501\"],\r\n    ExecutableOfficeContent = [\"scid-2502\"],\r\n    OfficeProcessInjection = [\"scid-2503\"],\r\n    ScriptExecutableDownload = [\"scid-2504\"],\r\n    ObfuscatedScript = [\"scid-2505\"],\r\n    AdobeReaderChildProcess = [\"scid-2513\"]\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ExecutableOfficeContent in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeProcessInjection in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ScriptExecutableDownload in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ObfuscatedScript in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AdobeReaderChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| summarize count = dcount(DeviceId) by Compliant",
-              "size": 3,
-              "timeContextFromParameter": "TimeRange",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
-              "visualization": "piechart",
-              "chartSettings": {
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "Unhealthy",
-                    "color": "red"
-                  },
-                  {
-                    "seriesName": "Healthy",
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "name": "query - 9"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "## Virtual Machines Health: Details\r\nSee below for description of Configuration items."
-            },
-            "name": "text - 10"
-          },
-          {
-            "type": 9,
-            "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
                 {
-                  "id": "f0024cf2-8e70-44b3-8415-0f36d4d25db4",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "HealthState",
-                  "label": "Health State",
-                  "type": 2,
-                  "isRequired": true,
-                  "multiSelect": true,
-                  "quote": "'",
-                  "delimiter": ",",
-                  "typeSettings": {
-                    "additionalResourceOptions": [
-                      "value::all"
+                  "type": 1,
+                  "content": {
+                    "json": "## Health Legend\r\n#### Healthy:\r\nHealthy Virtual Machines have **all of the following** ASR rules configured in 'block' mode:\r\n\r\nScripting Threats:\r\n- Block JavaScript or VBScript from launching downloaded executable content.\r\n- Block execution of potentially obfuscated scripts.\r\n\r\nEmail Threats:\r\n- Block executable content from email client and webmail.\r\n\r\nOffice Threats:\r\n- Block Office application from creating child processes.\r\n- Block Office applications from creating executable content.\r\n- Block Office applications from injecting code into other processes.\r\n- Block Adobe Reader from creating child processes.\r\n\r\n#### Unhealthy:\r\nUnhealthy Virtual Machines have **at least one** of the above ASR rules not configured in 'block' mode.",
+                    "style": "success"
+                  },
+                  "name": "text - 1"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "## Virtual Machines Health: Summary"
+                  },
+                  "name": "text - 8"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "DeviceTvmSecureConfigurationAssessment\r\n//| where OSPlatform != \"Linux\" //exclude Linux machines\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // Block executable content from email client and webmail\r\n    \"scid-2501\",    // Block Office applications from creating child processes\r\n    \"scid-2502\",    // Block Office applications from creating executable content\r\n    \"scid-2503\",    // Block Office applications from injecting code into other processes\r\n    \"scid-2504\",    // Block JavaScript or VBScript from launching downloaded executable content\r\n    \"scid-2505\",    // Block execution of potentially obfuscated scripts\r\n    \"scid-2513\"    // Block Adobe Reader from creating child processes\r\n)\r\n| extend Setting = tostring(Context[0].Unknown1)\r\n| where Setting != \"Unknown\"\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| project-rename\r\n    ExecutableEmailContent = [\"scid-2500\"],\r\n    OfficeChildProcess = [\"scid-2501\"],\r\n    ExecutableOfficeContent = [\"scid-2502\"],\r\n    OfficeProcessInjection = [\"scid-2503\"],\r\n    ScriptExecutableDownload = [\"scid-2504\"],\r\n    ObfuscatedScript = [\"scid-2505\"],\r\n    AdobeReaderChildProcess = [\"scid-2513\"]\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ExecutableOfficeContent in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeProcessInjection in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ScriptExecutableDownload in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ObfuscatedScript in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AdobeReaderChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| summarize count = dcount(DeviceId) by Compliant",
+                    "size": 3,
+                    "timeContextFromParameter": "TimeRange",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "crossComponentResources": [
+                      "{Workspace}"
                     ],
-                    "showDefault": false
-                  },
-                  "jsonData": "[\"Healthy\", \"Unhealthy\"]",
-                  "timeContext": {
-                    "durationMs": 86400000
-                  },
-                  "defaultValue": "value::all",
-                  "value": [
-                    "Healthy"
-                  ]
-                }
-              ],
-              "style": "pills",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces"
-            },
-            "name": "parameters - 9"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "DeviceTvmSecureConfigurationAssessment\r\n//| where OSPlatform != \"Linux\" //exclude Linux machines\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // Block executable content from email client and webmail\r\n    \"scid-2501\",    // Block Office applications from creating child processes\r\n    \"scid-2502\",    // Block Office applications from creating executable content\r\n    \"scid-2503\",    // Block Office applications from injecting code into other processes\r\n    \"scid-2504\",    // Block JavaScript or VBScript from launching downloaded executable content\r\n    \"scid-2505\",    // Block execution of potentially obfuscated scripts\r\n    \"scid-2513\"    // Block Adobe Reader from creating child processes\r\n)\r\n| extend Setting = tostring(Context[0].Unknown1)\r\n| where Setting != \"Unknown\"\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| project-rename\r\n    ExecutableEmailContent = [\"scid-2500\"],\r\n    OfficeChildProcess = [\"scid-2501\"],\r\n    ExecutableOfficeContent = [\"scid-2502\"],\r\n    OfficeProcessInjection = [\"scid-2503\"],\r\n    ScriptExecutableDownload = [\"scid-2504\"],\r\n    ObfuscatedScript = [\"scid-2505\"],\r\n    AdobeReaderChildProcess = [\"scid-2513\"]\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ExecutableOfficeContent in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeProcessInjection in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ScriptExecutableDownload in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ObfuscatedScript in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AdobeReaderChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| where Compliant in~ ({HealthState})\r\n| project-reorder DeviceName, DeviceId, Compliant, max_Timestamp\r\n| order by DeviceName asc, DeviceId asc",
-              "size": 0,
-              "timeContextFromParameter": "TimeRange",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
-              "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "Compliant",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "colors",
-                      "thresholdsGrid": [
+                    "visualization": "piechart",
+                    "chartSettings": {
+                      "seriesLabelSettings": [
                         {
-                          "operator": "==",
-                          "thresholdValue": "Healthy",
-                          "representation": "green",
-                          "text": "{0}{1}"
+                          "seriesName": "Unhealthy",
+                          "color": "red"
                         },
                         {
-                          "operator": "==",
-                          "thresholdValue": "Unhealthy",
-                          "representation": "red",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "gray",
-                          "text": "{0}{1}"
+                          "seriesName": "Healthy",
+                          "color": "green"
                         }
                       ]
                     }
                   },
-                  {
-                    "columnMatch": "ExecutableEmailContent",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "OfficeChildProcess",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "ExecutableOfficeContent",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "OfficeProcessInjection",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "ScriptExecutableDownload",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "ObfuscatedScript",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "columnMatch": "AdobeReaderChildProcess",
-                    "formatter": 18,
-                    "formatOptions": {
-                      "thresholdsOptions": "icons",
-                      "thresholdsGrid": [
-                        {
-                          "operator": "==",
-                          "thresholdValue": "Block",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "==",
-                          "thresholdValue": "NA",
-                          "representation": "success",
-                          "text": "{0}{1}"
-                        },
-                        {
-                          "operator": "Default",
-                          "thresholdValue": null,
-                          "representation": "critical",
-                          "text": "{0}{1}"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "sortBy": [
-                  {
-                    "itemKey": "OSPlatform",
-                    "sortOrder": 1
-                  }
-                ],
-                "labelSettings": [
-                  {
-                    "columnId": "DeviceName",
-                    "label": "Resource"
-                  },
-                  {
-                    "columnId": "Compliant",
-                    "label": "Health State"
-                  },
-                  {
-                    "columnId": "max_Timestamp",
-                    "label": "Timestamp"
-                  },
-                  {
-                    "columnId": "OSPlatform",
-                    "label": "OS Platform"
-                  }
-                ]
-              },
-              "sortBy": [
+                  "name": "query - 9"
+                },
                 {
-                  "itemKey": "OSPlatform",
-                  "sortOrder": 1
+                  "type": 1,
+                  "content": {
+                    "json": "## Virtual Machines Health: Details\r\nSee below for description of Configuration items."
+                  },
+                  "name": "text - 10"
+                },
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "f0024cf2-8e70-44b3-8415-0f36d4d25db4",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "HealthState",
+                        "label": "Health State",
+                        "type": 2,
+                        "isRequired": true,
+                        "multiSelect": true,
+                        "quote": "'",
+                        "delimiter": ",",
+                        "typeSettings": {
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
+                          "showDefault": false
+                        },
+                        "jsonData": "[\"Healthy\", \"Unhealthy\"]",
+                        "timeContext": {
+                          "durationMs": 86400000
+                        },
+                        "defaultValue": "value::all",
+                        "value": [
+                          "Healthy"
+                        ]
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces"
+                  },
+                  "name": "parameters - 9"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "DeviceTvmSecureConfigurationAssessment\r\n//| where OSPlatform != \"Linux\" //exclude Linux machines\r\n| where ConfigurationId in (\r\n    \"scid-2500\",    // Block executable content from email client and webmail\r\n    \"scid-2501\",    // Block Office applications from creating child processes\r\n    \"scid-2502\",    // Block Office applications from creating executable content\r\n    \"scid-2503\",    // Block Office applications from injecting code into other processes\r\n    \"scid-2504\",    // Block JavaScript or VBScript from launching downloaded executable content\r\n    \"scid-2505\",    // Block execution of potentially obfuscated scripts\r\n    \"scid-2513\"    // Block Adobe Reader from creating child processes\r\n)\r\n| extend Setting = tostring(Context[0].Unknown1)\r\n| where Setting != \"Unknown\"\r\n| extend Setting = iff(IsApplicable == false, \"NA\", Setting)\r\n| summarize arg_max(Timestamp, Setting) by DeviceId, DeviceName, OSPlatform, ConfigurationId\r\n| summarize make_bag(pack(ConfigurationId, Setting)), max(Timestamp) by DeviceId, DeviceName, OSPlatform\r\n| evaluate bag_unpack(bag_)\r\n| project-rename\r\n    ExecutableEmailContent = [\"scid-2500\"],\r\n    OfficeChildProcess = [\"scid-2501\"],\r\n    ExecutableOfficeContent = [\"scid-2502\"],\r\n    OfficeProcessInjection = [\"scid-2503\"],\r\n    ScriptExecutableDownload = [\"scid-2504\"],\r\n    ObfuscatedScript = [\"scid-2505\"],\r\n    AdobeReaderChildProcess = [\"scid-2513\"]\r\n// assess compliance\r\n| extend Compliant = iff(ExecutableEmailContent in~ (\"Block\", \"NA\"), \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ExecutableOfficeContent in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(OfficeProcessInjection in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ScriptExecutableDownload in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(ObfuscatedScript in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| extend Compliant = iff(AdobeReaderChildProcess in~ (\"Block\", \"NA\") and Compliant == \"Healthy\", \"Healthy\", \"Unhealthy\")\r\n| where Compliant in~ ({HealthState})\r\n| project-reorder DeviceName, DeviceId, Compliant, max_Timestamp\r\n| order by DeviceName asc, DeviceId asc",
+                    "size": 0,
+                    "timeContextFromParameter": "TimeRange",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "crossComponentResources": [
+                      "{Workspace}"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Compliant",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Healthy",
+                                "representation": "green",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Unhealthy",
+                                "representation": "red",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "gray",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ExecutableEmailContent",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OfficeChildProcess",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ExecutableOfficeContent",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OfficeProcessInjection",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ScriptExecutableDownload",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "ObfuscatedScript",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "AdobeReaderChildProcess",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Block",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "==",
+                                "thresholdValue": "NA",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "critical",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "sortBy": [
+                        {
+                          "itemKey": "OSPlatform",
+                          "sortOrder": 1
+                        }
+                      ],
+                      "labelSettings": [
+                        {
+                          "columnId": "DeviceName",
+                          "label": "Resource"
+                        },
+                        {
+                          "columnId": "Compliant",
+                          "label": "Health State"
+                        },
+                        {
+                          "columnId": "max_Timestamp",
+                          "label": "Timestamp"
+                        },
+                        {
+                          "columnId": "OSPlatform",
+                          "label": "OS Platform"
+                        }
+                      ]
+                    },
+                    "sortBy": [
+                      {
+                        "itemKey": "OSPlatform",
+                        "sortOrder": 1
+                      }
+                    ]
+                  },
+                  "name": "query - 8"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "## Supporting information: Description of configuration items "
+                  },
+                  "name": "text - 14"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "DeviceTvmSecureConfigurationAssessmentKB_CL\r\n| where ConfigurationId_s in (\"scid-2500\", \"scid-2501\", \"scid-2502\", \"scid-2503\", \"scid-2504\", \"scid-2505\", \"scid-2513\")\r\n| extend Config = case(\r\n    ConfigurationId_s == \"scid-2500\", \"ExecutableEmailContent\",\r\n    ConfigurationId_s == \"scid-2501\", \"OfficeChildProcess\",\r\n    ConfigurationId_s == \"scid-2502\", \"ExecutableOfficeContent\",\r\n    ConfigurationId_s == \"scid-2503\", \"OfficeProcessInjection\",\r\n    ConfigurationId_s == \"scid-2504\", \"ScriptExecutableDownload\",\r\n    ConfigurationId_s == \"scid-2505\", \"ObfuscatedScript\",\r\n    ConfigurationId_s == \"scid-2513\", \"AdobeReaderChildProcess\",\r\n    \"Error\"\r\n)\r\n| summarize arg_max(TimeGenerated, *) by ConfigurationId_s\r\n| parse ConfigurationDescription_s with * \"<a href=\\\"\" DocLink \"\\\" target=\\\"_blank\\\">ASR rule</a> \" ConfigurationDescription\r\n| extend ConfigurationDescription = strcat(\"This ASR rule \", ConfigurationDescription)\r\n| extend ConfigurationDescription = replace_string(ConfigurationDescription, \"<br/>\", \" \")\r\n| project Config, ConfigurationName_s, ConfigurationDescription, RiskDescription_s, ConfigurationId_s, DocLink\r\n| order by ConfigurationId_s asc",
+                    "size": 0,
+                    "timeContext": {
+                      "durationMs": 2592000000
+                    },
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "crossComponentResources": [
+                      "{Workspace}"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Config",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "15%"
+                          }
+                        },
+                        {
+                          "columnMatch": "ConfigurationName_s",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "25%"
+                          }
+                        },
+                        {
+                          "columnMatch": "ConfigurationDescription",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "25%"
+                          }
+                        },
+                        {
+                          "columnMatch": "RiskDescription_s",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "25%"
+                          }
+                        },
+                        {
+                          "columnMatch": "ConfigurationId_s",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "5%"
+                          }
+                        },
+                        {
+                          "columnMatch": "DocLink",
+                          "formatter": 7,
+                          "formatOptions": {
+                            "linkTarget": "Url",
+                            "linkLabel": "Link",
+                            "customColumnWidthSetting": "5%"
+                          }
+                        }
+                      ],
+                      "labelSettings": [
+                        {
+                          "columnId": "Config",
+                          "label": "Configuration Item"
+                        },
+                        {
+                          "columnId": "ConfigurationName_s",
+                          "label": "Configuration Name"
+                        },
+                        {
+                          "columnId": "ConfigurationDescription",
+                          "label": "Configuration Description"
+                        },
+                        {
+                          "columnId": "RiskDescription_s",
+                          "label": "Risk Description"
+                        },
+                        {
+                          "columnId": "ConfigurationId_s",
+                          "label": "Config Id"
+                        },
+                        {
+                          "columnId": "DocLink",
+                          "label": "Link"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "query - 13"
                 }
               ]
             },
-            "name": "query - 8"
+            "conditionalVisibility": {
+              "parameterName": "tvmExists",
+              "comparison": "isEqualTo",
+              "value": "True"
+            },
+            "name": "group - 9"
           },
           {
             "type": 1,
             "content": {
-              "json": "## Supporting information: Description of configuration items "
+              "json": "## Please make sure that you have selected the appropriate Sentinel workspace from the drop-down parameter above.\r\n\r\n### If you still see this message, it is because this strategy relies on data only available through a Microsoft Sentinel private preview feature.  \r\n### To see this strategy, and to provide feedback on this and other private preview features for Microsoft Sentinel and other Microsoft security products, join our Customer Connection Program.  \r\n### [Learn more here](https://techcommunity.microsoft.com/t5/security-compliance-and-identity/how-microsoft-security-wants-to-help-you-take-your-fandom-and/ba-p/3745057) or fill out the [form](https://www.aka.ms/JoinCCP) to join.",
+              "style": "warning"
             },
-            "name": "text - 14"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "DeviceTvmSecureConfigurationAssessmentKB_CL\r\n| where ConfigurationId_s in (\"scid-2500\", \"scid-2501\", \"scid-2502\", \"scid-2503\", \"scid-2504\", \"scid-2505\", \"scid-2513\")\r\n| extend Config = case(\r\n    ConfigurationId_s == \"scid-2500\", \"ExecutableEmailContent\",\r\n    ConfigurationId_s == \"scid-2501\", \"OfficeChildProcess\",\r\n    ConfigurationId_s == \"scid-2502\", \"ExecutableOfficeContent\",\r\n    ConfigurationId_s == \"scid-2503\", \"OfficeProcessInjection\",\r\n    ConfigurationId_s == \"scid-2504\", \"ScriptExecutableDownload\",\r\n    ConfigurationId_s == \"scid-2505\", \"ObfuscatedScript\",\r\n    ConfigurationId_s == \"scid-2513\", \"AdobeReaderChildProcess\",\r\n    \"Error\"\r\n)\r\n| summarize arg_max(TimeGenerated, *) by ConfigurationId_s\r\n| parse ConfigurationDescription_s with * \"<a href=\\\"\" DocLink \"\\\" target=\\\"_blank\\\">ASR rule</a> \" ConfigurationDescription\r\n| extend ConfigurationDescription = strcat(\"This ASR rule \", ConfigurationDescription)\r\n| extend ConfigurationDescription = replace_string(ConfigurationDescription, \"<br/>\", \" \")\r\n| project Config, ConfigurationName_s, ConfigurationDescription, RiskDescription_s, ConfigurationId_s, DocLink\r\n| order by ConfigurationId_s asc",
-              "size": 0,
-              "timeContext": {
-                "durationMs": 2592000000
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "ap hardening"
               },
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
-              "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "Config",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "15%"
-                    }
-                  },
-                  {
-                    "columnMatch": "ConfigurationName_s",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "25%"
-                    }
-                  },
-                  {
-                    "columnMatch": "ConfigurationDescription",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "25%"
-                    }
-                  },
-                  {
-                    "columnMatch": "RiskDescription_s",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "25%"
-                    }
-                  },
-                  {
-                    "columnMatch": "ConfigurationId_s",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "5%"
-                    }
-                  },
-                  {
-                    "columnMatch": "DocLink",
-                    "formatter": 7,
-                    "formatOptions": {
-                      "linkTarget": "Url",
-                      "linkLabel": "Link",
-                      "customColumnWidthSetting": "5%"
-                    }
-                  }
-                ],
-                "labelSettings": [
-                  {
-                    "columnId": "Config",
-                    "label": "Configuration Item"
-                  },
-                  {
-                    "columnId": "ConfigurationName_s",
-                    "label": "Configuration Name"
-                  },
-                  {
-                    "columnId": "ConfigurationDescription",
-                    "label": "Configuration Description"
-                  },
-                  {
-                    "columnId": "RiskDescription_s",
-                    "label": "Risk Description"
-                  },
-                  {
-                    "columnId": "ConfigurationId_s",
-                    "label": "Config Id"
-                  },
-                  {
-                    "columnId": "DocLink",
-                    "label": "Link"
-                  }
-                ]
+              {
+                "parameterName": "tvmExists",
+                "comparison": "isEqualTo",
+                "value": "False"
               }
-            },
-            "name": "query - 13"
+            ],
+            "name": "text - 2"
           }
         ]
       },
@@ -3454,11 +3556,18 @@
                 }
               ]
             },
-            "conditionalVisibility": {
-              "parameterName": "Tab",
-              "comparison": "isEqualTo",
-              "value": "General"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "General"
+              },
+              {
+                "parameterName": "tvmExists",
+                "comparison": "isEqualTo",
+                "value": "True"
+              }
+            ],
             "name": "group - 12"
           }
         ]
@@ -3474,7 +3583,7 @@
       }
     }
   ],
-  "fallbackResourceIds": [],  
-  "fromTemplateId": "sentinel-AcscEssential8Workbook",
+  "fallbackResourceIds": [],
+  "fromTemplateId": "sentinel-UserWorkbook",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/AcscEssential8.json
+++ b/Workbooks/AcscEssential8.json
@@ -3584,6 +3584,6 @@
     }
   ],
   "fallbackResourceIds": [],
-  "fromTemplateId": "sentinel-UserWorkbook",
+  "fromTemplateId": "sentinel-AcscEssential8",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/AcscEssential8.json
+++ b/Workbooks/AcscEssential8.json
@@ -89,6 +89,138 @@
         "version": "KqlParameterItem/1.0",
         "parameters": [
           {
+            "id": "cba48574-e67b-4daa-8cb8-526fc4d7e963",
+            "version": "KqlParameterItem/1.0",
+            "name": "hideSubscription",
+            "type": 1,
+            "isRequired": true,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "app control",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "macros",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "ap hardening",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "resultValType": "static",
+                  "resultVal": "False"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 86400000
+            }
+          },
+          {
+            "id": "1f7fb3a4-59af-4d6b-bc39-6d8adffcbc1b",
+            "version": "KqlParameterItem/1.0",
+            "name": "hideWorkspace",
+            "type": 1,
+            "isRequired": true,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "patch apps",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "admin priv",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "patch OS",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "MFA",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "Tab",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "backups",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "resultValType": "static",
+                  "resultVal": "False"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 86400000
+            }
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 15"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
             "id": "e6ded9a1-a83c-4762-938d-5bf8ff3d3d38",
             "version": "KqlParameterItem/1.0",
             "name": "Subscription",
@@ -113,6 +245,11 @@
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "hideSubscription",
+        "comparison": "isEqualTo",
+        "value": "False"
       },
       "customWidth": "33",
       "name": "parameters - 10"
@@ -201,6 +338,11 @@
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "hideWorkspace",
+        "comparison": "isEqualTo",
+        "value": "False"
       },
       "customWidth": "50",
       "name": "parameters - 8"

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -2302,7 +2302,7 @@
       "dataTypesDependencies": [ "DeviceTvmSecureConfigurationAssessment" ],
       "dataConnectorsDependencies": [],
       "previewImagesFileNames": [ "AcscEssential8Black1.png", "AcscEssential8White1.png", "AcscEssential8Black2.png", "AcscEssential8White2.png" ],
-      "version": "1.2.1",
+      "version": "1.3.0",
       "title": "ACSC Essential 8",
       "templateRelativePath": "AcscEssential8.json",
       "subtitle": "",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -2302,7 +2302,7 @@
       "dataTypesDependencies": [ "DeviceTvmSecureConfigurationAssessment" ],
       "dataConnectorsDependencies": [],
       "previewImagesFileNames": [ "AcscEssential8Black1.png", "AcscEssential8White1.png", "AcscEssential8Black2.png", "AcscEssential8White2.png" ],
-      "version": "1.3.0",
+      "version": "1.0.0",
       "title": "ACSC Essential 8",
       "templateRelativePath": "AcscEssential8.json",
       "subtitle": "",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -2302,7 +2302,7 @@
       "dataTypesDependencies": [ "DeviceTvmSecureConfigurationAssessment" ],
       "dataConnectorsDependencies": [],
       "previewImagesFileNames": [ "AcscEssential8Black1.png", "AcscEssential8White1.png", "AcscEssential8Black2.png", "AcscEssential8White2.png" ],
-      "version": "1.0.1",
+      "version": "1.0.2",
       "title": "ACSC Essential 8",
       "templateRelativePath": "AcscEssential8.json",
       "subtitle": "",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -2302,7 +2302,7 @@
       "dataTypesDependencies": [ "DeviceTvmSecureConfigurationAssessment" ],
       "dataConnectorsDependencies": [],
       "previewImagesFileNames": [ "AcscEssential8Black1.png", "AcscEssential8White1.png", "AcscEssential8Black2.png", "AcscEssential8White2.png" ],
-      "version": "1.2.0",
+      "version": "1.2.1",
       "title": "ACSC Essential 8",
       "templateRelativePath": "AcscEssential8.json",
       "subtitle": "",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -2302,7 +2302,7 @@
       "dataTypesDependencies": [ "DeviceTvmSecureConfigurationAssessment" ],
       "dataConnectorsDependencies": [],
       "previewImagesFileNames": [ "AcscEssential8Black1.png", "AcscEssential8White1.png", "AcscEssential8Black2.png", "AcscEssential8White2.png" ],
-      "version": "1.0.0",
+      "version": "1.0.1",
       "title": "ACSC Essential 8",
       "templateRelativePath": "AcscEssential8.json",
       "subtitle": "",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -2302,7 +2302,7 @@
       "dataTypesDependencies": [ "DeviceTvmSecureConfigurationAssessment" ],
       "dataConnectorsDependencies": [],
       "previewImagesFileNames": [ "AcscEssential8Black1.png", "AcscEssential8White1.png", "AcscEssential8Black2.png", "AcscEssential8White2.png" ],
-      "version": "1.0.2",
+      "version": "1.2.0",
       "title": "ACSC Essential 8",
       "templateRelativePath": "AcscEssential8.json",
       "subtitle": "",


### PR DESCRIPTION
   Change(s):
   - Updated workbook to hide query results if required tables don't exist

   Reason for Change(s):
   - Users can join private preview (instructions provided) to see reports that rely on TVM data in Sentinel
   - if they haven't joined private preview, the corresponding queries that would otherwise throw errors are hidden

   Version updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
