### PR TITLE
Fixed the incorrect URL

### DIFF
--- a/Solutions/ProofPointTap/Data Connectors/azuredeploy_ProofpointTAP_API_FunctionApp.json
+++ b/Solutions/ProofPointTap/Data Connectors/azuredeploy_ProofpointTAP_API_FunctionApp.json
@@ -181,7 +181,7 @@
                           "apiPassword": "[parameters('APIPassword')]",
                           "uri": "[parameters('Uri')]",
                           "logAnalyticsUri": "[variables('LogAnaltyicsUri')]",
-                          "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinelproofpointtapazurefunctionzip"
+                          "WEBSITE_RUN_FROM_PACKAGE": "https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/ProofPointTap/Data%20Connectors/AzureFunctionProofpointTAP.zip?raw=true"
                                    } 
                   }
               ]


### PR DESCRIPTION
The Proofpoint TAP ARM template has incorrect URL.  

**Current Path**: https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/Proofpoint%20TAP/AzureFunctionProofpointTAP.zip?raw=true 🛑 
**Expected Path**: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/ProofPointTap/Data%20Connectors/AzureFunctionProofpointTAP.zip?raw=true ✅

   Required items, please complete
   
   Change(s):
   - Updated the new URL for a package

   Reason for Change(s):
   - Incorrect URL

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - Tested in my local Sentinel environment by adding Proofpoint TAP connector

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


