### PR TITLE
Updating the case for AadUserId.

### DIFF
--- a/Solutions/Azure Activity/Analytic Rules/Creating_Anomalous_Number_Of_Resources_detection.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/Creating_Anomalous_Number_Of_Resources_detection.yaml
@@ -42,7 +42,7 @@ query: |
   | project-away Caller1
   | extend Name = iif(Caller has '@',tostring(split(Caller,'@',0)[0]),"")
   | extend UPNSuffix = iif(Caller has '@',tostring(split(Caller,'@',1)[0]),"")
-  | extend AaDUserId = iif(Caller !has '@',Caller,"")
+  | extend AadUserId = iif(Caller !has '@',Caller,"")
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -50,11 +50,11 @@ entityMappings:
         columnName: Name
       - identifier: UPNSuffix
         columnName: UPNSuffix
-      - identifier: AaDUserId
-        columnName: AaDUserId
+      - identifier: AadUserId
+        columnName: AadUserId
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: CallerIpAddress
-version: 2.0.2
+version: 2.0.3
 kind: Scheduled

--- a/Solutions/Azure Activity/Analytic Rules/NewResourceGroupsDeployedTo.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/NewResourceGroupsDeployedTo.yaml
@@ -35,7 +35,7 @@ query: |
   RareCaller
   | extend Name = iif(Caller has '@',tostring(split(Caller,'@',0)[0]),"")
   | extend UPNSuffix = iif(Caller has '@',tostring(split(Caller,'@',1)[0]),"")
-  | extend AaDUserId = iif(Caller !has '@',Caller,"")
+  | extend AadUserId = iif(Caller !has '@',Caller,"")
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -43,11 +43,11 @@ entityMappings:
         columnName: Name
       - identifier: UPNSuffix
         columnName: UPNSuffix
-      - identifier: AaDUserId
-        columnName: AaDUserId
+      - identifier: AadUserId
+        columnName: AadUserId
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: CallerIpAddress
-version: 2.0.1
+version: 2.0.2
 kind: Scheduled

--- a/Solutions/Azure Activity/Analytic Rules/TimeSeriesAnomaly_Mass_Cloud_Resource_Deletions.yaml
+++ b/Solutions/Azure Activity/Analytic Rules/TimeSeriesAnomaly_Mass_Cloud_Resource_Deletions.yaml
@@ -41,7 +41,7 @@ query: |
   | summarize count(), make_set(OperationNameValue,100), make_set(_ResourceId,100) by bin(TimeGenerated, timeframe), Caller ) on TimeGenerated, Caller 
   | extend Name = iif(Caller has '@',tostring(split(Caller,'@',0)[0]),"")
   | extend UPNSuffix = iif(Caller has '@',tostring(split(Caller,'@',1)[0]),"")
-  | extend AaDUserId = iif(Caller !has '@',Caller,"")
+  | extend AadUserId = iif(Caller !has '@',Caller,"")
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -49,7 +49,7 @@ entityMappings:
         columnName: Name
       - identifier: UPNSuffix
         columnName: UPNSuffix
-      - identifier: AaDUserId
-        columnName: AaDUserId
-version: 2.0.1
+      - identifier: AadUserId
+        columnName: AadUserId
+version: 2.0.2
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updating the case for entity identifier AadUserId as the incorrect casing was causing deployment issues.

   Reason for Change(s):
   - Updating the case for entity identifier AadUserId as the incorrect casing was causing deployment issues.

   Version Updated:
   - Yes


-----------------------------------------------------------------------------------------------------------
