### PR TITLE
Remove condition in Detection/Analytic rule SuspiciousModificationofGlobalAdminProperties.yaml

### DIFF
--- a/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
+++ b/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
@@ -42,7 +42,7 @@ query: |
                       "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
       )
       | where not(tostring(modifiedProperties["Included Updated Properties"]["newValue"]) in ("LastDirSyncTime", ""))
-      | where not(isnotempty(modifiedProperties["StrongAuthenticationPhoneAppDetail"]) and tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["newValue"])))) == tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["oldValue"])))))
+      | where not(array_length(bag_keys(modifiedProperties)) == 1 and isnotempty(modifiedProperties["StrongAuthenticationPhoneAppDetail"]) and tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["newValue"])))) == tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["oldValue"])))))
       | extend
           Initiator = iif(isnotempty(InitiatedBy["app"]), tostring(InitiatedBy["app"]["displayName"]), tostring(InitiatedBy["user"]["userPrincipalName"])),
           InitiatorId = iif(isnotempty(InitiatedBy["app"]), tostring(InitiatedBy["app"]["servicePrincipalId"]), tostring(InitiatedBy["user"]["id"])),

--- a/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
+++ b/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
@@ -34,7 +34,7 @@ query: |
       | mv-expand TargetResource = TargetResources
       | where TargetResource["type"] == "User"
       | extend AccountObjectId = tostring(TargetResource["id"])
-      | where not(tostring(TargetResource["modifiedProperties"]) == "[]")
+      | where tostring(TargetResource["modifiedProperties"]) != "[]"
       | mv-apply modifiedProperty = TargetResource["modifiedProperties"] on (
           summarize modifiedProperties = make_bag(
               bag_pack(tostring(modifiedProperty["displayName"]),

--- a/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
+++ b/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
@@ -11,36 +11,44 @@ requiredDataConnectors:
   - connectorId: BehaviorAnalytics
     dataTypes:
       - IdentityInfo
-queryFrequency: 1d
-queryPeriod: 1d
+queryFrequency: 1h
+queryPeriod: 14d
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
   - PrivilegeEscalation
 relevantTechniques:
   - T1078.004
-tags:
-  - GuestorExternalIdentities
 query: |
-  let lookback = 1d;
-  let GlobalAdmins = IdentityInfo
-  | where TimeGenerated > ago(lookback)
-  | extend IsGlobalAdmin = set_has_element(AssignedRoles, "Global Administrator")
-  | where IsGlobalAdmin == true
-  | distinct AccountUPN;
-  GlobalAdmins
-  | join kind=inner ( AuditLogs
-  | where TimeGenerated > ago(lookback)
-  | where OperationName=~ "Update user" 
-  | where Result =~ "success" 
-  | mv-expand TargetResources 
-  | mv-expand TargetResources.modifiedProperties 
-  | extend displayName_ = tostring(TargetResources_modifiedProperties.displayName) , oldValue_ = tostring(TargetResources_modifiedProperties.oldValue), newValue_ = tostring(TargetResources_modifiedProperties.newValue)
-  | where displayName_ == "UserPrincipalName" and oldValue_ !has "#EXT" and newValue_ has "#EXT"
-  | extend InitiatingApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName) 
-  | extend Initiator = iif(isnotempty(InitiatingApp), InitiatingApp, tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)) , IPAddress = tostring(InitiatedBy.["user"].["ipAddress"])
-  ) on $left.AccountUPN == $right.oldValue_
-  | project TimeGenerated, AADTenantId, IPAddress, Initiator, displayName_, oldValue_, newValue_
+  let query_frequency = 1h;
+  let query_period = 14d;
+  IdentityInfo
+  | where TimeGenerated > ago(query_period)
+  | where set_has_element(AssignedRoles, "Global Administrator")
+  | distinct AccountUPN, AccountObjectId
+  | join kind=inner (
+      AuditLogs
+      | where TimeGenerated > ago(query_frequency)
+      | where OperationName=~ "Update user" and Result =~ "success"
+      // | where isnotempty(InitiatedBy["user"])
+      | mv-expand TargetResource = TargetResources
+      | where TargetResource["type"] == "User"
+      | extend AccountObjectId = tostring(TargetResource["id"])
+      | where not(tostring(TargetResource["modifiedProperties"]) == "[]")
+      | mv-apply modifiedProperty = TargetResource["modifiedProperties"] on (
+          summarize modifiedProperties = make_bag(
+              bag_pack(tostring(modifiedProperty["displayName"]),
+                  bag_pack("oldValue", trim(@'[\"\s]+', tostring(modifiedProperty["oldValue"])),
+                      "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
+      )
+      | where not(tostring(modifiedProperties["Included Updated Properties"]["newValue"]) in ("LastDirSyncTime", ""))
+      | where not(isnotempty(modifiedProperties["StrongAuthenticationPhoneAppDetail"]) and tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["newValue"])))) == tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["oldValue"])))))
+      | extend
+          Initiator = iif(isnotempty(InitiatedBy["app"]), tostring(InitiatedBy["app"]["displayName"]), tostring(InitiatedBy["user"]["userPrincipalName"])),
+          InitiatorId = iif(isnotempty(InitiatedBy["app"]), tostring(InitiatedBy["app"]["servicePrincipalId"]), tostring(InitiatedBy["user"]["id"])),
+          IPAddress = tostring(InitiatedBy[tostring(bag_keys(InitiatedBy)[0])]["ipAddress"])
+  ) on AccountObjectId
+  | project TimeGenerated, Category, Identity, Initiator, IPAddress, OperationName, Result, AccountUPN, InitiatedBy, AdditionalDetails, TargetResources, AccountObjectId, InitiatorId, CorrelationId
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -49,12 +57,12 @@ entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: displayName_
+        columnName: AccountUPN
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
+++ b/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
@@ -42,7 +42,7 @@ query: |
                       "newValue", trim(@'[\"\s]+', tostring(modifiedProperty["newValue"])))))
       )
       | where not(tostring(modifiedProperties["Included Updated Properties"]["newValue"]) in ("LastDirSyncTime", ""))
-      | where not(array_length(bag_keys(modifiedProperties)) == 1 and isnotempty(modifiedProperties["StrongAuthenticationPhoneAppDetail"]) and tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["newValue"])))) == tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["oldValue"])))))
+      | where not(tostring(modifiedProperties["Included Updated Properties"]["newValue"]) == "StrongAuthenticationPhoneAppDetail" and isnotempty(modifiedProperties["StrongAuthenticationPhoneAppDetail"]) and tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["newValue"])))) == tostring(array_sort_asc(extract_all(@'\"Id\"\:\"([^\"]+)\"', tostring(modifiedProperties["StrongAuthenticationPhoneAppDetail"]["oldValue"])))))
       | extend
           Initiator = iif(isnotempty(InitiatedBy["app"]), tostring(InitiatedBy["app"]["displayName"]), tostring(InitiatedBy["user"]["userPrincipalName"])),
           InitiatorId = iif(isnotempty(InitiatedBy["app"]), tostring(InitiatedBy["app"]["servicePrincipalId"]), tostring(InitiatedBy["user"]["id"])),

--- a/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
+++ b/Detections/MultipleDataSources/SuspiciousModificationofGlobalAdminProperties.yaml
@@ -49,15 +49,24 @@ query: |
           IPAddress = tostring(InitiatedBy[tostring(bag_keys(InitiatedBy)[0])]["ipAddress"])
   ) on AccountObjectId
   | project TimeGenerated, Category, Identity, Initiator, IPAddress, OperationName, Result, AccountUPN, InitiatedBy, AdditionalDetails, TargetResources, AccountObjectId, InitiatorId, CorrelationId
+  | extend
+      InitiatorName = tostring(split(Initiator, "@")[0]),
+      InitiatorUPNSuffix = tostring(split(Initiator, "@")[1]),
+      AccountName = tostring(split(AccountUPN, "@")[0]),
+      AccountUPNSuffix = tostring(split(AccountUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: Initiator
+      - identifier: Name
+        columnName: InitiatorName
+      - identifier: UPNSuffix
+        columnName: InitiatorUPNSuffix
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountUPN
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address


### PR DESCRIPTION
I believe the current description does not match the current query. One of them has to changed, the current query is pretty much the same as the one in (https://github.com/Azure/Azure-Sentinel/blob/master/Detections/AuditLogs/SuspiciousLinkingofExternalIdtoExistingUsers.yaml), with just one additional condition.

This PR would be to change the query, instead of the description, as a consequence I think this rule could be more noisy than expected. In any case, the query period of this rule needs to be changed, the 1st change below is needed.
   
   Change(s):
   1. Change query frequency to 1 hour, and query period to 14 days.
   2. Remove condition about the UserPrincipalName being changed to something that contains the string ""EXT".

   Reason for Change(s):
   1. IdentityInfo table get renewed every 14 days. Previously to this change "GlobalAdmins" was not returing all accounts with Global Administrator role.
   2. This rule was effectively working as the one in (https://github.com/Azure/Azure-Sentinel/blob/master/Detections/AuditLogs/SuspiciousLinkingofExternalIdtoExistingUsers.yaml), there was only one additional condition , that the account was also in table "GlobalAdmins", which was not correctly computed. This rule does not match its current description.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes