### PR TITLE
More rule fixes

### DIFF
--- a/Detections/MultipleDataSources/Dev-0530_FileExtRename.yaml
+++ b/Detections/MultipleDataSources/Dev-0530_FileExtRename.yaml
@@ -20,18 +20,41 @@ tags:
   - Schema: ASIMFileEvent
     SchemaVersion: 0.1.0
 query: |
-  (union isfuzzy=true
-  (DeviceFileEvents
-  | where ActionType == "FileCreated"
-  | where FileName endswith ".h0lyenc" or FolderPath == "C:\\FOR_DECRYPT.html" 
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by AccountCustomEntity = iff(isnotempty(InitiatingProcessAccountUpn), InitiatingProcessAccountUpn, InitiatingProcessAccountName), HostCustomEntity = DeviceName, Type, InitiatingProcessId, FileName, FolderPath, EventType = ActionType, Commandline = InitiatingProcessCommandLine, InitiatingProcessFileName, InitiatingProcessSHA256, FileHashCustomEntity = SHA256
-  ),
-  (imFileEvent
-  | where EventType == "FileCreated" 
-  | where TargetFilePath endswith ".h0lyenc" or TargetFilePath == "C:\\FOR_DECRYPT.html" 
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by AccountCustomEntity = ActorUsername, HostCustomEntity = DvcHostname, DvcId, Type, EventType,  FileHashCustomEntity = TargetFileSHA256, Hash, TargetFilePath, Commandline = ActingProcessCommandLine
-  )
-  )
+  union isfuzzy=true
+      (DeviceFileEvents
+      | where ActionType == "FileCreated"
+      | where FileName endswith ".h0lyenc" or FolderPath == "C:\\FOR_DECRYPT.html"
+      | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated)
+          by
+          AccountCustomEntity = iff(isnotempty(InitiatingProcessAccountUpn), InitiatingProcessAccountUpn, InitiatingProcessAccountName),
+          HostCustomEntity = DeviceName,
+          Type,
+          InitiatingProcessId,
+          FileName,
+          FolderPath,
+          EventType = ActionType,
+          Commandline = InitiatingProcessCommandLine,
+          InitiatingProcessFileName,
+          InitiatingProcessSHA256,
+          FileHashCustomEntity = SHA256,
+          AlgorithmCustomEntity = "SHA256"
+      ),
+      (imFileEvent
+      | where EventType == "FileCreated"
+      | where TargetFilePath endswith ".h0lyenc" or TargetFilePath == "C:\\FOR_DECRYPT.html"
+      | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated)
+          by
+          AccountCustomEntity = ActorUsername,
+          HostCustomEntity = DvcHostname,
+          DvcId,
+          Type,
+          EventType,
+          FileHashCustomEntity = TargetFileSHA256,
+          Hash,
+          TargetFilePath,
+          Commandline = ActingProcessCommandLine,
+          AlgorithmCustomEntity = "SHA256"
+      )
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -47,5 +70,5 @@ entityMappings:
         columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/Log4jVulnerableMachines.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/Log4jVulnerableMachines.yaml
@@ -1,7 +1,7 @@
 id: 3d71fc38-f249-454e-8479-0a358382ef9a
 name: Vulnerable Machines related to log4j CVE-2021-44228
 description: |
-  'This query uses the Azure Defender Security Nested Recommendations data to find machines vulnerable to log4j CVE-2021-44228. Log4j is an open-source Apache logging library that is used in 
+  'This query uses the Azure Defender Security Nested Recommendations data to find machines vulnerable to log4j CVE-2021-44228. Log4j is an open-source Apache logging library that is used in
    many Java-based applications. Security Nested Recommendations data is sent to Microsoft Sentinel using the continuous export feature of Azure Defender(refrence link below).
    Reference: https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/
    Reference: https://docs.microsoft.com/azure/security-center/continuous-export?tabs=azure-portal
@@ -29,10 +29,10 @@ query: |
   | parse ResourceDetails with * 'virtualMachines/' VirtualMachine '"' *
   | summarize arg_min(TimeGenerated, *) by TenantId, RecommendationSubscriptionId, VirtualMachine, RecommendationName,Description,RemediationDescription, tostring(AdditionalData),VulnerabilityId
   | extend Timestamp = TimeGenerated
-entityMappings: 
+entityMappings:
   - entityType: Host
     fieldMappings:
-      - identifier: Name
+      - identifier: HostName
         columnName: VirtualMachine
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Attacker Tools Threat Protection Essentials/Analytic Rules/powershell_empire.yaml
+++ b/Solutions/Attacker Tools Threat Protection Essentials/Analytic Rules/powershell_empire.yaml
@@ -22,12 +22,16 @@ queryPeriod: 12h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
+  - Collection
+  - CommandAndControl
+  - CredentialAccess
+  - DefenseEvasion
+  - Discovery
   - Execution
+  - Exfiltration
+  - LateralMovement
   - Persistence
   - PrivilegeEscalation
-  - LateralMovement
-  - DefenseEvasion
-  - CommandAndControl
 relevantTechniques:
   - T1548.002
   - T1134
@@ -147,12 +151,12 @@ entityMappings:
       - identifier: Name
         columnName: SubjectUserName
       - identifier: NTDomain
-        columnName: SubjectDomainName 
+        columnName: SubjectDomainName
   - entityType: Host
     fieldMappings:
       - identifier: HostName
         columnName: HostName
       - identifier: DnsDomain
         columnName: DnsDomain
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled

--- a/Solutions/FalconFriday/Analytic Rules/DLLSideLoading.yaml
+++ b/Solutions/FalconFriday/Analytic Rules/DLLSideLoading.yaml
@@ -1,8 +1,8 @@
 id: 3084b487-fad6-4000-9544-6085b9657290
 name: Hijack Execution Flow - DLL Side-Loading
 description: |
-  This detection tries to identify all DLLs loaded by "high integrity" processes and cross-checks the DLL paths against FileCreate/FileModify events of the same DLL by a medium integrity process. 
-  Of course, we need to do some magic to filter out false positives as much as possible. So any FileCreate/FileModify done by "NT Authoriy\System" and the "RID 500" users aren't interesting. 
+  This detection tries to identify all DLLs loaded by "high integrity" processes and cross-checks the DLL paths against FileCreate/FileModify events of the same DLL by a medium integrity process.
+  Of course, we need to do some magic to filter out false positives as much as possible. So any FileCreate/FileModify done by "NT Authoriy\System" and the "RID 500" users aren't interesting.
   Also, we only want to see the FileCreate/FileModify actions which are performed with a default or limited token elevation. If done with a full elevated token, the user is apparently admin already.
 severity: Medium
 status: Available
@@ -28,11 +28,11 @@ query: |
       | project FolderPath=tolower(FolderPath), InitiatingProcessFileName, InitiatingProcessIntegrityLevel, DeviceId, DeviceName
       | distinct FolderPath, InitiatingProcessFileName, InitiatingProcessIntegrityLevel, DeviceId, DeviceName
   );
-  imls 
+  imls
   | join (
-      DeviceFileEvents 
-      | where FolderPath in~ ((imls | project FolderPath)) and ActionType in ("FileCreated", "FileModified") and 
-      InitiatingProcessIntegrityLevel !in ("High", "System", "") and InitiatingProcessAccountSid != "S-1-5-18" and 
+      DeviceFileEvents
+      | where FolderPath in~ ((imls | project FolderPath)) and ActionType in ("FileCreated", "FileModified") and
+      InitiatingProcessIntegrityLevel !in ("High", "System", "") and InitiatingProcessAccountSid != "S-1-5-18" and
       InitiatingProcessTokenElevation in ("TokenElevationTypeDefault", "TokenElevationTypeLimited") and InitiatingProcessAccountSid !endswith "-500"
       | extend FolderPath=tolower(FolderPath)
   ) on FolderPath, DeviceId, DeviceName
@@ -45,14 +45,14 @@ entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Sid
-        columnName: AccountSid 
+        columnName: InitiatingProcessAccountSid
       - identifier: Name
-        columnName: AccountName
+        columnName: InitiatingProcessAccountName
       - identifier: NTDomain
-        columnName: AccountDomain
+        columnName: InitiatingProcessAccountDomain
   - entityType: Process
     fieldMappings:
       - identifier: CommandLine
-        columnName: ProcessCommandLine
-version: 1.0.0
+        columnName: InitiatingProcessCommandLine
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Microsoft Defender for Cloud Apps/Analytic Rules/AdditionalFilesUploadedByActor.yaml
+++ b/Solutions/Microsoft Defender for Cloud Apps/Analytic Rules/AdditionalFilesUploadedByActor.yaml
@@ -76,7 +76,7 @@ query: |
   | extend LinkedMaliciousFileName = tostring(UploadedFileInfo.FileName)
   | extend LinkedMaliciousFileHash = tostring(UploadedFileInfo.Md5Hash)
   | extend HashAlgorithm = "MD5"
-  | project AlertTimeGenerated = TimeGenerated, LinkedMaliciousFileName, LinkedMaliciousFileHash, AlertType, AttackerIP, AttackerCountry, MaliciousFileDirectory, MaliciousFileName, FilesUploaded, UploadedFileInfo
+  | project AlertTimeGenerated = TimeGenerated, LinkedMaliciousFileName, LinkedMaliciousFileHash, HashAlgorithm, AlertType, AttackerIP, AttackerCountry, MaliciousFileDirectory, MaliciousFileName, FilesUploaded, UploadedFileInfo
 entityMappings:
   - entityType: IP
     fieldMappings:
@@ -88,5 +88,5 @@ entityMappings:
         columnName: HashAlgorithm
       - identifier: Value
         columnName: LinkedMaliciousFileHash
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
This PR fixes a number of bugs in rules
   
   Change(s):
   - `Dev-0530 File Extension Rename`: Make sure `AlgorithmCustomEntity` column exists and reformat rule
   - `Hijack Execution Flow - DLL Side-Loading`: Use existing columns for entities, the current columns don't exist
   - `Linked Malicious Storage Artifacts`: the `HashAlgorithm` column is expected as an entity but wasn't included in the project statement
   - `Vulnerable Machines related to log4j CVE-2021-44228`: Using incorrect entity identifier, changed from `Name` to `HostName`
   - `Powershell Empire Cmdlets Executed in Command Line`: Add requisite tactics to match listed techniques. Rule can't be deployed without them

   Version Updated: ✅

   Testing Completed: ✅
