### PR TITLE
Update SharePoint_Downloads_byNewUserAgent.yaml

### DIFF
--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewUserAgent.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewUserAgent.yaml
@@ -10,7 +10,7 @@ requiredDataConnectors:
     dataTypes:
       - OfficeActivity
 queryFrequency: 1d
-queryPeriod: 14d
+queryPeriod: 8d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -21,7 +21,7 @@ query: |
   let threshold = 5;
   let szSharePointFileOperation = "SharePointFileOperation";
   let szOperations = dynamic(["FileDownloaded", "FileUploaded"]);
-  let starttime = 14d;
+  let starttime = 8d;
   let endtime = 1d;
   let historicalActivity =
   OfficeActivity
@@ -31,11 +31,11 @@ query: |
   | where isnotempty(UserAgent)
   | summarize historicalCount = count() by UserAgent, RecordType, Operation;
   let recentActivity = OfficeActivity
+  | where TimeGenerated > ago(endtime)
   | where RecordType =~ szSharePointFileOperation
   | where Operation in~ (szOperations)
-  | where TimeGenerated > ago(endtime)
   | where isnotempty(UserAgent)
-  | summarize min(Start_Time), max(Start_Time), recentCount = count() by UserAgent, RecordType, Operation;
+  | summarize recentCount = count() by UserAgent, RecordType, Operation;
   let RareUserAgent = recentActivity | join kind = leftanti (historicalActivity) on UserAgent
   | order by recentCount desc, UserAgent
   // More than 5 downloads/uploads from a new user agent today
@@ -47,23 +47,26 @@ query: |
   | where isnotempty(UserAgent)
   | join kind= inner (RareUserAgent)
   on UserAgent, RecordType, Operation
-  | where Start_Time between(min_Start_Time .. max_Start_Time)
-  | summarize StartTimeUtc = min(min_Start_Time), EndTimeUtc = max(max_Start_Time) by RecordType, Operation, UserAgent, UserType, UserId, ClientIP, OfficeWorkload, Site_Url, OfficeObjectId, UserAgentSeenCount = recentCount
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
-  | order by UserAgentSeenCount desc, UserAgent asc, Operation asc, UserId asc
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OfficeObjectIdCount = dcount(OfficeObjectId), OfficeObjectIdList = make_list(OfficeObjectId) 
+  by RecordType, Operation, UserAgent, UserType, UserId, ClientIP, OfficeWorkload, Site_Url, UserAgentSeenCount = recentCount
+  | extend UserIdName = tostring(split(UserId, '@')[0]), UserIdUPNSuffix = tostring(split(UserId, '@')[1])
+  | project-reorder StartTime, EndTime, UserAgent, UserAgentSeenCount, UserId, ClientIP, Site_Url
+  | order by UserAgentSeenCount desc, UserAgent asc, UserId asc, Site_Url asc
 
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: UserIdName
+      - identifier: UPNSuffix
+        columnName: UserIdName
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: URLCustomEntity
-version: 2.0.1
+        columnName: Site_Url
+version: 2.2.0
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewUserAgent.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewUserAgent.yaml
@@ -47,7 +47,7 @@ query: |
   | where isnotempty(UserAgent)
   | join kind= inner (RareUserAgent)
   on UserAgent, RecordType, Operation
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OfficeObjectIdCount = dcount(OfficeObjectId), OfficeObjectIdList = make_list(OfficeObjectId) 
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), OfficeObjectIdCount = dcount(OfficeObjectId), OfficeObjectIdList = make_set(OfficeObjectId) 
   by RecordType, Operation, UserAgent, UserType, UserId, ClientIP, OfficeWorkload, Site_Url, UserAgentSeenCount = recentCount
   | extend UserIdName = tostring(split(UserId, '@')[0]), UserIdUPNSuffix = tostring(split(UserId, '@')[1])
   | project-reorder StartTime, EndTime, UserAgent, UserAgentSeenCount, UserId, ClientIP, Site_Url


### PR DESCRIPTION
   
   Change(s):
   - Adjusted to `8d` due to perf considerations and doing 8d as query should be comparing the last day to the previous 7 days to the last day, otherwise it will miss like actions for the same day one week ago
   - Change order of operation for checking time
   - Do not need to summarize the min/max time in the `RecentActivity` portion of the query as it is timebound to the last day
   - Do not need to check the time frame of the results as again it is already time bound to last day after the join back to get full details of identified events
   - Removing old entity mapping rows
   - Bringing through proper account entity fields
   - Adjusted order to make more table view of the results more useful

   Reason for Change(s):
   - Primarily performance and high alert count returns

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
