### PR TITLE
Mr mongo

### DIFF
--- a/Solutions/Microsoft Defender Threat Intelligence/Package/mainTemplate.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Package/mainTemplate.json
@@ -1,1908 +1,2051 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "metadata": {
-    "author": "Microsoft - support@microsoft.com",
-    "comments": "Solution template for Microsoft Defender Threat Intelligence"
-  },
-  "parameters": {
-    "location": {
-      "type": "string",
-      "minLength": 1,
-      "defaultValue": "[resourceGroup().location]",
-      "metadata": {
-        "description": "Not used, but needed to pass arm-ttk test `Location-Should-Not-Be-Hardcoded`.  We instead use the `workspace-location` which is derived from the LA workspace"
-      }
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "author": "Microsoft - support@microsoft.com",
+        "comments": "Solution template for Microsoft Defender Threat Intelligence"
     },
-    "workspace-location": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "[concat('Region to deploy solution resources -- separate from location selection',parameters('location'))]"
-      }
-    },
-    "workspace": {
-      "defaultValue": "",
-      "type": "string",
-      "metadata": {
-        "description": "Workspace name for Log Analytics where Microsoft Sentinel is setup"
-      }
-    }
-  },
-  "variables": {
-    "solutionId": "azuresentinel.azure-sentinel-solution-microsoftdefenderthreatint",
-    "_solutionId": "[variables('solutionId')]",
-    "email": "support@microsoft.com",
-    "_email": "[variables('email')]",
-    "MDTI-Automated-Triage": "MDTI-Automated-Triage",
-    "_MDTI-Automated-Triage": "[variables('MDTI-Automated-Triage')]",
-    "playbookVersion1": "1.0",
-    "playbookContentId1": "MDTI-Automated-Triage",
-    "_playbookContentId1": "[variables('playbookContentId1')]",
-    "playbookId1": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId1'))]",
-    "playbookTemplateSpecName1": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId1')))]",
-    "workspaceResourceId": "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]",
-    "MDTI-Base": "MDTI-Base",
-    "_MDTI-Base": "[variables('MDTI-Base')]",
-    "playbookVersion2": "1.0",
-    "playbookContentId2": "MDTI-Base",
-    "_playbookContentId2": "[variables('playbookContentId2')]",
-    "playbookId2": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId2'))]",
-    "playbookTemplateSpecName2": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId2')))]",
-    "MDTI-Data-WebComponents": "MDTI-Data-WebComponents",
-    "_MDTI-Data-WebComponents": "[variables('MDTI-Data-WebComponents')]",
-    "playbookVersion3": "1.0",
-    "playbookContentId3": "MDTI-Data-WebComponents",
-    "_playbookContentId3": "[variables('playbookContentId3')]",
-    "playbookId3": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId3'))]",
-    "playbookTemplateSpecName3": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId3')))]",
-    "MDTI-Intel-Reputation": "MDTI-Intel-Reputation",
-    "_MDTI-Intel-Reputation": "[variables('MDTI-Intel-Reputation')]",
-    "playbookVersion4": "1.0",
-    "playbookContentId4": "MDTI-Intel-Reputation",
-    "_playbookContentId4": "[variables('playbookContentId4')]",
-    "playbookId4": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId4'))]",
-    "playbookTemplateSpecName4": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId4')))]"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Resources/templateSpecs",
-      "apiVersion": "2021-05-01",
-      "name": "[variables('playbookTemplateSpecName1')]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "properties": {
-        "description": "MDTI-Automated-Triage playbook",
-        "displayName": "MDTI-Automated-Triage playbook"
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs/versions",
-      "apiVersion": "2021-05-01",
-      "name": "[concat(variables('playbookTemplateSpecName1'),'/',variables('playbookVersion1'))]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName1'))]"
-      ],
-      "properties": {
-        "description": "MDTI-Automated-Triage Playbook with template version 2.0.1",
-        "mainTemplate": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "[variables('playbookVersion1')]",
-          "parameters": {
-            "PlaybookName": {
-              "defaultValue": "MDTI-Automated-Triage",
-              "type": "String"
+    "parameters": {
+        "location": {
+            "type": "string",
+            "minLength": 1,
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Not used, but needed to pass arm-ttk test `Location-Should-Not-Be-Hardcoded`.  We instead use the `workspace-location` which is derived from the LA workspace"
             }
-          },
-          "variables": {
-            "AzureSentinelConnectionName": "[[concat('azuresentinel-', parameters('PlaybookName'))]",
-            "connection-1": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]",
-            "_connection-1": "[[variables('connection-1')]",
-            "workspace-location-inline": "[concat('[resourceGroup().locatio', 'n]')]",
-            "workspace-name": "[parameters('workspace')]",
-            "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Web/connections",
-              "apiVersion": "2016-06-01",
-              "name": "[[variables('AzureSentinelConnectionName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "properties": {
-                "api": {
-                  "id": "[[variables('_connection-1')]"
-                }
-              }
+        },
+        "workspace-location": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "[concat('Region to deploy solution resources -- separate from location selection',parameters('location'))]"
+            }
+        },
+        "workspace": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "Workspace name for Log Analytics where Microsoft Sentinel is setup"
+            }
+        }
+    },
+    "variables": {
+        "solutionId": "azuresentinel.azure-sentinel-solution-microsoftdefenderthreatint",
+        "_solutionId": "[variables('solutionId')]",
+        "email": "support@microsoft.com",
+        "_email": "[variables('email')]",
+        "MDTI-Automated-Triage": "MDTI-Automated-Triage",
+        "_MDTI-Automated-Triage": "[variables('MDTI-Automated-Triage')]",
+        "playbookVersion1": "1.0",
+        "playbookContentId1": "MDTI-Automated-Triage",
+        "_playbookContentId1": "[variables('playbookContentId1')]",
+        "playbookId1": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId1'))]",
+        "playbookTemplateSpecName1": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId1')))]",
+        "workspaceResourceId": "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]",
+        "MDTI-Base": "MDTI-Base",
+        "_MDTI-Base": "[variables('MDTI-Base')]",
+        "playbookVersion2": "1.0",
+        "playbookContentId2": "MDTI-Base",
+        "_playbookContentId2": "[variables('playbookContentId2')]",
+        "playbookId2": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId2'))]",
+        "playbookTemplateSpecName2": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId2')))]",
+        "MDTI-Data-WebComponents": "MDTI-Data-WebComponents",
+        "_MDTI-Data-WebComponents": "[variables('MDTI-Data-WebComponents')]",
+        "playbookVersion3": "1.0",
+        "playbookContentId3": "MDTI-Data-WebComponents",
+        "_playbookContentId3": "[variables('playbookContentId3')]",
+        "playbookId3": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId3'))]",
+        "playbookTemplateSpecName3": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId3')))]",
+        "MDTI-Intel-Reputation": "MDTI-Intel-Reputation",
+        "_MDTI-Intel-Reputation": "[variables('MDTI-Intel-Reputation')]",
+        "playbookVersion4": "1.0",
+        "playbookContentId4": "MDTI-Intel-Reputation",
+        "_playbookContentId4": "[variables('playbookContentId4')]",
+        "playbookId4": "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId4'))]",
+        "playbookTemplateSpecName4": "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId4')))]",
+        "keyvaultname": "[concat('kv-mdti-', uniqueString(parameters('workspace')))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/templateSpecs",
+            "apiVersion": "2021-05-01",
+            "name": "[variables('playbookTemplateSpecName1')]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
             },
-            {
-              "type": "Microsoft.Logic/workflows",
-              "apiVersion": "2017-07-01",
-              "name": "[[parameters('PlaybookName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "tags": {
-                "LogicAppsCategory": "security",
-                "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
-              },
-              "dependsOn": [
-                "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
-              ],
-              "properties": {
-                "state": "Enabled",
-                "definition": {
-                  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-                  "contentVersion": "1.0.0.0",
-                  "parameters": {
-                    "$connections": {
-                      "type": "Object"
-                    }
-                  },
-                  "triggers": {
-                    "When_Azure_Sentinel_incident_creation_rule_was_triggered": {
-                      "type": "ApiConnectionWebhook",
-                      "inputs": {
-                        "body": {
-                          "callback_url": "@{listCallbackUrl()}"
-                        },
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "path": "/incident-creation"
-                      }
-                    }
-                  },
-                  "actions": {
-                    "Entities_-_Get_Hosts": {
-                      "runAfter": {
-                        "Init_Classification_Bit": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "ApiConnection",
-                      "inputs": {
-                        "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "method": "post",
-                        "path": "/entities/host"
-                      }
-                    },
-                    "Entities_-_Get_IPs": {
-                      "runAfter": {
-                        "Init_Classification_Bit": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "ApiConnection",
-                      "inputs": {
-                        "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "method": "post",
-                        "path": "/entities/ip"
-                      }
-                    },
-                    "For_each_Host": {
-                      "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
-                      "actions": {
-                        "Add_comment_to_incident_(V3)": {
-                          "runAfter": {
-                            "Create_Host_HTML_table": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ApiConnection",
-                          "inputs": {
-                            "body": {
-                              "incidentArmId": "@triggerBody()?['object']?['id']",
-                              "message": "<p>MDTI Reputation: @{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}<br>\nClassification: @{body('Get_Reputation_for_host')?['classification']} (@{body('Get_Reputation_for_host')?['score']})<br>\n@{body('Create_Host_HTML_table')}</p>"
-                            },
-                            "host": {
-                              "connection": {
-                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                              }
-                            },
-                            "method": "post",
-                            "path": "/Incidents/Comment"
-                          }
-                        },
-                        "Append_host_classification": {
-                          "runAfter": {
-                            "Get_Reputation_for_host": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "AppendToArrayVariable",
-                          "inputs": {
-                            "name": "classification_bit",
-                            "value": "@body('Get_Reputation_for_host')?['classification']"
-                          }
-                        },
-                        "Create_Host_HTML_table": {
-                          "runAfter": {
-                            "Set_host_variable": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Table",
-                          "inputs": {
-                            "format": "HTML",
-                            "from": "@variables('result_output_host')"
-                          }
-                        },
-                        "Get_Reputation_for_host": {
-                          "type": "Http",
-                          "inputs": {
-                            "authentication": {
-                              "audience": "@body('MDTI-Base')?['resource']",
-                              "clientId": "@body('MDTI-Base')?['clientId']",
-                              "secret": "@body('MDTI-Base')?['clientSecret']",
-                              "tenant": "@body('MDTI-Base')?['tenantId']",
-                              "type": "ActiveDirectoryOAuth"
-                            },
-                            "headers": {
-                              "Content-Type": "application/json"
-                            },
-                            "method": "GET",
-                            "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}')/reputation"
-                          }
-                        },
-                        "Reset_host_variable": {
-                          "runAfter": {
-                            "Add_comment_to_incident_(V3)": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_host"
-                          }
-                        },
-                        "Set_host_variable": {
-                          "runAfter": {
-                            "Append_host_classification": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_host",
-                            "value": "@body('Get_Reputation_for_host')?['rules']"
-                          }
+            "properties": {
+                "description": "MDTI-Automated-Triage playbook",
+                "displayName": "MDTI-Automated-Triage playbook"
+            }
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs/versions",
+            "apiVersion": "2021-05-01",
+            "name": "[concat(variables('playbookTemplateSpecName1'),'/',variables('playbookVersion1'))]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName1'))]"
+            ],
+            "properties": {
+                "description": "MDTI-Automated-Triage Playbook with template version 2.0.1",
+                "mainTemplate": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "[variables('playbookVersion1')]",
+                    "parameters": {
+                        "PlaybookName": {
+                            "defaultValue": "MDTI-Automated-Triage",
+                            "type": "String"
                         }
-                      },
-                      "runAfter": {
-                        "Init_Result_Host": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "Foreach"
                     },
-                    "For_each_IP_Address": {
-                      "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
-                      "actions": {
-                        "Add_comment_to_incident_(V3)_2": {
-                          "runAfter": {
-                            "Create_IP_HTML_table": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ApiConnection",
-                          "inputs": {
-                            "body": {
-                              "incidentArmId": "@triggerBody()?['object']?['id']",
-                              "message": "<p>MDTI Reputation: @{items('For_each_IP_Address')?['Address']}<br>\nClassification: @{body('Get_reputation')?['classification']} (@{body('Get_reputation')?['score']})<br>\n@{body('Create_IP_HTML_table')}</p>"
-                            },
-                            "host": {
-                              "connection": {
-                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                              }
-                            },
-                            "method": "post",
-                            "path": "/Incidents/Comment"
-                          }
-                        },
-                        "Append_ip_classification": {
-                          "runAfter": {
-                            "Get_reputation": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "AppendToArrayVariable",
-                          "inputs": {
-                            "name": "classification_bit",
-                            "value": "@body('Get_reputation')?['classification']"
-                          }
-                        },
-                        "Create_IP_HTML_table": {
-                          "runAfter": {
-                            "Set_IP_variable": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Table",
-                          "inputs": {
-                            "format": "HTML",
-                            "from": "@variables('result_output_ip')"
-                          }
-                        },
-                        "Get_reputation": {
-                          "type": "Http",
-                          "inputs": {
-                            "authentication": {
-                              "audience": "@body('MDTI-Base')?['resource']",
-                              "clientId": "@body('MDTI-Base')?['clientId']",
-                              "secret": "@body('MDTI-Base')?['clientSecret']",
-                              "tenant": "@body('MDTI-Base')?['tenantId']",
-                              "type": "ActiveDirectoryOAuth"
-                            },
-                            "headers": {
-                              "Content-Type": "application/json"
-                            },
-                            "method": "GET",
-                            "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_IP_Address')?['Address']}')/reputation"
-                          }
-                        },
-                        "Reset_IP_Variable": {
-                          "runAfter": {
-                            "Add_comment_to_incident_(V3)_2": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_ip"
-                          }
-                        },
-                        "Set_IP_variable": {
-                          "runAfter": {
-                            "Append_ip_classification": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_ip",
-                            "value": "@body('Get_reputation')?['rules']"
-                          }
-                        }
-                      },
-                      "runAfter": {
-                        "Init_Result_IP": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "Foreach"
+                    "variables": {
+                        "AzureSentinelConnectionName": "[[concat('azuresentinel-', parameters('PlaybookName'))]",
+                        "connection-1": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]",
+                        "_connection-1": "[[variables('connection-1')]",
+                        "workspace-location-inline": "[resourceGroup().location]",
+                        "workspace-name": "[parameters('workspace')]",
+                        "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
                     },
-                    "Init_Classification_Bit": {
-                      "runAfter": {
-                        "MDTI-Base": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "classification_bit",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "Init_Result_Host": {
-                      "runAfter": {
-                        "Entities_-_Get_Hosts": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "result_output_host",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "Init_Result_IP": {
-                      "runAfter": {
-                        "Entities_-_Get_IPs": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "result_output_ip",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "MDTI-Base": {
-                      "type": "Workflow",
-                      "inputs": {
-                        "host": {
-                          "triggerName": "manual",
-                          "workflow": {
-                            "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/MDTI-Base')]"
-                          }
-                        }
-                      }
-                    },
-                    "Malicious_or_Suspicious": {
-                      "actions": {
-                        "Condition_2": {
-                          "actions": {
-                            "Update_incident": {
-                              "type": "ApiConnection",
-                              "inputs": {
-                                "body": {
-                                  "incidentArmId": "@triggerBody()?['object']?['id']",
-                                  "owner": "@triggerBody()?['object']?['properties']?['owner']?['objectId']",
-                                  "ownerAction": "Unassign",
-                                  "severity": "High",
-                                  "status": "Active",
-                                  "tagsToAdd": {
-                                    "TagsToAdd": [
-                                      {
-                                        "Tag": "MDTI Malicious"
-                                      }
-                                    ]
-                                  }
-                                },
-                                "host": {
-                                  "connection": {
-                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                  }
-                                },
-                                "method": "put",
-                                "path": "/Incidents"
-                              }
+                    "resources": [
+                        {
+                            "type": "Microsoft.Web/connections",
+                            "apiVersion": "2016-06-01",
+                            "name": "[[variables('AzureSentinelConnectionName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "properties": {
+                                "api": {
+                                    "id": "[[variables('_connection-1')]"
+                                }
                             }
-                          },
-                          "else": {
-                            "actions": {
-                              "Update_incident_2": {
-                                "type": "ApiConnection",
-                                "inputs": {
-                                  "body": {
-                                    "incidentArmId": "@triggerBody()?['object']?['id']",
-                                    "owner": "@triggerBody()?['object']?['properties']?['owner']?['objectId']",
-                                    "ownerAction": "Unassign",
-                                    "severity": "Medium",
-                                    "status": "Active",
-                                    "tagsToAdd": {
-                                      "TagsToAdd": [
-                                        {
-                                          "Tag": "MDTI Suspicious"
+                        },
+                        {
+                            "type": "Microsoft.Logic/workflows",
+                            "apiVersion": "2017-07-01",
+                            "name": "[[parameters('PlaybookName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "tags": {
+                                "LogicAppsCategory": "security",
+                                "Source": "MDTI",
+                                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
+                            },
+                            "dependsOn": [
+                                "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                            ],
+                            "properties": {
+                                "state": "Enabled",
+                                "definition": {
+                                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                                    "contentVersion": "1.0.0.0",
+                                    "parameters": {
+                                        "$connections": {
+                                            "type": "Object"
                                         }
-                                      ]
+                                    },
+                                    "triggers": {
+                                        "When_Azure_Sentinel_incident_creation_rule_was_triggered": {
+                                            "type": "ApiConnectionWebhook",
+                                            "inputs": {
+                                                "body": {
+                                                    "callback_url": "@{listCallbackUrl()}"
+                                                },
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "path": "/incident-creation"
+                                            }
+                                        }
+                                    },
+                                    "actions": {
+                                        "Entities_-_Get_Hosts": {
+                                            "runAfter": {
+                                                "Init_Classification_Bit": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/entities/host"
+                                            }
+                                        },
+                                        "Entities_-_Get_IPs": {
+                                            "runAfter": {
+                                                "Init_Classification_Bit": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/entities/ip"
+                                            }
+                                        },
+                                        "For_each_Host": {
+                                            "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
+                                            "actions": {
+                                                "Add_comment_to_incident_(V3)": {
+                                                    "runAfter": {
+                                                        "Create_Host_HTML_table": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>MDTI Reputation: @{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}<br>\nClassification: @{body('Get_Reputation_for_host')?['classification']} (@{body('Get_Reputation_for_host')?['score']})<br>\n@{body('Create_Host_HTML_table')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                },
+                                                "Append_host_classification": {
+                                                    "runAfter": {
+                                                        "Get_Reputation_for_host": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "AppendToArrayVariable",
+                                                    "inputs": {
+                                                        "name": "classification_bit",
+                                                        "value": "@body('Get_Reputation_for_host')?['classification']"
+                                                    }
+                                                },
+                                                "Create_Host_HTML_table": {
+                                                    "runAfter": {
+                                                        "Set_host_variable": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Table",
+                                                    "inputs": {
+                                                        "format": "HTML",
+                                                        "from": "@variables('result_output_host')"
+                                                    }
+                                                },
+                                                "Get_Reputation_for_host": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "@body('MDTI-Base')?['resource']",
+                                                            "clientId": "@body('MDTI-Base')?['clientId']",
+                                                            "secret": "@body('MDTI-Base')?['clientSecret']",
+                                                            "tenant": "@body('MDTI-Base')?['tenantId']",
+                                                            "type": "ActiveDirectoryOAuth"
+                                                        },
+                                                        "headers": {
+                                                            "Content-Type": "application/json"
+                                                        },
+                                                        "method": "GET",
+                                                        "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}')/reputation"
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Set_host_variable": {
+                                                    "runAfter": {
+                                                        "Append_host_classification": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "result_output_host",
+                                                        "value": "@body('Get_Reputation_for_host')?['rules']"
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Init_Result_Host": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach"
+                                        },
+                                        "For_each_IP_Address": {
+                                            "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
+                                            "actions": {
+                                                "Add_comment_to_incident_(V3)_2": {
+                                                    "runAfter": {
+                                                        "Create_IP_HTML_table": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>MDTI Reputation: @{items('For_each_IP_Address')?['Address']}<br>\nClassification: @{body('Get_reputation')?['classification']} (@{body('Get_reputation')?['score']})<br>\n@{body('Create_IP_HTML_table')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                },
+                                                "Append_ip_classification": {
+                                                    "runAfter": {
+                                                        "Get_reputation": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "AppendToArrayVariable",
+                                                    "inputs": {
+                                                        "name": "classification_bit",
+                                                        "value": "@body('Get_reputation')?['classification']"
+                                                    }
+                                                },
+                                                "Create_IP_HTML_table": {
+                                                    "runAfter": {
+                                                        "Set_IP_variable": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Table",
+                                                    "inputs": {
+                                                        "format": "HTML",
+                                                        "from": "@variables('result_output_ip')"
+                                                    }
+                                                },
+                                                "Get_reputation": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "@body('MDTI-Base')?['resource']",
+                                                            "clientId": "@body('MDTI-Base')?['clientId']",
+                                                            "secret": "@body('MDTI-Base')?['clientSecret']",
+                                                            "tenant": "@body('MDTI-Base')?['tenantId']",
+                                                            "type": "ActiveDirectoryOAuth"
+                                                        },
+                                                        "headers": {
+                                                            "Content-Type": "application/json"
+                                                        },
+                                                        "method": "GET",
+                                                        "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_IP_Address')?['Address']}')/reputation"
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Set_IP_variable": {
+                                                    "runAfter": {
+                                                        "Append_ip_classification": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "result_output_ip",
+                                                        "value": "@body('Get_reputation')?['rules']"
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Init_Result_IP": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach"
+                                        },
+                                        "Init_Classification_Bit": {
+                                            "runAfter": {
+                                                "MDTI-Base": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "classification_bit",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Init_Result_Host": {
+                                            "runAfter": {
+                                                "Entities_-_Get_Hosts": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "result_output_host",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Init_Result_IP": {
+                                            "runAfter": {
+                                                "Entities_-_Get_IPs": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "result_output_ip",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "MDTI-Base": {
+                                            "type": "Workflow",
+                                            "inputs": {
+                                                "host": {
+                                                    "triggerName": "manual",
+                                                    "workflow": {
+                                                        "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/MDTI-Base')]"
+                                                    }
+                                                }
+                                            },
+                                            "runtimeConfiguration": {
+                                                "secureData": {
+                                                    "properties": [
+                                                        "outputs"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "Malicious_or_Suspicious": {
+                                            "actions": {
+                                                "Condition_2": {
+                                                    "actions": {
+                                                        "Update_incident": {
+                                                            "type": "ApiConnection",
+                                                            "inputs": {
+                                                                "body": {
+                                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                                    "owner": "@triggerBody()?['object']?['properties']?['owner']?['objectId']",
+                                                                    "ownerAction": "Unassign",
+                                                                    "severity": "High",
+                                                                    "status": "Active",
+                                                                    "tagsToAdd": {
+                                                                        "TagsToAdd": [
+                                                                            {
+                                                                                "Tag": "MDTI Malicious"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "host": {
+                                                                    "connection": {
+                                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                                    }
+                                                                },
+                                                                "method": "put",
+                                                                "path": "/Incidents"
+                                                            }
+                                                        }
+                                                    },
+                                                    "else": {
+                                                        "actions": {
+                                                            "Update_incident_2": {
+                                                                "type": "ApiConnection",
+                                                                "inputs": {
+                                                                    "body": {
+                                                                        "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                                        "owner": "@triggerBody()?['object']?['properties']?['owner']?['objectId']",
+                                                                        "ownerAction": "Unassign",
+                                                                        "severity": "Medium",
+                                                                        "status": "Active",
+                                                                        "tagsToAdd": {
+                                                                            "TagsToAdd": [
+                                                                                {
+                                                                                    "Tag": "MDTI Suspicious"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "host": {
+                                                                        "connection": {
+                                                                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                                        }
+                                                                    },
+                                                                    "method": "put",
+                                                                    "path": "/Incidents"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "expression": {
+                                                        "and": [
+                                                            {
+                                                                "contains": [
+                                                                    "@variables('classification_bit')",
+                                                                    "malicious"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "type": "If"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "For_each_Host": [
+                                                    "Succeeded"
+                                                ],
+                                                "For_each_IP_Address": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "expression": {
+                                                "or": [
+                                                    {
+                                                        "contains": [
+                                                            "@variables('classification_bit')",
+                                                            "malicious"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "contains": [
+                                                            "@variables('classification_bit')",
+                                                            "suspicious"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "type": "If"
+                                        }
                                     }
-                                  },
-                                  "host": {
-                                    "connection": {
-                                      "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                },
+                                "parameters": {
+                                    "$connections": {
+                                        "value": {
+                                            "azuresentinel": {
+                                                "connectionId": "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                                "connectionName": "[[variables('AzureSentinelConnectionName')]",
+                                                "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]"
+                                            }
+                                        }
                                     }
-                                  },
-                                  "method": "put",
-                                  "path": "/Incidents"
                                 }
-                              }
                             }
-                          },
-                          "expression": {
-                            "and": [
-                              {
-                                "contains": [
-                                  "@variables('classification_bit')",
-                                  "malicious"
-                                ]
-                              }
-                            ]
-                          },
-                          "type": "If"
+                        },
+                        {
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                            "apiVersion": "2022-01-01-preview",
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId1'),'/'))))]",
+                            "properties": {
+                                "parentId": "[variables('playbookId1')]",
+                                "contentId": "[variables('_playbookContentId1')]",
+                                "kind": "Playbook",
+                                "version": "[variables('playbookVersion1')]",
+                                "source": {
+                                    "kind": "Solution",
+                                    "name": "Microsoft Defender Threat Intelligence",
+                                    "sourceId": "[variables('_solutionId')]"
+                                },
+                                "author": {
+                                    "name": "Microsoft",
+                                    "email": "[variables('_email')]"
+                                },
+                                "support": {
+                                    "name": "Microsoft Corporation",
+                                    "email": "support@microsoft.com",
+                                    "tier": "Microsoft",
+                                    "link": "https://support.microsoft.com"
+                                }
+                            }
                         }
-                      },
-                      "runAfter": {
-                        "For_each_Host": [
-                          "Succeeded"
+                    ],
+                    "metadata": {
+                        "comments": "Perform automated triage actions on the Microsoft Sentinels Incident based on MDTI Reputation data.",
+                        "title": "MDTI-Automated-Triage",
+                        "description": "This playbook uses the MDTI Reputation data to automatically enrich incidents generated by Microsoft Sentinel. Indicators from an incident will be evaluated with MDTI reputation data. If any indicators are labeled as 'suspicious', the incident will be tagged as such and its severity will be marked as 'medium'. If any indicators are labeled as 'malicious', the incident will be tagged as such and its severity will be marked as 'high'. Regardless of the reputation state, comments will be added to the incident outlining the reputation details with links to further information if applicable.",
+                        "prerequisites": [
+                            "This playbook inherits API connections created and established within a base playbook. Ensure you have deployed [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) prior to deploying this playbook. If you have trouble accessing your account or your credentials contact your account representative or (mdtidiscussion[@]microsoft.com)."
                         ],
-                        "For_each_IP_Address": [
-                          "Succeeded"
+                        "lastUpdateTime": "2023-03-09T00:00:00Z",
+                        "postDeployment": [
+                            "After deploying the playbook, you must authorize the connections leveraged.",
+                            "1. Visit the playbook resource.",
+                            "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
+                            "3. Ensure each connection has been authorized.",
+                            "**Note: If you've deployed the [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) playbook, you will only need to authorize the Microsoft Sentinel connection.**"
+                        ],
+                        "releaseNotes": [
+                            {
+                                "version": "1.0.1",
+                                "title": "MDTI Automated Triage",
+                                "notes": [
+                                    "Initial version"
+                                ]
+                            }
                         ]
-                      },
-                      "expression": {
-                        "or": [
-                          {
-                            "contains": [
-                              "@variables('classification_bit')",
-                              "malicious"
-                            ]
-                          },
-                          {
-                            "contains": [
-                              "@variables('classification_bit')",
-                              "suspicious"
-                            ]
-                          }
-                        ]
-                      },
-                      "type": "If"
                     }
-                  }
-                },
-                "parameters": {
-                  "$connections": {
-                    "value": {
-                      "azuresentinel": {
-                        "connectionId": "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                        "connectionName": "[[variables('AzureSentinelConnectionName')]",
-                        "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]"
-                      }
-                    }
-                  }
                 }
-              }
-            },
-            {
-              "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
-              "apiVersion": "2022-01-01-preview",
-              "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId1'),'/'))))]",
-              "properties": {
-                "parentId": "[variables('playbookId1')]",
-                "contentId": "[variables('_playbookContentId1')]",
-                "kind": "Playbook",
-                "version": "[variables('playbookVersion1')]",
-                "source": {
-                  "kind": "Solution",
-                  "name": "Microsoft Defender Threat Intelligence",
-                  "sourceId": "[variables('_solutionId')]"
-                },
-                "author": {
-                  "name": "Microsoft",
-                  "email": "[variables('_email')]"
-                },
-                "support": {
-                  "name": "Microsoft Corporation",
-                  "email": "support@microsoft.com",
-                  "tier": "Microsoft",
-                  "link": "https://support.microsoft.com"
-                }
-              }
             }
-          ],
-          "metadata": {
-            "comments": "Perform automated triage actions on the Microsoft Sentinels Incident based on MDTI Reputation data.",
-            "title": "MDTI-Automated-Triage",
-            "description": "This playbook uses the MDTI Reputation data to automatically enrich incidents generated by Microsoft Sentinel. Indicators from an incident will be evaluated with MDTI reputation data. If any indicators are labeled as 'suspicious', the incident will be tagged as such and its severity will be marked as 'medium'. If any indicators are labeled as 'malicious', the incident will be tagged as such and its severity will be marked as 'high'. Regardless of the reputation state, comments will be added to the incident outlining the reputation details with links to further information if applicable.",
-            "prerequisites": [
-              "This playbook inherits API connections created and established within a base playbook. Ensure you have deployed [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) prior to deploying this playbook. If you have trouble accessing your account or your credentials contact your account representative or (mdtidiscussion[@]microsoft.com)."
-            ],
-            "lastUpdateTime": "2023-03-09T00:00:00Z",
-            "postDeployment": [
-              "After deploying the playbook, you must authorize the connections leveraged.",
-              "1. Visit the playbook resource.",
-              "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
-              "3. Ensure each connection has been authorized.",
-              "**Note: If you've deployed the [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) playbook, you will only need to authorize the Microsoft Sentinel connection.**"
-            ],
-            "releaseNotes": [
-              {
-                "version": "1.0.0",
-                "title": "MDTI Automated Triage",
-                "notes": [
-                  "Initial version"
-                ]
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs",
-      "apiVersion": "2021-05-01",
-      "name": "[variables('playbookTemplateSpecName2')]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "properties": {
-        "description": "MDTI-Base playbook",
-        "displayName": "MDTI-Base playbook"
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs/versions",
-      "apiVersion": "2021-05-01",
-      "name": "[concat(variables('playbookTemplateSpecName2'),'/',variables('playbookVersion2'))]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName2'))]"
-      ],
-      "properties": {
-        "description": "MDTI-Base Playbook with template version 2.0.1",
-        "mainTemplate": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "[variables('playbookVersion2')]",
-          "parameters": {
-            "PlaybookName": {
-              "defaultValue": "MDTI-Base",
-              "type": "String"
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs",
+            "apiVersion": "2021-05-01",
+            "name": "[variables('playbookTemplateSpecName2')]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
             },
-            "Client-Id": {
-              "defaultValue": "Client-ID",
-              "type": "String"
-            },
-            "Client-Secret": {
-              "defaultValue": "Client-Secret",
-              "type": "SecureString"
-            },
-            "MDTI-Resource": {
-              "defaultValue": "https://graph.microsoft.com",
-              "type": "String"
-            },
-            "MDTI-BaseUrl": {
-              "defaultValue": "graph.microsoft.com",
-              "type": "String"
-            },
-            "Api-Version": {
-              "defaultValue": "beta",
-              "type": "String"
+            "properties": {
+                "description": "MDTI-Base playbook",
+                "displayName": "MDTI-Base playbook"
             }
-          },
-          "variables": {
-            "workspace-location-inline": "[concat('[resourceGroup().locatio', 'n]')]",
-            "workspace-name": "[parameters('workspace')]",
-            "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Logic/workflows",
-              "apiVersion": "2017-07-01",
-              "name": "[[parameters('PlaybookName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "tags": {
-                "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
-              },
-              "properties": {
-                "state": "Enabled",
-                "definition": {
-                  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-                  "contentVersion": "1.0.0.0",
-                  "parameters": {
-                    "Client-Id": {
-                      "defaultValue": "Client-Id",
-                      "type": "String"
-                    },
-                    "Client-Secret": {
-                      "defaultValue": "Client-Secret",
-                      "type": "SecureString"
-                    },
-                    "MDTI-Resource": {
-                      "defaultValue": "https://graph.microsoft.com",
-                      "type": "String"
-                    },
-                    "MDTI-BaseUrl": {
-                      "defaultValue": "graph.microsoft.com",
-                      "type": "String"
-                    },
-                    "Api-Version": {
-                      "defaultValue": "beta",
-                      "type": "String"
-                    },
-                    "ResourceGroupName": {
-                      "defaultValue": "[[resourceGroup().name]",
-                      "type": "String"
-                    },
-                    "Subscription-Id": {
-                      "defaultValue": "[[subscription().subscriptionId]",
-                      "type": "String"
-                    },
-                    "Tenant-Id": {
-                      "defaultValue": "[[subscription().tenantId]",
-                      "type": "String"
-                    }
-                  },
-                  "triggers": {
-                    "manual": {
-                      "type": "Request",
-                      "kind": "Http"
-                    }
-                  },
-                  "actions": {
-                    "Response": {
-                      "runtimeConfiguration": {
-                        "secureData": {
-                          "properties": [
-                            "inputs"
-                          ]
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs/versions",
+            "apiVersion": "2021-05-01",
+            "name": "[concat(variables('playbookTemplateSpecName2'),'/',variables('playbookVersion2'))]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName2'))]"
+            ],
+            "properties": {
+                "description": "MDTI-Base Playbook with template version 2.0.1",
+                "mainTemplate": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "[variables('playbookVersion2')]",
+                    "parameters": {
+                        "PlaybookName": {
+                            "defaultValue": "MDTI-Base",
+                            "type": "String"
+                        },
+                        "Client-Id": {
+                            "defaultValue": "Client-ID",
+                            "type": "String"
+                        },
+                        "Client-Secret": {
+                            "defaultValue": "Client-Secret",
+                            "type": "SecureString"
+                        },
+                        "MDTI-Resource": {
+                            "defaultValue": "https://graph.microsoft.com",
+                            "type": "String"
+                        },
+                        "MDTI-BaseUrl": {
+                            "defaultValue": "graph.microsoft.com",
+                            "type": "String"
+                        },
+                        "Api-Version": {
+                            "defaultValue": "beta",
+                            "type": "String"
+                        },
+                        "Key-Vault-Sku": {
+                            "defaultValue": "standard",
+                            "type": "string",
+                            "metadata": {
+                                "description": "Key Vault SKU name"
+                            },
+                            "allowedValues": [
+                                "premium",
+                                "standard"
+                            ]
+                        },
+                        "Key-Vault-Secret-Name": {
+                            "defaultValue": "mdti-api",
+                            "type": "string",
+                            "metadata": {
+                                "description": "The name for the Client-Secret in the Key Vault"
+                            }
+                        },
+                        "User-Object-Id": {
+                            "defaultValue": "00000000-0000-0000-0000-000000000000",
+                            "type": "string",
+                            "metadata": {
+                                "description": "Object ID, aka Principal ID, of the User to assign Key Vault Administrator role. If not changed from the default, then a role must be assigned manually the Key Vault Access Control (IAM) in order to view Key Vault contents"
+                            }
                         }
-                      },
-                      "type": "Response",
-                      "kind": "Http",
-                      "inputs": {
-                        "body": {
-                          "clientId": "@parameters('Client-Id')",
-                          "clientSecret": "@parameters('Client-Secret')",
-                          "resource": "@{parameters('MDTI-Resource')}",
-                          "tenantId": "@parameters('Tenant-Id')",
-                          "MDTI-BaseUrl": "@{parameters('MDTI-BaseUrl')}",
-                          "Api-Version": "@parameters('Api-Version')"
-                        },
-                        "headers": {
-                          "Content-Type": "application/json"
-                        },
-                        "schema": {
-                          "properties": {
-                            "clientId": {
-                              "type": "string"
-                            },
-                            "clientSecret": {
-                              "type": "string"
-                            },
-                            "resource": {
-                              "type": "string"
-                            },
-                            "tenantId": {
-                              "type": "string"
-                            },
-                            "MDTI-BaseUrl": {
-                              "type": "string"
-                            },
-                            "Api-Version": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "statusCode": 200
-                      }
-                    }
-                  }
-                },
-                "parameters": {
-                  "Client-Id": {
-                    "value": "[[parameters('Client-Id')]"
-                  },
-                  "Client-Secret": {
-                    "value": "[[parameters('Client-Secret')]"
-                  },
-                  "MDTI-Resource": {
-                    "value": "[[parameters('MDTI-Resource')]"
-                  },
-                  "MDTI-BaseUrl": {
-                    "value": "[[parameters('MDTI-BaseUrl')]"
-                  },
-                  "Api-Version": {
-                    "value": "[[parameters('Api-Version')]"
-                  }
-                }
-              }
-            },
-            {
-              "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
-              "apiVersion": "2022-01-01-preview",
-              "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId2'),'/'))))]",
-              "properties": {
-                "parentId": "[variables('playbookId2')]",
-                "contentId": "[variables('_playbookContentId2')]",
-                "kind": "Playbook",
-                "version": "[variables('playbookVersion2')]",
-                "source": {
-                  "kind": "Solution",
-                  "name": "Microsoft Defender Threat Intelligence",
-                  "sourceId": "[variables('_solutionId')]"
-                },
-                "author": {
-                  "name": "Microsoft",
-                  "email": "[variables('_email')]"
-                },
-                "support": {
-                  "name": "Microsoft Corporation",
-                  "email": "support@microsoft.com",
-                  "tier": "Microsoft",
-                  "link": "https://support.microsoft.com"
-                }
-              }
-            }
-          ],
-          "metadata": {
-            "comments": "Establish the needed base resources to leverage with all MDTI playbooks.",
-            "title": "MDTI-Base",
-            "description": "This playbook creates a shared API Connection for all MDTI playbooks to leverage. This eases the configuration process for a user during deployment of the Microsoft Defender Threat Intelligence(MDTI) solution. In time, this base playbook may be extended to set more functionality. Azure AD App Registration credentials(ClientId/ClientSecret/TenantId) with MDTI API Permissions are needed when configuring this playbook. Those can be found on your [Azure Client App](https://learn.microsoft.com/en-us/rest/api/azure/#register-your-client-application-with-azure-ad) page. If you have trouble accessing your account or your credentials contact your account representative (mdtidiscussion[@]microsoft.com).",
-            "prerequisites": [
-              "None"
-            ],
-            "lastUpdateTime": "2023-03-09T00:00:00Z",
-            "postDeployment": [
-              "After deploying the playbook, you must authorize the connections leveraged.",
-              "1. Visit the playbook resource.",
-              "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
-              "3. Ensure each connection has been authorized."
-            ],
-            "releaseNotes": [
-              {
-                "version": "1.0.0",
-                "title": "MDTI Base",
-                "notes": [
-                  "Initial version"
-                ]
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs",
-      "apiVersion": "2021-05-01",
-      "name": "[variables('playbookTemplateSpecName3')]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "properties": {
-        "description": "MDTI-Data-WebComponents playbook",
-        "displayName": "MDTI-Data-WebComponents playbook"
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs/versions",
-      "apiVersion": "2021-05-01",
-      "name": "[concat(variables('playbookTemplateSpecName3'),'/',variables('playbookVersion3'))]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName3'))]"
-      ],
-      "properties": {
-        "description": "MDTI-Data-WebComponents Playbook with template version 2.0.1",
-        "mainTemplate": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "[variables('playbookVersion3')]",
-          "parameters": {
-            "PlaybookName": {
-              "defaultValue": "MDTI-Data-WebComponents",
-              "type": "String"
-            }
-          },
-          "variables": {
-            "AzureSentinelConnectionName": "[[concat('azuresentinel-', parameters('PlaybookName'))]",
-            "connection-1": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]",
-            "_connection-1": "[[variables('connection-1')]",
-            "workspace-location-inline": "[concat('[resourceGroup().locatio', 'n]')]",
-            "workspace-name": "[parameters('workspace')]",
-            "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Web/connections",
-              "apiVersion": "2016-06-01",
-              "name": "[[variables('AzureSentinelConnectionName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "properties": {
-                "api": {
-                  "id": "[[variables('_connection-1')]"
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Logic/workflows",
-              "apiVersion": "2017-07-01",
-              "name": "[[parameters('PlaybookName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "tags": {
-                "LogicAppsCategory": "security",
-                "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
-              },
-              "dependsOn": [
-                "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
-              ],
-              "properties": {
-                "state": "Enabled",
-                "definition": {
-                  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-                  "contentVersion": "1.0.0.0",
-                  "parameters": {
-                    "$connections": {
-                      "type": "Object"
-                    }
-                  },
-                  "triggers": {
-                    "When_Azure_Sentinel_incident_creation_rule_was_triggered": {
-                      "type": "ApiConnectionWebhook",
-                      "inputs": {
-                        "body": {
-                          "callback_url": "@{listCallbackUrl()}"
-                        },
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "path": "/incident-creation"
-                      }
-                    }
-                  },
-                  "actions": {
-                    "Entities_-_Get_Hosts": {
-                      "runAfter": {
-                        "MDTI-Base": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "ApiConnection",
-                      "inputs": {
-                        "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "method": "post",
-                        "path": "/entities/host"
-                      }
                     },
-                    "Entities_-_Get_IPs": {
-                      "runAfter": {
-                        "MDTI-Base": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "ApiConnection",
-                      "inputs": {
-                        "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "method": "post",
-                        "path": "/entities/ip"
-                      }
+                    "variables": {
+                        "workspace-location-inline": "[resourceGroup().location]",
+                        "workspace-name": "[parameters('workspace')]",
+                        "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]",
+                        "keyvaultname": "[concat('kv-mdti-', uniqueString(parameters('workspace')))]",
+                        "connections_keyvault_name": "[[format('keyvault-{0}', parameters('Playbook-Name'))]"
                     },
-                    "For_each_Host": {
-                      "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
-                      "actions": {
-                        "Add_comment_to_incident_(V3)": {
-                          "runAfter": {
-                            "Create_Host_HTML_table": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ApiConnection",
-                          "inputs": {
-                            "body": {
-                              "incidentArmId": "@triggerBody()?['object']?['id']",
-                              "message": "<p>MDTI Web Components for Indicator : @{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}<br>\n@{body('Create_Host_HTML_table')}</p>"
-                            },
-                            "host": {
-                              "connection": {
-                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                              }
-                            },
-                            "method": "post",
-                            "path": "/Incidents/Comment"
-                          }
-                        },
-                        "Create_Host_HTML_table": {
-                          "runAfter": {
-                            "For_each_host_component": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Table",
-                          "inputs": {
-                            "format": "HTML",
-                            "from": "@variables('result_output_host')"
-                          }
-                        },
-                        "For_each_host_component": {
-                          "foreach": "@body('Parse_host_components')",
-                          "actions": {
-                            "Append_to_array_variable": {
-                              "type": "AppendToArrayVariable",
-                              "inputs": {
-                                "name": "result_output_host",
-                                "value": {
-                                  "Category": "@items('For_each_host_component')['category']",
-                                  "LastSeenDateTime": "@items('For_each_host_component')['lastSeenDateTime']",
-                                  "Name": "@items('For_each_host_component')['name']",
-                                  "Version": "@items('For_each_host_component')['version']"
-                                }
-                              }
-                            }
-                          },
-                          "runAfter": {
-                            "Set_Result_Host": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Foreach"
-                        },
-                        "Get_components_for_host": {
-                          "type": "Http",
-                          "inputs": {
-                            "authentication": {
-                              "audience": "@body('MDTI-Base')?['resource']",
-                              "clientId": "@body('MDTI-Base')?['clientId']",
-                              "secret": "@body('MDTI-Base')?['clientSecret']",
-                              "tenant": "@body('MDTI-Base')?['tenantId']",
-                              "type": "ActiveDirectoryOAuth"
-                            },
-                            "headers": {
-                              "Content-Type": "application/json"
-                            },
-                            "method": "GET",
-                            "queries": {
-                              "$count": "true",
-                              "$top": "25"
-                            },
-                            "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}')/components"
-                          }
-                        },
-                        "Parse_host_components": {
-                          "runAfter": {
-                            "Get_components_for_host": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ParseJson",
-                          "inputs": {
-                            "content": "@body('Get_components_for_host')?['value']",
-                            "schema": {
-                              "items": {
-                                "properties": {
-                                  "category": {
-                                    "type": "string"
-                                  },
-                                  "firstSeenDateTime": {
-                                    "type": "string"
-                                  },
-                                  "host": {
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "id": {
-                                    "type": "string"
-                                  },
-                                  "lastSeenDateTime": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "version": {
-                                    "type": "string"
-                                  }
+                    "resources": [
+                        {
+                            "type": "Microsoft.KeyVault/vaults",
+                            "apiVersion": "2022-07-01",
+                            "name": "[[variables('keyvaultname')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "properties": {
+                                "sku": {
+                                    "family": "A",
+                                    "name": "[[parameters('Key-Vault-Sku')]"
                                 },
-                                "required": [
-                                  "id",
-                                  "firstSeenDateTime",
-                                  "lastSeenDateTime",
-                                  "name",
-                                  "version",
-                                  "category",
-                                  "host"
-                                ],
-                                "type": "object"
-                              },
-                              "type": "array"
-                            }
-                          }
-                        },
-                        "Set_Result_Host": {
-                          "runAfter": {
-                            "Parse_host_components": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_host",
-							"value": []
-                          }
-                        }
-                      },
-                      "runAfter": {
-                        "Init_Result_Host": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "Foreach",
-                      "runtimeConfiguration": {
-                        "concurrency": {
-                          "repetitions": 1
-                        }
-                      }
-                    },
-                    "For_each_IP_Address": {
-                      "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
-                      "actions": {
-                        "Add_comment_to_incident_(V3)_2": {
-                          "runAfter": {
-                            "Create_IP_HTML_table": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ApiConnection",
-                          "inputs": {
-                            "body": {
-                              "incidentArmId": "@triggerBody()?['object']?['id']",
-                              "message": "<p>MDTI Web Components for Indicator: @{items('For_each_IP_Address')?['Address']}<br>\n@{body('Create_IP_HTML_table')}</p>"
-                            },
-                            "host": {
-                              "connection": {
-                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                              }
-                            },
-                            "method": "post",
-                            "path": "/Incidents/Comment"
-                          }
-                        },
-                        "Create_IP_HTML_table": {
-                          "runAfter": {
-                            "For_each_component": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Table",
-                          "inputs": {
-                            "format": "HTML",
-                            "from": "@variables('result_output_ip')"
-                          }
-                        },
-                        "For_each_component": {
-                          "foreach": "@body('Parse_components')",
-                          "actions": {
-                            "Append_to_Result_IP": {
-                              "type": "AppendToArrayVariable",
-                              "inputs": {
-                                "name": "result_output_ip",
-                                "value": {
-                                  "Category": "@items('For_each_component')?['category']",
-                                  "LastSeenDateTime": "@items('For_each_component')?['lastSeenDateTime']",
-                                  "Name": "@items('For_each_component')?['name']",
-                                  "Version": "@items('For_each_component')?['version']"
+                                "tenantId": "[subscription().tenantId]",
+                                "enabledForDeployment": false,
+                                "enabledForDiskEncryption": false,
+                                "enabledForTemplateDeployment": false,
+                                "enableRbacAuthorization": true,
+                                "networkAcls": {
+                                    "defaultAction": "Allow",
+                                    "bypass": "AzureServices"
                                 }
-                              }
                             }
-                          },
-                          "runAfter": {
-                            "Set_Result_IP": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Foreach"
                         },
-                        "Get_components": {
-                          "type": "Http",
-                          "inputs": {
-                            "authentication": {
-                              "audience": "@body('MDTI-Base')?['resource']",
-                              "clientId": "@body('MDTI-Base')?['clientId']",
-                              "secret": "@body('MDTI-Base')?['clientSecret']",
-                              "tenant": "@body('MDTI-Base')?['tenantId']",
-                              "type": "ActiveDirectoryOAuth"
+                        {
+                            "type": "Microsoft.KeyVault/vaults/secrets",
+                            "apiVersion": "2021-10-01",
+                            "name": "[[format('{0}/{1}', variables('keyvaultname'), parameters('Key-Vault-Secret-Name'))]",
+                            "properties": {
+                                "value": "[[parameters('Client-Secret')]"
                             },
-                            "headers": {
-                              "Content-Type": "application/json"
-                            },
-                            "method": "GET",
-                            "queries": {
-                              "$count": "true",
-                              "$top": "25"
-                            },
-                            "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_IP_Address')?['Address']}')/components"
-                          }
-                        },
-                        "Parse_components": {
-                          "runAfter": {
-                            "Get_components": [
-                              "Succeeded"
+                            "dependsOn": [
+                                "[resourceId('Microsoft.KeyVault/vaults', variables('keyvaultname'))]"
                             ]
-                          },
-                          "type": "ParseJson",
-                          "inputs": {
-                            "content": "@body('Get_components')?['value']",
-                            "schema": {
-                              "items": {
-                                "properties": {
-                                  "category": {
-                                    "type": "string"
-                                  },
-                                  "firstSeenDateTime": {
-                                    "type": "string"
-                                  },
-                                  "host": {
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "type": "object"
-                                  },
-                                  "id": {
-                                    "type": "string"
-                                  },
-                                  "lastSeenDateTime": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "version": {
-                                    "type": "string"
-                                  }
+                        },
+                        {
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "apiVersion": "2020-10-01-preview",
+                            "scope": "[format('Microsoft.KeyVault/vaults/{0}', variables('keyvaultname'))]",
+                            "name": "[guid('4633458b-17de-408a-b874-0445c86b69e6', resourceId('Microsoft.KeyVault/vaults', variables('keyvaultname')))]",
+                            "properties": {
+                                "principalId": "[[reference(resourceId('Microsoft.Logic/workflows', parameters('PlaybookName')), '2017-07-01', 'full').identity.principalId]",
+                                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+                                "principalType": "ServicePrincipal"
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.KeyVault/vaults', variables('keyvaultname'))]",
+                                "[[resourceId('Microsoft.Logic/workflows', parameters('Playbook-Name'))]"
+                            ]
+                        },
+                        {
+                            "condition": "[[not(empty(parameters('User-Object-Id')))]",
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "apiVersion": "2020-10-01-preview",
+                            "scope": "[format('Microsoft.KeyVault/vaults/{0}', variables('keyvaultname'))]",
+                            "name": "[guid('00482a5a-887f-4fb3-b363-3b7fe8e74483', resourceId('Microsoft.KeyVault/vaults', variables('keyvaultname')))]",
+                            "properties": {
+                                "principalId": "[[parameters('User-Object-Id')]",
+                                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                                "principalType": "User"
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.KeyVault/vaults', variables('keyvaultname'))]"
+                            ]
+                        },
+                        {
+                            "type": "Microsoft.Web/connections",
+                            "apiVersion": "2018-07-01-preview",
+                            "name": "[[variables('connections_keyvault_name')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "kind": "V1",
+                            "properties": {
+                                "displayName": "keyvault",
+                                "api": {
+                                    "id": "[[subscriptionResourceId('Microsoft.Web/locations/managedApis', variables('workspace-location-inline'), 'keyvault')]"
                                 },
-                                "required": [
-                                  "id",
-                                  "firstSeenDateTime",
-                                  "lastSeenDateTime",
-                                  "name",
-                                  "version",
-                                  "category",
-                                  "host"
-                                ],
-                                "type": "object"
-                              },
-                              "type": "array"
+                                "parameterValueType": "Alternative",
+                                "alternativeParameterValues": {
+                                    "vaultName": "[variables('keyvaultname')]"
+                                }
                             }
-                          }
                         },
-                        "Set_Result_IP": {
-                          "runAfter": {
-                            "Parse_components": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_ip",
-							"value": []
-                          }
+                        {
+                            "type": "Microsoft.Logic/workflows",
+                            "apiVersion": "2017-07-01",
+                            "name": "[[parameters('PlaybookName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "tags": {
+                                "Source": "MDTI",
+                                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
+                            },
+                            "properties": {
+                                "state": "Enabled",
+                                "definition": {
+                                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                                    "contentVersion": "1.0.0.0",
+                                    "parameters": {
+                                        "$connections": {
+                                            "defaultValue": {},
+                                            "type": "Object"
+                                        },
+                                        "Client-Id": {
+                                            "defaultValue": "[[parameters('Client-Id')]",
+                                            "type": "String"
+                                        },
+                                        "MDTI-Resource": {
+                                            "defaultValue": "[[parameters('MDTI-Resource')]",
+                                            "type": "String"
+                                        },
+                                        "MDTI-BaseUrl": {
+                                            "defaultValue": "[[parameters('MDTI-BaseUrl')]",
+                                            "type": "String"
+                                        },
+                                        "Api-Version": {
+                                            "defaultValue": "[[parameters('Api-Version')]",
+                                            "type": "String"
+                                        },
+                                        "ResourceGroupName": {
+                                            "defaultValue": "[[resourceGroup().name]",
+                                            "type": "String"
+                                        },
+                                        "Subscription-Id": {
+                                            "defaultValue": "[[subscription().subscriptionId]",
+                                            "type": "String"
+                                        },
+                                        "Tenant-Id": {
+                                            "defaultValue": "[[subscription().tenantId]",
+                                            "type": "String"
+                                        }
+                                    },
+                                    "triggers": {
+                                        "manual": {
+                                            "type": "Request",
+                                            "kind": "Http"
+                                        }
+                                    },
+                                    "actions": {
+                                        "Response": {
+                                            "runAfter": {
+                                                "Get_ClientSecret": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "runtimeConfiguration": {
+                                                "secureData": {
+                                                    "properties": [
+                                                        "inputs"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "Response",
+                                            "kind": "Http",
+                                            "inputs": {
+                                                "body": {
+                                                    "clientId": "@parameters('Client-Id')",
+                                                    "clientSecret": "@body('Get_ClientSecret')?['value']",
+                                                    "resource": "@{parameters('MDTI-Resource')}",
+                                                    "tenantId": "@parameters('Tenant-Id')",
+                                                    "MDTI-BaseUrl": "@{parameters('MDTI-BaseUrl')}",
+                                                    "Api-Version": "@parameters('Api-Version')"
+                                                },
+                                                "headers": {
+                                                    "Content-Type": "application/json"
+                                                },
+                                                "schema": {
+                                                    "properties": {
+                                                        "clientId": {
+                                                            "type": "string"
+                                                        },
+                                                        "clientSecret": {
+                                                            "type": "string"
+                                                        },
+                                                        "resource": {
+                                                            "type": "string"
+                                                        },
+                                                        "tenantId": {
+                                                            "type": "string"
+                                                        },
+                                                        "MDTI-BaseUrl": {
+                                                            "type": "string"
+                                                        },
+                                                        "Api-Version": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "statusCode": 200
+                                            }
+                                        },
+                                        "Get_ClientSecret": {
+                                            "runAfter": {},
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "get",
+                                                "path": "[[format('/secrets/@{{encodeURIComponent(''{0}'')}}/value', parameters('Key-Vault-Secret-Name'))]"
+                                            }
+                                        }
+                                    }
+                                },
+                                "parameters": {
+                                    "$connections": {
+                                        "value": {
+                                            "keyvault": {
+                                                "connectionId": "[[resourceId('Microsoft.Web/connections', variables('connections_keyvault_name'))]",
+                                                "connectionName": "keyvault-MDTI-Base",
+                                                "connectionProperties": {
+                                                    "authentication": {
+                                                        "type": "ManagedServiceIdentity"
+                                                    }
+                                                },
+                                                "id": "[[subscriptionResourceId('Microsoft.Web/locations/managedApis', variables('workspace-location-inline'), 'keyvault')]"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                            "apiVersion": "2022-01-01-preview",
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId2'),'/'))))]",
+                            "properties": {
+                                "parentId": "[variables('playbookId2')]",
+                                "contentId": "[variables('_playbookContentId2')]",
+                                "kind": "Playbook",
+                                "version": "[variables('playbookVersion2')]",
+                                "source": {
+                                    "kind": "Solution",
+                                    "name": "Microsoft Defender Threat Intelligence",
+                                    "sourceId": "[variables('_solutionId')]"
+                                },
+                                "author": {
+                                    "name": "Microsoft",
+                                    "email": "[variables('_email')]"
+                                },
+                                "support": {
+                                    "name": "Microsoft Corporation",
+                                    "email": "support@microsoft.com",
+                                    "tier": "Microsoft",
+                                    "link": "https://support.microsoft.com"
+                                }
+                            }
                         }
-                      },
-                      "runAfter": {
-                        "Init_Result_IP": [
-                          "Succeeded"
+                    ],
+                    "metadata": {
+                        "comments": "Establish the needed base resources to leverage with all MDTI playbooks.",
+                        "title": "MDTI-Base",
+                        "description": "This playbook creates a shared API Connection for all MDTI playbooks to leverage. This eases the configuration process for a user during deployment of the Microsoft Defender Threat Intelligence(MDTI) solution. In time, this base playbook may be extended to set more functionality. Azure AD App Registration credentials(ClientId/ClientSecret/TenantId) with MDTI API Permissions are needed when configuring this playbook. Those can be found on your [Azure Client App](https://learn.microsoft.com/en-us/rest/api/azure/#register-your-client-application-with-azure-ad) page. If you have trouble accessing your account or your credentials contact your account representative (mdtidiscussion[@]microsoft.com).",
+                        "prerequisites": [
+                            "None"
+                        ],
+                        "lastUpdateTime": "2023-04-01T00:00:00Z",
+                        "postDeployment": [
+                            "After deploying the playbook, you must authorize the connections leveraged.",
+                            "1. Visit the playbook resource.",
+                            "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
+                            "3. Ensure each connection has been authorized."
+                        ],
+                        "releaseNotes": [
+                            {
+                                "version": "1.0.1",
+                                "title": "MDTI Base",
+                                "notes": [
+                                    "Version 1.0.1 with Key Vault to hold Client-Secret"
+                                ]
+                            }
                         ]
-                      },
-                      "type": "Foreach",
-                      "runtimeConfiguration": {
-                        "concurrency": {
-                          "repetitions": 1
-                        }
-                      }
-                    },
-                    "Init_Result_Host": {
-                      "runAfter": {
-                        "Entities_-_Get_Hosts": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "result_output_host",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "Init_Result_IP": {
-                      "runAfter": {
-                        "Entities_-_Get_IPs": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "result_output_ip",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "MDTI-Base": {
-                      "type": "Workflow",
-                      "inputs": {
-                        "host": {
-                          "triggerName": "manual",
-                          "workflow": {
-                            "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/MDTI-Base')]"
-                          }
-                        }
-                      }
                     }
-                  }
-                },
-                "parameters": {
-                  "$connections": {
-                    "value": {
-                      "azuresentinel": {
-                        "connectionId": "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                        "connectionName": "[[variables('AzureSentinelConnectionName')]",
-                        "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]"
-                      }
-                    }
-                  }
                 }
-              }
+            }
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs",
+            "apiVersion": "2021-05-01",
+            "name": "[variables('playbookTemplateSpecName3')]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
             },
-            {
-              "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
-              "apiVersion": "2022-01-01-preview",
-              "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId3'),'/'))))]",
-              "properties": {
-                "parentId": "[variables('playbookId3')]",
-                "contentId": "[variables('_playbookContentId3')]",
-                "kind": "Playbook",
-                "version": "[variables('playbookVersion3')]",
+            "properties": {
+                "description": "MDTI-Data-WebComponents playbook",
+                "displayName": "MDTI-Data-WebComponents playbook"
+            }
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs/versions",
+            "apiVersion": "2021-05-01",
+            "name": "[concat(variables('playbookTemplateSpecName3'),'/',variables('playbookVersion3'))]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName3'))]"
+            ],
+            "properties": {
+                "description": "MDTI-Data-WebComponents Playbook with template version 2.0.1",
+                "mainTemplate": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "[variables('playbookVersion3')]",
+                    "parameters": {
+                        "PlaybookName": {
+                            "defaultValue": "MDTI-Data-WebComponents",
+                            "type": "String"
+                        }
+                    },
+                    "variables": {
+                        "AzureSentinelConnectionName": "[[concat('azuresentinel-', parameters('PlaybookName'))]",
+                        "connection-1": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]",
+                        "_connection-1": "[[variables('connection-1')]",
+                        "workspace-location-inline": "[resourceGroup().location]",
+                        "workspace-name": "[parameters('workspace')]",
+                        "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
+                    },
+                    "resources": [
+                        {
+                            "type": "Microsoft.Web/connections",
+                            "apiVersion": "2016-06-01",
+                            "name": "[[variables('AzureSentinelConnectionName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "properties": {
+                                "api": {
+                                    "id": "[[variables('_connection-1')]"
+                                }
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Logic/workflows",
+                            "apiVersion": "2017-07-01",
+                            "name": "[[parameters('PlaybookName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "tags": {
+                                "LogicAppsCategory": "security",
+                                "Source": "MDTI",
+                                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
+                            },
+                            "dependsOn": [
+                                "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                            ],
+                            "properties": {
+                                "state": "Enabled",
+                                "definition": {
+                                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                                    "contentVersion": "1.0.0.0",
+                                    "parameters": {
+                                        "$connections": {
+                                            "type": "Object"
+                                        }
+                                    },
+                                    "triggers": {
+                                        "When_Azure_Sentinel_incident_creation_rule_was_triggered": {
+                                            "type": "ApiConnectionWebhook",
+                                            "inputs": {
+                                                "body": {
+                                                    "callback_url": "@{listCallbackUrl()}"
+                                                },
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "path": "/incident-creation"
+                                            }
+                                        }
+                                    },
+                                    "actions": {
+                                        "Entities_-_Get_Hosts": {
+                                            "runAfter": {
+                                                "MDTI-Base": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/entities/host"
+                                            }
+                                        },
+                                        "Entities_-_Get_IPs": {
+                                            "runAfter": {
+                                                "MDTI-Base": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/entities/ip"
+                                            }
+                                        },
+                                        "For_each_Host": {
+                                            "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
+                                            "actions": {
+                                                "Add_comment_to_incident_(V3)": {
+                                                    "runAfter": {
+                                                        "Create_Host_HTML_table": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>MDTI Web Components for Indicator : @{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}<br>\n@{body('Create_Host_HTML_table')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                },
+                                                "Create_Host_HTML_table": {
+                                                    "runAfter": {
+                                                        "For_each_host_component": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Table",
+                                                    "inputs": {
+                                                        "format": "HTML",
+                                                        "from": "@variables('result_output_host')"
+                                                    }
+                                                },
+                                                "For_each_host_component": {
+                                                    "foreach": "@body('Parse_host_components')",
+                                                    "actions": {
+                                                        "Append_to_array_variable": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "result_output_host",
+                                                                "value": {
+                                                                    "Category": "@items('For_each_host_component')['category']",
+                                                                    "LastSeenDateTime": "@items('For_each_host_component')['lastSeenDateTime']",
+                                                                    "Name": "@items('For_each_host_component')['name']",
+                                                                    "Version": "@items('For_each_host_component')['version']"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Set_Result_Host": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Foreach"
+                                                },
+                                                "Get_components_for_host": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "@body('MDTI-Base')?['resource']",
+                                                            "clientId": "@body('MDTI-Base')?['clientId']",
+                                                            "secret": "@body('MDTI-Base')?['clientSecret']",
+                                                            "tenant": "@body('MDTI-Base')?['tenantId']",
+                                                            "type": "ActiveDirectoryOAuth"
+                                                        },
+                                                        "headers": {
+                                                            "Content-Type": "application/json"
+                                                        },
+                                                        "method": "GET",
+                                                        "queries": {
+                                                            "$count": "true",
+                                                            "$top": "25"
+                                                        },
+                                                        "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}')/components"
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Parse_host_components": {
+                                                    "runAfter": {
+                                                        "Get_components_for_host": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ParseJson",
+                                                    "inputs": {
+                                                        "content": "@body('Get_components_for_host')?['value']",
+                                                        "schema": {
+                                                            "items": {
+                                                                "properties": {
+                                                                    "category": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "firstSeenDateTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "host": {
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    },
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "lastSeenDateTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "version": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id",
+                                                                    "firstSeenDateTime",
+                                                                    "lastSeenDateTime",
+                                                                    "name",
+                                                                    "version",
+                                                                    "category",
+                                                                    "host"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    }
+                                                },
+                                                "Set_Result_Host": {
+                                                    "runAfter": {
+                                                        "Parse_host_components": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "result_output_host",
+                                                        "value": []
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Init_Result_Host": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach",
+                                            "runtimeConfiguration": {
+                                                "concurrency": {
+                                                    "repetitions": 1
+                                                }
+                                            }
+                                        },
+                                        "For_each_IP_Address": {
+                                            "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
+                                            "actions": {
+                                                "Add_comment_to_incident_(V3)_2": {
+                                                    "runAfter": {
+                                                        "Create_IP_HTML_table": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>MDTI Web Components for Indicator: @{items('For_each_IP_Address')?['Address']}<br>\n@{body('Create_IP_HTML_table')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                },
+                                                "Create_IP_HTML_table": {
+                                                    "runAfter": {
+                                                        "For_each_component": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Table",
+                                                    "inputs": {
+                                                        "format": "HTML",
+                                                        "from": "@variables('result_output_ip')"
+                                                    }
+                                                },
+                                                "For_each_component": {
+                                                    "foreach": "@body('Parse_components')",
+                                                    "actions": {
+                                                        "Append_to_Result_IP": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "result_output_ip",
+                                                                "value": {
+                                                                    "Category": "@items('For_each_component')?['category']",
+                                                                    "LastSeenDateTime": "@items('For_each_component')?['lastSeenDateTime']",
+                                                                    "Name": "@items('For_each_component')?['name']",
+                                                                    "Version": "@items('For_each_component')?['version']"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Set_Result_IP": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Foreach"
+                                                },
+                                                "Get_components": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "@body('MDTI-Base')?['resource']",
+                                                            "clientId": "@body('MDTI-Base')?['clientId']",
+                                                            "secret": "@body('MDTI-Base')?['clientSecret']",
+                                                            "tenant": "@body('MDTI-Base')?['tenantId']",
+                                                            "type": "ActiveDirectoryOAuth"
+                                                        },
+                                                        "headers": {
+                                                            "Content-Type": "application/json"
+                                                        },
+                                                        "method": "GET",
+                                                        "queries": {
+                                                            "$count": "true",
+                                                            "$top": "25"
+                                                        },
+                                                        "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_IP_Address')?['Address']}')/components"
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Parse_components": {
+                                                    "runAfter": {
+                                                        "Get_components": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ParseJson",
+                                                    "inputs": {
+                                                        "content": "@body('Get_components')?['value']",
+                                                        "schema": {
+                                                            "items": {
+                                                                "properties": {
+                                                                    "category": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "firstSeenDateTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "host": {
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    },
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "lastSeenDateTime": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "version": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id",
+                                                                    "firstSeenDateTime",
+                                                                    "lastSeenDateTime",
+                                                                    "name",
+                                                                    "version",
+                                                                    "category",
+                                                                    "host"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    }
+                                                },
+                                                "Set_Result_IP": {
+                                                    "runAfter": {
+                                                        "Parse_components": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "result_output_ip",
+                                                        "value": []
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Init_Result_IP": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach",
+                                            "runtimeConfiguration": {
+                                                "concurrency": {
+                                                    "repetitions": 1
+                                                }
+                                            }
+                                        },
+                                        "Init_Result_Host": {
+                                            "runAfter": {
+                                                "Entities_-_Get_Hosts": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "result_output_host",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Init_Result_IP": {
+                                            "runAfter": {
+                                                "Entities_-_Get_IPs": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "result_output_ip",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "MDTI-Base": {
+                                            "type": "Workflow",
+                                            "inputs": {
+                                                "host": {
+                                                    "triggerName": "manual",
+                                                    "workflow": {
+                                                        "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/MDTI-Base')]"
+                                                    }
+                                                }
+                                            },
+                                            "runtimeConfiguration": {
+                                                "secureData": {
+                                                    "properties": [
+                                                        "outputs"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "parameters": {
+                                    "$connections": {
+                                        "value": {
+                                            "azuresentinel": {
+                                                "connectionId": "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                                "connectionName": "[[variables('AzureSentinelConnectionName')]",
+                                                "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                            "apiVersion": "2022-01-01-preview",
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId3'),'/'))))]",
+                            "properties": {
+                                "parentId": "[variables('playbookId3')]",
+                                "contentId": "[variables('_playbookContentId3')]",
+                                "kind": "Playbook",
+                                "version": "[variables('playbookVersion3')]",
+                                "source": {
+                                    "kind": "Solution",
+                                    "name": "Microsoft Defender Threat Intelligence",
+                                    "sourceId": "[variables('_solutionId')]"
+                                },
+                                "author": {
+                                    "name": "Microsoft",
+                                    "email": "[variables('_email')]"
+                                },
+                                "support": {
+                                    "name": "Microsoft Corporation",
+                                    "email": "support@microsoft.com",
+                                    "tier": "Microsoft",
+                                    "link": "https://support.microsoft.com"
+                                }
+                            }
+                        }
+                    ],
+                    "metadata": {
+                        "comments": "Perform automated enrichment on the Microsoft Sentinel Incidents based on MDTI Internet data.",
+                        "title": "MDTI-Data-WebComponents",
+                        "description": "This playbook uses the MDTI Components data to automatically enrich incidents generated by Microsoft Sentinel. Leverage this playbook in order to enrich your incidents with [Webcomponents](https://learn.microsoft.com/en-us/defender/threat-intelligence/data-sets#components) data hosted by the indicators found within the incident. These components allow a user to understand the makeup of a webpage or the technology and services driving a specific piece of infrastructure. Pivoting on unique components can find actors' infrastructure or other sites that are compromised. Users can also understand if a website might be vulnerable to a specific attack or compromise based on the technologies that it is running.",
+                        "prerequisites": [
+                            "This playbook inherits API connections created and established within a base playbook. Ensure you have deployed [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) prior to deploying this playbook. If you have trouble accessing your account or your credentials contact your account representative (mdtidiscussion[@]microsoft.com)."
+                        ],
+                        "lastUpdateTime": "2023-03-09T00:00:00Z",
+                        "postDeployment": [
+                            "After deploying the playbook, you must authorize the connections leveraged.",
+                            "1. Visit the playbook resource.",
+                            "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
+                            "3. Ensure each connection has been authorized.",
+                            "**Note: If you've deployed the [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) playbook, you will only need to authorize the Microsoft Sentinel connection.**"
+                        ],
+                        "releaseNotes": [
+                            {
+                                "version": "1.0.1",
+                                "title": "MDTI Data WebComponents",
+                                "notes": [
+                                    "Updated version with Secure Inputs for HTTP REST and Secure Output for MDTI-Base actions"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs",
+            "apiVersion": "2021-05-01",
+            "name": "[variables('playbookTemplateSpecName4')]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
+            },
+            "properties": {
+                "description": "MDTI-Intel-Reputation playbook",
+                "displayName": "MDTI-Intel-Reputation playbook"
+            }
+        },
+        {
+            "type": "Microsoft.Resources/templateSpecs/versions",
+            "apiVersion": "2021-05-01",
+            "name": "[concat(variables('playbookTemplateSpecName4'),'/',variables('playbookVersion4'))]",
+            "location": "[parameters('workspace-location')]",
+            "tags": {
+                "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
+                "hidden-sentinelContentType": "Playbook"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName4'))]"
+            ],
+            "properties": {
+                "description": "MDTI-Intel-Reputation Playbook with template version 2.0.1",
+                "mainTemplate": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "[variables('playbookVersion4')]",
+                    "parameters": {
+                        "PlaybookName": {
+                            "defaultValue": "MDTI-Intel-Reputation",
+                            "type": "String"
+                        }
+                    },
+                    "variables": {
+                        "AzureSentinelConnectionName": "[[concat('azuresentinel-', parameters('PlaybookName'))]",
+                        "connection-1": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]",
+                        "_connection-1": "[[variables('connection-1')]",
+                        "workspace-location-inline": "[resourceGroup().location]",
+                        "workspace-name": "[parameters('workspace')]",
+                        "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
+                    },
+                    "resources": [
+                        {
+                            "type": "Microsoft.Web/connections",
+                            "apiVersion": "2016-06-01",
+                            "name": "[[variables('AzureSentinelConnectionName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "properties": {
+                                "api": {
+                                    "id": "[[variables('_connection-1')]"
+                                }
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Logic/workflows",
+                            "apiVersion": "2017-07-01",
+                            "name": "[[parameters('PlaybookName')]",
+                            "location": "[[variables('workspace-location-inline')]",
+                            "tags": {
+                                "LogicAppsCategory": "security",
+                                "Source": "MDTI",
+                                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
+                            },
+                            "dependsOn": [
+                                "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                            ],
+                            "properties": {
+                                "state": "Enabled",
+                                "definition": {
+                                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                                    "contentVersion": "1.0.0.0",
+                                    "parameters": {
+                                        "$connections": {
+                                            "type": "Object"
+                                        }
+                                    },
+                                    "triggers": {
+                                        "When_Azure_Sentinel_incident_creation_rule_was_triggered": {
+                                            "type": "ApiConnectionWebhook",
+                                            "inputs": {
+                                                "body": {
+                                                    "callback_url": "@{listCallbackUrl()}"
+                                                },
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "path": "/incident-creation"
+                                            }
+                                        }
+                                    },
+                                    "actions": {
+                                        "Entities_-_Get_Hosts": {
+                                            "runAfter": {
+                                                "MDTI-Base": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/entities/host"
+                                            }
+                                        },
+                                        "Entities_-_Get_IPs": {
+                                            "runAfter": {
+                                                "MDTI-Base": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/entities/ip"
+                                            }
+                                        },
+                                        "For_each_Host": {
+                                            "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
+                                            "actions": {
+                                                "Add_comment_to_incident_(V3)": {
+                                                    "runAfter": {
+                                                        "Create_Host_HTML_table": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>MDTI Reputation: @{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}<br>\nClassification: @{body('Get_reputation_for_host')?['classification']} (@{body('Get_reputation_for_host')?['score']})<br>\n@{body('Create_Host_HTML_table')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                },
+                                                "Create_Host_HTML_table": {
+                                                    "runAfter": {
+                                                        "Set_host_variable": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Table",
+                                                    "inputs": {
+                                                        "format": "HTML",
+                                                        "from": "@variables('result_output_host')"
+                                                    }
+                                                },
+                                                "Get_reputation_for_host": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "@body('MDTI-Base')?['resource']",
+                                                            "clientId": "@body('MDTI-Base')?['clientId']",
+                                                            "secret": "@body('MDTI-Base')?['clientSecret']",
+                                                            "tenant": "@body('MDTI-Base')?['tenantId']",
+                                                            "type": "ActiveDirectoryOAuth"
+                                                        },
+                                                        "headers": {
+                                                            "Content-Type": "application/json"
+                                                        },
+                                                        "method": "GET",
+                                                        "path": "/reputation",
+                                                        "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}')/reputation"
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Set_host_variable": {
+                                                    "runAfter": {
+                                                        "Get_reputation_for_host": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "result_output_host",
+                                                        "value": "@body('Get_reputation_for_host')?['rules']"
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Init_Result_Host": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach"
+                                        },
+                                        "For_each_IP_Address": {
+                                            "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
+                                            "actions": {
+                                                "Add_comment_to_incident_(V3)_2": {
+                                                    "runAfter": {
+                                                        "Create_IP_HTML_table": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>MDTI Reputation: @{items('For_each_IP_Address')?['Address']}<br>\nClassification: @{body('Get_reputation')?['classification']} (@{body('Get_reputation')?['score']})<br>\n@{body('Create_IP_HTML_table')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                },
+                                                "Create_IP_HTML_table": {
+                                                    "runAfter": {
+                                                        "Set_ip_variable": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Table",
+                                                    "inputs": {
+                                                        "format": "HTML",
+                                                        "from": "@variables('result_output_ip')"
+                                                    }
+                                                },
+                                                "Get_reputation": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "@body('MDTI-Base')?['resource']",
+                                                            "clientId": "@body('MDTI-Base')?['clientId']",
+                                                            "secret": "@body('MDTI-Base')?['clientSecret']",
+                                                            "tenant": "@body('MDTI-Base')?['tenantId']",
+                                                            "type": "ActiveDirectoryOAuth"
+                                                        },
+                                                        "headers": {
+                                                            "Content-Type": "application/json"
+                                                        },
+                                                        "method": "GET",
+                                                        "path": "/reputation",
+                                                        "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_IP_Address')?['Address']}')/reputation"
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Set_ip_variable": {
+                                                    "runAfter": {
+                                                        "Get_reputation": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "result_output_ip",
+                                                        "value": "@body('Get_reputation')?['rules']"
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Init_Result_IP": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach"
+                                        },
+                                        "Init_Result_Host": {
+                                            "runAfter": {
+                                                "Entities_-_Get_Hosts": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "result_output_host",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Init_Result_IP": {
+                                            "runAfter": {
+                                                "Entities_-_Get_IPs": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "result_output_ip",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "MDTI-Base": {
+                                            "type": "Workflow",
+                                            "inputs": {
+                                                "host": {
+                                                    "triggerName": "manual",
+                                                    "workflow": {
+                                                        "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/MDTI-Base')]"
+                                                    }
+                                                }
+                                            },
+                                            "runtimeConfiguration": {
+                                                "secureData": {
+                                                    "properties": [
+                                                        "outputs"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "parameters": {
+                                    "$connections": {
+                                        "value": {
+                                            "azuresentinel": {
+                                                "connectionId": "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                                "connectionName": "[[variables('AzureSentinelConnectionName')]",
+                                                "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                            "apiVersion": "2022-01-01-preview",
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId4'),'/'))))]",
+                            "properties": {
+                                "parentId": "[variables('playbookId4')]",
+                                "contentId": "[variables('_playbookContentId4')]",
+                                "kind": "Playbook",
+                                "version": "[variables('playbookVersion4')]",
+                                "source": {
+                                    "kind": "Solution",
+                                    "name": "Microsoft Defender Threat Intelligence",
+                                    "sourceId": "[variables('_solutionId')]"
+                                },
+                                "author": {
+                                    "name": "Microsoft",
+                                    "email": "[variables('_email')]"
+                                },
+                                "support": {
+                                    "name": "Microsoft Corporation",
+                                    "email": "support@microsoft.com",
+                                    "tier": "Microsoft",
+                                    "link": "https://support.microsoft.com"
+                                }
+                            }
+                        }
+                    ],
+                    "metadata": {
+                        "comments": "Perform automated enrichment on the Microsoft Sentinel Incidents based on MDTI Reputation data.",
+                        "title": "MDTI-Intel-Reputation",
+                        "description": "This playbook uses the MDTI API to automatically enrich incidents generated by Microsoft Sentinel. Reputation information provides analyst with a decision as to whether an indicator is considered benign, suspicious or malicious. Analysts can leverage this playbook in order to enrich indicators found within an incident. Each reputation result is contained within a comment and will include detailed scoring information noting why a given indicator is considered suspicious or malicious with links back to the MDTI platform for more information.",
+                        "prerequisites": [
+                            "This playbook inherits API connections created and established within a base playbook. Ensure you have deployed [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) prior to deploying this playbook. If you have trouble accessing your account or your credentials contact your account representative (mdtidiscussion[@]microsoft.com)."
+                        ],
+                        "lastUpdateTime": "2023-03-09T00:00:00Z",
+                        "postDeployment": [
+                            "After deploying the playbook, you must authorize the connections leveraged.",
+                            "1. Visit the playbook resource.",
+                            "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
+                            "3. Ensure each connection has been authorized.",
+                            "**Note: If you've deployed the [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) playbook, you will only need to authorize the Microsoft Sentinel connection.**"
+                        ],
+                        "releaseNotes": [
+                            {
+                                "version": "1.0.1",
+                                "title": "MDTI Intel Reputation",
+                                "notes": [
+                                    "Updated version with Secure Inputs for HTTP REST and Secure Output for MDTI-Base actions"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+            "apiVersion": "2022-01-01-preview",
+            "location": "[parameters('workspace-location')]",
+            "properties": {
+                "version": "2.0.1",
+                "kind": "Solution",
+                "contentSchemaVersion": "2.0.0",
+                "contentId": "[variables('_solutionId')]",
+                "parentId": "[variables('_solutionId')]",
                 "source": {
-                  "kind": "Solution",
-                  "name": "Microsoft Defender Threat Intelligence",
-                  "sourceId": "[variables('_solutionId')]"
+                    "kind": "Solution",
+                    "name": "Microsoft Defender Threat Intelligence",
+                    "sourceId": "[variables('_solutionId')]"
                 },
                 "author": {
-                  "name": "Microsoft",
-                  "email": "[variables('_email')]"
+                    "name": "Microsoft",
+                    "email": "[variables('_email')]"
                 },
                 "support": {
-                  "name": "Microsoft Corporation",
-                  "email": "support@microsoft.com",
-                  "tier": "Microsoft",
-                  "link": "https://support.microsoft.com"
-                }
-              }
-            }
-          ],
-          "metadata": {
-            "comments": "Perform automated enrichment on the Microsoft Sentinel Incidents based on MDTI Internet data.",
-            "title": "MDTI-Data-WebComponents",
-            "description": "This playbook uses the MDTI Components data to automatically enrich incidents generated by Microsoft Sentinel. Leverage this playbook in order to enrich your incidents with [Webcomponents](https://learn.microsoft.com/en-us/defender/threat-intelligence/data-sets#components) data hosted by the indicators found within the incident. These components allow a user to understand the makeup of a webpage or the technology and services driving a specific piece of infrastructure. Pivoting on unique components can find actors' infrastructure or other sites that are compromised. Users can also understand if a website might be vulnerable to a specific attack or compromise based on the technologies that it is running.",
-            "prerequisites": [
-              "This playbook inherits API connections created and established within a base playbook. Ensure you have deployed [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) prior to deploying this playbook. If you have trouble accessing your account or your credentials contact your account representative (mdtidiscussion[@]microsoft.com)."
-            ],
-            "lastUpdateTime": "2023-03-09T00:00:00Z",
-            "postDeployment": [
-              "After deploying the playbook, you must authorize the connections leveraged.",
-              "1. Visit the playbook resource.",
-              "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
-              "3. Ensure each connection has been authorized.",
-              "**Note: If you've deployed the [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) playbook, you will only need to authorize the Microsoft Sentinel connection.**"
-            ],
-            "releaseNotes": [
-              {
-                "version": "1.0.0",
-                "title": "MDTI Data WebComponents",
-                "notes": [
-                  "Initial version"
-                ]
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs",
-      "apiVersion": "2021-05-01",
-      "name": "[variables('playbookTemplateSpecName4')]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "properties": {
-        "description": "MDTI-Intel-Reputation playbook",
-        "displayName": "MDTI-Intel-Reputation playbook"
-      }
-    },
-    {
-      "type": "Microsoft.Resources/templateSpecs/versions",
-      "apiVersion": "2021-05-01",
-      "name": "[concat(variables('playbookTemplateSpecName4'),'/',variables('playbookVersion4'))]",
-      "location": "[parameters('workspace-location')]",
-      "tags": {
-        "hidden-sentinelWorkspaceId": "[variables('workspaceResourceId')]",
-        "hidden-sentinelContentType": "Playbook"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName4'))]"
-      ],
-      "properties": {
-        "description": "MDTI-Intel-Reputation Playbook with template version 2.0.1",
-        "mainTemplate": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "[variables('playbookVersion4')]",
-          "parameters": {
-            "PlaybookName": {
-              "defaultValue": "MDTI-Intel-Reputation",
-              "type": "String"
-            }
-          },
-          "variables": {
-            "AzureSentinelConnectionName": "[[concat('azuresentinel-', parameters('PlaybookName'))]",
-            "connection-1": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]",
-            "_connection-1": "[[variables('connection-1')]",
-            "workspace-location-inline": "[concat('[resourceGroup().locatio', 'n]')]",
-            "workspace-name": "[parameters('workspace')]",
-            "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Web/connections",
-              "apiVersion": "2016-06-01",
-              "name": "[[variables('AzureSentinelConnectionName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "properties": {
-                "api": {
-                  "id": "[[variables('_connection-1')]"
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Logic/workflows",
-              "apiVersion": "2017-07-01",
-              "name": "[[parameters('PlaybookName')]",
-              "location": "[[variables('workspace-location-inline')]",
-              "tags": {
-                "LogicAppsCategory": "security",
-                "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
-              },
-              "dependsOn": [
-                "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
-              ],
-              "properties": {
-                "state": "Enabled",
-                "definition": {
-                  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-                  "contentVersion": "1.0.0.0",
-                  "parameters": {
-                    "$connections": {
-                      "type": "Object"
-                    }
-                  },
-                  "triggers": {
-                    "When_Azure_Sentinel_incident_creation_rule_was_triggered": {
-                      "type": "ApiConnectionWebhook",
-                      "inputs": {
-                        "body": {
-                          "callback_url": "@{listCallbackUrl()}"
-                        },
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "path": "/incident-creation"
-                      }
-                    }
-                  },
-                  "actions": {
-                    "Entities_-_Get_Hosts": {
-                      "runAfter": {
-                        "MDTI-Base": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "ApiConnection",
-                      "inputs": {
-                        "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "method": "post",
-                        "path": "/entities/host"
-                      }
-                    },
-                    "Entities_-_Get_IPs": {
-                      "runAfter": {
-                        "MDTI-Base": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "ApiConnection",
-                      "inputs": {
-                        "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
-                        "host": {
-                          "connection": {
-                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                          }
-                        },
-                        "method": "post",
-                        "path": "/entities/ip"
-                      }
-                    },
-                    "For_each_Host": {
-                      "foreach": "@body('Entities_-_Get_Hosts')?['Hosts']",
-                      "actions": {
-                        "Add_comment_to_incident_(V3)": {
-                          "runAfter": {
-                            "Create_Host_HTML_table": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ApiConnection",
-                          "inputs": {
-                            "body": {
-                              "incidentArmId": "@triggerBody()?['object']?['id']",
-                              "message": "<p>MDTI Reputation: @{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}<br>\nClassification: @{body('Get_reputation_for_host')?['classification']} (@{body('Get_reputation_for_host')?['score']})<br>\n@{body('Create_Host_HTML_table')}</p>"
-                            },
-                            "host": {
-                              "connection": {
-                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                              }
-                            },
-                            "method": "post",
-                            "path": "/Incidents/Comment"
-                          }
-                        },
-                        "Create_Host_HTML_table": {
-                          "runAfter": {
-                            "Set_host_variable": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Table",
-                          "inputs": {
-                            "format": "HTML",
-                            "from": "@variables('result_output_host')"
-                          }
-                        },
-                        "Get_reputation_for_host": {
-                          "type": "Http",
-                          "inputs": {
-                            "authentication": {
-                              "audience": "@body('MDTI-Base')?['resource']",
-                              "clientId": "@body('MDTI-Base')?['clientId']",
-                              "secret": "@body('MDTI-Base')?['clientSecret']",
-                              "tenant": "@body('MDTI-Base')?['tenantId']",
-                              "type": "ActiveDirectoryOAuth"
-                            },
-                            "headers": {
-                              "Content-Type": "application/json"
-                            },
-                            "method": "GET",
-                            "path": "/reputation",
-                            "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_Host')?['HostName']}.@{items('For_each_Host')?['DnsDomain']}')/reputation"
-                          }
-                        },
-                        "Set_host_variable": {
-                          "runAfter": {
-                            "Get_reputation_for_host": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_host",
-                            "value": "@body('Get_reputation_for_host')?['rules']"
-                          }
-                        },
-                        "Reset_host_variable": {
-                          "runAfter": {
-                            "Add_comment_to_incident_(V3)": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_host"
-                          }
-                        }
-                      },
-                      "runAfter": {
-                        "Init_Result_Host": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "Foreach"
-                    },
-                    "For_each_IP_Address": {
-                      "foreach": "@body('Entities_-_Get_IPs')?['IPs']",
-                      "actions": {
-                        "Add_comment_to_incident_(V3)_2": {
-                          "runAfter": {
-                            "Create_IP_HTML_table": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "ApiConnection",
-                          "inputs": {
-                            "body": {
-                              "incidentArmId": "@triggerBody()?['object']?['id']",
-                              "message": "<p>MDTI Reputation: @{items('For_each_IP_Address')?['Address']}<br>\nClassification: @{body('Get_reputation')?['classification']} (@{body('Get_reputation')?['score']})<br>\n@{body('Create_IP_HTML_table')}</p>"
-                            },
-                            "host": {
-                              "connection": {
-                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                              }
-                            },
-                            "method": "post",
-                            "path": "/Incidents/Comment"
-                          }
-                        },
-                        "Create_IP_HTML_table": {
-                          "runAfter": {
-                            "Set_ip_variable": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "Table",
-                          "inputs": {
-                            "format": "HTML",
-                            "from": "@variables('result_output_ip')"
-                          }
-                        },
-                        "Get_reputation": {
-                          "type": "Http",
-                          "inputs": {
-                            "authentication": {
-                              "audience": "@body('MDTI-Base')?['resource']",
-                              "clientId": "@body('MDTI-Base')?['clientId']",
-                              "secret": "@body('MDTI-Base')?['clientSecret']",
-                              "tenant": "@body('MDTI-Base')?['tenantId']",
-                              "type": "ActiveDirectoryOAuth"
-                            },
-                            "headers": {
-                              "Content-Type": "application/json"
-                            },
-                            "method": "GET",
-                            "path": "/reputation",
-                            "uri": "https://@{body('MDTI-Base')?['MDTI-BaseUrl']}/@{body('MDTI-Base')?['Api-Version']}/security/threatIntelligence/hosts('@{items('For_each_IP_Address')?['Address']}')/reputation"
-                          }
-                        },
-                        "Set_ip_variable": {
-                          "runAfter": {
-                            "Get_reputation": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_ip",
-                            "value": "@body('Get_reputation')?['rules']"
-                          }
-                        },
-                        "Reset_IP_variable": {
-                          "runAfter": {
-                            "Add_comment_to_incident_(V3)_2": [
-                              "Succeeded"
-                            ]
-                          },
-                          "type": "SetVariable",
-                          "inputs": {
-                            "name": "result_output_ip"
-                          }
-                        }
-                      },
-                      "runAfter": {
-                        "Init_Result_IP": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "Foreach"
-                    },
-                    "Init_Result_Host": {
-                      "runAfter": {
-                        "Entities_-_Get_Hosts": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "result_output_host",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "Init_Result_IP": {
-                      "runAfter": {
-                        "Entities_-_Get_IPs": [
-                          "Succeeded"
-                        ]
-                      },
-                      "type": "InitializeVariable",
-                      "inputs": {
-                        "variables": [
-                          {
-                            "name": "result_output_ip",
-                            "type": "array"
-                          }
-                        ]
-                      }
-                    },
-                    "MDTI-Base": {
-                      "type": "Workflow",
-                      "inputs": {
-                        "host": {
-                          "triggerName": "manual",
-                          "workflow": {
-                            "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/MDTI-Base')]"
-                          }
-                        }
-                      }
-                    }
-                  }
+                    "name": "Microsoft Corporation",
+                    "email": "support@microsoft.com",
+                    "tier": "Microsoft",
+                    "link": "https://support.microsoft.com"
                 },
-                "parameters": {
-                  "$connections": {
-                    "value": {
-                      "azuresentinel": {
-                        "connectionId": "[[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                        "connectionName": "[[variables('AzureSentinelConnectionName')]",
-                        "id": "[[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', variables('workspace-location-inline'), '/managedApis/azuresentinel')]"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
-              "apiVersion": "2022-01-01-preview",
-              "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId4'),'/'))))]",
-              "properties": {
-                "parentId": "[variables('playbookId4')]",
-                "contentId": "[variables('_playbookContentId4')]",
-                "kind": "Playbook",
-                "version": "[variables('playbookVersion4')]",
-                "source": {
-                  "kind": "Solution",
-                  "name": "Microsoft Defender Threat Intelligence",
-                  "sourceId": "[variables('_solutionId')]"
+                "dependencies": {
+                    "operator": "AND",
+                    "criteria": [
+                        {
+                            "kind": "Playbook",
+                            "contentId": "[variables('_MDTI-Automated-Triage')]",
+                            "version": "[variables('playbookVersion1')]"
+                        },
+                        {
+                            "kind": "Playbook",
+                            "contentId": "[variables('_MDTI-Base')]",
+                            "version": "[variables('playbookVersion2')]"
+                        },
+                        {
+                            "kind": "Playbook",
+                            "contentId": "[variables('_MDTI-Data-WebComponents')]",
+                            "version": "[variables('playbookVersion3')]"
+                        },
+                        {
+                            "kind": "Playbook",
+                            "contentId": "[variables('_MDTI-Intel-Reputation')]",
+                            "version": "[variables('playbookVersion4')]"
+                        }
+                    ]
                 },
-                "author": {
-                  "name": "Microsoft",
-                  "email": "[variables('_email')]"
-                },
-                "support": {
-                  "name": "Microsoft Corporation",
-                  "email": "support@microsoft.com",
-                  "tier": "Microsoft",
-                  "link": "https://support.microsoft.com"
+                "firstPublishDate": "2023-03-23",
+                "providers": [
+                    "Microsoft"
+                ],
+                "categories": {
+                    "domains": [
+                        "Security - Threat Intelligence",
+                        "Security - Automation (SOAR)"
+                    ]
                 }
-              }
-            }
-          ],
-          "metadata": {
-            "comments": "Perform automated enrichment on the Microsoft Sentinel Incidents based on MDTI Reputation data.",
-            "title": "MDTI-Intel-Reputation",
-            "description": "This playbook uses the MDTI API to automatically enrich incidents generated by Microsoft Sentinel. Reputation information provides analyst with a decision as to whether an indicator is considered benign, suspicious or malicious. Analysts can leverage this playbook in order to enrich indicators found within an incident. Each reputation result is contained within a comment and will include detailed scoring information noting why a given indicator is considered suspicious or malicious with links back to the MDTI platform for more information.",
-            "prerequisites": [
-              "This playbook inherits API connections created and established within a base playbook. Ensure you have deployed [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) prior to deploying this playbook. If you have trouble accessing your account or your credentials contact your account representative (mdtidiscussion[@]microsoft.com)."
-            ],
-            "lastUpdateTime": "2023-03-09T00:00:00Z",
-            "postDeployment": [
-              "After deploying the playbook, you must authorize the connections leveraged.",
-              "1. Visit the playbook resource.",
-              "2. Under 'Development Tools' (located on the left), click 'API Connections'.",
-              "3. Ensure each connection has been authorized.",
-              "**Note: If you've deployed the [MDTI-Base](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Microsoft%20Defender%20Threat%20Intelligence/Playbooks/MDTI-Base/azuredeploy.json) playbook, you will only need to authorize the Microsoft Sentinel connection.**"
-            ],
-            "releaseNotes": [
-              {
-                "version": "1.0.0",
-                "title": "MDTI Intel Reputation",
-                "notes": [
-                  "Initial version"
-                ]
-              }
-            ]
-          }
+            },
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('_solutionId'))]"
         }
-      }
-    },
-    {
-      "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
-      "apiVersion": "2022-01-01-preview",
-      "location": "[parameters('workspace-location')]",
-      "properties": {
-        "version": "2.0.1",
-        "kind": "Solution",
-        "contentSchemaVersion": "2.0.0",
-        "contentId": "[variables('_solutionId')]",
-        "parentId": "[variables('_solutionId')]",
-        "source": {
-          "kind": "Solution",
-          "name": "Microsoft Defender Threat Intelligence",
-          "sourceId": "[variables('_solutionId')]"
-        },
-        "author": {
-          "name": "Microsoft",
-          "email": "[variables('_email')]"
-        },
-        "support": {
-          "name": "Microsoft Corporation",
-          "email": "support@microsoft.com",
-          "tier": "Microsoft",
-          "link": "https://support.microsoft.com"
-        },
-        "dependencies": {
-          "operator": "AND",
-          "criteria": [
-            {
-              "kind": "Playbook",
-              "contentId": "[variables('_MDTI-Automated-Triage')]",
-              "version": "[variables('playbookVersion1')]"
-            },
-            {
-              "kind": "Playbook",
-              "contentId": "[variables('_MDTI-Base')]",
-              "version": "[variables('playbookVersion2')]"
-            },
-            {
-              "kind": "Playbook",
-              "contentId": "[variables('_MDTI-Data-WebComponents')]",
-              "version": "[variables('playbookVersion3')]"
-            },
-            {
-              "kind": "Playbook",
-              "contentId": "[variables('_MDTI-Intel-Reputation')]",
-              "version": "[variables('playbookVersion4')]"
-            }
-          ]
-        },
-        "firstPublishDate": "2023-03-23",
-        "providers": [
-          "Microsoft"
-        ],
-        "categories": {
-          "domains": [
-            "Security - Threat Intelligence",
-            "Security - Automation (SOAR)"
-          ]
-        }
-      },
-      "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('_solutionId'))]"
-    }
-  ],
-  "outputs": {}
+    ],
+    "outputs": {}
 }

--- a/Solutions/Microsoft Defender Threat Intelligence/Package/mainTemplate.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Package/mainTemplate.json
@@ -706,7 +706,7 @@
                         "workspace-name": "[parameters('workspace')]",
                         "workspaceResourceId": "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]",
                         "keyvaultname": "[concat('kv-mdti-', uniqueString(parameters('workspace')))]",
-                        "connections_keyvault_name": "[[format('keyvault-{0}', parameters('Playbook-Name'))]"
+                        "connections_keyvault_name": "[[format('keyvault-{0}', parameters('PlaybookName'))]"
                     },
                     "resources": [
                         {
@@ -753,7 +753,7 @@
                             },
                             "dependsOn": [
                                 "[resourceId('Microsoft.KeyVault/vaults', variables('keyvaultname'))]",
-                                "[[resourceId('Microsoft.Logic/workflows', parameters('Playbook-Name'))]"
+                                "[[resourceId('Microsoft.Logic/workflows', parameters('PlaybookName'))]"
                             ]
                         },
                         {
@@ -793,6 +793,9 @@
                             "apiVersion": "2017-07-01",
                             "name": "[[parameters('PlaybookName')]",
                             "location": "[[variables('workspace-location-inline')]",
+                            "identity": {
+                              "type": "SystemAssigned"
+                            },
                             "tags": {
                                 "Source": "MDTI",
                                 "hidden-SentinelWorkspaceId": "[[variables('workspaceResourceId')]"
@@ -927,7 +930,10 @@
                                         }
                                     }
                                 }
-                            }
+                            },
+                            "dependsOn": [
+                                "[[resourceId('Microsoft.Web/connections', variables('connections_keyvault_name'))]"
+                            ]
                         },
                         {
                             "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",


### PR DESCRIPTION
Change(s):
  MDTI-Base
  1. Create the MDTI-Base Logic App with a System-Managed Identity
  2. Create a Key Vault with RBAC permissions, assign a user to the `Key Vault Administrator` role (*you must provide the AzureAD Object ID for that user*), and assign the MDTI-Base System-Managed Identity to the `Key Vault Secrets User` role
  3. Store the Client-Secret in the Key Vault, remove the built-in Logic App SecureString Client-Secret, and create a connection to the Key Vault from MDTI-Base
  4. Make use of the built-in Logic App Parameters menu pane for all other parameter values, rather than requiring users to modify values in the Code View
  
  MDTI-Automated-Triage
  MDTI-Data-WebComponents
  MDTI-Intel-Reputation
  1. Secure Inputs for HTTP REST and Secure Output for MDTI-Base actions
   

Reason for Change(s):
  enable more secure Client-Secret storage and retrieval, along with better user experience via Parameters menu for non-Secret variables and not requiring template redeployment on Secret update


Version Updated:
  1.0.1


Testing Completed:
  Yes


Checked that the validations are passing and have addressed any issues that are present:
  Yes
