### PR TITLE
Updating windows security hunting rules - 2

### DIFF
--- a/Solutions/Windows Security Events/Hunting Queries/HostsWithNewLogons.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/HostsWithNewLogons.yaml
@@ -17,7 +17,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = totimespan((endtime-starttime)*7);
@@ -43,5 +42,5 @@ query: |
   | where ActionType == 'Logon'
   | summarize count() by ComputerName, AccountName
   ) on ComputerName, AccountName
-  | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), HostCount=dcount(ComputerName), HostSet=makeset(ComputerName, 10)  by AccountName, ComputerName
+  | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), HostCount=dcount(ComputerName), HostSet=make_set(ComputerName, 10)  by AccountName, ComputerName
   | extend timestamp = StartTimeUtc, AccountCustomEntity = AccountName

--- a/Solutions/Windows Security Events/Hunting Queries/HostsWithNewLogons.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/HostsWithNewLogons.yaml
@@ -34,13 +34,22 @@ query: |
   };
   LogonEvents
   | where TimeGenerated between(ago(lookback)..starttime)
-  | where ActionType == 'Logon'
+  | where ActionType =~ 'Logon'
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), count() by ComputerName, AccountName
   | join kind=leftanti (
   LogonEvents
   | where TimeGenerated between(starttime..endtime)
-  | where ActionType == 'Logon'
+  | where ActionType =~ 'Logon'
   | summarize count() by ComputerName, AccountName
   ) on ComputerName, AccountName
   | summarize StartTimeUtc = min(StartTimeUtc), EndTimeUtc = max(EndTimeUtc), HostCount=dcount(ComputerName), HostSet=make_set(ComputerName, 10)  by AccountName, ComputerName
   | extend timestamp = StartTimeUtc, AccountCustomEntity = AccountName
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: ComputerName
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: AccountName

--- a/Solutions/Windows Security Events/Hunting Queries/HostsWithNewLogons.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/HostsWithNewLogons.yaml
@@ -53,3 +53,4 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: AccountName
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Invoke-PowerShellTcpOneLine.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Invoke-PowerShellTcpOneLine.yaml
@@ -18,12 +18,15 @@ query: |
   | where EventID == 4688
   | where Process has_any ("powershell.exe", "PowerShell_ISE.exe", "cmd.exe")
   | where CommandLine has "$client = New-Object System.Net.Sockets.TCPClient"
+  | extend NTDomain = tostring(split(Account,'\\',0)[0]), Name = tostring(split(Account,'\\',1)[0])
   | extend timestamp = TimeGenerated, AccountCustomEntity = Account, HostCustomEntity = Computer, IPCustomEntity = IpAddress
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain
   - entityType: Host
     fieldMappings:
       - identifier: FullName

--- a/Solutions/Windows Security Events/Hunting Queries/Invoke-PowerShellTcpOneLine.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Invoke-PowerShellTcpOneLine.yaml
@@ -35,3 +35,4 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Invoke-PowerShellTcpOneLine.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Invoke-PowerShellTcpOneLine.yaml
@@ -29,8 +29,8 @@ entityMappings:
         columnName: NTDomain
   - entityType: Host
     fieldMappings:
-      - identifier: FullName
-        columnName: HostCustomEntity
+      - identifier: HostName
+        columnName: Computer
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Windows Security Events/Hunting Queries/Least_Common_Parent_Child_Process.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Least_Common_Parent_Child_Process.yaml
@@ -32,3 +32,4 @@ query: |
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = make_set(Computer,maxSize=1000), UserCount = dcount(SubjectUserName), Users = make_set(SubjectUserName,maxSize=1000) by ParentChildPair
   | where TimesSeen < Sensitivity
   | extend timestamp = StartTimeUtc
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Least_Common_Parent_Child_Process.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Least_Common_Parent_Child_Process.yaml
@@ -14,7 +14,6 @@ requiredDataConnectors:
 tactics:
   - Execution
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = starttime - 7d;
@@ -22,14 +21,14 @@ query: |
   let Sensitivity = 5;
   SecurityEvent
   | where TimeGenerated between(lookback..endtime)
-  | where EventID == 4688 and isnotnull(ParentProcessName)
+  | where EventID == 4688 and isnotempty(ParentProcessName)  
   | extend ProcArray = split(NewProcessName, '\\'), ParentProcArray = split(ParentProcessName, '\\')
   // ProcArrayLength is Folder Depth
-  | extend ProcArrayLength = arraylength(ProcArray), ParentProcArrayLength = arraylength(ParentProcArray)
+  | extend ProcArrayLength = array_length(ProcArray), ParentProcArrayLength = array_length(ParentProcArray)
   | extend LastIndex = ProcArrayLength - 1, ParentLastIndex = ParentProcArrayLength - 1
   | extend Proc = ProcArray[LastIndex], ParentProc = ParentProcArray[ParentLastIndex]
   | where Proc !in (Allowlist)
   | extend ParentChildPair = strcat(ParentProc , ' > ', Proc)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = makeset(Computer), UserCount = dcount(SubjectUserName), Users = makeset(SubjectUserName) by ParentChildPair
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = make_set(Computer,maxSize=1000), UserCount = dcount(SubjectUserName), Users = make_set(SubjectUserName,maxSize=1000) by ParentChildPair
   | where TimesSeen < Sensitivity
   | extend timestamp = StartTimeUtc

--- a/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_Command_Lines.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_Command_Lines.yaml
@@ -12,21 +12,20 @@ requiredDataConnectors:
 tactics:
   - Execution
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
-  let lookback = starttime - 7d;
+  let lookback = starttime - 7d;  
   let Allowlist = dynamic (['foo.exe', 'baz.exe']);
-  let Sensitivity = 5;
+  let Sensitivity = 5;  
   SecurityEvent
   | where TimeGenerated between(lookback..endtime)
   | where EventID == 4688 and NewProcessName !endswith 'conhost.exe'
   | extend ProcArray = split(NewProcessName, '\\')
   // ProcArrayLength is Folder Depth
-  | extend ProcArrayLength = arraylength(ProcArray)
+  | extend ProcArrayLength = array_length(ProcArray)
   | extend LastIndex = ProcArrayLength - 1
   | extend Proc = ProcArray[LastIndex]
   | where Proc !in (Allowlist)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = makeset(Computer), UserCount = dcount(SubjectUserName), Users = makeset(SubjectUserName) by CommandLine
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = make_set(Computer,maxSize=500), UserCount = dcount(SubjectUserName), Users = make_set(SubjectUserName,maxSize=500) by CommandLine
   | where TimesSeen < Sensitivity
   | extend timestamp = StartTimeUtc

--- a/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_Command_Lines.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_Command_Lines.yaml
@@ -29,3 +29,4 @@ query: |
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = make_set(Computer,maxSize=500), UserCount = dcount(SubjectUserName), Users = make_set(SubjectUserName,maxSize=500) by CommandLine
   | where TimesSeen < Sensitivity
   | extend timestamp = StartTimeUtc
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_With_Depth.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_With_Depth.yaml
@@ -31,3 +31,4 @@ query: |
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = make_set(Computer,maxSize=2000), UserCount = dcount(SubjectUserName), Users = make_set(SubjectUserName,maxSize=2000) by DriveDepthProc
   | where TimesSeen < Sensitivity
   | extend timestamp = StartTimeUtc
+version: 2.0.1

--- a/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_With_Depth.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/Least_Common_Process_With_Depth.yaml
@@ -12,10 +12,9 @@ requiredDataConnectors:
 tactics:
   - Execution
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
-  let lookback = starttime - 7d;
+  let lookback = starttime - 7d;  
   let Allowlist = dynamic (['foo.exe', 'baz.exe']);
   let Sensitivity = 15;
   SecurityEvent
@@ -23,12 +22,12 @@ query: |
   | where EventID == 4688
   | extend ProcArray = split(NewProcessName, '\\')
   // ProcArrayLength is Folder Depth
-  | extend ProcArrayLength = arraylength(ProcArray)
+  | extend ProcArrayLength = array_length(ProcArray)
   | extend LastIndex = ProcArrayLength - 1
   | extend Proc = ProcArray[LastIndex]
   | where Proc !in (Allowlist)
   // ProcArray[0] is the proc's Drive
   | extend DriveDepthProc = strcat(ProcArray[0], '-', ProcArrayLength, '-', Proc)
-  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = makeset(Computer), UserCount = dcount(SubjectUserName), Users = makeset(SubjectUserName) by DriveDepthProc
+  | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), TimesSeen = count(), HostCount = dcount(Computer), Hosts = make_set(Computer,maxSize=2000), UserCount = dcount(SubjectUserName), Users = make_set(SubjectUserName,maxSize=2000) by DriveDepthProc
   | where TimesSeen < Sensitivity
   | extend timestamp = StartTimeUtc


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updating hunting queries of windows security events

   Reason for Change(s):
   - decommissioned commands, improper handling of variable has been handled in this PR

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes