### PR TITLE
Fix readme markup tables in AtlassianJiraAudit playbooks for customfield_ids to match azuredeploy.json definition

### DIFF
--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
@@ -63,7 +63,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
 | Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |
 | Sentinel Workspace ID | customfield_10172 | Text Field (Singline) |
-| Sentinel Incident ID | customfield_10172 | Text Field (Singline) |
+| Sentinel Incident ID | customfield_10173 | Text Field (Singline) |
 | Sentinel Incident ARM ID | customfield_10175 | Text Field (Singline) |
 
 The Att&ck Tactics list contains all Sentinel Tactics.

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
@@ -58,7 +58,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Tenant Name | customfield_10149 | Select List (Single Choice) |
 | Created At | customfield_10154 | Date Time Picker |
 | Att&ck Tactics | customfield_10155 | Select List (Multiple choices) |
-| Affected User | customfield_10058 | Text Field (Multiline) |
+| Affected User | customfield_10158 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
 | Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
@@ -57,7 +57,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Closure Reason | customfield_10047 | Select List (Single choice) |
 | Tenant Name | customfield_10149 | Select List (Single Choice) |
 | Created At | customfield_10154 | Date Time Picker |
-| Att&ck Tactics | customfield_10055 | Select List (Multiple choices) |
+| Att&ck Tactics | customfield_10155 | Select List (Multiple choices) |
 | Affected User | customfield_10058 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-AssignedUser/readme.md
@@ -61,7 +61,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Affected User | customfield_10158 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
-| Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |
+| Sentinel Workspace Name | customfield_10170 | Text Field (Singline) |
 | Sentinel Workspace ID | customfield_10172 | Text Field (Singline) |
 | Sentinel Incident ID | customfield_10173 | Text Field (Singline) |
 | Sentinel Incident ARM ID | customfield_10175 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
@@ -63,7 +63,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
 | Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |
 | Sentinel Workspace ID | customfield_10172 | Text Field (Singline) |
-| Sentinel Incident ID | customfield_10172 | Text Field (Singline) |
+| Sentinel Incident ID | customfield_10173 | Text Field (Singline) |
 | Sentinel Incident ARM ID | customfield_10175 | Text Field (Singline) |
 
 The Att&ck Tactics list contains all Sentinel Tactics.

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
@@ -58,7 +58,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Tenant Name | customfield_10149 | Select List (Single Choice) |
 | Created At | customfield_10154 | Date Time Picker |
 | Att&ck Tactics | customfield_10155 | Select List (Multiple choices) |
-| Affected User | customfield_10058 | Text Field (Multiline) |
+| Affected User | customfield_10158 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
 | Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
@@ -57,7 +57,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Closure Reason | customfield_10047 | Select List (Single choice) |
 | Tenant Name | customfield_10149 | Select List (Single Choice) |
 | Created At | customfield_10154 | Date Time Picker |
-| Att&ck Tactics | customfield_10055 | Select List (Multiple choices) |
+| Att&ck Tactics | customfield_10155 | Select List (Multiple choices) |
 | Affected User | customfield_10058 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/Sync-Incidents/readme.md
@@ -61,7 +61,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Affected User | customfield_10158 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
-| Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |
+| Sentinel Workspace Name | customfield_10170 | Text Field (Singline) |
 | Sentinel Workspace ID | customfield_10172 | Text Field (Singline) |
 | Sentinel Incident ID | customfield_10173 | Text Field (Singline) |
 | Sentinel Incident ARM ID | customfield_10175 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/readme.md
@@ -63,7 +63,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
 | Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |
 | Sentinel Workspace ID | customfield_10172 | Text Field (Singline) |
-| Sentinel Incident ID | customfield_10172 | Text Field (Singline) |
+| Sentinel Incident ID | customfield_10173 | Text Field (Singline) |
 | Sentinel Incident ARM ID | customfield_10175 | Text Field (Singline) |
 
 The Att&ck Tactics list contains all Sentinel Tactics.

--- a/Solutions/AtlassianJiraAudit/Playbooks/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/readme.md
@@ -58,7 +58,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Tenant Name | customfield_10149 | Select List (Single Choice) |
 | Created At | customfield_10154 | Date Time Picker |
 | Att&ck Tactics | customfield_10155 | Select List (Multiple choices) |
-| Affected User | customfield_10058 | Text Field (Multiline) |
+| Affected User | customfield_10158 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
 | Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/readme.md
@@ -57,7 +57,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Closure Reason | customfield_10047 | Select List (Single choice) |
 | Tenant Name | customfield_10149 | Select List (Single Choice) |
 | Created At | customfield_10154 | Date Time Picker |
-| Att&ck Tactics | customfield_10055 | Select List (Multiple choices) |
+| Att&ck Tactics | customfield_10155 | Select List (Multiple choices) |
 | Affected User | customfield_10058 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |

--- a/Solutions/AtlassianJiraAudit/Playbooks/readme.md
+++ b/Solutions/AtlassianJiraAudit/Playbooks/readme.md
@@ -61,7 +61,7 @@ All Logic Apps need to be updated with the correct ID's of the fields.
 | Affected User | customfield_10158 | Text Field (Multiline) |
 | Subscription ID | customfield_10162 | Text Field (Singline) |
 | Sentinel Resource Group | customfield_10169 | Text Field (Singline) |
-| Sentinel Workspace Name | customfield_10070 | Text Field (Singline) |
+| Sentinel Workspace Name | customfield_10170 | Text Field (Singline) |
 | Sentinel Workspace ID | customfield_10172 | Text Field (Singline) |
 | Sentinel Incident ID | customfield_10173 | Text Field (Singline) |
 | Sentinel Incident ARM ID | customfield_10175 | Text Field (Singline) |


### PR DESCRIPTION
Fix readme markup table for Sentinel Incident ID to customfield_10173 as customfield_10172 was duplicate
based on information from .\Solutions\AtlassianJiraAudit\Package\mainTemplate.json line 6932 "customfield_10173": "@{triggerBody()?['object']?['properties']?['incidentNumber']}", and according.

Only documentation changes

   Required items, please complete
   
   Change(s):
   - Replace Sentinel Incident ID identifier from customfield_10172 to customfield_10173 in Solutions/AtlassianJiraAudit/Playbooks readme tables

   Reason for Change(s):
   - customfield_10172 was a duplicate entry in the Custom Fields overview table
   - Sentinel Incident ID is referenced by customfield_10173 in the solution files: eg. .\Solutions\AtlassianJiraAudit\Package\mainTemplate.json:6932

   Version Updated:
   - No
   - Only update in documentation

   Testing Completed:
   - No, only changes in markdown documentation 

   Checked that the validations are passing and have addressed any issues that are present:
   - No, only changes in markdown documentation