### PR TITLE
CiscoDuoSecurity Function App code update

### DIFF
--- a/Solutions/CiscoDuoSecurity/Data Connectors/AzureFunctionCiscoDuo/main.py
+++ b/Solutions/CiscoDuoSecurity/Data Connectors/AzureFunctionCiscoDuo/main.py
@@ -121,7 +121,7 @@ def process_auth_logs(admin_api: duo_client.Admin, state_manager: StateManager, 
     maxtime = int(time.time() - 120) * 1000
     diff = maxtime - mintime
     if(diff > 3600000):
-        maxtime = (int(mintime) + 3600) * 1000
+        maxtime = (int(mintime/1000) + 3600) * 1000
 
     for event in get_auth_logs(admin_api, mintime, maxtime):
         sentinel.send(event)


### PR DESCRIPTION
Fixed error : 400 Invalid request parameters ('maxtime' must be a timestamp in milliseconds)

   Required items, please complete
   
   Change(s):
   - Updated maxtime variable definition when the difference is greater than 3600000 ms

   Reason for Change(s):
   - When the difference between the mintime & maxtime is greater than 3600000, the new maxtime value becomes invalid. This is because the value is referencing the existing mintime value (which is already multiplied by 1000) which is then multiplied by another 1000.
   - Resolves issue identified here: https://github.com/Azure/Azure-Sentinel/pull/8208#issuecomment-1594091137

   Version Updated:
   - N/A

   Testing Completed:
   - Yes. Testing results:
   ![image](https://github.com/Azure/Azure-Sentinel/assets/99451213/ce43c732-bba9-4dec-9e7f-f71316a9b532)
   Changes made at: ~2023-06-16 05:15:00.000

   Checked that the validations are passing and have addressed any issues that are present:
   - Need help