### PR TITLE
Updating windows security hunting rules - 1

### DIFF
--- a/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
@@ -39,7 +39,7 @@ query: |
 entityMappings:
   - entityType: Host
     fieldMappings:
-      - identifier: FullName
+      - identifier: HostName
         columnName: Computer
   - entityType: Account
     fieldMappings:

--- a/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
@@ -47,4 +47,4 @@ entityMappings:
         columnName: Name
       - identifier: NTDomain
         columnName: NTDomain
-version: 2.0.0
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
@@ -47,3 +47,4 @@ entityMappings:
         columnName: Name
       - identifier: NTDomain
         columnName: NTDomain
+version: 2.0.0

--- a/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/CommandsexecutedbyWMIonnewhosts-potentialImpacket.yaml
@@ -35,6 +35,7 @@ query: |
     | where ParentProcessName endswith "wmiprvse.exe"
     | where CommandLine has_all (impacket_artifacts)
     | project-reorder TimeGenerated, Computer, CommandLine, Account
+    | extend NTDomain = tostring(split(Account,'\\',0)[0]), Name = tostring(split(Account,'\\',1)[0])
 entityMappings:
   - entityType: Host
     fieldMappings:
@@ -42,5 +43,7 @@ entityMappings:
         columnName: Computer
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: Account
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain

--- a/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
@@ -34,4 +34,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: Computer   
-version: 2.0.0
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
@@ -34,3 +34,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: Computer   
+version: 2.0.0

--- a/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
@@ -22,12 +22,15 @@ query: |
     | where ObjectValueName =~ "CrashDumpEnabled"
     | extend  RegistryValueData = iff (OperationType == "%%1906", OldValue, NewValue)
     | where RegistryValueData == 0
+    | extend NTDomain = tostring(split(Account,'\\',0)[0]), Name = tostring(split(Account,'\\',1)[0])    
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: Account
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain     
   - entityType: Host
     fieldMappings:
       - identifier: FullName
-        columnName: Computer
+        columnName: Computer   

--- a/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Crashdumpdisabledonhost.yaml
@@ -32,5 +32,5 @@ entityMappings:
         columnName: NTDomain     
   - entityType: Host
     fieldMappings:
-      - identifier: FullName
+      - identifier: HostName
         columnName: Computer   

--- a/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
@@ -25,7 +25,7 @@ query: |
 entityMappings:
 - entityType: Account
   fieldMappings:
-    - identifier: FullName
+    - identifier: Name
       columnName: TargetUserName
 - entityType: Host
   fieldMappings:
@@ -35,5 +35,5 @@ entityMappings:
   fieldMappings:
     - identifier: Address
       columnName: IpAddress
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
@@ -35,5 +35,5 @@ entityMappings:
   fieldMappings:
     - identifier: Address
       columnName: IpAddress
-version: 1.0.1
+version: 2.0.0
 kind: Scheduled

--- a/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
@@ -29,7 +29,7 @@ entityMappings:
       columnName: TargetUserName
 - entityType: Host
   fieldMappings:
-    - identifier: FullName
+    - identifier: HostName
       columnName: Computer
 - entityType: IP
   fieldMappings:

--- a/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/DecoyUserAccountAuthenticationAttempt.yaml
@@ -35,5 +35,5 @@ entityMappings:
   fieldMappings:
     - identifier: Address
       columnName: IpAddress
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
@@ -33,5 +33,5 @@ entityMappings:
         columnName: NTDomain
   - entityType: Host
     fieldMappings:
-      - identifier: FullName
+      - identifier: HostName
         columnName: Computer

--- a/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
@@ -35,3 +35,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: Computer
+version: 2.0.0

--- a/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
@@ -35,4 +35,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: Computer
-version: 2.0.0
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Discorddownloadinvokedfromcmdline.yaml
@@ -23,11 +23,14 @@ query: |
     | where Process has_any ("powershell.exe", "powershell_ise.exe", "cmd.exe") or CommandLine has "powershell"
     | where CommandLine has_any ("cdn.discordapp.com", "moc.ppadrocsid.ndc")
     | project-reorder TimeGenerated, Computer, Account, Process, CommandLine
+    | extend NTDomain = tostring(split(Account,'\\',0)[0]), Name = tostring(split(Account,'\\',1)[0])   
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: Account
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain
   - entityType: Host
     fieldMappings:
       - identifier: FullName

--- a/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
@@ -31,5 +31,5 @@ entityMappings:
         columnName: NTDomain
   - entityType: Host
     fieldMappings:
-      - identifier: FullName
+      - identifier: HostName
         columnName: HostCustomEntity

--- a/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
@@ -17,15 +17,18 @@ query: |
   SecurityEvent
   | where EventID == 4688
   | where Process has_any ("cmd.exe", "powershell.exe", "PowerShell_ISE.exe")
-  | where isnotempty(CommandLine)
-  | where CommandLine contains "Add-PSSnapin Microsoft.Exchange.Management.Powershell.Snapin"
-  | summarize FirstSeen = min(TimeGenerated), LastSeen = max(TimeGenerated) by Computer, Account, CommandLine 
+  | where isnotempty(CommandLine)  
+  | where CommandLine has "Add-PSSnapin Microsoft.Exchange.Management.Powershell.Snapin"
+  | summarize FirstSeen = min(TimeGenerated), LastSeen = max(TimeGenerated) by Computer, Account, CommandLine
+  | extend NTDomain = tostring(split(Account,'\\',0)[0]), Name = tostring(split(Account,'\\',1)[0])  
   | extend timestamp = FirstSeen, AccountCustomEntity = Account, HostCustomEntity = Computer
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain
   - entityType: Host
     fieldMappings:
       - identifier: FullName

--- a/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
@@ -33,4 +33,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
-version: 2.0.0
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/ExchangePowerShellSnapin.yaml
@@ -33,3 +33,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
+version: 2.0.0

--- a/Solutions/Windows Security Events/Hunting Queries/HostExportingMailboxAndRemovingExport.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/HostExportingMailboxAndRemovingExport.yaml
@@ -44,5 +44,5 @@ entityMappings:
         columnName: AccountCustomEntity
   - entityType: Host
     fieldMappings:
-      - identifier: FullName
+      - identifier: HostName
         columnName: HostCustomEntity

--- a/Solutions/Windows Security Events/Hunting Queries/HostExportingMailboxAndRemovingExport.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/HostExportingMailboxAndRemovingExport.yaml
@@ -21,28 +21,26 @@ tags:
   - Solorigate
   - NOBELIUM
 query: |
-
   // Adjust the timeframe to change the window events need to occur within to alert
   let timeframe = 1h;
   SecurityEvent
   | where EventID == 4688
   | where Process in~ ("powershell.exe", "cmd.exe")
-  | where CommandLine contains 'New-MailboxExportRequest'
+  | where CommandLine has 'New-MailboxExportRequest'
   | summarize by Computer, timekey = bin(TimeGenerated, timeframe), CommandLine, SubjectUserName
   | join kind=inner (SecurityEvent
   | where EventID == 4688
   | where Process in~ ("powershell.exe", "cmd.exe")
-  | where CommandLine contains 'Remove-MailboxExportRequest'
+  | where CommandLine has 'Remove-MailboxExportRequest'
   | summarize by Computer, timekey = bin(TimeGenerated, timeframe), CommandLine, SubjectUserName) on Computer, timekey, SubjectUserName
   | extend commands = pack_array(CommandLine1, CommandLine)
   | summarize by timekey, Computer, tostring(commands), SubjectUserName
   | project-reorder timekey, Computer, SubjectUserName, ['commands']
   | extend HostCustomEntity = Computer, AccountCustomEntity = SubjectUserName
-
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
+      - identifier: Name
         columnName: AccountCustomEntity
   - entityType: Host
     fieldMappings:

--- a/Solutions/Windows Security Events/Hunting Queries/HostExportingMailboxAndRemovingExport.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/HostExportingMailboxAndRemovingExport.yaml
@@ -46,3 +46,4 @@ entityMappings:
     fieldMappings:
       - identifier: HostName
         columnName: HostCustomEntity
+version: 2.0.1


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updating hunting queries of windows security events

   Reason for Change(s):
   - decommissioned commands, improper handling of variable has been handled in this PR

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes