### PR TITLE
InfobloxCDC.txt Parser Update

### DIFF
--- a/Solutions/Infoblox Cloud Data Connector/Parsers/InfobloxCDC.txt
+++ b/Solutions/Infoblox Cloud Data Connector/Parsers/InfobloxCDC.txt
@@ -1,8 +1,8 @@
 // Title:           Infoblox Cloud Data Connector Parser
 // Author:          Infoblox
-// Version:         1.0
-// Last Updated:    12/2/2021
-// Comment:         Initial Release
+// Version:         2.0.9
+// Last Updated:    4/10/2023
+// Comment:         
 //  
 // DESCRIPTION:
 // This parser takes raw Infoblox Cloud Data Connector (CDC) logs from a Syslog (CEF) stream and parses the logs into a normalized schema.
@@ -17,15 +17,23 @@
 // 
 CommonSecurityLog
 | where DeviceVendor == "Infoblox" and DeviceProduct == "Data Connector"
-| parse-kv AdditionalExtensions as (InfobloxAnCount:int, InfobloxArCount:int, InfobloxDNSQClass:string, InfobloxDNSQFlags:string, InfobloxDNSQType:string, InfobloxDNSRCode:string, InfobloxDNSView:string, InfobloxNsCount:int) with (pair_delimiter=';', kv_delimiter='=')
+| extend AEcopy = AdditionalExtensions
+//Remove DHCP Option codes at end of DHCP logs to prevent invalid chars in fieldnames, causing errors. If you require these advanced fields, remove the following line.
+| extend AEcopy = trim_end("InfobloxDHCPOptions=;(.*?)",AEcopy)
+| extend AEcopy = extract_all(@"(?P<key>[^=;]+)=(?P<value>[^=;]+)", dynamic(["key","value"]), AEcopy)
+| mv-apply AEcopy on (
+    summarize AdditionalExtensionsParsedNested = make_bag(pack(tostring(AEcopy[0]), AEcopy[1]))
+)
+| extend AdditionalExtensionsParsed = AdditionalExtensionsParsedNested
+| evaluate bag_unpack(AdditionalExtensionsParsed)
 | extend ThreatLevel_Score = toint(column_ifexists("InfobloxThreatLevel", ""))
 | extend ThreatLevel = case(ThreatLevel_Score>=80, "High",
                        ThreatLevel_Score>=30 and ThreatLevel_Score<80, "Medium",
                        ThreatLevel_Score<30 and ThreatLevel_Score>=1, "Low",
                        ThreatLevel_Score == 0,"Info",
                        "N/A" )
-| extend ThreatClass = column_ifexists("ThreatClass", "")
-| extend ThreatProperty = column_ifexists("ThreatProperty", "")
+| extend ThreatClass = extract("(.*?)_", 1, tostring(column_ifexists("InfobloxThreatProperty", "")))
+| extend ThreatProperty = extract("([^_]*$)", 1, tostring(column_ifexists("InfobloxThreatProperty", "")))
 | extend InfobloxB1FeedName = column_ifexists("InfobloxB1FeedName", "")
 | extend InfobloxRPZ = column_ifexists("InfobloxRPZ", "")
 | extend InfobloxB1PolicyAction = column_ifexists("InfobloxB1PolicyAction", "")


### PR DESCRIPTION
   Change(s):
   - Update InfobloxCDC.txt parser.

   Reason for Change(s):
   - Recent change to parser from PR #7318 removed many fields relied on by Sentinel content. This update brings them back.
   - Removed InfobloxDHCPOptions field when parsing DHCP logs. Depending on [DHCP options](https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml), sometimes parsing this results in invalid chars within fieldnames, causing errors in Sentinel. Advanced users who may need this field can still uncomment the line that removes it if necessary however they must be careful of invalid chars.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes
