### PR TITLE
Added support for the case when adding a user takes place outside/wit…

### DIFF
--- a/Detections/AuditLogs/UserAddedtoAdminRole.yaml
+++ b/Detections/AuditLogs/UserAddedtoAdminRole.yaml
@@ -21,16 +21,27 @@ tags:
 query: |
   AuditLogs
     | where OperationName in ("Add eligible member (permanent)", "Add eligible member (eligible)", "Add member to role")
-    | extend Role = iff(OperationName=="Add member to role", tostring(parse_json(tostring(parse_json(tostring(TargetResources[0].modifiedProperties))[1].newValue))),tostring(TargetResources[0].displayName))
-    | where Role contains "admin"
-    | extend AddedBy = iff(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)=="", tostring(parse_json(tostring(InitiatedBy.app)).displayName), tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
+    | mv-apply TargetResource = TargetResources on 
+    (
+        where TargetResource.type =~ "User"
+        | extend Target = tostring(TargetResource.userPrincipalName),
+                 props = TargetResource.modifiedProperties
+    )
+    | mv-apply Property = props on 
+    (
+        where Property.displayName =~ "Role.DisplayName"
+        | extend RoleName = trim('"',tostring(Property.newValue))
+    )
+    | where RoleName contains "admin"
+    | extend InitiatingApp = tostring(InitiatedBy.app.displayName)
+    | extend Initiator = iif(isnotempty(InitiatingApp), InitiatingApp, tostring(InitiatedBy.user.userPrincipalName))
     | extend AddedUser = iff(OperationName=="Add member to role",tostring(TargetResources[0].userPrincipalName),tostring(TargetResources[2].userPrincipalName))
-    | project-reorder TimeGenerated, AddedUser, Role, AddedBy
+    | project-reorder TimeGenerated, AddedUser, RoleName, Initiator
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AddedBy
+        columnName: Initiator
   - entityType: Account
     fieldMappings:
       - identifier: FullName

--- a/Detections/AuditLogs/UserAddedtoAdminRole.yaml
+++ b/Detections/AuditLogs/UserAddedtoAdminRole.yaml
@@ -23,7 +23,7 @@ query: |
     | where OperationName in ("Add eligible member (permanent)", "Add eligible member (eligible)", "Add member to role")
     | extend Role = iff(OperationName=="Add member to role", tostring(parse_json(tostring(parse_json(tostring(TargetResources[0].modifiedProperties))[1].newValue))),tostring(TargetResources[0].displayName))
     | where Role contains "admin"
-    | extend AddedBy = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+    | extend AddedBy = iff(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)=="", tostring(parse_json(tostring(InitiatedBy.app)).displayName), tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
     | extend AddedUser = iff(OperationName=="Add member to role",tostring(TargetResources[0].userPrincipalName),tostring(TargetResources[2].userPrincipalName))
     | project-reorder TimeGenerated, AddedUser, Role, AddedBy
 entityMappings:
@@ -35,13 +35,13 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: AddedUser
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:
         kind: Community
     author:
-        name: Pete Bryan
+        name: Pete Bryan, Wojciech Lesicki
     support:
         tier: Community
     categories:

--- a/Detections/AuditLogs/UserAddedtoAdminRole.yaml
+++ b/Detections/AuditLogs/UserAddedtoAdminRole.yaml
@@ -20,11 +20,11 @@ tags:
   - AADSecOpsGuide
 query: |
   AuditLogs
-    | where OperationName in ("Add eligible member (permanent)", "Add eligible member (eligible)")
-    | extend Role = tostring(TargetResources[0].displayName)
+    | where OperationName in ("Add eligible member (permanent)", "Add eligible member (eligible)", "Add member to role")
+    | extend Role = iff(OperationName=="Add member to role", tostring(parse_json(tostring(parse_json(tostring(TargetResources[0].modifiedProperties))[1].newValue))),tostring(TargetResources[0].displayName))
     | where Role contains "admin"
     | extend AddedBy = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-    | extend AddedUser = tostring(TargetResources[2].userPrincipalName)
+    | extend AddedUser = iff(OperationName=="Add member to role",tostring(TargetResources[0].userPrincipalName),tostring(TargetResources[2].userPrincipalName))
     | project-reorder TimeGenerated, AddedUser, Role, AddedBy
 entityMappings:
   - entityType: Account


### PR DESCRIPTION
…hout PIM.
Currently this detection works only in cases when the user is added to the role via PIM, more precisely if PIM added via "eligible". If PIM performs user activations, but especially when the user is added to a role in an environment where there is no PIM, this detection will not detect this case. I added support for the situation when adding a role takes place without PIM or when PIM activated the user.
To maintain the consistency of the fields that we provide in the detection result (Role and AddedUser), I added the iff() functions.

   Required items, please complete
   
   Change(s):
   - Adding "Add member to role" as another OperationName
   - Adding iff() to correctly populate the Role and AddedUser fields

   Reason for Change(s):
   - No support for adding a user to a role with the word "admin" when PIM is not used or when PIM activated the user

   Version Updated:
   - No, will be in next commit

   Testing Completed:
   - I tested the rule in a test environment.

   Checked that the validations are passing and have addressed any issues that are present:
   - Change successfully tested via KqlvalidationsTests...still wating for DetectionTemplateSchemaValidation results.