### PR TITLE
TargetResourceName entityType CloudApplication

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/RareApplicationConsent.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/RareApplicationConsent.yaml
@@ -82,13 +82,13 @@ entityMappings:
         columnName: Name
       - identifier: UPNSuffix
         columnName: UPNSuffix
-  - entityType: Host
+  - entityType: CloudApplication
     fieldMappings:
-      - identifier: FullName
+      - identifier: Name
         columnName: TargetResourceName
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IpAddress
-version: 1.1.3
+version: 1.1.4
 kind: Scheduled


### PR DESCRIPTION
TargetResourceName contains the name of the application, not the Host. So to avoid confusion this should not be mapped to an entity type of Host. Change is to set the TargetResourceName to by type CloudApplication which is a closer match.

   Required items, please complete
   
   Change(s):
   - Update entityMapping in RareApplicationConsent.yaml

   Reason for Change(s):
   - To avoid confusion TargetResourceName should not be mapped to an entity type of Host.
   - TargetResourceName contains the name of the application, not the Host.
   - CloudApplication is a closer match.

   Version Updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes