### PR TITLE
Get-GeoFromIpAndTagIncident Playbook Issue fix

### DIFF
--- a/Playbooks/Get-GeoFromIpAndTagIncident/customConnector/azuredeploy.json
+++ b/Playbooks/Get-GeoFromIpAndTagIncident/customConnector/azuredeploy.json
@@ -6,6 +6,20 @@
         "author": "Nicholas DiCola"
     },
     "parameters": {
+        "ConnectorName": {
+            "defaultValue": "IPAPICustomConnector",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the custom IP-API Connector."
+            }
+        },
+        "ServiceEndpoint": {
+            "defaultValue": "https://ip-api.com/json",
+            "type": "String",
+            "metadata": {
+                "description": "Enter the IP-API Endpoint Url"
+            }
+        }
     },
     "variables": {
     },
@@ -13,22 +27,22 @@
         {
             "type": "Microsoft.Web/customApis",
             "apiVersion": "2016-06-01",
-            "name": "IP-API",
+            "name": "[parameters('ConnectorName')]",
             "location": "[resourceGroup().location]",
             "properties": {
                 "backendService": {
-                    "serviceUrl": "https://ip-api.com/json"
+                    "serviceUrl": "[parameters('ServiceEndPoint')]"
                 },
-                "displayName": "IP-API",
+                "displayName": "[parameters('ConnectorName')]",
                 "iconUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAhCAYAAAC4JqlRAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5QYDFTM5piv2fAAABGZJREFUWIWl12mMnVMYB/Df3BlubUeiWlVLKaWKBpVWY2lRPqAhNLG1IbHTCGL7IPhAUrFEhNiXCNogqNiaIEJjCRV7aGjFvpTyVOmgHR/OufrONZ17Z/yTyTvvc573/J97nvV0aEJKaRwuwjQMxU94HtdFxIdFZ31shk3xN5ZhRUSsad6vFTqayE/Gbaj3oduNs/EeXkCqrL2Pb7EKz+HRiPixHQNqFfKpuLNCvgLvlqcivwObYF6R/YyzMBGvYTi+wfSU0tB2DOgo5PAm9i7yu3F+RKxIKW2MG3BaWVuEE8rzDzyNLfA7ZkXEH+0QNxuwHZaU9w+wR0SsbiillDrxNsajBzvKLvlVjoHuiOhJKS3AGpwWEV+1Y0DDBaOtjYcFVXIo7wsqRo+OiK8j4reIWIWJKaX9cA52xcKU0kYDMWBVRbb5OnSHVf7/vWntZDyL5ThEzo6j2jGg4YKh+B6dWIkJEfFJQymlNEZ2wcb4CyMi4ueSjtfgWFyOsRiJY+QAPjQifil7dKALwyLim14GFIXXsE95/QFz5JTbHZfKgQYvRcSBlU3nYXhDVuR3yEH7Lg4vf1fIdWV9TI2Il6snsAFmymnWCidGxEP9KaSURmIhtsePGCKnbwNvYHJE9NRKCt6DJ/FFC/KP8XArC8sRH1T2G9ZEDpMwBTrr9foo3I4/8RBmrGPfHpwUEYtbGZBS2go7IXDAuvS6u7vnd+EwOfguxF6YjyP70L9fjvT+iEfIfeRMbNjCzsNSSp1d2K8IhuBeOYL3xLYV5cU4NyL6I98Gr8tZ0A6GY0wN4yrCSfJJzJDTkXyMM6If9lKuHx8AeQNjaxjRJDxPPoHj8Juc47s2V7aU0gYppX1Lmb4YEwZIDlvW9N16b5ZdMlZuuw/gxpTS8JI18BiewCdyCR4MhnTJ0d+M9fAgbpXbbSdOkf12kzwPXCK7Z+kgyWFVZ71eP9F/3aCQ7lOe5KK1MybX6/Wh+AWf4lVMx5dyZ9xQ06DTD+7uSCnNlf09GCzCoYV4RSHeTi5CU+Tq2h/G1eRfMFhMwEfYKyJ6ImJNRCyJiLswC7f08+0yLK7hGXmIGCxq8jTVCyVrz5MzpK8UfjYiVtfwGV75HwbMi4iVfS1ExN8RcS12kXtNFfdBrVh6/f8w4JhW009pTtUp6y28xNqJ6KmGYBAYidn9KaSUJurdXy5p3CFqxcIenCFXvsHg+EqBaibvwFXW/ti7IuLFxvq/94LSZk83uIDcDdv0Qb6v7PtpRbRIDsx/0dX0zVx59LpB+8WEXKy2lotRg3xb2a0Njo9xRHPA1qovJSBvxKl6T8qtsBLvNMlmVsgXYkpEfNf8Ya1ZEBEi4h7sL19S2sEbjRtRSmlISmkOrpQn6KtxcET80NeH/zGgYshb8oQ0G5+3MGBpIR8j+/kCPIrxEXFZRPTV8NCmn1NK68mBdJRc43fQO36ejIgjU0pHYxQeafdqNpBAaxhD7ngjrL2ofBcRywe6F/wDhBx6oUpxUmgAAAAASUVORK5CYII=",
                 "swagger": {
                     "swagger": "2.0",
                     "info": {
-                        "title": "IP-API",
+                        "title": "[parameters('ConnectorName')]",
                         "description": "IP-API Geolocation API",
                         "version": "1.0"
                     },
-                    "host": "ip-api.com",
+                    "host": "[replace(replace(parameters('ServiceEndpoint'),'https://',''),'http://','')]",
                     "basePath": "/json",
                     "schemes": [
                         "https"

--- a/Playbooks/Get-GeoFromIpAndTagIncident/customConnector/azuredeploy.json
+++ b/Playbooks/Get-GeoFromIpAndTagIncident/customConnector/azuredeploy.json
@@ -14,7 +14,7 @@
             }
         },
         "ServiceEndpoint": {
-            "defaultValue": "https://ip-api.com/json",
+            "defaultValue": "http://ip-api.com/json",
             "type": "String",
             "metadata": {
                 "description": "Enter the IP-API Endpoint Url"
@@ -45,7 +45,7 @@
                     "host": "[replace(replace(parameters('ServiceEndpoint'),'https://',''),'http://','')]",
                     "basePath": "/json",
                     "schemes": [
-                        "https"
+                        "http"
                     ],
                     "consumes": [],
                     "produces": [],

--- a/Playbooks/Get-GeoFromIpAndTagIncident/incident-trigger/azuredeploy.json
+++ b/Playbooks/Get-GeoFromIpAndTagIncident/incident-trigger/azuredeploy.json
@@ -9,6 +9,13 @@
         "PlaybookName": {
             "defaultValue": "Get-GeoFromIpAndTagIncident",
             "type": "string"
+        },
+        "CustomConnectorName": {
+            "defaultValue": "IPAPICustomConnector",
+            "type": "string",
+            "metadata": {
+                "description": "Name of the logic app connector which performs Shodan actions."
+            }
         }
     },
     "variables": {
@@ -40,7 +47,7 @@
                 "displayName": "[parameters('PlaybookName')]",
                 "customParameterValues": {},
                 "api": {
-                    "id": "[concat('/subscriptions/', subscription().subscriptionId ,'/resourceGroups/', resourcegroup().name ,'/providers/Microsoft.Web/customApis/IP-API')]"
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId ,'/resourceGroups/', resourcegroup().name ,'/providers/Microsoft.Web/customApis/', parameters('CustomConnectorName'))]"
                 }
             }
         },
@@ -208,7 +215,7 @@
                             "IP-API": {
                                 "connectionId": "[resourceId('Microsoft.Web/connections', variables('IPAPIConnectionName'))]",
                                 "connectionName": "[variables('IPAPIConnectionName')]",
-                                "id": "[concat('/subscriptions/', subscription().subscriptionId ,'/resourceGroups/', resourcegroup().name ,'/providers/Microsoft.Web/customApis/IP-API')]"
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId ,'/resourceGroups/', resourcegroup().name ,'/providers/Microsoft.Web/customApis/', parameters('CustomConnectorName'))]"
                             },
                             "azuresentinel": {
                                 "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Changes for Get-GeoFromIpAndTagIncident where ip-api was failing because http is required instead of https.

   Reason for Change(s):
   - There is github issue for which we have fixed this. 

   Version Updated:
   - No

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Testing Images:**
![image](https://user-images.githubusercontent.com/107389644/223629289-5e5a4a5e-52f5-482f-a909-4b30f26be69b.png)

![image](https://user-images.githubusercontent.com/107389644/223629182-c1263fa7-56bb-45f6-af3c-3ef2f1e9fa30.png)
