### PR TITLE
Add "CreatePolicyVersion" EventName in several AWS Analytics Rules

### DIFF
--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDDyanmoDBPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDDyanmoDBPolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDDyanmoDBPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDDyanmoDBPolicytoPrivilegeEscalation.yaml
@@ -18,17 +18,17 @@ relevantTechniques:
   - T1484
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDIAMtoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDIAMtoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDIAMtoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDIAMtoPrivilegeEscalation.yaml
@@ -18,17 +18,17 @@ relevantTechniques:
   - T1484
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDKMSPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDKMSPolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDKMSPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDKMSPolicytoPrivilegeEscalation.yaml
@@ -18,17 +18,17 @@ relevantTechniques:
   - T1484
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDS3PolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDS3PolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDS3PolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCRUDS3PolicytoPrivilegeEscalation.yaml
@@ -18,17 +18,17 @@ relevantTechniques:
   - T1484
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCURDLambdaPolicytoPrivilegEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCURDLambdaPolicytoPrivilegEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCURDLambdaPolicytoPrivilegEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCURDLambdaPolicytoPrivilegEscalation.yaml
@@ -18,17 +18,17 @@ relevantTechniques:
   - T1484
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCloudFormationPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCloudFormationPolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCloudFormationPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedCloudFormationPolicytoPrivilegeEscalation.yaml
@@ -17,45 +17,45 @@ tactics:
 relevantTechniques:
   - T1484
 query: |
-    let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-      let createPolicy = "CreatePolicy";
-      let timeframe = 1d;
-      let lookback = 14d;
-      // Creating Master table with all the events to use with materialize for better performance
-      let EventInfo = AWSCloudTrail
-      | where TimeGenerated >= ago(lookback)
-      | where EventName in (EventNameList) or EventName == createPolicy;
-      //Checking for Policy creation event with Full Admin Privileges since lookback period.
-      let FullAdminPolicyEvents =  materialize(  EventInfo
-      | where TimeGenerated >= ago(lookback)
-      | where EventName == createPolicy
-      | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
-      | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
-      | mvexpand Statement
-      | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
-      | extend Action = tostring(Action)
-      | where Effect =~ "Allow" and (((Action has "iam:*" or Action has "iam:PassRole") and Action has "cloudformation:*") or ((Action has "iam:*" or Action has "iam:PassRole") and Action contains "cloudformation:DescribeStacks" and Action contains "cloudformation:CreateStack") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "cloudformation:Describe*" and Action contains "cloudformation:Create*")) and Resource == "*" and Condition == ""
-      | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
-      | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
-      | project-rename StartTime = TimeGenerated  );
-      let PolicyAttach = materialize(  EventInfo
-      | where TimeGenerated >= ago(timeframe)
-      | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
-      | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
-      | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
-      | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
-      | project EventSource, PolicyName, AttachEvent, AttachEventCount
-      );
-      // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
-      // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
-      FullAdminPolicyEvents
-      | join kind=leftouter
-      (
-          PolicyAttach
-      )
-      on PolicyName
-      | project-away PolicyName1
-      | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
+  let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
+  let timeframe = 1d;
+  let lookback = 14d;
+  // Creating Master table with all the events to use with materialize for better performance
+  let EventInfo = AWSCloudTrail
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (EventNameList) or EventName in (createPolicy);
+  //Checking for Policy creation event with Full Admin Privileges since lookback period.
+  let FullAdminPolicyEvents =  materialize(  EventInfo
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (createPolicy)
+  | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
+  | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
+  | mvexpand Statement
+  | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
+  | extend Action = tostring(Action)
+  | where Effect =~ "Allow" and (((Action has "iam:*" or Action has "iam:PassRole") and Action has "cloudformation:*") or ((Action has "iam:*" or Action has "iam:PassRole") and Action contains "cloudformation:DescribeStacks" and Action contains "cloudformation:CreateStack") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "cloudformation:Describe*" and Action contains "cloudformation:Create*")) and Resource == "*" and Condition == ""
+  | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
+  | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
+  | project-rename StartTime = TimeGenerated  );
+  let PolicyAttach = materialize(  EventInfo
+  | where TimeGenerated >= ago(timeframe)
+  | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
+  | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
+  | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
+  | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
+  | project EventSource, PolicyName, AttachEvent, AttachEventCount
+  );
+  // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
+  // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
+  FullAdminPolicyEvents
+  | join kind=leftouter
+  (
+      PolicyAttach
+  )
+  on PolicyName
+  | project-away PolicyName1
+  | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedDataPipelinePolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedDataPipelinePolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedDataPipelinePolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedDataPipelinePolicytoPrivilegeEscalation.yaml
@@ -17,45 +17,45 @@ tactics:
 relevantTechniques:
   - T1484
 query: |
-    let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-      let createPolicy = "CreatePolicy";
-      let timeframe = 1d;
-      let lookback = 14d;
-      // Creating Master table with all the events to use with materialize for better performance
-      let EventInfo = AWSCloudTrail
-      | where TimeGenerated >= ago(lookback)
-      | where EventName in (EventNameList) or EventName == createPolicy;
-      //Checking for Policy creation event with Full Admin Privileges since lookback period.
-      let FullAdminPolicyEvents =  materialize(  EventInfo
-      | where TimeGenerated >= ago(lookback)
-      | where EventName == createPolicy
-      | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
-      | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
-      | mvexpand Statement
-      | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
-      | extend Action = tostring(Action)
-      | where Effect =~ "Allow" and (((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "datapipeline:*") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "datapipeline:CreatePipeline" and Action contains "datapipeline:PutPipelineDefinition" and Action contains "datapipeline:ActivatePipeline") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "datapipeline:Create*" and Action contains "datapipeline:Put*" and Action contains "datapipeline:Activate*")) and Resource == "*" and Condition == ""
-      | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
-      | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
-      | project-rename StartTime = TimeGenerated  );
-      let PolicyAttach = materialize(  EventInfo
-      | where TimeGenerated >= ago(timeframe)
-      | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
-      | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
-      | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
-      | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
-      | project EventSource, PolicyName, AttachEvent, AttachEventCount
-      );
-      // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
-      // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
-      FullAdminPolicyEvents
-      | join kind=leftouter
-      (
-          PolicyAttach
-      )
-      on PolicyName
-      | project-away PolicyName1
-      | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
+  let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
+  let timeframe = 1d;
+  let lookback = 14d;
+  // Creating Master table with all the events to use with materialize for better performance
+  let EventInfo = AWSCloudTrail
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (EventNameList) or EventName in (createPolicy);
+  //Checking for Policy creation event with Full Admin Privileges since lookback period.
+  let FullAdminPolicyEvents =  materialize(  EventInfo
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (createPolicy)
+  | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
+  | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
+  | mvexpand Statement
+  | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
+  | extend Action = tostring(Action)
+  | where Effect =~ "Allow" and (((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "datapipeline:*") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "datapipeline:CreatePipeline" and Action contains "datapipeline:PutPipelineDefinition" and Action contains "datapipeline:ActivatePipeline") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "datapipeline:Create*" and Action contains "datapipeline:Put*" and Action contains "datapipeline:Activate*")) and Resource == "*" and Condition == ""
+  | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
+  | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
+  | project-rename StartTime = TimeGenerated  );
+  let PolicyAttach = materialize(  EventInfo
+  | where TimeGenerated >= ago(timeframe)
+  | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
+  | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
+  | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
+  | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
+  | project EventSource, PolicyName, AttachEvent, AttachEventCount
+  );
+  // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
+  // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
+  FullAdminPolicyEvents
+  | join kind=leftouter
+  (
+      PolicyAttach
+  )
+  on PolicyName
+  | project-away PolicyName1
+  | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedEC2PolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedEC2PolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedEC2PolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedEC2PolicytoPrivilegeEscalation.yaml
@@ -17,45 +17,45 @@ tactics:
 relevantTechniques:
   - T1484
 query: |
-    let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-      let createPolicy = "CreatePolicy";
-      let timeframe = 1d;
-      let lookback = 14d;
-      // Creating Master table with all the events to use with materialize for better performance
-      let EventInfo = AWSCloudTrail
-      | where TimeGenerated >= ago(lookback)
-      | where EventName in (EventNameList) or EventName == createPolicy;
-      //Checking for Policy creation event with Full Admin Privileges since lookback period.
-      let FullAdminPolicyEvents =  materialize(  EventInfo
-      | where TimeGenerated >= ago(lookback)
-      | where EventName == createPolicy
-      | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
-      | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
-      | mvexpand Statement
-      | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
-      | extend Action = tostring(Action)
-      | where Effect =~ "Allow" and ((((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "ec2:*") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "ec2:RunInstances") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "ec2:Run*")) or (Action contains "ec2:*") or (Action contains "ec2:ListInstances" and Action contains "ec2:StartInstance" and Action contains "ec2:ModifyInstanceAttribute") or (Action contains "ec2:List*" and Action contains "ec2:Start*" and Action contains "ec2:Modify*")) and Resource == "*" and Condition == ""
-      | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
-      | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
-      | project-rename StartTime = TimeGenerated  );
-      let PolicyAttach = materialize(  EventInfo
-      | where TimeGenerated >= ago(timeframe)
-      | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
-      | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
-      | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
-      | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
-      | project EventSource, PolicyName, AttachEvent, AttachEventCount
-      );
-      // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
-      // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
-      FullAdminPolicyEvents
-      | join kind=leftouter
-      (
-          PolicyAttach
-      )
-      on PolicyName
-      | project-away PolicyName1
-      | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
+  let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
+  let timeframe = 1d;
+  let lookback = 14d;
+  // Creating Master table with all the events to use with materialize for better performance
+  let EventInfo = AWSCloudTrail
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (EventNameList) or EventName in (createPolicy);
+  //Checking for Policy creation event with Full Admin Privileges since lookback period.
+  let FullAdminPolicyEvents =  materialize(  EventInfo
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (createPolicy)
+  | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
+  | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
+  | mvexpand Statement
+  | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
+  | extend Action = tostring(Action)
+  | where Effect =~ "Allow" and ((((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "ec2:*") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "ec2:RunInstances") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "ec2:Run*")) or (Action contains "ec2:*") or (Action contains "ec2:ListInstances" and Action contains "ec2:StartInstance" and Action contains "ec2:ModifyInstanceAttribute") or (Action contains "ec2:List*" and Action contains "ec2:Start*" and Action contains "ec2:Modify*")) and Resource == "*" and Condition == ""
+  | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
+  | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
+  | project-rename StartTime = TimeGenerated  );
+  let PolicyAttach = materialize(  EventInfo
+  | where TimeGenerated >= ago(timeframe)
+  | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
+  | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
+  | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
+  | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
+  | project EventSource, PolicyName, AttachEvent, AttachEventCount
+  );
+  // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
+  // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
+  FullAdminPolicyEvents
+  | join kind=leftouter
+  (
+      PolicyAttach
+  )
+  on PolicyName
+  | project-away PolicyName1
+  | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedGluePolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedGluePolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedGluePolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedGluePolicytoPrivilegeEscalation.yaml
@@ -17,45 +17,45 @@ tactics:
 relevantTechniques:
   - T1484
 query: |
-    let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-      let createPolicy = "CreatePolicy";
-      let timeframe = 1d;
-      let lookback = 14d;
-      // Creating Master table with all the events to use with materialize for better performance
-      let EventInfo = AWSCloudTrail
-      | where TimeGenerated >= ago(lookback)
-      | where EventName in (EventNameList) or EventName == createPolicy;
-      //Checking for Policy creation event with Full Admin Privileges since lookback period.
-      let FullAdminPolicyEvents =  materialize(  EventInfo
-      | where TimeGenerated >= ago(lookback)
-      | where EventName == createPolicy
-      | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
-      | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
-      | mvexpand Statement
-      | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
-      | extend Action = tostring(Action)
-      | where Effect =~ "Allow" and ((((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "glue:*") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "glue:CreateDevEndpoint" and Action contains "glue:GetDevEndpoints") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "glue:Create*" and Action contains "glue:Get*")) or (Action contains "glue:*") or (Action contains "glue:GetDevEndpoints" and Action contains "glue:UpdateDevEndpoint") or (Action contains "glue:Get*" and Action contains "glue:Update*")) and Resource == "*" and Condition == ""
-      | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
-      | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
-      | project-rename StartTime = TimeGenerated  );
-      let PolicyAttach = materialize(  EventInfo
-      | where TimeGenerated >= ago(timeframe)
-      | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
-      | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
-      | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
-      | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
-      | project EventSource, PolicyName, AttachEvent, AttachEventCount
-      );
-      // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
-      // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
-      FullAdminPolicyEvents
-      | join kind=leftouter
-      (
-          PolicyAttach
-      )
-      on PolicyName
-      | project-away PolicyName1
-      | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
+  let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
+  let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
+  let timeframe = 1d;
+  let lookback = 14d;
+  // Creating Master table with all the events to use with materialize for better performance
+  let EventInfo = AWSCloudTrail
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (EventNameList) or EventName in (createPolicy);
+  //Checking for Policy creation event with Full Admin Privileges since lookback period.
+  let FullAdminPolicyEvents =  materialize(  EventInfo
+  | where TimeGenerated >= ago(lookback)
+  | where EventName in (createPolicy)
+  | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
+  | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
+  | mvexpand Statement
+  | extend Action = parse_json(Statement).Action , Effect = tostring(parse_json(Statement).Effect), Resource = tostring(parse_json(Statement).Resource), Condition = tostring(parse_json(Statement).Condition)
+  | extend Action = tostring(Action)
+  | where Effect =~ "Allow" and ((((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "glue:*") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "glue:CreateDevEndpoint" and Action contains "glue:GetDevEndpoints") or ((Action contains "iam:*" or Action contains "iam:PassRole") and Action contains "glue:Create*" and Action contains "glue:Get*")) or (Action contains "glue:*") or (Action contains "glue:GetDevEndpoints" and Action contains "glue:UpdateDevEndpoint") or (Action contains "glue:Get*" and Action contains "glue:Update*")) and Resource == "*" and Condition == ""
+  | distinct TimeGenerated, EventName, PolicyName, SourceIpAddress, UserIdentityArn, UserIdentityUserName
+  | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
+  | project-rename StartTime = TimeGenerated  );
+  let PolicyAttach = materialize(  EventInfo
+  | where TimeGenerated >= ago(timeframe)
+  | where EventName in (EventNameList) and isempty(ErrorCode) and isempty(ErrorMessage)
+  | extend PolicyName = tostring(split(tostring(parse_json(RequestParameters).policyArn),"/")[1])
+  | summarize AttachEventCount=count(), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by EventSource, EventName,   UserIdentityType , UserIdentityArn, SourceIpAddress, UserIdentityUserName = iff(isnotempty(UserIdentityUserName),   UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1])), PolicyName
+  | extend AttachEvent = pack("StartTime", StartTime, "EndTime", EndTime, "EventName", EventName, "UserIdentityType",   UserIdentityType, "UserIdentityArn", UserIdentityArn, "SourceIpAddress", SourceIpAddress, "UserIdentityUserName", UserIdentityUserName)
+  | project EventSource, PolicyName, AttachEvent, AttachEventCount
+  );
+  // Joining the list of PolicyNames and checking if it has been attached to any Roles/Users/Groups.
+  // These Roles/Users/Groups will be Privileged and can be used by adversaries as pivot point for privilege escalation via multiple ways.
+  FullAdminPolicyEvents
+  | join kind=leftouter
+  (
+      PolicyAttach
+  )
+  on PolicyName
+  | project-away PolicyName1
+  | extend timestamp = StartTime, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedLambdaPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedLambdaPolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedLambdaPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedLambdaPolicytoPrivilegeEscalation.yaml
@@ -18,17 +18,17 @@ relevantTechniques:
   - T1484
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+    let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedSSMPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedSSMPolicytoPrivilegeEscalation.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedSSMPolicytoPrivilegeEscalation.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_CreatedSSMPolicytoPrivilegeEscalation.yaml
@@ -17,18 +17,18 @@ tactics:
 relevantTechniques:
   - T1484
 query: |
- let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
+    let createPolicy =  dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement

--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_FullAdminPolicyAttachedToRolesUsersGroups.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_FullAdminPolicyAttachedToRolesUsersGroups.yaml
@@ -23,17 +23,17 @@ tactics:
   - PrivilegeEscalation
 query: |
   let EventNameList = dynamic(["AttachUserPolicy","AttachRolePolicy","AttachGroupPolicy"]);
-  let createPolicy = "CreatePolicy";
+  let createPolicy = dynamic(["CreatePolicy", "CreatePolicyVersion"]);
   let timeframe = 1d;
   let lookback = 14d;
   // Creating Master table with all the events to use with materialize for better performance
   let EventInfo = AWSCloudTrail
   | where TimeGenerated >= ago(lookback)
-  | where EventName in (EventNameList) or EventName == createPolicy;
+  | where EventName in (EventNameList) or EventName in (createPolicy);
   //Checking for Policy creation event with Full Admin Privileges since lookback period.
   let FullAdminPolicyEvents =  materialize(  EventInfo
   | where TimeGenerated >= ago(lookback)
-  | where EventName == createPolicy
+  | where EventName in (createPolicy)
   | extend PolicyName = tostring(parse_json(RequestParameters).policyName)
   | extend Statement = parse_json(tostring((parse_json(RequestParameters).policyDocument))).Statement
   | mvexpand Statement
@@ -71,5 +71,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Add the alternative operation of a policy modification ("create a new version of the policy")

   Reason for Change(s):
   - Maybe a new version of the policy is created (instead of a complete new policy) and this is used to escalate privileges.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
  AWS accounts might not follow the Windows account syntax (with a suffix).