### PR TITLE
Increased bin to 10m and fixed deprecated commands

### DIFF
--- a/Solutions/Windows Security Events/Analytic Rules/MultipleFailedFollowedBySuccess.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/MultipleFailedFollowedBySuccess.yaml
@@ -29,11 +29,11 @@ query: |
     let authenticationThreshold = 5;
     SecurityEvent
     | where TimeGenerated > ago(timeRange)
-    | where EventID == 4624 or EventID == 4625
+    | where EventID in (4624, 4625)
     | where IpAddress != "-" and isnotempty(Account)
     | extend Outcome = iff(EventID == 4624, "Success", "Failure")
-    // bin outcomes into 5 minute windows to reduce the volume of data
-    | summarize OutcomeCount=count() by Account, IpAddress, Computer, Outcome, bin(TimeGenerated, 5m)
+    // bin outcomes into 10 minute windows to reduce the volume of data
+    | summarize OutcomeCount=count() by bin(TimeGenerated, 10m), Account, IpAddress, Computer, Outcome
     | project TimeGenerated, Account, IpAddress, Computer, Outcome, OutcomeCount
     // sort ready for sessionizing - by account and time of the authentication outcome
     | sort by Account asc, TimeGenerated asc
@@ -41,7 +41,7 @@ query: |
     // sessionize into failure groupings until either the account changes or there is a success
     | extend SessionStartedUtc = row_window_session(TimeGenerated, timeRange, authenticationWindow, Account != prev(Account) or prev(Outcome) == "Success")
     // count the failures in each session
-    | summarize FailureCountBeforeSuccess=sumif(OutcomeCount, Outcome == "Failure"), StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), makelist(Outcome), makeset(Computer), makeset(IpAddress) by SessionStartedUtc, Account
+    | summarize FailureCountBeforeSuccess=sumif(OutcomeCount, Outcome == "Failure"), StartTime=min(TimeGenerated), EndTime=max(TimeGenerated), make_list(Outcome,50), make_set(Computer,50), make_set(IpAddress,50) by SessionStartedUtc, Account
     // the session must not start with a success, and must end with one
     | where array_index_of(list_Outcome, "Success") != 0
     | where array_index_of(list_Outcome, "Success") == array_length(list_Outcome) - 1
@@ -49,7 +49,7 @@ query: |
     // where the number of failures before the success is above the threshold
     | where FailureCountBeforeSuccess >= authenticationThreshold
     // expand out ip and computer for customer entity assignment
-    | mvexpand set_IpAddress, set_Computer
+    | mv-expand set_IpAddress, set_Computer
     | extend IpAddress = tostring(set_IpAddress), Computer = tostring(set_Computer)
     | extend timestamp=StartTime, AccountCustomEntity=Account, HostCustomEntity=Computer, IPCustomEntity=IpAddress
 entityMappings:
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/MultipleFailedFollowedBySuccess.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/MultipleFailedFollowedBySuccess.yaml
@@ -4,7 +4,7 @@ description: |
   'Identifies accounts who have failed to logon to the domain multiple times in a row, followed by a successful authentication
   within a short time frame. Multiple failed attempts followed by a success can be an indication of a brute force attempt or
   possible mis-configuration of a service account within an environment.
-  The lookback is set to 6h and the authentication window and threshold are set to 1h and 5, meaning we need to see a minimum
+  The lookback is set to 2h and the authentication window and threshold are set to 1h and 5, meaning we need to see a minimum
   of 5 failures followed by a success for an account within 1 hour to surface an alert.'
 severity: Low
 requiredDataConnectors:
@@ -14,8 +14,8 @@ requiredDataConnectors:
   - connectorId: WindowsSecurityEvents
     dataTypes:
       - SecurityEvent
-queryFrequency: 6h
-queryPeriod: 6h
+queryFrequency: 2h
+queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0
 status: Available
@@ -24,7 +24,7 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-    let timeRange = 6h;
+    let timeRange = 2h;
     let authenticationWindow = 1h;
     let authenticationThreshold = 5;
     SecurityEvent
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
Increased bin outcomes from 5 to 10 minutes to reduce even more the volume of data Fixed deprecated commands:
- makeset to make_set
- makelist to make_list
- mvexpand to mv-expand

   Change(s):
   - Increased bin to 10m 
   - fixed deprecated commands

   Reason for Change(s):
   - Increased bin outcomes from 5 to 10 minutes to reduce even more the volume of data Fixed deprecated commands:
   - replaced makeset with make_set and limit
   - replaced makelist with make_list and limit
   - replaced mvexpand with mv-expand

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes