### PR TITLE
Update Endpoint Agent Health Status Report.yaml

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/General queries/Endpoint Agent Health Status Report.yaml
@@ -69,37 +69,37 @@ query: |
     | summarize Tests = make_bag(packed), DeviceName = any(DeviceName) by DeviceId, OSPlatform
     | evaluate bag_unpack(Tests)
     | extend CloudProtection = case(
-        OSPlatform has "Windows", CloudProtectionWin,
+        OSPlatform startswith "Windows", CloudProtectionWin,
         OSPlatform has "macOS",   CloudProtectionMac,
         OSPlatform has "Linux",   CloudProtectionLin,
         "NULL")
     | extend PUAProtection = case(
-        OSPlatform has "Windows", PUAProtectionWin,
+        OSPlatform startswith "Windows", PUAProtectionWin,
         OSPlatform has "macOS",   PUAProtectionMac,
         OSPlatform has "Linux",   PUAProtectionLin,
         "NULL")
     | extend TamperProtection = case(
-        OSPlatform has "Windows", TamperProtectionWin,
+        OSPlatform startswith "Windows", TamperProtectionWin,
         OSPlatform has "macOS",   TamperProtectionMac,
         //OSPlatform has "Linux",   TamperProtectionLin,
         "NULL")
     | extend SensorDataCollection = case(
-        OSPlatform has "Windows", SensorDataCollectionWin,
+        OSPlatform startswith "Windows", SensorDataCollectionWin,
         OSPlatform has "macOS",   SensorDataCollectionMac,
         OSPlatform has "Linux",   SensorDataCollectionLin,
         "NULL")
     | extend ImpairedCommunications = case(
-        OSPlatform has "Windows", ImpairedCommunicationsWin,
+        OSPlatform startswith "Windows", ImpairedCommunicationsWin,
         OSPlatform has "macOS",   ImpairedCommunicationsMac,
         OSPlatform has "Linux",   ImpairedCommunicationsLin,
         "NULL")
     | extend RealtimeProtection = case(
-        OSPlatform has "Windows", RealtimeProtectionWin,
+        OSPlatform startswith "Windows", RealtimeProtectionWin,
         OSPlatform has "macOS",   RealtimeProtectionMac,
         OSPlatform has "Linux",   RealtimeProtectionLin,
         "NULL")
     | extend AntivirusSignatureVersion = case(
-        OSPlatform has "Windows", AntivirusSignatureVersionWin,
+        OSPlatform startswith "Windows", AntivirusSignatureVersionWin,
         OSPlatform has "macOS",   AntivirusSignatureVersionMac,
         OSPlatform has "Linux",   AntivirusSignatureVersionLin,
         "NULL")


### PR DESCRIPTION
   Change:
   - Updated query from `has` to `startswith` statements in Endpoint Agent Health Status Report.yaml

   Reason for Change:
   -  `has` statement returns `NULL` in all applicable columns for Windows OS as it looks for `Windows` in the `OSPlatform` column
   -  Example of Windows OS versions in the `OSPlatform` column: WindowsServer2022, WindowsServer2019, Windows10, Windows11

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
