### PR TITLE
Added new Event Vendor for Network Schema

### DIFF
--- a/ASIM/dev/ASimTester/ASimTester.csv
+++ b/ASIM/dev/ASimTester/ASimTester.csv
@@ -667,7 +667,7 @@ EventStartTime,datetime,Mandatory,NetworkSession,,,
 EventSubType,string,Optional,NetworkSession,Enumerated,Start|End|,
 EventType,string,Mandatory,NetworkSession,Enumerated,NetworkSession|L2NetworkSession|EndpointNetworkSession|Flow,
 EventUid,string,Recommended,NetworkSession,,,
-EventVendor,string,Mandatory,NetworkSession,Enumerated,Fortinet|AppGate|Palo Alto|Microsoft|Zscaler|AWS|Vectra AI|WatchGuard|Cisco|Corelight|Check Point,
+EventVendor,string,Mandatory,NetworkSession,Enumerated,Fortinet|AppGate|Palo Alto|Microsoft|Zscaler|AWS|Vectra AI|WatchGuard|Cisco|Corelight|Check Point|FORCEPOINT,
 Hostname,string,Alias,NetworkSession,Hostname,,DstHostname
 InnerVlanId,string,Alias,NetworkSession,,,SrcVlanId
 IpAddr,string,Alias,NetworkSession,IP Address,,SrcIpAddr

--- a/ASIM/dev/ASimTester/ASimTester.csv
+++ b/ASIM/dev/ASimTester/ASimTester.csv
@@ -667,7 +667,7 @@ EventStartTime,datetime,Mandatory,NetworkSession,,,
 EventSubType,string,Optional,NetworkSession,Enumerated,Start|End|,
 EventType,string,Mandatory,NetworkSession,Enumerated,NetworkSession|L2NetworkSession|EndpointNetworkSession|Flow,
 EventUid,string,Recommended,NetworkSession,,,
-EventVendor,string,Mandatory,NetworkSession,Enumerated,Fortinet|AppGate|Palo Alto|Microsoft|Zscaler|AWS|Vectra AI|WatchGuard|Cisco|Corelight|Check Point|FORCEPOINT,
+EventVendor,string,Mandatory,NetworkSession,Enumerated,Fortinet|AppGate|Palo Alto|Microsoft|Zscaler|AWS|Vectra AI|WatchGuard|Cisco|Corelight|Check Point|Forcepoint,
 Hostname,string,Alias,NetworkSession,Hostname,,DstHostname
 InnerVlanId,string,Alias,NetworkSession,,,SrcVlanId
 IpAddr,string,Alias,NetworkSession,IP Address,,SrcIpAddr
@@ -697,7 +697,7 @@ SrcDeviceType,string,Optional,NetworkSession,Enumerated,Computer|Mobile Device|I
 SrcDomain,string,Recommended,NetworkSession,Domain,,
 SrcDomainType,string,Conditional,NetworkSession,Enumerated,Windows|FQDN|ResourceGroup,SrcDomain
 SrcDvcId,string,Optional,NetworkSession,,,
-SrcDvcIdType,string,Conditional,NetworkSession,Enumerated,AzureResourceId|MDEid|MD4IoTid|VMConnectionId|AwsVpcId|VectraId|AppGateId|Other,SrcDvcId
+SrcDvcIdType,string,Conditional,NetworkSession,Enumerated,AzureResourceId|MDEid|MD4IoTid|VMConnectionId|AwsVpcId|VectraId|AppGateId|ForcepointId|Other,SrcDvcId
 SrcFQDN,string,Optional,NetworkSession,FQDN,,
 SrcGeoCity,string,Optional,NetworkSession,City,,
 SrcGeoCountry,string,Optional,NetworkSession,Country,,


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added new FORCEPOINT Event Vendor for Network Schema

   Reason for Change(s):
   - Adding new ASIM Parser

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
