### PR TITLE
Updated the Watchlist displayName to Sources_by_SourceType

### DIFF
--- a/ASIM/deploy/Watchlists/ASimSourceType.json
+++ b/ASIM/deploy/Watchlists/ASimSourceType.json
@@ -17,7 +17,7 @@
           "properties": {
               "displayName": "Sources_by_SourceType",
               "source": "Sources_by_SourceType.csv",
-              "description": "The watchlist is used by ASim/Parser to specify Sources and their types.",
+              "description": "The watchlist is used by ASim Prarsers / regular parsers to specify Sources and their types.",
               "provider": "Custom",
               "isDeleted": false,
               "labels": [

--- a/ASIM/deploy/Watchlists/ASimSourceType.json
+++ b/ASIM/deploy/Watchlists/ASimSourceType.json
@@ -15,9 +15,9 @@
           "type": "Microsoft.OperationalInsights/workspaces/providers/Watchlists",
           "kind": "",
           "properties": {
-              "displayName": "ASimSourceType",
-              "source": "ASimSourceType.csv",
-              "description": "The watchlist is used by ASim to specify Sources and their types.",
+              "displayName": "Sources_by_SourceType",
+              "source": "Sources_by_SourceType.csv",
+              "description": "The watchlist is used by ASim/Parser to specify Sources and their types.",
               "provider": "Custom",
               "isDeleted": false,
               "labels": [


### PR DESCRIPTION
Updated the Watchlist displayName as per documentation

   Required items, please complete
   
   Change(s):
   - Updated the Watchlist displayName as per documentation

   Reason for Change(s):
   - Updated the Watchlist displayName to Sources_by_SourceType to use this for both ASIM and regular Parser use cases and also to keep in sync as per this [documentation](https://learn.microsoft.com/en-us/azure/sentinel/normalization-manage-parsers#configure-the-sources-relevant-to-a-source-specific-parser)

   Version Updated:
   - NA

   Testing Completed:
   - Yes

