### PR TITLE
ASimTester: Relax NetworkSession/EventSeverity to Recommended

### DIFF
--- a/ASIM/dev/ASimTester/ASimTester.csv
+++ b/ASIM/dev/ASimTester/ASimTester.csv
@@ -660,7 +660,7 @@ EventResult,string,Mandatory,NetworkSession,Enumerated,Success|Partial|Failure|N
 EventResultDetails,string,Recommended,NetworkSession,Enumerated,Failover|Invalid TCP|Invalid Tunnel|Maximum Retry|Reset|Routing issue|Simulation|Terminated|Timeout|Transient error|Unknown|NA,
 EventSchema,string,Mandatory,NetworkSession,Enumerated,NetworkSession,
 EventSchemaVersion,string,Mandatory,NetworkSession,SchemaVersion,,
-EventSeverity,string,Mandatory,NetworkSession,Enumerated,Informational|Low|Medium|High,
+EventSeverity,string,Recommended,NetworkSession,Enumerated,Informational|Low|Medium|High,
 EventStartTime,datetime,Mandatory,NetworkSession,,,
 EventSubType,string,Optional,NetworkSession,Enumerated,Start|End|,
 EventType,string,Mandatory,NetworkSession,Enumerated,NetworkSession|L2NetworkSession|EndpointNetworkSession|Flow,


### PR DESCRIPTION
In current ASIM common fields and NetworkSession schemas EventSeverity is listed as a Recommended field.

Change its class from Mandatory to Recommended.

https://learn.microsoft.com/en-us/azure/sentinel/normalization-common-fields
https://learn.microsoft.com/en-us/azure/sentinel/normalization-schema-network

   Required items, please complete
   
   Change(s):
   - ASimTester: Change EventSeverity field's class from Mandatory to Recommended

   Reason for Change(s):
   - To have ASIM tester function match current documentation

   Version Updated:
   - N/A

   Testing Completed:
   - N/A
   - I tried modifying re-saving ASimSchemaTester with a URL to changed CSV version, but looks like the function cannot be saved using GUI.
   - ASimSchemaTester has parameters "T:(ColumnName:string,ColumnType:string),selected_schema:string", and the function dialog does not support that yet.

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A

-----------------------------------------------------------------------------------------------------------
