### PR TITLE
Fixes broken analytics

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/MFARejectedbyUser.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/MFARejectedbyUser.yaml
@@ -35,11 +35,9 @@ entityMappings:
         columnName: UPNSuffix
       - identifier: AadUserId
         columnName: UserId
-      - identifier: AadTenantId
-        columnName: AADTenantId
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.4
+version: 1.0.5
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/NRT_MFARejectedbyUser.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/NRT_MFARejectedbyUser.yaml
@@ -31,11 +31,9 @@ entityMappings:
         columnName: UPNSuffix
       - identifier: AadUserId
         columnName: UserId
-      - identifier: AadTenantId
-        columnName: AADTenantId
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.2
+version: 1.0.3
 kind: NRT

--- a/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_CommonSecurityLog.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_CommonSecurityLog.yaml
@@ -79,7 +79,7 @@ query: |
 entityMappings:
   - entityType: Host
     fieldMappings:
-      - identifier: Name
+      - identifier: HostName
         columnName: DeviceName
   - entityType: IP
     fieldMappings:
@@ -89,5 +89,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: PA_Url
-version: 1.3.1
+version: 1.3.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_PaloAlto.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_PaloAlto.yaml
@@ -78,13 +78,13 @@ query: |
   ) on $left.TI_DomainEntity==$right.Domain
   | where CommonSecurityLog_TimeGenerated < ExpirationDateTime
   | summarize CommonSecurityLog_TimeGenerated = arg_max(CommonSecurityLog_TimeGenerated, *) by IndicatorId, Domain, IoC
-  | project CommonSecurityLog_TimeGenerated, Description, ActivityGroupNames, PA_Url, Domain, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, 
+  | project CommonSecurityLog_TimeGenerated, Description, ActivityGroupNames, PA_Url, Domain, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore,
     DeviceAction, DestinationIP, DestinationPort, DeviceName, SourceIP, SourcePort, ApplicationProtocol, RequestMethod, Type, IoC, TI_DomainEntity
   | extend timestamp = CommonSecurityLog_TimeGenerated
 entityMappings:
   - entityType: Host
     fieldMappings:
-      - identifier: Name
+      - identifier: HostName
         columnName: DeviceName
   - entityType: IP
     fieldMappings:
@@ -94,5 +94,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: PA_Url
-version: 1.3.1
+version: 1.3.2
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_SecurityAlert.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_SecurityAlert.yaml
@@ -79,7 +79,7 @@ query: |
   )
   | extend Alert_TimeGenerated = TimeGenerated
   | extend Alert_Description = Description
-  ) on $left.TI_DomainEntity==$right.domain 
+  ) on $left.TI_DomainEntity==$right.domain
   | where Alert_TimeGenerated < ExpirationDateTime
   | summarize Alert_TimeGenerated = arg_max(Alert_TimeGenerated, *) by IndicatorId, AlertName, IoC
   | project Alert_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, DomainName, AlertName, Alert_Description, ProviderName, AlertSeverity, ConfidenceLevel, HostName, IP_addr, Url, Entities, Type, IoC, TI_DomainEntity
@@ -87,7 +87,7 @@ query: |
 entityMappings:
   - entityType: Host
     fieldMappings:
-      - identifier: Name
+      - identifier: HostName
         columnName: HostName
   - entityType: IP
     fieldMappings:
@@ -97,5 +97,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: Url
-version: 1.3.4
+version: 1.3.5
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s): 
  - Fix broken TI analytics using the incorrect identifier for the `Host` entity type
  - Fix MFA analytic with too many field mappings

   Reason for Change(s): 
  - Errors when deploying to Sentinel `Invalid data model. [: Invalid identifier 'Name' for type 'Host' encountered. Valid identifiers are: [DnsDomain, NTDomain, HostName, NetBiosName, AzureID, OMSAgentID, OSFamily, OSVersion, IsDomainJoined, FullName]]`
  - Invalid length of '4' for 'FieldMappings'

   Version Updated: ✅

   Testing Completed: ✅

   Checked that the validations are passing and have addressed any issues that are present:
   - [x] See guidance below



-----------------------------------------------------------------------------------------------------------
