### PR TITLE
Updates for first cred added, performance, cleanup, entity addition

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/FirstAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/FirstAppOrServicePrincipalCredential.yaml
@@ -24,7 +24,7 @@ tags:
   - NOBELIUM
 query: |
   AuditLogs
-  | where OperationName has_any ("Add service principal", "Certificates and secrets management") // captures "Add service principal", "Add service principal credentials", and "Update application - Certificates and secrets management" events
+  | where OperationName has ("Certificates and secrets management")
   | where Result =~ "success"
   | where tostring(InitiatedBy.user.userPrincipalName) has "@" or tostring(InitiatedBy.app.displayName) has "@"
   | mv-apply TargetResource = TargetResources on 
@@ -52,8 +52,7 @@ query: |
     )
   | extend InitiatingUserOrApp = iff(isnotempty(InitiatedBy.user.userPrincipalName),tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName))
   | extend InitiatingIpAddress = iff(isnotempty(InitiatedBy.user.ipAddress), tostring(InitiatedBy.user.ipAddress), tostring(InitiatedBy.app.ipAddress))
-  // The below line is currently commented out but Microsoft Sentinel users can modify this query to show only Application or only Service Principal events in their environment
-    | project-away new_value_set, old_value_set
+  | project-away new_value_set, old_value_set
   | project-reorder TimeGenerated, OperationName, InitiatingUserOrApp, InitiatingIpAddress, UserAgent, targetDisplayName, targetId, targetType, keyDisplayName, keyType, keyUsage, keyIdentifier, CorrelationId, TenantId
   | extend timestamp = TimeGenerated, Name = tostring(split(InitiatingUserOrApp,'@',0)[0]), UPNSuffix = tostring(split(InitiatingUserOrApp,'@',1)[0])
 entityMappings:
@@ -67,5 +66,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.1.3
+version: 1.1.4
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/FirstAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/FirstAppOrServicePrincipalCredential.yaml
@@ -66,5 +66,9 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: Name
+        columnName: targetDisplayName
 version: 1.1.4
 kind: Scheduled


### PR DESCRIPTION

   Required items, please complete
   
   Change(s):
   - Removed OperationName search for `add service principal` as brings more results in to filter on and not needed, `where old_value_set == "[]"` looks for empty prior value and restricts to FIRST password or certificate added only.
   - Removed comment for code removed in [prior commit ](https://github.com/Azure/Azure-Sentinel/commit/634c4abe7d42332ad44ce22aa5038518a514bd90?diff=unified#diff-157d168077ce95b5777c0525ed4ea258ef8d3410e1fd9c9e534dd665b2442597L46) | [PR](https://github.com/Azure/Azure-Sentinel/pull/7589)
   - Add entity for SPN/App Registration name

   Reason for Change(s):
   - OperationName change results in less results to filter on, increases performance slightly
   - Remove comment since code was removed prior, prevent confusion
   - Entity added for Analyst easier to see, also populate the investigation graph/gui

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes