### PR TITLE
Add modern Recycle Bin path in Analytic rule malware_in_recyclebin.yaml

### DIFF
--- a/Solutions/Endpoint Threat Protection Essentials/Analytic Rules/malware_in_recyclebin.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Analytic Rules/malware_in_recyclebin.yaml
@@ -27,6 +27,7 @@ tactics:
   - DefenseEvasion
 query: |
   let procList = externaldata(Process:string) [@"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Sample%20Data/Microsoft_Lolbas_Execution_Binaries.csv"] with (format="csv", ignoreFirstRecord=True);
+  let recycle_bin_paths = dynamic([@":\RECYCLER", @":\$RECYCLE.BIN"]);
   let ProcessCreationEvents=() {
   let processEvents=(union isfuzzy=true
   (SecurityEvent
@@ -36,7 +37,7 @@ query: |
   FileName = Process, CommandLine,  ParentProcessName
   ),
   (WindowsEvent
-  | where EventID==4688 and EventData has_any (procList) and EventData has ":\\recycler"
+  | where EventID==4688 and EventData has_any (procList) and EventData has_any (recycle_bin_paths)
   | extend CommandLine = tostring(EventData.CommandLine)
   | where isnotempty(CommandLine)
   | extend SubjectUserName = tostring(EventData.SubjectUserName)
@@ -50,7 +51,7 @@ query: |
   processEvents};
   ProcessCreationEvents 
   | where FileName in~ (procList)
-  | where CommandLine contains ":\\recycler"
+  | where CommandLine has_any (recycle_bin_paths)
   | project StartTimeUtc = TimeGenerated, Computer, Account, NewProcessName, FileName, CommandLine, ParentProcessName
   | extend timestamp = StartTimeUtc, AccountCustomEntity = Account, HostCustomEntity = Computer
   
@@ -63,6 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: HostCustomEntity
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled
-


### PR DESCRIPTION
   Change(s):
   - Add another path for the recycle bin files to be checked.

   Reason for Change(s):
   - It seems ```RECYCLER``` path was for XP and older systems and ```$RECYCLE.BIN``` is being used by newer Windows systems.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

Maybe this rule should not look for the process to be a LOLBAS and the command to have a Recycle Bin path... maybe it should strictly look for a path that contains the recycle bin strings and the lolbas strings, but I prefer not to question that part in this pull request.