### PR TITLE
Fixed "quoatSetting" typo and replaced with "quotaSetting"

### DIFF
--- a/Tools/Sentinel-All-In-One/ARMTemplates/azuredeploy.json
+++ b/Tools/Sentinel-All-In-One/ARMTemplates/azuredeploy.json
@@ -123,7 +123,7 @@
         }
     },
     "variables": {
-        "quoatSetting": {
+        "quotaSetting": {
             "dailyQuotaGb": "[parameters('dailyQuota')]"
         }
     },
@@ -135,7 +135,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "retentionInDays": "[parameters('dataRetention')]",
-                "workspaceCapping": "[if(equals(parameters('dailyQuota'),0), json('null'), variables('quoatSetting'))]",
+                "workspaceCapping": "[if(equals(parameters('dailyQuota'),0), json('null'), variables('quotaSetting'))]",
                 "features": {
                     "immediatePurgeDataOn30Days": "[parameters('immediatePurgeDataOn30Days')]"
                 },

--- a/Tools/Sentinel-All-In-One/MSSPversion/LinkedTemplates/workspace.json
+++ b/Tools/Sentinel-All-In-One/MSSPversion/LinkedTemplates/workspace.json
@@ -55,7 +55,7 @@
     },
     "functions": [],
     "variables": {
-        "quoatSetting": {
+        "quotaSetting": {
             "dailyQuotaGb": "[parameters('dailyQuota')]"
         }
     },
@@ -67,7 +67,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "retentionInDays": "[parameters('dataRetention')]",
-                "workspaceCapping": "[if(equals(parameters('dailyQuota'),0), json('null'), variables('quoatSetting'))]",
+                "workspaceCapping": "[if(equals(parameters('dailyQuota'),0), json('null'), variables('quotaSetting'))]",
                 "features": {
                     "immediatePurgeDataOn30Days": "[parameters('immediatePurgeDataOn30Days')]"
                 },


### PR DESCRIPTION
 
   Change(s):
   - Fixed "quoatSetting" typo and replaced with "quotaSetting" which is the intended and correct spelling.

   Reason for Change(s):
   - Typo

   Version Updated:
   - No. The only change is the typo being fixed.

   Testing Completed:
   - No. The only change is the typo being fixed.

   Checked that the validations are passing and have addressed any issues that are present:
   - No. The only change is the typo being fixed.