### PR TITLE
Update Dev-0530AVHits.yaml for performance

### DIFF
--- a/Detections/SecurityAlert/Dev-0530AVHits.yaml
+++ b/Detections/SecurityAlert/Dev-0530AVHits.yaml
@@ -20,15 +20,15 @@ tags:
   -  Dev-0530 actors
 query: |
   let Dev0530_threats = dynamic(["Trojan:Win32/SiennaPurple.A", "Ransom:Win32/SiennaBlue.A", "Ransom:Win32/SiennaBlue.B"]);
-  DeviceInfo
-  | extend DeviceName = tolower(DeviceName)
-  | join kind=inner ( SecurityAlert
+  SecurityAlert
   | where ProviderName == "MDATP"
   | extend ThreatName = tostring(parse_json(ExtendedProperties).ThreatName)
   | extend ThreatFamilyName = tostring(parse_json(ExtendedProperties).ThreatFamilyName)
   | where ThreatName in~ (Dev0530_threats) or ThreatFamilyName in~ (Dev0530_threats)
   | extend CompromisedEntity = tolower(CompromisedEntity)
-  ) on $left.DeviceName == $right.CompromisedEntity
+  | join kind=inner (DeviceInfo
+      | extend DeviceName = tolower(DeviceName)
+  ) on $left.CompromisedEntity == $right.DeviceName
   | summarize by DisplayName, ThreatName, ThreatFamilyName, PublicIP, AlertSeverity, Description, tostring(LoggedOnUsers), DeviceId, TenantId , bin(TimeGenerated, 1d), CompromisedEntity, tostring(LoggedOnUsers), ProductName, Entities
 entityMappings:
   - entityType: Host
@@ -39,5 +39,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: PublicIP
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Update Dev-0530AVHits.yaml for performance

   Reason for Change(s):
   - The DeviceInfo table is significantly larger than SecurityAlert in most organizations, and a large join using DeviceInfo as $left was causing Log Analytics lookup failure leading to Auto Disablement of the analytic query. Per https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/lookupoperator, `join` assumes that $left is smaller than $right, which was not true in the previous commit. Alternatively, lookup assumes $left is the larger table.

   Version Updated:
   - Yes, 1.0.0 -> 1.0.1

   Testing Completed:
   - Need Help: KQL functions fine but can't verify with live data as I don't have means to trigger MDE to alert to Sienna* IOC's.  

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

