### PR TITLE
Fixingworkspacedetection

### DIFF
--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -29,13 +29,16 @@ query: |
     | where TimeGenerated > ago(1d)
     | where ProductName == "Azure Active Directory Identity Protection"
     | where AlertName == "Sign-in from an infected device"
-    | mv-expand EntityAccount = todynamic(Entities)
-    | where EntityAccount .Type == "account"
-    | extend AadTenantId = tostring(EntityAccount.AadTenantId)
-    | extend AadUserId = tostring(EntityAccount.AadUserId)
-    | mv-expand EntityIp = todynamic(Entities)
-    | where EntityIp.Type == "ip"
+    | mv-apply EntityAccount=todynamic(Entities) on
+    (
+    where EntityAccount.Type == "account"
+    | extend AadTenantId = tostring(EntityAccount.AadTenantId), AadUserId = tostring(EntityAccount.AadUserId)
+    )
+    | mv-apply EntityIp=todynamic(Entities) on
+    (
+    where EntityIp.Type == "ip"
     | extend IpAddress = tostring(EntityIp.Address)
+    )
     | join kind=inner (
     IdentityInfo
     | distinct AccountTenantId, AccountObjectId, AccountUPN, AccountDisplayName
@@ -66,7 +69,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled
 metadata:
     source:

--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -29,11 +29,13 @@ query: |
     | where TimeGenerated > ago(1d)
     | where ProductName == "Azure Active Directory Identity Protection"
     | where AlertName == "Sign-in from an infected device"
-    | mv-expand Entity = todynamic(Entities)
-    | where Entity.Type == "account"
-    | extend AadTenantId = tostring(Entity.AadTenantId)
-    | extend AadUserId = tostring(Entity.AadUserId)
-    | extend IpAddress = tostring(parse_json(Entities)[2].Address)
+    | mv-expand EntityAccount = todynamic(Entities)
+    | where EntityAccount .Type == "account"
+    | extend AadTenantId = tostring(EntityAccount.AadTenantId)
+    | extend AadUserId = tostring(EntityAccount.AadUserId)
+    | mv-expand EntityIp = todynamic(Entities)
+    | where EntityIp.Type == "ip"
+    | extend IpAddress = tostring(EntityIp.Address)
     | join kind=inner (
     IdentityInfo
     | distinct AccountTenantId, AccountObjectId, AccountUPN, AccountDisplayName

--- a/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
+++ b/Detections/SecurityAlert/Suspicious_WorkSpaceDeletion_Attempt.yaml
@@ -69,6 +69,10 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
+  - entityType: AzureResource
+    fieldMappings:
+      - identifier: ResourceId
+        columnName: _ResourceId
 version: 1.0.6
 kind: Scheduled
 metadata:


### PR DESCRIPTION
 Change(s):
  1. Updated method of finding IP in dataset with a `mv-expand on where` mechanism
  2. Added a new entity for the resource(s) deleted  

 Reason for Change(s):
   - From our testing across multiple tenants, some change around February 6/7th caused the data structure to shift slightly
   - existing method was a little more brittle as it expected the IP to exist in array/index [2] and the change shifted IP address to index [3]
   - **this is fairly critical, as the alert does not fire with the current [2] index and gives a false sense of security if enabled**
   - Using the `mv-expand` and `where` logic we can concisely select the the correct index based on key name, which should work even if more indexes are added later

 Version updated:
   - Yes

 Testing Completed:
   - Yes
