### PR TITLE
Change limit on request to Oracle API to 250 due to message size limit

### DIFF
--- a/Solutions/Oracle Cloud Infrastructure/Data Connectors/AzureFunctionOCILogs/main.py
+++ b/Solutions/Oracle Cloud Infrastructure/Data Connectors/AzureFunctionOCILogs/main.py
@@ -99,7 +99,7 @@ def get_cursor_by_group(sc, sid, group_name, instance_name):
 def process_events(client: oci.streaming.StreamClient, stream_id, initial_cursor, sentinel: AzureSentinelConnector, start_ts):
     cursor = initial_cursor
     while True:
-        get_response = client.get_messages(stream_id, cursor, limit=1000)
+        get_response = client.get_messages(stream_id, cursor, limit=250)
         if not get_response.data:
             return
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Change the limit from 1000  to 250 on the requests to Oracle Cloud Streaming API.

   Reason for Change(s):
   - The Oracle Cloud Streaming API have a max limit of 1MB per request. The request limit of 1000 is making the requests to fail due to hitting the max size limit per request. This is changed to 250 to mitigate this. It might be a good idea to have this as an configuration option. For reference see more here https://docs.oracle.com/en-us/iaas/Content/Streaming/Concepts/streamingoverview_topic-Limits_on_Streaming_Resources.htm

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


