### PR TITLE
add the rulename, transactionID, Resourcetype and resourceID for WAF

### DIFF
--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
@@ -60,7 +60,7 @@ query: |
   (AzureDiagnostics
   | where Category in ("FrontdoorWebApplicationFirewallLog", "FrontdoorAccessLog", "ApplicationGatewayFirewallLog", "ApplicationGatewayAccessLog")
   | where userAgent_s has_any (UserAgentString) or userAgent_s matches regex UARegex
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = clientIP_s, Type, host_s, requestUri_s, httpStatus_d
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = clientIP_s, Type, host_s, requestUri_s, httpStatus_d, ruleName_s, transactionId_g, ResourceType, ResourceId
   | extend timestamp = StartTime, IPCustomEntity = SourceIP, UrlCustomEntity = requestUri_s
   ),
   (
@@ -104,5 +104,5 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: AccountCustomEntity
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Add more details when alert fires for WAF item(s): ruleName_s, transactionId_g, ResourceType, ResourceId

   Reason for Change(s):
   - We had this alert fire off for an application gateway and the existing items pulled into the alert do not state the actual resourcetype (from 4 in rule), or any details for the Resource or WAF Rule. The offending IP, URL, statuscode, useragent are not enough to easily figure out "what" WAF protected (or perhaps unprotected) resource is in question.
   - Adding the rulename is helpful if the data is passed and not blocked - we see what rule allows attempt
   - Adding Resourcetype + ResourceID helps the analyst determine the target quickly
   - Adding the transactionID is a unique search item to dig in deeper for details from WAF?azurediagnostics log directly

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
