### PR TITLE
Updated Function APP Version to 4

### DIFF
--- a/Solutions/SecurityScorecard Cybersecurity Ratings/Data Connectors/SecurityScorecardFactor/azuredeploy_Connector_SecurityScorecardFactorAPI_AzureFunction.json
+++ b/Solutions/SecurityScorecard Cybersecurity Ratings/Data Connectors/SecurityScorecardFactor/azuredeploy_Connector_SecurityScorecardFactorAPI_AzureFunction.json
@@ -172,7 +172,7 @@
                         "[concat('Microsoft.Web/sites/', variables('FunctionName'))]"
                     ],
                     "properties": {
-                        "FUNCTIONS_EXTENSION_VERSION": "~3",
+                        "FUNCTIONS_EXTENSION_VERSION": "~4",
                         "FUNCTIONS_WORKER_RUNTIME": "python",
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.insights/components', variables('FunctionName')), '2015-05-01').InstrumentationKey]",
                         "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('microsoft.insights/components', variables('FunctionName')), '2015-05-01').ConnectionString]",

--- a/Solutions/SecurityScorecard Cybersecurity Ratings/Data Connectors/SecurityScorecardIssue/azuredeploy_Connector_SecurityScorecardIssueAPI_AzureFunction.json
+++ b/Solutions/SecurityScorecard Cybersecurity Ratings/Data Connectors/SecurityScorecardIssue/azuredeploy_Connector_SecurityScorecardIssueAPI_AzureFunction.json
@@ -164,7 +164,7 @@
                         "[concat('Microsoft.Web/sites/', variables('FunctionName'))]"
                     ],
                     "properties": {
-                        "FUNCTIONS_EXTENSION_VERSION": "~3",
+                        "FUNCTIONS_EXTENSION_VERSION": "~4",
                         "FUNCTIONS_WORKER_RUNTIME": "python",
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.insights/components', variables('FunctionName')), '2015-05-01').InstrumentationKey]",
                         "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('microsoft.insights/components', variables('FunctionName')), '2015-05-01').ConnectionString]",

--- a/Solutions/SecurityScorecard Cybersecurity Ratings/Data Connectors/SecurityScorecardRatings/azuredeploy_Connector_SecurityScorecardRatingsAPI_AzureFunction.json
+++ b/Solutions/SecurityScorecard Cybersecurity Ratings/Data Connectors/SecurityScorecardRatings/azuredeploy_Connector_SecurityScorecardRatingsAPI_AzureFunction.json
@@ -172,7 +172,7 @@
                         "[concat('Microsoft.Web/sites/', variables('FunctionName'))]"
                     ],
                     "properties": {
-                        "FUNCTIONS_EXTENSION_VERSION": "~3",
+                        "FUNCTIONS_EXTENSION_VERSION": "~4",
                         "FUNCTIONS_WORKER_RUNTIME": "python",
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.insights/components', variables('FunctionName')), '2015-05-01').InstrumentationKey]",
                         "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('microsoft.insights/components', variables('FunctionName')), '2015-05-01').ConnectionString]",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated the Function App version to 4

   Reason for Change(s):
   - The Function App version 3 is no longer supported from the December 2023 as per the warning message in the Azure Portal. Please refer the below screen capture of the warning.
<img width="412" alt="image" src="https://github.com/Azure/Azure-Sentinel/assets/98145046/880b683e-59ad-4936-a374-cef694383de1">

   Version Updated:
   - Updated to 2.0.1

   Testing Completed:
   - Tested that no warning message exist related to version update

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
