### PR TITLE
Update vimAuthenticationEmpty.yaml

### DIFF
--- a/Parsers/ASimAuthentication/Parsers/vimAuthenticationEmpty.yaml
+++ b/Parsers/ASimAuthentication/Parsers/vimAuthenticationEmpty.yaml
@@ -16,8 +16,7 @@ Description: |
   This function returns an empty ASIM Authentication schema.
 ParserName: vimAuthenticationEmpty
 ParserQuery: |
-  let EmptyAuthenticationTable=(){
-    datatable(
+  let EmptyAuthenticationTable=datatable(
       EventProduct:string
     , EventProductVersion: string
     , EventVendor:string
@@ -49,7 +48,6 @@ ParserQuery: |
     , ActorUserIdType:string
     , ActorUsernameType:string
     , ActorScopeId:string
-    , ActorScopeId:string
     , ActorOriginalUserType:string
     , TargetUserId:string
     , TargetUsername:string
@@ -72,7 +70,6 @@ ParserQuery: |
     , SrcDomainType:string
     , SrcFQDN:string
     , SrcDescription:string
-    , SrcDvcScopeId:string
     , SrcDvcScopeId:string
     , SrcRiskLevel:int
     , SrcOriginalRiskLevel:string
@@ -103,21 +100,16 @@ ParserQuery: |
     , TargetGeoLongitude:real
     , LogonMethod: string	
     , LogonProtocol: string	
-    , ActorUserIdType: string	 
-    , ActorUsernameType: string	 
     , TargetUserIdType: string	
     , TargetUsernameType: string	
-    , TargetUserIdType:string
-    , TargetUsernameType:string
     , UserScope:string
     , UserScopeId:string
-    , TargetUserType:string,
     , TargetOriginalUserType:string
     , TargetUserSessionId:string
     , User: string	
     , IpAddr: string
     , SrcDvcHostnameType: string	
-   	, LogonTarget: string
+    , LogonTarget: string
     , Dvc: string	
     , DvcId: string
     , DvcIpAddr: string	
@@ -151,10 +143,8 @@ ParserQuery: |
     , ThreatField:string
     , ThreatConfidence:int
     , ThreatRiskLevel:string
-    , ThreatField:string
     , ThreatFirstReportedTime:datetime
     , ThreatLastReportedTime:datetime
     , Application:string
-    )[]
-  };
+    )[];
   EmptyAuthenticationTable


### PR DESCRIPTION
And convert to more standard datatable syntax

   Required items, please complete
   
   Change(s):
   - removed duplicate column headings from empty Authentication parser
   - changed datatable construction to format more consistent with other late-version parsers

   Reason for Change(s):
   - installing ASIM auth parsers didn't work with ASimAuthentication | take 30  , failing with syntax error.
   - After fixing empty parser, still further syntax errors to investigate.

   Testing Completed:
   - parsing validates correctly in my workspace now, but ASimAuthentication fails with another syntax error elsewhere.

   Checked that the validations are passing and have addressed any issues that are present:
   - No

