### PR TITLE
Infoblox parser dns client

### DIFF
--- a/Solutions/Infoblox NIOS/Parser/Infoblox_dnsclient.txt
+++ b/Solutions/Infoblox NIOS/Parser/Infoblox_dnsclient.txt
@@ -13,7 +13,8 @@
 // LOG SAMPLES:
 // This parser assumes the raw log are formatted as follows:
 // 
-//      07-Apr-2013 20:16:49.083 client 10.120.20.198#57398 UDP: query: a2.foo.com IN A response: NOERROR +AED a2.foo.com. 28800 IN A 1.1.1.2;
+//      07-Apr-2013 20:16:49.083 client 10.120.20.198#57398 UDP: query: a2.foo.com IN A response: NOERROR +AED a2.foo.com. 28800 IN A 1.1.1.2
+//      22-Mar-2023 08:59:34.790 client 1.1.1.1#50164: UDP: query: 2.2.2.2.in-addr.arpa IN PTR response: NOERROR +A 3.3.3.3.in-addr.arpa. 3600 IN PTR myhost.mydomain.local
 //      30-Apr-2013 13:35:02.187 client 10.120.20.32#42386: query: foo.com IN A + (100.90.80.102)
 //
 // Update 'Sources_by_SourceType' Watchlist by adding names of your Infoblox NIOS servers. This Watchlist would get created as part Infoblox NIOS solution.
@@ -25,7 +26,7 @@ let response =
     | where SyslogMessage has_all ("client", "query:", "response:")
     | parse SyslogMessage with *
         "client " SrcIpAddr: string
-        "#" SrcPortNumber: int
+        "#" SrcPortNumber: string
         " " NetworkProtocol: string
         ": query: " DnsQuery: string
         " " DnsQueryClassName: string
@@ -35,9 +36,10 @@ let response =
     | extend DnsResponseNameIndex= indexof(DnsFlags, " ")
     | extend EventMessage =iif(DnsResponseNameIndex != "-1", substring(DnsFlags, DnsResponseNameIndex+1), "")
     | extend DnsFlags =iif(DnsResponseNameIndex != "-1", substring(DnsFlags, 0, DnsResponseNameIndex), DnsFlags)
+    | extend SrcPortNumber = iif(SrcPortNumber has ':',replace_string(SrcPortNumber,':',''),SrcPortNumber)
+    | extend SrcPortNumber = toint(SrcPortNumber)
     | extend EventSubType = "response"
-    | project-away DnsResponseNameIndex,SyslogMessage
-    ;
+    | project-away DnsResponseNameIndex,SyslogMessage;
 //
 // Parse Request Logs
 //

--- a/Solutions/Infoblox NIOS/Parser/Infoblox_dnsclient.txt
+++ b/Solutions/Infoblox NIOS/Parser/Infoblox_dnsclient.txt
@@ -1,8 +1,7 @@
 // Title:           Infoblox parser for type - DNS-client
 // Author:          Microsoft
-// Version:         1.3
-// Last Updated:    Sept 23 2022
-// Comment:         Updated parser by replacing 'Regex' with 'Parse' operator.
+// Version:         1.4
+// Last Updated:    27-Apr-2023
 //
 // DESCRIPTION:
 // This parser takes raw Infoblox NIOS logs from a Syslog stream and parses the logs into a normalized schema.


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Parse logic changes

   Reason for Change(s):
   - Parsing was failing when ':' was coming just after srcPortNumber. Added support to handle both conditions

   Version Updated:
   - 1.4

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


-----------------------------------------------------------------------------------------------------------
