### PR TITLE
Start working on filtering test

### DIFF
--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -29,7 +29,6 @@ days_delta = args.days_delta
 
 end_time = datetime.now(timezone.utc)
 start_time = end_time - timedelta(days = days_delta)
-required_fields = ["ParserParams", "ParserQuery", "Normalization.Schema" ]
 
 
 def attempt_to_connect(credential):
@@ -142,6 +141,7 @@ class FilteringTest(unittest.TestCase):
 
     # Checking if all fields from "required_fields" array are in the yaml file.
     def check_required_fields(self, parser_file):
+        required_fields = ["ParserParams", "ParserQuery", "Normalization.Schema" ]
         missing_fields = []
         for full_field in required_fields:
             file = parser_file

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -14,7 +14,6 @@ from azure.identity import DefaultAzureCredential
 from schemasParameters import all_schemas_parameters
 
 
-#REPO_PATH = f"{os.getcwd()}/../../../../"
 DUMMY_VALUE = "\'!not_REAL_vAlUe\'"
 DAYS_DELTA = 730
 
@@ -30,7 +29,7 @@ days_delta = args.days_delta
 
 
 end_time = datetime.now(timezone.utc)
-start_time = end_time - timedelta(days = DAYS_DELTA)
+start_time = end_time - timedelta(days = days_delta)
 required_fields = ["ParserParams", "ParserQuery", "Normalization.Schema" ]
 no_test_list = [] # No data was found for testing
 partial_test_list = [] # Parameters with only one value in their relevant column
@@ -99,11 +98,6 @@ def create_call_with_parameter(parameter, value, column_name):
 
 
 class FilteringTest(unittest.TestCase):
-    def show_traceback(self, test, outcome):
-        # Override the show_traceback method to suppress traceback output
-        pass
-
-
     def tests_main_func(self):
         if not os.path.exists(parser_file_path):
             self.fail(f"File path does not exist: {parser_file_path}")
@@ -141,13 +135,14 @@ class FilteringTest(unittest.TestCase):
             self.scalar_test(param, no_call_query, column_name_in_table)
 
     
+    # Checking if the provided workspace has some data
     def check_data_in_workspace(self, no_call_query):
         check_data_response = self.send_query(no_call_query + "query() | take 5")
         if len(check_data_response.tables[0].rows) == 0:
             self.fail("No data in the provided workspace")
-        
-            
+          
 
+    # Checking if all fields from "required_fields" array are in the yaml file.
     def check_required_fields(self, parser_file):
         missing_fields = []
         for full_field in required_fields:
@@ -160,7 +155,6 @@ class FilteringTest(unittest.TestCase):
                 file = file[field_name]
         if len(missing_fields) != 0:
             self.fail(f"The following fields are missing in the file:\n{missing_fields}")
-        #self.assertTrue(len(missing_fields) == 0, f"The following fields are missing in the file:\n{missing_fields}")
     
 
     # Test for parameter which are not datetime,dynamic or disabled

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -3,26 +3,31 @@ import os
 import sys
 import yaml
 import contextlib
-import pandas as pd
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
-from schemasParameters import Dns_params
+from schemasParameters import all_schemas_parameters
 
 
-class Schema:
-    def __init__(self, name, directory):
-        self.name = name
-        self.directory = directory
+REPO_PATH = f"{os.getcwd()}/../../../../"
+DUMMY_VALUE = "\'!not_REAL_vAlUe\'"
+DAYS_DELTA = 729
 
 
-KQL_FILES_FOLDER = "/Parsers"
-REPO_PATH = "C:/One/ASI/Azure-Sentinel/Parsers/" #TODO - change when decided on final location
+if len(sys.argv) == 3:
+    ws_id = sys.argv[1]
+    parser_file_relative_path = sys.argv[2]
+else:
+    print("Please provide the correct number of arguments")
+    exit(-1)
 
-schemas = [Schema("Dns", "ASimDns")]
-ws_id = sys.argv[1]
+end_time = datetime.now(timezone.utc)
+start_time = end_time - timedelta(days = DAYS_DELTA)
+no_test_list = [] # No data was found for testing
+partial_test_list = [] # Parameters with only one value in their relevant column
+
 
 # Authenticating the user
 credential = DefaultAzureCredential(exclude_interactive_browser_credential = False)
@@ -42,21 +47,21 @@ except Exception as e:
 client = LogsQueryClient(credential)
 
 
-# Returning all parser files of a specific schema
-def get_parsers(schema):
-    files_path = f"{REPO_PATH}{schema.directory}{KQL_FILES_FOLDER}"
-    parser_files = []
-    for file_name in os.listdir(files_path):
-        if not file_name.endswith('.yaml'):
-            continue
-        with open(f"{files_path}/{file_name}") as file_stream:
-            parser_files.append(yaml.safe_load(file_stream))
-    return parser_files
+def get_parser(parser_path):
+    parser_full_path = f"{REPO_PATH}{parser_path}"
+    if os.path.exists(parser_full_path) or not parser_full_path.endswith('.yaml'):
+        try:
+            with open(parser_full_path, 'r') as file_stream:
+                return yaml.safe_load(file_stream)
+        except:
+            print(f"Cannot open file: {parser_path}")
+    else:
+        print(f"yml file does not exist: {parser_path}")
 
 
 # Creating a string of the parameters of a parser
 def create_parameters_string(parser_file):
-    if "ParserParams" not in parser_file: # TODO check for FunctionParams for functions 
+    if "ParserParams" not in parser_file:
         return ""
     paramsList = []
     for param in parser_file['ParserParams']:
@@ -67,62 +72,120 @@ def create_parameters_string(parser_file):
 
 def create_query_without_call(parser_file):
     params_str = create_parameters_string(parser_file) 
-    query_from_yaml = "" 
-    if "FunctionQuery" in parser_file:
-        query_from_yaml = parser_file['FunctionQuery']
-    elif "ParserQuery" in parser_file:
-        query_from_yaml = parser_file['ParserQuery']
+    query_from_yaml = parser_file['ParserQuery']
     return f"let query= ({params_str}) {{ {query_from_yaml} }};\n"
-    
-
-def send_query(query_str):
-    try:
-        response = client.query_workspace(
-            workspace_id = ws_id,
-            query = query_str,
-            timespan=timedelta(days = 730)
-            )
-        if response.status == LogsQueryStatus.PARTIAL:
-            error = response.partial_error
-            data = response.partial_data
-            #print(error)
-        elif response.status == LogsQueryStatus.SUCCESS:
-            data = response.tables
-        for table in data:
-            df = pd.DataFrame(data=table.rows, columns=table.columns)
-            print(df)
-    except HttpResponseError as err:
-        #print("something fatal happened")
-        #print (err)
-        pass
 
 
 class FilteringTest(unittest.TestCase):
     def tests_main_func(self):
-        for schema in schemas:
-            parser_files = get_parsers(schema)
-            for parser in parser_files:
-                with self.subTest(parser = parser):
-                    self.handle_parser(parser)
+        parser_file = get_parser(parser_file_relative_path)
+        with self.subTest():
+            self.handle_parser(parser_file)
 
     
     def handle_parser(self, parser_file):
         no_call_query = create_query_without_call(parser_file)
+        columns_in_answer = self.get_columns_of_parser_answer(no_call_query)
+        param_to_column_mapping = all_schemas_parameters[parser_file['Normalization']['Schema']]
         for param in parser_file['ParserParams']:
-            with self.subTest(param = param):
-                self.handle_param(param, no_call_query)
-                      #paramDefault = f"\'{param['Default']}\'" if param['Type']=="string" else param['Default']
+            with self.subTest():
+                self.handle_param(param, no_call_query, columns_in_answer, param_to_column_mapping)
                       
         
-    def handle_param(self, param, no_call_query):
+    def handle_param(self, param, no_call_query, columns_in_answer, param_to_column_mapping):
         param_name = param['Name']
+        param_type = param['Type']
         if (param_name == "pack"):
+            return 
+        if (param_name == "disabled"):
+            self.disabled_test(param, no_call_query)
+        elif  param_to_column_mapping[param_name] not in columns_in_answer:
             return
-        no_filter_result = no_call_query + f"query() | summarize count() by {Dns_params[param_name]}"    
-        #TODO SEND QUERY
+        elif (param_type == "datetime"):
+            pass
+        elif (param_type == "dynamic"):
+            pass
+        else:
+            self.scalar_test(param, no_call_query, param_to_column_mapping)
+
+    
+    # Test for parameter which are not datetime,dynamic or disabled
+    def scalar_test(self, param, no_call_query, param_to_column_mapping):
+        param_name = param['Name']
+        no_filter_query = no_call_query + f"query() | summarize count() by {param_to_column_mapping[param_name]}\n"
+        no_filter_response = self.send_query(no_filter_query)
+        if len(no_filter_response.tables[0].rows) == 0:
+            no_test_list.append(param_name)
+            return
+        # Taking the first value returned in the response
+        selected_value = no_filter_response.tables[0].rows[0][0]
+        value_to_filter = f"\'{selected_value}\'" if param['Type']=="string" else selected_value
+
+        # Performing a query with a non-existing value, expecting to return no results
+        no_results_query = no_call_query + f"query({param_name}={DUMMY_VALUE}) | summarize count() by {param_to_column_mapping[param_name]}\n"
+        no_results_response = self.send_query(no_results_query)
+        self.assertEqual(0, len(no_results_response.tables[0].rows), "Returned results for non existing filter value")
+
+        # Performing a filtering by the first value returned in the first response
+        query_with_filter = no_call_query + f"query({param_name}={value_to_filter}) | summarize count() by {param_to_column_mapping[param_name]}\n"
+        if selected_value=="":
+            query_with_filter = no_call_query + f"query() | where isempty({param_to_column_mapping[param_name]}) | summarize count() by {param_to_column_mapping[param_name]}\n"
+        filtered_response = self.send_query(query_with_filter)
+        self.assertEqual(1, len(filtered_response.tables[0].rows), "Expected to have results for only one value after filtering")
+        if len(no_filter_response.tables[0].rows) == 1:
+            partial_test_list.append(param_name)
+        
+
+        
+    def disabled_test(self, param, no_call_query):
+        no_filter_query = no_call_query + f"query() | summarize count()\n"
+        no_filter_response = self.send_query(no_filter_query)
+        if no_filter_response.tables[0].rows[0][0] == 0:
+            no_test_list.append(param['Name'])
+            return
+
+        disabled_true_query = no_call_query + f"query(disabled=true) | summarize count()\n"
+        disabled_true_response = self.send_query(disabled_true_query)
+        self.assertEqual(0, disabled_true_response.tables[0].rows[0][0], "Expected to return 0 results for disabled=true")
+
+        disabled_false_query = no_call_query + f"query(disabled=false) | summarize count()\n"
+        disabled_false_response = self.send_query(disabled_false_query)
+        self.assertNotEqual(0, disabled_false_response.tables[0].rows[0][0], "Expected to return results for disabled=false")
+
+
+    # Return a set of the columns that will appear in a response of a query call
+    def get_columns_of_parser_answer(self, no_call_query):
+        response = self.send_query(no_call_query + f"query() | getschema\n")
+        columns_set = set()
+        for row in response.tables[0].rows:
+            columns_set.add(row['ColumnName'])
+        return columns_set
+
+
+    def send_query(self, query_str):
+        try:
+            response = client.query_workspace(
+                workspace_id = ws_id,
+                query = query_str,
+                timespan = (start_time, end_time)
+                )
+            if response.status == LogsQueryStatus.PARTIAL:
+                print(response.partial_error)
+                self.fail("Query failed")
+            elif response.status == LogsQueryStatus.SUCCESS:
+                return response
+        except HttpResponseError as err:
+            print (err)
+            self.fail("Query failed")
 
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(FilteringTest)
     runner = unittest.TextTestRunner()
     runner.run(suite)
+    if len(no_test_list) != 0:
+        print("The following parameters weren't tested because no data was found to test them:")
+        print(no_test_list)
+    if len(partial_test_list) != 0:
+        print("The following parameters passed a partial test:")
+        print(partial_test_list)

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -173,15 +173,15 @@ class FilteringTest(unittest.TestCase):
             query_with_filter = no_call_query + f"query() | where isempty({column_name_in_table}) | summarize count() by {column_name_in_table}\n"
         filtered_response = self.send_query(query_with_filter)
         with self.subTest():
-            self.assertNotEqual(0, len(filtered_response.tables[0].rows), f"Parameter: {param_name} - Got no results at all after filtering")
+            self.assertNotEqual(0, len(filtered_response.tables[0].rows), f"Parameter: {param_name} - Got no results at all after filtering. Filtered by value: {value_to_filter}")
         with self.subTest():
-            self.assertEqual(1, len(filtered_response.tables[0].rows), f"Parameter: {param_name} - Expected to have results for only one value after filtering")
+            self.assertEqual(1, len(filtered_response.tables[0].rows), f"Parameter: {param_name} - Expected to have results for only one value after filtering. Filtered by value: {value_to_filter}")
 
         # Performing a query with a non-existing value, expecting to return no results
         no_results_query = no_call_query + create_call_with_parameter(param_name, DUMMY_VALUE, column_name_in_table)
         no_results_response = self.send_query(no_results_query)
         with self.subTest():
-            self.assertEqual(0, len(no_results_response.tables[0].rows), f"Parameter: {param_name} - Returned results for non existing filter value")
+            self.assertEqual(0, len(no_results_response.tables[0].rows), f"Parameter: {param_name} - Returned results for non existing filter value. Filtered by value: {DUMMY_VALUE}")
         
 
         

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -1,0 +1,128 @@
+import unittest
+import os
+import sys
+import yaml
+import contextlib
+import pandas as pd
+from datetime import datetime, timedelta
+from azure.monitor.query import LogsQueryClient, LogsQueryStatus
+from azure.identity import DefaultAzureCredential
+from azure.core.exceptions import HttpResponseError
+from azure.identity import DefaultAzureCredential
+from schemasParameters import Dns_params
+
+
+class Schema:
+    def __init__(self, name, directory):
+        self.name = name
+        self.directory = directory
+
+
+KQL_FILES_FOLDER = "/Parsers"
+REPO_PATH = "C:/One/ASI/Azure-Sentinel/Parsers/" #TODO - change when decided on final location
+
+schemas = [Schema("Dns", "ASimDns")]
+ws_id = sys.argv[1]
+
+# Authenticating the user
+credential = DefaultAzureCredential(exclude_interactive_browser_credential = False)
+try:
+    with contextlib.redirect_stderr(None):
+        client = LogsQueryClient(credential)
+        empty_query = ""
+        response = client.query_workspace(
+                workspace_id = ws_id, 
+                query = empty_query,
+                timespan = timedelta(days = 1)
+                )
+        if response.status == LogsQueryStatus.PARTIAL:
+            raise Exception()
+except Exception as e:
+    credential = DefaultAzureCredential(exclude_interactive_browser_credential = False, exclude_shared_token_cache_credential = True)
+client = LogsQueryClient(credential)
+
+
+# Returning all parser files of a specific schema
+def get_parsers(schema):
+    files_path = f"{REPO_PATH}{schema.directory}{KQL_FILES_FOLDER}"
+    parser_files = []
+    for file_name in os.listdir(files_path):
+        if not file_name.endswith('.yaml'):
+            continue
+        with open(f"{files_path}/{file_name}") as file_stream:
+            parser_files.append(yaml.safe_load(file_stream))
+    return parser_files
+
+
+# Creating a string of the parameters of a parser
+def create_parameters_string(parser_file):
+    if "ParserParams" not in parser_file: # TODO check for FunctionParams for functions 
+        return ""
+    paramsList = []
+    for param in parser_file['ParserParams']:
+        paramDefault = f"\'{param['Default']}\'" if param['Type']=="string" else param['Default']
+        paramsList.append(f"{param['Name']}:{param['Type']}={paramDefault}")
+    return ','.join(paramsList)
+    
+
+def create_query_without_call(parser_file):
+    params_str = create_parameters_string(parser_file) 
+    query_from_yaml = "" 
+    if "FunctionQuery" in parser_file:
+        query_from_yaml = parser_file['FunctionQuery']
+    elif "ParserQuery" in parser_file:
+        query_from_yaml = parser_file['ParserQuery']
+    return f"let query= ({params_str}) {{ {query_from_yaml} }};\n"
+    
+
+def send_query(query_str):
+    try:
+        response = client.query_workspace(
+            workspace_id = ws_id,
+            query = query_str,
+            timespan=timedelta(days = 730)
+            )
+        if response.status == LogsQueryStatus.PARTIAL:
+            error = response.partial_error
+            data = response.partial_data
+            #print(error)
+        elif response.status == LogsQueryStatus.SUCCESS:
+            data = response.tables
+        for table in data:
+            df = pd.DataFrame(data=table.rows, columns=table.columns)
+            print(df)
+    except HttpResponseError as err:
+        #print("something fatal happened")
+        #print (err)
+        pass
+
+
+class FilteringTest(unittest.TestCase):
+    def tests_main_func(self):
+        for schema in schemas:
+            parser_files = get_parsers(schema)
+            for parser in parser_files:
+                with self.subTest(parser = parser):
+                    self.handle_parser(parser)
+
+    
+    def handle_parser(self, parser_file):
+        no_call_query = create_query_without_call(parser_file)
+        for param in parser_file['ParserParams']:
+            with self.subTest(param = param):
+                self.handle_param(param, no_call_query)
+                      #paramDefault = f"\'{param['Default']}\'" if param['Type']=="string" else param['Default']
+                      
+        
+    def handle_param(self, param, no_call_query):
+        param_name = param['Name']
+        if (param_name == "pack"):
+            return
+        no_filter_result = no_call_query + f"query() | summarize count() by {Dns_params[param_name]}"    
+        #TODO SEND QUERY
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(FilteringTest)
+    runner = unittest.TextTestRunner()
+    runner.run(suite)

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -170,7 +170,7 @@ class FilteringTest(unittest.TestCase):
         no_filter_response = self.send_query(no_filter_query)
         self.assertNotEqual(len(no_filter_response.tables[0].rows) , 0 , f"No data for parameter:{param_name}")
         with  self.subTest():
-            self.assertNotEqual(len(no_filter_response.tables[0].rows), 1 )
+            self.assertNotEqual(len(no_filter_response.tables[0].rows), 1, f"Only one value exists for parameter: {param_name}, validations for this parameter are partial" )
         # Taking the first value returned in the response
         selected_value = no_filter_response.tables[0].rows[0][0]
         value_to_filter = f"\'{selected_value}\'" if param['Type']=="string" else selected_value
@@ -181,13 +181,15 @@ class FilteringTest(unittest.TestCase):
         if selected_value=="":
             query_with_filter = no_call_query + f"query() | where isempty({column_name_in_table}) | summarize count() by {column_name_in_table}\n"
         filtered_response = self.send_query(query_with_filter)
-        self.assertEqual(1, len(filtered_response.tables[0].rows), f"Parameter: {param_name} - Expected to have results for only one value after filtering")
+        with self.subTest():
+            self.assertEqual(1, len(filtered_response.tables[0].rows), f"Parameter: {param_name} - Expected to have results for only one value after filtering")
 
         # Performing a query with a non-existing value, expecting to return no results
         no_results_query = no_call_query + create_call_with_parameter(param_name, DUMMY_VALUE, column_name_in_table)
         #no_results_query = no_call_query + f"query({param_name}={DUMMY_VALUE}) | summarize count() by {column_name_in_table}\n"
         no_results_response = self.send_query(no_results_query)
-        self.assertEqual(0, len(no_results_response.tables[0].rows), f"Parameter: {param_name} - Returned results for non existing filter value")
+        with self.subTest():
+            self.assertEqual(0, len(no_results_response.tables[0].rows), f"Parameter: {param_name} - Returned results for non existing filter value")
         
 
         

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -106,9 +106,9 @@ class FilteringTest(unittest.TestCase):
         except:
             self.fail(f"Cannot open file: {parser_file_path}")
         self.check_required_fields(parser_file)
-        query_definition_query = create_query_definition_string(parser_file)
-        self.check_data_in_workspace(query_definition_query)
-        columns_in_answer = self.get_columns_of_parser_answer(query_definition_query)
+        query_definition = create_query_definition_string(parser_file)
+        self.check_data_in_workspace(query_definition)
+        columns_in_answer = self.get_columns_of_parser_answer(query_definition)
         schema_of_parser = parser_file['Normalization']['Schema']
         if schema_of_parser not in all_schemas_parameters:
             self.fail(f"Schema: {schema_of_parser} - Not an existing schema or not supported by the validations script")
@@ -119,7 +119,7 @@ class FilteringTest(unittest.TestCase):
                 if param_name not in param_to_column_mapping:
                     self.fail(f"parameter: {param_name} - No such parameter in {schema_of_parser} schema")
                 column_name_in_table = param_to_column_mapping[param_name]
-                self.send_param_to_test(param, query_definition_query, columns_in_answer, column_name_in_table)            
+                self.send_param_to_test(param, query_definition, columns_in_answer, column_name_in_table)            
 
 
     def send_param_to_test(self, param, query_definition, columns_in_answer, column_name_in_table):
@@ -236,8 +236,8 @@ class FilteringTest(unittest.TestCase):
 
 
     # Return a set of the columns that will appear in a response of a query call
-    def get_columns_of_parser_answer(self, query_definition_query):
-        response = self.send_query(query_definition_query + f"query() | getschema\n")
+    def get_columns_of_parser_answer(self, query_definition):
+        response = self.send_query(query_definition + f"query() | getschema\n")
         columns_set = set()
         for row in response.tables[0].rows:
             columns_set.add(row['ColumnName'])

--- a/ASIM/dev/ASimTester/filteringTest/filteringTest.py
+++ b/ASIM/dev/ASimTester/filteringTest/filteringTest.py
@@ -106,9 +106,9 @@ class FilteringTest(unittest.TestCase):
         except:
             self.fail(f"Cannot open file: {parser_file_path}")
         self.check_required_fields(parser_file)
-        no_call_query = create_query_definition_string(parser_file)
-        self.check_data_in_workspace(no_call_query)
-        columns_in_answer = self.get_columns_of_parser_answer(no_call_query)
+        query_definition_query = create_query_definition_string(parser_file)
+        self.check_data_in_workspace(query_definition_query)
+        columns_in_answer = self.get_columns_of_parser_answer(query_definition_query)
         schema_of_parser = parser_file['Normalization']['Schema']
         if schema_of_parser not in all_schemas_parameters:
             self.fail(f"Schema: {schema_of_parser} - Not an existing schema or not supported by the validations script")
@@ -119,8 +119,9 @@ class FilteringTest(unittest.TestCase):
                 if param_name not in param_to_column_mapping:
                     self.fail(f"parameter: {param_name} - No such parameter in {schema_of_parser} schema")
                 column_name_in_table = param_to_column_mapping[param_name]
-                self.send_param_to_test(param, no_call_query, columns_in_answer, column_name_in_table)            
-                      
+                self.send_param_to_test(param, query_definition_query, columns_in_answer, column_name_in_table)            
+
+
     def send_param_to_test(self, param, query_definition, columns_in_answer, column_name_in_table):
         """
         Sending parameters to the suitable test according to the parameter type  
@@ -235,8 +236,8 @@ class FilteringTest(unittest.TestCase):
 
 
     # Return a set of the columns that will appear in a response of a query call
-    def get_columns_of_parser_answer(self, no_call_query):
-        response = self.send_query(no_call_query + f"query() | getschema\n")
+    def get_columns_of_parser_answer(self, query_definition_query):
+        response = self.send_query(query_definition_query + f"query() | getschema\n")
         columns_set = set()
         for row in response.tables[0].rows:
             columns_set.add(row['ColumnName'])

--- a/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
+++ b/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
@@ -1,0 +1,11 @@
+Dns_params = {
+                "disabled" : "",
+                "domain_has_any" : "Domain",
+                "eventtype" : "EventType",
+                "endtime" : "TimeGenerated",
+                "response_has_any_prefix" : "DnsResponseName",
+                "response_has_ipv4" : "DnsResponseName",
+                "responsecodename" : "DnsResponseCodeName",
+                "srcipaddr" : "SrcIpAddr",
+                "starttime" : "TimeGenerated"
+            }

--- a/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
+++ b/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
@@ -9,8 +9,6 @@ all_schemas_parameters = {
         "response_has_ipv4" : "DnsResponseName",
         "responsecodename" : "DnsResponseCodeName",
         "srcipaddr" : "SrcIpAddr",
-        "fictivesrc" : "SrcIpAddr",
-        "srcipaddrnotreal" : "SrcIpAddr",
         "starttime" : "EventStartTime"
     },
     "NetworkSession" :

--- a/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
+++ b/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
@@ -9,6 +9,8 @@ all_schemas_parameters = {
         "response_has_ipv4" : "DnsResponseName",
         "responsecodename" : "DnsResponseCodeName",
         "srcipaddr" : "SrcIpAddr",
+        "fictivesrc" : "SrcIpAddr",
+        "srcipaddrnotreal" : "SrcIpAddr",
         "starttime" : "EventStartTime"
     },
     "NetworkSession" :

--- a/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
+++ b/ASIM/dev/ASimTester/filteringTest/schemasParameters.py
@@ -1,11 +1,28 @@
-Dns_params = {
-                "disabled" : "",
-                "domain_has_any" : "Domain",
-                "eventtype" : "EventType",
-                "endtime" : "TimeGenerated",
-                "response_has_any_prefix" : "DnsResponseName",
-                "response_has_ipv4" : "DnsResponseName",
-                "responsecodename" : "DnsResponseCodeName",
-                "srcipaddr" : "SrcIpAddr",
-                "starttime" : "TimeGenerated"
-            }
+all_schemas_parameters = {
+    "Dns" : 
+    {
+        "disabled" : "",
+        "domain_has_any" : "Domain",
+        "eventtype" : "EventType",
+        "endtime" : "EventEndTime",
+        "response_has_any_prefix" : "DnsResponseName",
+        "response_has_ipv4" : "DnsResponseName",
+        "responsecodename" : "DnsResponseCodeName",
+        "srcipaddr" : "SrcIpAddr",
+        "starttime" : "EventStartTime"
+    },
+    "NetworkSession" :
+    {
+        "disabled" : "",
+        "dstipaddr_has_any_prefix" : "DstIpAddr",
+        "dstportnumber" : "DstPortNumber",
+        "dvcaction" : "DvcAction",
+        "endtime" : "EventEndTime",
+        "eventresult" : "EventResult",
+        "hostname_has_any" : "",
+        "ipaddr_has_any_prefix" : "IpAddr",
+        "srcipaddr_has_any_prefix" : "SrcIpAddr",
+        "starttime" : "EventStartTime"
+    }
+    
+}


### PR DESCRIPTION
Working on creating a test for parameter filtering in parsers.
- filteringTest.py contains the test itself
- schemasParameters.py will contain a mapping between parameter names and the column that each parameter filters.

Running the tests:
python filteringTest.py \<ws-id> \<relative-path-to-parser-file> \<days-range-to-query-ws-over>

for example, to test vimDnsMicrosoftOMS.yaml, queries will be sent for data from last 720 days:
python filteringTest.py \<ws-id> Parsers/ASimDns/Parsers/vimDnsMicrosoftOMS.yaml 720