### PR TITLE
modify guid for uniqueness

### DIFF
--- a/DataConnectors/Templates/Connector_API_CCP_template.json
+++ b/DataConnectors/Templates/Connector_API_CCP_template.json
@@ -9,8 +9,8 @@
     },
     "resources": [
         {
-            "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'),'/providers/Microsoft.SecurityInsights/dataConnectors/',guid(subscription().subscriptionId))]",
-            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',guid(subscription().subscriptionId))]",
+            "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'),'/providers/Microsoft.SecurityInsights/dataConnectors/',guid(resourceGroup().id, deployment().name))]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',guid(resourceGroup().id, deployment().name))]",
             "apiVersion": "2021-03-01-preview",
             "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
             "kind": "APIPolling",


### PR DESCRIPTION
If customers use the template as is with an ID that is a GUID only based on subscriptionID, any new CCP will overwrite previous CCP made with this template, including the GitHub data connector. By revising the GUID to be based on resourcegroup and deployment name, additional use of this template for new CCP won't overwrite previous.

Tested and found this revised Id GUID won't overwrite other CCP.