### PR TITLE
Update template_WindowsFirewallAma.JSON - add fwlink to description that points to Docs install info

### DIFF
--- a/Solutions/Windows Firewall/Data Connectors/template_WindowsFirewallAma.JSON
+++ b/Solutions/Windows Firewall/Data Connectors/template_WindowsFirewallAma.JSON
@@ -2,7 +2,7 @@
   "id": "WindowsFirewallAma",
   "title": "Windows Firewall Events via AMA (Preview)",
   "publisher": "Microsoft",
-  "descriptionMarkdown": "Windows Firewall is a Microsoft Windows application that filters information coming to your system from the internet and blocking potentially harmful programs. The firewall software blocks most programs from communicating through the firewall. Customers wishing to stream their Windows Firewall application logs collected from their machines can now use the AMA to stream those logs to the Microsoft Sentinel workspace.",
+  "descriptionMarkdown": "Windows Firewall is a Microsoft Windows application that filters information coming to your system from the internet and blocking potentially harmful programs. The firewall software blocks most programs from communicating through the firewall. Customers wishing to stream their Windows Firewall application logs collected from their machines can now use the AMA to stream those logs to the Microsoft Sentinel workspace. For more information, see the [Microsoft Sentinel documentation](https://go.microsoft.com/fwlink/p/?linkid=2228623&wt.mc_id=sentinel_dataconnectordocs_content_cnl_csasci).",
   "graphQueries": [
     {
       "metricName": "Total data received",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
Add fwlink to description that points to Docs install info. This will get picked up and published here: https://learn.microsoft.com/en-us/azure/sentinel/data-connectors/windows-firewall-events-via-ama

   Reason for Change(s):
Needed for Docs because we can't pull install info from source files. So instead we cross-link to install info in Docs.

   Version Updated:
n/a

   Testing Completed:
no

   Checked that the validations are passing and have addressed any issues that are present:
 n/a

