### PR TITLE
update GUID creation for uniqueness

### DIFF
--- a/Solutions/GitHub/Data Connectors/azuredeploy_GitHub_native_poller_connector.json
+++ b/Solutions/GitHub/Data Connectors/azuredeploy_GitHub_native_poller_connector.json
@@ -9,8 +9,8 @@
     },
     "resources": [
         {
-            "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'),'/providers/Microsoft.SecurityInsights/dataConnectors/',guid(subscription().subscriptionId))]",
-            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',guid(subscription().subscriptionId))]",
+            "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'),'/providers/Microsoft.SecurityInsights/dataConnectors/',guid(resourceGroup().id, deployment().name))]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',guid(resourceGroup().id, deployment().name))]",
             "apiVersion": "2021-03-01-preview",
             "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
 	"kind": "APIPolling",


### PR DESCRIPTION
id and name GUID too generic and was overwriting other codeless connectors using same subscriptionid as GUID. With this new logic, the GitHub codeless connector will play nice with other codeless connectors.

Testing completed:
Yes