### PR TITLE
Update Infoblox_dnsclient.txt

### DIFF
--- a/Solutions/Infoblox NIOS/Parser/Infoblox_dnsclient.txt
+++ b/Solutions/Infoblox NIOS/Parser/Infoblox_dnsclient.txt
@@ -26,7 +26,7 @@ let response =
     | parse SyslogMessage with *
         "client " SrcIpAddr: string
         "#" SrcPortNumber: int
-        " " NetworkProtocol: string
+        ": " NetworkProtocol: string
         ": query: " DnsQuery: string
         " " DnsQueryClassName: string
         " " DnsQueryType: string


### PR DESCRIPTION
Parser fix to match source Syslog.
   
   Change(s):
   - Added ':' to match ':' at the end of SrcPortNumber from the source Syslog data to parse correctly.

   Reason for Change(s):
   - Out of the box parser does not correctly parse and is missing fields because it is missing the ':'

   Version Updated:
   - No version update

   Testing Completed:
   - Making this change corrected the parsing in a local environment.