### PR TITLE
Cloudflare Data Connector - Parameterize blob download chunk size

### DIFF
--- a/Solutions/Cloudflare/Data Connectors/AzureFunctionCloudflare/main.py
+++ b/Solutions/Cloudflare/Data Connectors/AzureFunctionCloudflare/main.py
@@ -12,6 +12,7 @@ from .sentinel_connector_async import AzureSentinelConnectorAsync
 
 
 logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.ERROR)
+logging.getLogger('charset_normalizer').setLevel(logging.ERROR)
 
 
 MAX_SCRIPT_EXEC_TIME_MINUTES = 5

--- a/Solutions/Cloudflare/Data Connectors/AzureFunctionCloudflare/main.py
+++ b/Solutions/Cloudflare/Data Connectors/AzureFunctionCloudflare/main.py
@@ -34,6 +34,9 @@ MAX_PAGE_SIZE = int(MAX_CONCURRENT_PROCESSING_FILES * 1.5)
 # Defines max number of events that can be sent in one request to Azure Sentinel
 MAX_BUCKET_SIZE = int(os.environ.get('MAX_BUCKET_SIZE', 2000))
 
+# Defines max chunk download size for blob storage in MB
+MAX_CHUNK_SIZE_MB = int(os.environ.get('MAX_CHUNK_SIZE_MB', 2))
+
 LOG_ANALYTICS_URI = os.environ.get('logAnalyticsUri')
 
 if not LOG_ANALYTICS_URI or str(LOG_ANALYTICS_URI).isspace():
@@ -80,7 +83,7 @@ class AzureBlobStorageConnector:
         self.total_events = 0
 
     def _create_container_client(self):
-        return ContainerClient.from_connection_string(self.__conn_string, self.__container_name, logging_enable=False, max_single_get_size=2*1024*1024, max_chunk_get_size=2*1024*1024)
+        return ContainerClient.from_connection_string(self.__conn_string, self.__container_name, logging_enable=False, max_single_get_size=MAX_CHUNK_SIZE_MB*1024*1024, max_chunk_get_size=MAX_CHUNK_SIZE_MB*1024*1024)
 
     async def get_blobs(self):
         container_client = self._create_container_client()


### PR DESCRIPTION
  
   Change(s):
   - Set log level to ERROR for transitive library charset_normalizer
   - Parameterize chunk size for the container client
   - Update `AzureFunctionCloudflare/main.py` in `CloudflareConn.zip`. Done via
      ```sh
      $ zip CloudflareConn.zip AzureFunctionCloudflare/main.py
      updating: AzureFunctionCloudflare/main.py (deflated 68%)
      ```

   Reason for Change(s):
   - When debugging issues, we encountered the logline `Encoding detection on empty bytes, assuming utf_8 intention.` at least once per processed file, but for large files, the line would be repeated hundreds of times. It did not seem to provide value, and made sifting through logs tedious.
   - We had multiple log files in the range of 3 to 5 mb in size, and the chunking behavior was not handling that well. Each time the client encountered these log files, we saw the exception
      ```
      Exception while executing function: Functions.AzureFunctionCloudflare Result: Failure
      Exception: HttpResponseError: Download stream interrupted.
      Stack:   File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/dispatcher.py", line 461, in _handle__invocation_request
          call_result = await self._run_async_func(
        File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/dispatcher.py", line 739, in _run_async_func
          return await ExtensionManager.get_async_invocation_wrapper(
        File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/extension.py", line 147, in get_async_invocation_wrapper
          result = await function(**args)
        File "/home/site/wwwroot/AzureFunctionCloudflare/main.py", line 55, in main
          await conn.process_blob(blob, container_client, session)
        File "/home/site/wwwroot/AzureFunctionCloudflare/main.py", line 101, in process_blob
          async for chunk in blob_cor.chunks():
        File "/home/site/wwwroot/.python_packages/lib/site-packages/azure/storage/blob/aio/_download_async.py", line 151, in __anext__
          self._current_content = await self._iter_downloader.yield_chunk(chunk)
        File "/home/site/wwwroot/.python_packages/lib/site-packages/azure/storage/blob/aio/_download_async.py", line 62, in yield_chunk
          return await self._download_chunk(chunk_start, chunk_end - 1)
        File "/home/site/wwwroot/.python_packages/lib/site-packages/azure/storage/blob/aio/_download_async.py", line 105, in _download_chunk
          chunk_data = await process_content(response, offset[0], offset[1], self.encryption_options)
        File "/home/site/wwwroot/.python_packages/lib/site-packages/azure/storage/blob/aio/_download_async.py", line 27, in process_content
          raise HttpResponseError(message="Download stream interrupted.", response=data.response, error=error)
      ```
      This was regardless of the concurrency being set to one or many files. The only remediation was to set the chunk size to be larger than the largest blob in the container.

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No
   - I am unsure if that is required since this doesn't touch KQL or Yaml

