### PR TITLE
added url encoding to avoid breaking api call

### DIFF
--- a/Playbooks/Enrich-Sentinel-Incident-AlienVault-OTX/azuredeploy.json
+++ b/Playbooks/Enrich-Sentinel-Incident-AlienVault-OTX/azuredeploy.json
@@ -555,7 +555,7 @@
                                             "type": "Http",
                                             "inputs": {
                                                 "method": "GET",
-                                                "uri": "https://otx.alienvault.com/api/v1/indicators/url/@{items('For_each_URL')?['Url']}/general"
+                                                "uri": "https://otx.alienvault.com/api/v1/indicators/url/@{encodeUriComponent(items('For_each_URL')?['Url'])}/general"
                                             }
                                         }
                                     },

--- a/Playbooks/Enrich-Sentinel-Incident-AlienVault-OTX/azuredeploy.json
+++ b/Playbooks/Enrich-Sentinel-Incident-AlienVault-OTX/azuredeploy.json
@@ -21,6 +21,13 @@
     },
     "releaseNotes": [
       {
+        "version": "1.0.1",
+        "title": "Enrich multiple entities - AlienVault-OTX",
+        "notes": [
+          "Added encodeUriComponent(..) to HTTP_-_OTX_URL step to avoid 404 when URL contains special characters"
+        ]
+      },
+      {
         "version": "1.0.0",
         "title": "Enrich multiple entities - AlienVault-OTX",
         "notes": [

--- a/Playbooks/Enrich-Sentinel-Incident-AlienVault-OTX/azuredeploy.json
+++ b/Playbooks/Enrich-Sentinel-Incident-AlienVault-OTX/azuredeploy.json
@@ -4,7 +4,7 @@
   "metadata": {
     "title": "Enrich multiple entities - AlienVault-OTX",
     "description": "This playbook will enrich a Sentinel Incident with pulse information from AlienVault OTX.  If any pulses are found the Incident will also be tagged and the severity raised to High.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "mainSteps": [ "The following entity types will be enriched with this playbook: \n\n - IP \n\n - URL \n\n - File hash \n\n - DNS" ],
     "prerequisites": [ "After deploying the the playbook you will need to grant the playbook's Managed Identity \n\n **Microsoft Sentinel Responder** \n\n (or greater) access to the resource group where Microsoft Sentinel is installed. This gives the Managed Identity the necessary permissions to add comments, tags, and change incident severity." ],
     "lastUpdateTime": "2022-07-25T10:00:00.000Z",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added `encodeUriComponent(..)` to `HTTP_-_OTX_URL` step

   Reason for Change(s):
   - When submitting a unencoded URL to the Alienvault OTX API, it would respond with `404` instead of the expected report. 

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

