### PR TITLE
Cisco umbrella backward compatibility to python 3.6 issue fixed

### DIFF
--- a/Solutions/CiscoUmbrella/Data Connectors/requirements.txt
+++ b/Solutions/CiscoUmbrella/Data Connectors/requirements.txt
@@ -2,7 +2,7 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.6.0
 boto3==1.9.180
 requests==2.22.0
 python-dateutil==2.8.2

--- a/Solutions/CiscoUmbrella/Data Connectors/requirements.txt
+++ b/Solutions/CiscoUmbrella/Data Connectors/requirements.txt
@@ -7,3 +7,5 @@ boto3==1.9.180
 requests==2.22.0
 python-dateutil==2.8.2
 azure-storage-file-share==12.5.0
+cryptography==36.0.0
+typing-extensions==4.0.0


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Cisco umbrella backward compatibility to python 3.6 issue fixed

   Reason for Change(s):
   - Customers who are on 3.6 is facing issue.

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
