### PR TITLE
Updating windows security hunting rules - 3

### DIFF
--- a/Solutions/Windows Security Events/Hunting Queries/GroupAddedToPrivlegeGroup.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/GroupAddedToPrivlegeGroup.yaml
@@ -17,7 +17,6 @@ relevantTechniques:
   - T1098
   - T1078
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = starttime - 7d;
@@ -54,4 +53,15 @@ query: |
   GroupAddition
   ) on GroupSid
   | extend timestamp = GroupCreateTime, AccountCustomEntity = Account, HostCustomEntity = Computer
+  | extend NTDomain = tostring(split(AccountCustomEntity,'\\',0)[0]), Name = tostring(split(AccountCustomEntity,'\\',1)[0])
+entityMappings:
+  - entityType: Account
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity  
 

--- a/Solutions/Windows Security Events/Hunting Queries/cscript_summary.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/cscript_summary.yaml
@@ -12,7 +12,6 @@ requiredDataConnectors:
 tactics:
   - Execution
 query: |
-
   let ProcessCreationEvents=() {
   let processEvents=SecurityEvent
   | where EventID==4688
@@ -40,3 +39,12 @@ query: |
   | summarize min(EventTime), count() by ComputerName, AccountName, ScriptName, ScriptParams
   | order by count_ asc nulls last 
   | extend timestamp = min_EventTime, HostCustomEntity = ComputerName, AccountCustomEntity = AccountName
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity

--- a/Solutions/Windows Security Events/Hunting Queries/enumeration_user_and_group.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/enumeration_user_and_group.yaml
@@ -12,11 +12,10 @@ requiredDataConnectors:
 tactics:
   - Discovery
 query: |
-
   let ProcessCreationEvents=() {
   let processEvents=SecurityEvent
   | where EventID==4688
-  | project TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName,        AccountDomain=SubjectDomainName,
+  | project TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName,AccountDomain=SubjectDomainName,
   FileName=tostring(split(NewProcessName, '\\')[-1]),
   ProcessCommandLine = CommandLine, 
   FolderPath = "",
@@ -30,4 +29,13 @@ query: |
   | project minTimeGenerated, maxTimeGenerated, count_, AccountName, Target, ProcessCommandLine, ComputerName
   | sort by AccountName, Target
   | extend timestamp = minTimeGenerated, AccountCustomEntity = AccountName, HostCustomEntity = ComputerName
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity 
   

--- a/Solutions/Windows Security Events/Hunting Queries/masquerading_files.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/masquerading_files.yaml
@@ -16,7 +16,6 @@ requiredDataConnectors:
 tactics:
   - Execution
 query: |
-
   SecurityEvent
   | where NewProcessName endswith "\\svchost.exe"
   | where SubjectUserSid !in ("S-1-5-18", "S-1-5-19", "S-1-5-20")
@@ -25,4 +24,13 @@ query: |
   | summarize minTimeGenerated=min(TimeGenerated), maxTimeGenerated=max(TimeGenerated), count() by Computer, SubjectUserName, NewProcessName, CommandLine, Account
   | project minTimeGenerated , maxTimeGenerated , count_ , Computer , SubjectUserName , NewProcessName , CommandLine, Account 
   | extend timestamp = minTimeGenerated, HostCustomEntity = Computer, AccountCustomEntity = Account
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity
   

--- a/Solutions/Windows Security Events/Hunting Queries/new_processes.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/new_processes.yaml
@@ -14,7 +14,6 @@ requiredDataConnectors:
 tactics:
   - Execution
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = starttime - 14d;
@@ -30,11 +29,14 @@ query: |
   | join kind=rightanti (
       ProcessCreationEvents
       | where TimeGenerated between(starttime..endtime)
-      | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Computers = makeset(Computer) , HostCount=dcount(Computer) by Account, NewProcessName, FileName, ProcessCommandLine, InitiatingProcessFileName
+      | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated), Computers = make_set(Computer,1000) , HostCount=dcount(Computer) by Account, NewProcessName, FileName, ProcessCommandLine, InitiatingProcessFileName
   ) on FileName
   | extend timestamp = StartTime, AccountCustomEntity = Account
+  | extend NTDomain = tostring(split(AccountCustomEntity,'\\',0)[0]), Name = tostring(split(AccountCustomEntity,'\\',1)[0])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain

--- a/Solutions/Windows Security Events/Hunting Queries/persistence_create_account.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/persistence_create_account.yaml
@@ -20,7 +20,6 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-
   SecurityEvent
   | where EventID==4688
   | project TimeGenerated, ComputerName=Computer,AccountName=SubjectUserName, 
@@ -31,8 +30,13 @@ query: |
   | where FileName in~ ("net.exe", "net1.exe")
   | parse kind=regex flags=iU ProcessCommandLine with * "user " CreatedUser " " * "/ad"
   | where not(FileName =~ "net1.exe" and InitiatingProcessFileName =~ "net.exe" and replace("net", "net1", InitiatingProcessCommandLine) =~ ProcessCommandLine)
-  | extend CreatedOnLocalMachine=(ProcessCommandLine !contains "/do")
-  | where ProcessCommandLine contains "/add" or (CreatedOnLocalMachine == 0 and ProcessCommandLine !contains "/domain")
+  | extend CreatedOnLocalMachine=(ProcessCommandLine !has "/do")
+  | where ProcessCommandLine has "/add" or (CreatedOnLocalMachine == 0 and ProcessCommandLine !has "/domain")
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), MachineCount=dcount(ComputerName) by CreatedUser, CreatedOnLocalMachine, InitiatingProcessFileName, FileName, ProcessCommandLine, InitiatingProcessCommandLine
   | extend timestamp = StartTimeUtc, AccountCustomEntity = CreatedUser
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: AccountCustomEntity
   

--- a/Solutions/Windows Security Events/Hunting Queries/powershell_downloads.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/powershell_downloads.yaml
@@ -13,7 +13,6 @@ tactics:
   - Execution
   - CommandAndControl
 query: |
-
   let ProcessCreationEvents=() {
   let processEvents=SecurityEvent
   | where EventID==4688
@@ -35,7 +34,7 @@ query: |
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
+      - identifier: Name
         columnName: AccountCustomEntity
   - entityType: Host
     fieldMappings:

--- a/Solutions/Windows Security Events/Hunting Queries/powershell_newencodedscipts.yaml
+++ b/Solutions/Windows Security Events/Hunting Queries/powershell_newencodedscipts.yaml
@@ -13,7 +13,6 @@ tactics:
   - Execution
   - CommandAndControl
 query: |
-
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
   let lookback = totimespan((endtime-starttime)*3);
@@ -43,12 +42,14 @@ query: |
     | extend decodedCommand = base64_decode_tostring(substring(encodedCommand, 0, strlen(encodedCommand) - (strlen(encodedCommand) %8)))
   ) on encodedCommand, decodedCommand
   | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = Computer
+  | extend NTDomain = tostring(split(AccountCustomEntity,'\\',0)[0]), Name = tostring(split(AccountCustomEntity,'\\',1)[0])  
 entityMappings:
   - entityType: Account
-    fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: NTDomain
   - entityType: Host
     fieldMappings:
       - identifier: FullName
-        columnName: HostCustomEntity
+        columnName: HostCustomEntity  


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updating hunting queries of windows security events

   Reason for Change(s):
   - decommissioned commands, improper handling of variable has been handled in this PR

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes