### PR TITLE
Update ssh_potentialBruteForce.yaml

### DIFF
--- a/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
+++ b/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
@@ -24,14 +24,15 @@ query: |
   | parse kind=relaxed SyslogMessage with * "invalid user " user " from " ip " port" port " ssh2" *
   // using distinct below as it has been seen that Syslog can duplicate entries depending on implementation
   | distinct TimeGenerated, Computer, user, ip, port, SyslogMessage, _ResourceId
-  | summarize EventTimes = make_list(TimeGenerated), PerHourCount = count() by bin(TimeGenerated,4h), ip, Computer, user
+  | summarize EventTimes = make_list(TimeGenerated), PerHourCount = count() by bin(TimeGenerated,4h), ip, Computer, user, _ResourceId
   | where PerHourCount > threshold
   | mvexpand EventTimes
   | extend EventTimes = tostring(EventTimes) 
-  | summarize StartTime = min(EventTimes), EndTime = max(EventTimes), UserList = makeset(user), ComputerList = makeset(Computer), sum(PerHourCount) by IPAddress = ip
+  | summarize StartTime = min(EventTimes), EndTime = max(EventTimes), UserList = make_set(user), ComputerList = make_set(Computer), ResourceIdList = make_set(_ResourceId), sum(PerHourCount) by IPAddress = ip
   // bringing through single computer and user if array only has 1, otherwise, referencing the column and hashing the ComputerList or UserList so we don't get accidental entity matches when reviewing alerts
   | extend HostName = iff(array_length(ComputerList) == 1, tostring(ComputerList[0]), strcat("SeeComputerListField","_", tostring(hash(tostring(ComputerList)))))
   | extend Account = iff(array_length(ComputerList) == 1, tostring(UserList[0]), strcat("SeeUserListField","_", tostring(hash(tostring(UserList)))))
+  | extend ResourceId = iff(array_length(ResourceIdList) == 1, tostring(ResourceIdList[0]), strcat("SeeResourceIdListField","_", tostring(hash(tostring(ResourceIdList)))))
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -45,5 +46,9 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: HostName
+  - entityType: Azure resource
+    fieldMappings:
+      - identifier: ResourceId
+        columnName: ResourceId
 version: 1.1.0
 kind: Scheduled

--- a/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
+++ b/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
@@ -1,7 +1,12 @@
 id: e1ce0eab-10d1-4aae-863f-9a383345ba88
 name: SSH - Potential Brute Force
 description: |
-  'Identifies an IP address that had 15 failed attempts to sign in via SSH in a 4 hour block during a 24 hour time period.'
+  'Identifies an IP address that had 15 failed attempts to sign in via SSH in a 4 hour block during a 24 hour time period.
+   Please note that entity mapping for arrays is not supported, so when there is a single value in an array, we will pull that
+   value from the array as a single string to populate the entity to support entity mapping features within Sentinel. Additionally,
+   if the array is multivalued, we will input a string to indicate this with a unique hash so that matching will not occur.
+   As an example - ComputerList is an array that we check for a single value and write that into the HostName field for use in 
+   the entity mapping within Sentinel.'
 severity: Low
 requiredDataConnectors:
   - connectorId: Syslog

--- a/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
+++ b/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
@@ -21,23 +21,29 @@ query: |
   Syslog
   | where ProcessName =~ "sshd" 
   | where SyslogMessage contains "Failed password for invalid user"
-  | parse kind=relaxed SyslogMessage with * "invalid user" user " from " ip " port" port " ssh2"
-  | project user, ip, port, SyslogMessage, EventTime
-  | summarize EventTimes = make_list(EventTime), PerHourCount = count() by ip, bin(EventTime, 4h), user
+  | parse kind=relaxed SyslogMessage with * "invalid user " user " from " ip " port" port " ssh2" *
+  // using distinct below as it has been seen that Syslog can duplicate entries depending on implementation
+  | distinct TimeGenerated, Computer, user, ip, port, SyslogMessage, _ResourceId
+  | summarize EventTimes = make_list(TimeGenerated), PerHourCount = count() by bin(TimeGenerated,4h), ip, Computer, user
   | where PerHourCount > threshold
   | mvexpand EventTimes
   | extend EventTimes = tostring(EventTimes) 
-  | summarize StartTimeUtc = min(EventTimes), EndTimeUtc = max(EventTimes), UserList = makeset(user), sum(PerHourCount) by IPAddress = ip
-  | extend UserList = tostring(UserList) 
-  | extend timestamp = StartTimeUtc, IPCustomEntity = IPAddress, AccountCustomEntity = UserList
+  | summarize StartTime = min(EventTimes), EndTime = max(EventTimes), UserList = makeset(user), ComputerList = makeset(Computer), sum(PerHourCount) by IPAddress = ip
+  // bringing through single computer and user if array only has 1, otherwise, referencing the column and hashing the ComputerList or UserList so we don't get accidental entity matches when reviewing alerts
+  | extend HostName = iff(array_length(ComputerList) == 1, tostring(ComputerList[0]), strcat("SeeComputerListField","_", tostring(hash(tostring(ComputerList)))))
+  | extend Account = iff(array_length(ComputerList) == 1, tostring(UserList[0]), strcat("SeeUserListField","_", tostring(hash(tostring(UserList)))))
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Account
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IPAddress
+  - entityType: Host
+    fieldMappings:
+      - identifier: Name
+        columnName: HostName
+version: 1.1.0
 kind: Scheduled


### PR DESCRIPTION
   
   Change(s):
   - Changed from EventTime to TimeGenerated
   - Added Computer and _ResourceId to output
   - Fixed regex parse from SyslogMessage as it would fail if there were characters after ssh2
   - Fixed regex parse from SyslogMessage as it was leaving the space in front of user
   - Added distinct to reduce duplicate rows
   - Removed legacy entity mappings and time field names with UTC at end
   - added single account and host outputs when array has only 1 value

   Reason for Change(s):
   - high alert counts in some situations
   - EventTime does have detail level to seconds which is causing duplicates
   - regex not parsing user out of SyslogMessage if it ends with characters right after ssh2
   - duplicate rows depending on how Syslog is implemented
   - if array only has single value, it can be used for entity mapping
   - ResourceId can be used for entity mapping

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes