### PR TITLE
Fixing Concurrency for the Nested "For Loop" in the playbook

### DIFF
--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Data-WebComponents/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Data-WebComponents/azuredeploy.json
@@ -281,7 +281,12 @@
                                     "Succeeded"
                                 ]
                             },
-                            "type": "Foreach"
+                            "type": "Foreach",
+                            "runtimeConfiguration": {
+                                "concurrency": {
+                                    "repetitions": 1
+                                }
+                            }
                         },
                         "For_each_IP_Address": {
                             "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
@@ -437,7 +442,12 @@
                                     "Succeeded"
                                 ]
                             },
-                            "type": "Foreach"
+                            "type": "Foreach",
+                            "runtimeConfiguration": {
+                                "concurrency": {
+                                    "repetitions": 1
+                                }
+                            }
                         },
                         "Init_Result_Host": {
                             "runAfter": {


### PR DESCRIPTION
Hi, 

Fixing Concurrency for the Nested "For Loop" in the MDTI-Data-WebComponents Playbook. changed the concurrency value to 1 to remove parallelism to avoid overlapping of data within the Nested for loop.

   Required items, please complete
   
   Change(s):
   - updated azuredeploy.json
  
   Reason for Change(s):
   -  - Fixing Concurrency for the Nested "For Loop" in the MDTI-Data-WebComponents Playbook. changed the concurrency value to 1 to remove parallelism to avoid overlapping of data within the Nested for loop.

   Version Updated:
   - No

   Testing Completed:
   - Yes in the CxE Ninja Build Environment

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A

