### PR TITLE
Bumped cryptography from 3.3.2 to 39.0.1

### DIFF
--- a/Solutions/SailPointIdentityNow/Data Connectors/requirements.txt
+++ b/Solutions/SailPointIdentityNow/Data Connectors/requirements.txt
@@ -9,4 +9,4 @@ azure-storage==0.36.0
 azure-data-tables==12.1.0
 azure-cosmos==4.2.0
 azure-cosmosdb-table==1.0.6
-cryptography==3.3.2
+cryptography==39.0.1

--- a/Solutions/SailPointIdentityNow/Data Connectors/requirements.txt
+++ b/Solutions/SailPointIdentityNow/Data Connectors/requirements.txt
@@ -3,7 +3,7 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions==1.6.0
-requests
+requests==2.31.0
 azure-core==1.19.0
 azure-storage==0.36.0
 azure-data-tables==12.1.0

--- a/Solutions/SailPointIdentityNow/Data Connectors/requirements.txt
+++ b/Solutions/SailPointIdentityNow/Data Connectors/requirements.txt
@@ -9,4 +9,4 @@ azure-storage==0.36.0
 azure-data-tables==12.1.0
 azure-cosmos==4.2.0
 azure-cosmosdb-table==1.0.6
-cryptography==39.0.1
+cryptography==41.0.0


### PR DESCRIPTION
   Change(s):
   - Bumped cryptography from 3.3.2 to 39.0.1

   Reason for Change(s):
   - Updated cryptography from 3.3.2 to 39.0.1

   Version Updated:
   - No

   Testing Completed:
   - Yes