### PR TITLE
feat: add Playbooks/AzureMonitor-ManagedId

### DIFF
--- a/Playbooks/AzureMonitor-ManagedId/azuredeploy.json
+++ b/Playbooks/AzureMonitor-ManagedId/azuredeploy.json
@@ -1,0 +1,269 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceTags": {
+            "type": "object",
+            "defaultValue": {
+                "LogicAppsCategory": "security"
+            },
+            "metadata": {
+                "description": "The Azure tags to set on the resource."
+            }
+        },
+        "PlaybookName": {
+            "defaultValue": "AzureMonitor-ManagedId",
+            "type": "string",
+            "metadata": {
+                "description": "The Playbook aka LogicApp name."
+            }
+        },
+        "integrationAccounts_externalid": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Azure ResourceId of Integration account."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('PlaybookName')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "state": "Enabled",
+                "integrationAccount": {
+                    "id": "[parameters('integrationAccounts_externalid')]"
+                },
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "triggers": {
+                        "manual": {
+                            "type": "Request",
+                            "kind": "Http",
+                            "inputs": {
+                                "schema": {
+                                    "properties": {
+                                        "query": {
+                                            "type": "string"
+                                        },
+                                        "resource_group": {
+                                            "type": "string"
+                                        },
+                                        "resource_name": {
+                                            "type": "string"
+                                        },
+                                        "subscription_id": {
+                                            "type": "string"
+                                        },
+                                        "subscription_name": {
+                                            "type": "string"
+                                        },
+                                        "timerange": {
+                                            "type": "string"
+                                        },
+                                        "workspace_id": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "actions": {
+                        "Condition": {
+                            "actions": {
+                                "Set_variable_html_as_message": {
+                                    "runAfter": {},
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "html_output",
+                                        "value": "Error (@{outputs('HTTP')['statusCode']}): @{body('Parse_JSON')?['error']?['innererror']?['message']} - innererror: @{body('Parse_JSON')?['error']?['innererror']?['innererror']}"
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Parse_JSON": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "else": {
+                                "actions": {
+                                    "Create_HTML_table": {
+                                        "runAfter": {
+                                            "Transform_JSON_to_JSON": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "Table",
+                                        "inputs": {
+                                            "format": "HTML",
+                                            "from": "@body('Transform_JSON_to_JSON')"
+                                        }
+                                    },
+                                    "Set_variable_html_table": {
+                                        "runAfter": {
+                                            "Create_HTML_table": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "SetVariable",
+                                        "inputs": {
+                                            "name": "html_output",
+                                            "value": "@body('Create_HTML_table')"
+                                        }
+                                    },
+                                    "Transform_JSON_to_JSON": {
+                                        "runAfter": {},
+                                        "type": "Liquid",
+                                        "kind": "JsonToJson",
+                                        "inputs": {
+                                            "content": "@body('HTTP')",
+                                            "integrationAccount": {
+                                                "map": {
+                                                    "name": "azuremonitor"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "not": {
+                                            "equals": [
+                                                "@outputs('HTTP')['statusCode']",
+                                                200
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "type": "If"
+                        },
+                        "HTTP": {
+                            "runAfter": {
+                                "Initialize_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "authentication": {
+                                    "audience": "https://api.loganalytics.io",
+                                    "type": "ManagedServiceIdentity"
+                                },
+                                "method": "GET",
+                                "queries": {
+                                    "query": "@triggerBody()?['query']"
+                                },
+                                "uri": "https://api.loganalytics.io/v1/workspaces/@{triggerBody()?['workspace_id']}/query"
+                            }
+                        },
+                        "Initialize_variable": {
+                            "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "html_output",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        "Parse_JSON": {
+                            "runAfter": {
+                                "HTTP": [
+                                    "Succeeded",
+                                    "Failed"
+                                ]
+                            },
+                            "type": "ParseJson",
+                            "inputs": {
+                                "content": "@body('HTTP')",
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "properties": {
+                                                "code": {
+                                                    "type": "string"
+                                                },
+                                                "correlationId": {
+                                                    "type": "string"
+                                                },
+                                                "innererror": {
+                                                    "properties": {
+                                                        "code": {
+                                                            "type": "string"
+                                                        },
+                                                        "innererror": {
+                                                            "properties": {
+                                                                "code": {
+                                                                    "type": "string"
+                                                                },
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "Response": {
+                            "runAfter": {
+                                "Condition": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Response",
+                            "kind": "Http",
+                            "inputs": {
+                                "body": {
+                                    "html_output": "@{variables('html_output')}",
+                                    "status_code": "@outputs('HTTP')['statusCode']"
+                                },
+                                "statusCode": "@outputs('HTTP')['statusCode']"
+                            }
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {}
+            }
+        }
+    ]
+}

--- a/Playbooks/AzureMonitor-ManagedId/azuremonitor.liquid
+++ b/Playbooks/AzureMonitor-ManagedId/azuremonitor.liquid
@@ -1,0 +1,15 @@
+{% assign rows = content.tables[0].rows %}
+{% assign columns = content.tables[0].columns %}
+{% assign index = columns.size | minus: 1 %}
+[
+    {% for row in rows %}
+        {
+            {% for num in (0..index) %}
+            {% if num == index %}
+            {% break %}
+            {% endif %}
+                "{{columns[num].name}}": "{{row[num] | Replace: '"', '\"'}}",
+            {% endfor %}
+        },
+    {% endfor %}
+]

--- a/Playbooks/AzureMonitor-ManagedId/readme.md
+++ b/Playbooks/AzureMonitor-ManagedId/readme.md
@@ -1,0 +1,22 @@
+# AzureMonitor-ManagedId
+
+This playbook is an equivalent of AzureMonitor KQL query base block but allowing to use Managed Identity with HTTP request block.
+Credits to @koosg for initial work.
+
+## Prerequisite:
+
+* Create Azure Integration account in same region than targeted logic app and load the liquid map. (manual only at this point)
+* Make role assignment "Log Analytics Reader" to managed identity for appropriate scope (target log analytics).
+
+## Deploy to Azure
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FAzureMonitor-ManagedId2Fazuredeploy.json)
+[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FAzureMonitor-ManagedId%2Fazuredeploy.json)
+
+## References
+
+* https://medium.com/@koosg/secure-your-microsoft-sentinel-playbooks-with-managed-identities-fce1f232df3a
+* https://www.m365princess.com/blogs/query-azure-monitor/
+* https://learn.microsoft.com/en-us/azure/logic-apps/create-managed-service-identity?tabs=consumption
+* https://learn.microsoft.com/en-us/rest/api/loganalytics/dataaccess/query/get?tabs=HTTP
+* https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-enterprise-integration-liquid-transform?tabs=consumption
+* https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-enterprise-integration-create-integration-account?tabs=azure-portal%2Cconsumption


### PR DESCRIPTION
   
   Change(s):
   - add Playbooks/AzureMonitor-ManagedId

   Reason for Change(s):
This playbook is an equivalent of AzureMonitor KQL query base block but allowing to use Managed Identity with HTTP request block.
Credits to koosg for initial work.

   Testing Completed:
   - Yes. used in production for many months

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes. Deployed in production with Sentinel Repository feature, precommit and psrule
