### PR TITLE
MTTC/MTTT Calculation are inconsistent in Security Operations Efficiency workbook

### DIFF
--- a/Workbooks/SecurityOperationsEfficiency.json
+++ b/Workbooks/SecurityOperationsEfficiency.json
@@ -522,7 +522,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SecurityIncident\n| where FirstModifiedTime  >= {TimeRange:start} and FirstModifiedTime  <= {TimeRange:end}\n| where Severity in ({Severity}) or \"*\" in ({Severity})\n| extend Tactics = todynamic(AdditionalData.tactics)\n| where Tactics in ({Tactics}) or \"*\" in ({Tactics})\n| extend Owner = todynamic(Owner.assignedTo) \n| where Owner in ({Owner}) or \"*\" in ({Owner})\n| extend Product = todynamic((parse_json(tostring(AdditionalData.alertProductNames))[0])) \n| where Product in ({Product}) or \"*\" in ({Product})\n| summarize arg_max(LastModifiedTime,*) by IncidentNumber \n| extend TimeToTriage =  (FirstModifiedTime - CreatedTime)/1h\n| summarize 50th_Percentile=percentile(TimeToTriage, 50) \n",
+              "query": "SecurityIncident\n| where FirstModifiedTime  >= {TimeRange:start} and FirstModifiedTime  <= {TimeRange:end}\n| where Severity in ({Severity}) or \"*\" in ({Severity})\n| extend Tactics = todynamic(AdditionalData.tactics)\n| where Tactics in ({Tactics}) or \"*\" in ({Tactics})\n| extend Owner = todynamic(Owner.assignedTo) \n| where Owner in ({Owner}) or \"*\" in ({Owner})\n| extend Product = todynamic((parse_json(tostring(AdditionalData.alertProductNames))[0])) \n| where Product in ({Product}) or \"*\" in ({Product})\n| summarize arg_max(LastModifiedTime,*) by IncidentNumber \n| extend TimeToTriage =  (FirstModifiedTime - CreatedTime)/1h\n| summarize AvgTTT=avg(TimeToTriage) \n",
               "size": 1,
               "title": "Mean time to triage",
               "timeContext": {
@@ -540,7 +540,7 @@
                   "formatter": 1
                 },
                 "leftContent": {
-                  "columnMatch": "50th_Percentile",
+                  "columnMatch": "AvgTTT",
                   "formatter": 12,
                   "formatOptions": {
                     "palette": "auto"
@@ -565,7 +565,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SecurityIncident\n| where ClosedTime >= {TimeRange:start} and ClosedTime <= {TimeRange:end}\n| where Severity in ({Severity}) or \"*\" in ({Severity})\n| extend Tactics = todynamic(AdditionalData.tactics)\n| where Tactics in ({Tactics}) or \"*\" in ({Tactics})\n| extend Owner = todynamic(Owner.assignedTo) \n| where Owner in ({Owner}) or \"*\" in ({Owner})\n| extend Product = todynamic((parse_json(tostring(AdditionalData.alertProductNames))[0])) \n| where Product in ({Product}) or \"*\" in ({Product})\n| summarize arg_max(TimeGenerated,*) by IncidentNumber \n| extend TimeToClosure =  (ClosedTime - CreatedTime)/1h\n| summarize 50th_Percentile=percentile(TimeToClosure, 50)",
+              "query": "SecurityIncident\n| where ClosedTime >= {TimeRange:start} and ClosedTime <= {TimeRange:end}\n| where Severity in ({Severity}) or \"*\" in ({Severity})\n| extend Tactics = todynamic(AdditionalData.tactics)\n| where Tactics in ({Tactics}) or \"*\" in ({Tactics})\n| extend Owner = todynamic(Owner.assignedTo) \n| where Owner in ({Owner}) or \"*\" in ({Owner})\n| extend Product = todynamic((parse_json(tostring(AdditionalData.alertProductNames))[0])) \n| where Product in ({Product}) or \"*\" in ({Product})\n| summarize arg_max(TimeGenerated,*) by IncidentNumber \n| extend TimeToClosure =  (ClosedTime - CreatedTime)/1h\n| summarize AvgTTC=avg(TimeToClosure)",
               "size": 1,
               "title": "Mean time to closure ",
               "timeContext": {
@@ -586,7 +586,7 @@
                   "formatOptions": {}
                 },
                 "leftContent": {
-                  "columnMatch": "50th_Percentile",
+                  "columnMatch": "AvgTTC",
                   "formatter": 12,
                   "formatOptions": {
                     "palette": "auto"

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -1353,7 +1353,7 @@
     "dataTypesDependencies": [ "SecurityAlert", "SecurityIncident" ],
     "dataConnectorsDependencies": [],
     "previewImagesFileNames": [ "SecurityEfficiencyWhite1.png", "SecurityEfficiencyWhite2.png", "SecurityEfficiencyBlack1.png", "SecurityEfficiencyBlack2.png" ],
-    "version": "1.5.0",
+    "version": "1.5.1",
     "title": "Security Operations Efficiency",
     "templateRelativePath": "SecurityOperationsEfficiency.json",
     "subtitle": "",

--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -1357,7 +1357,19 @@
     "title": "Security Operations Efficiency",
     "templateRelativePath": "SecurityOperationsEfficiency.json",
     "subtitle": "",
-    "provider": "Microsoft"
+    "provider": "Microsoft",
+    "support": {
+      "tier": "Microsoft"
+    },
+    "author": {
+      "name": "Microsoft Corporation"
+    },
+    "source": {
+      "kind": "Community"
+    },
+    "categories": {
+      "domains": [ "IT Operations", "Security - Others" ]
+    }
   },
   {
     "workbookKey": "DataCollectionHealthMonitoring",


### PR DESCRIPTION
   Change(s):
   - Changed the Mean time to triage and Mean time to closure to actual calculate the mean.  The current iteration of the workbook calculates the median which is not standard for this metric.

   Reason for Change(s):
   - Industry standard calculations for MTTx is to use a mean (average) not a median/50th percentile
   - Also part of the workbook with MTTC/MTTT BY Owner already used means, but the overall numbers used a median so this change is also important for consistency in the workbook itself

   Version Updated:
   - N/A

   Testing Completed:
   - Yes, deploys without error

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes, validates successfully