### PR TITLE
Update UserAgentSearch_log4j.yaml

### DIFF
--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
@@ -59,7 +59,7 @@ query: |
   (AzureDiagnostics
   | where Category in ("FrontdoorWebApplicationFirewallLog", "FrontdoorAccessLog", "ApplicationGatewayFirewallLog", "ApplicationGatewayAccessLog")
   | where userAgent_s has_any (UserAgentString) or userAgent_s matches regex UARegex
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = coalesce(clientIP_s,clientIp_s), Type, host_s, Url = requestUri_s, HttpStatus = coalesce(httpStatus_d,httpStatusDetails_s), ruleName_s, transactionId_g, ResourceType, ResourceId
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = coalesce(clientIP_s,clientIp_s), Type, host_s, Url = requestUri_s, HttpStatus = coalesce(tostring(httpStatus_d),tostring(httpStatusDetails_s)), ruleName_s, transactionId_g, ResourceType, ResourceId
   ),
   (
   W3CIISLog
@@ -97,5 +97,5 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: Account
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled

--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
@@ -59,7 +59,7 @@ query: |
   (AzureDiagnostics
   | where Category in ("FrontdoorWebApplicationFirewallLog", "FrontdoorAccessLog", "ApplicationGatewayFirewallLog", "ApplicationGatewayAccessLog")
   | where userAgent_s has_any (UserAgentString) or userAgent_s matches regex UARegex
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = clientIP_s, Type, host_s, Url = requestUri_s, httpStatus_d, ruleName_s, transactionId_g, ResourceType, ResourceId
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = coalesce(clientIP_s,clientIp_s), Type, host_s, Url = requestUri_s, HttpStatus = coalesce(httpStatus_d,httpStatusDetails_s), ruleName_s, transactionId_g, ResourceType, ResourceId
   ),
   (
   W3CIISLog
@@ -97,5 +97,5 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: Account
-version: 1.0.4
+version: 1.0.5
 kind: Scheduled

--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/UserAgentSearch_log4j.yaml
@@ -59,7 +59,7 @@ query: |
   (AzureDiagnostics
   | where Category in ("FrontdoorWebApplicationFirewallLog", "FrontdoorAccessLog", "ApplicationGatewayFirewallLog", "ApplicationGatewayAccessLog")
   | where userAgent_s has_any (UserAgentString) or userAgent_s matches regex UARegex
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = coalesce(clientIP_s,clientIp_s), Type, host_s, Url = requestUri_s, HttpStatus = coalesce(tostring(httpStatus_d),tostring(httpStatusDetails_s)), ruleName_s, transactionId_g, ResourceType, ResourceId
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent = userAgent_s, SourceIP = column_ifexists("clientIp_s",clientIP_s), Type, column_ifexists("originalHost_s",host_s), Url = requestUri_s, HttpStatus = column_ifexists("httpStatusDetails_s",httpStatus_d), column_ifexists("transactionId_g",trackingReference_s), ruleName_s, ResourceType, ResourceId
   ),
   (
   W3CIISLog
@@ -97,5 +97,5 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: Account
-version: 1.0.6
+version: 1.0.7
 kind: Scheduled


### PR DESCRIPTION
Fixed SourceIP and httpStatus fields in AzureDiagnostics

   Required items, please complete
   
   Change(s):
   - Fixed SourceIP and httpStatus fields in AzureDiagnostics

   Reason for Change(s):
   - The query was missing fields when you have clientIp_s instead of clientIP_s and httpStatusDetails_s instead of httpStatus_d

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
-----------------------------------------------------------------------------------------------------------
