### PR TITLE
Update AzureWAFmatching_log4j_vuln.yaml

### DIFF
--- a/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/AzureWAFmatching_log4j_vuln.yaml
+++ b/Solutions/Apache Log4j Vulnerability Detection/Analytic Rules/AzureWAFmatching_log4j_vuln.yaml
@@ -26,9 +26,10 @@ query: |
   AzureDiagnostics
   | where ResourceProvider == "MICROSOFT.NETWORK" and Category in ("ApplicationGatewayFirewallLog", "FrontdoorWebApplicationFirewallLog")
   | extend details_data_s = column_ifexists("details_data_s", tostring(AdditionalFields.details_data))
-  |where requestUri_s has_any (log4jioc) or details_message_s has_any (log4jioc) or details_data_s has_any (log4jioc)
+  | extend details_message_s = column_ifexists("details_message_s", tostring(AdditionalFields.details_message_s))
+  | where requestUri_s has_any (log4jioc) or details_message_s has_any (log4jioc) or details_data_s has_any (log4jioc)
   | extend Malicious = iff(isnotempty( details_data_s),details_data_s,iff(isnotempty( requestUri_s),requestUri_s,""))
-  |parse Malicious with * '${' MaliciousCommand '}' * 
+  | parse Malicious with * '${' MaliciousCommand '}' * 
   | extend EncodeCmd = iff(MaliciousCommand has 'Base64/', split(split(MaliciousCommand, "Base64/",1)[0], "}", 0)[0], "")
   | extend EncodeCmd1 = iff(MaliciousCommand has 'base64/', split(split(MaliciousCommand, "base64/",1)[0], "}", 0)[0], "")
   | extend CmdLine = iff( isnotempty(EncodeCmd), EncodeCmd, EncodeCmd1)
@@ -43,5 +44,5 @@ entityMappings:
   fieldMappings:
     - identifier: Address
       columnName: MaliciousHost
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
Fixed indentation for the where and parse commands Added column_ifexists also for details_message_s

   Required items, please complete
   
   Change(s):
   - Fixed indentation for the where and parse commands
   - Added column_ifexists also for details_message_s

   Reason for Change(s):
   - Last change broke the query as details_message_s sometimes doesn't exist

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes