### PR TITLE
Fix condition in Analytic Rule AWS_NetworkACLOpenToAllPorts.yaml

### DIFF
--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_NetworkACLOpenToAllPorts.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_NetworkACLOpenToAllPorts.yaml
@@ -24,7 +24,7 @@ query: |
              total_ports=(toint(parse_json(parse_json(RequestParameters)['portRange'])['to']) - toint(parse_json(parse_json(RequestParameters)['portRange'])['from'])),
              aclProtocol=parse_json(RequestParameters)['aclProtocol']
     | where isnotempty(total_ports)
-    | where ruleAction == 'allow' and egress == false and aclProtocol == '-1' and (total_ports > 1024)
+    | where ruleAction == 'allow' and egress == false and (aclProtocol == '-1' or (total_ports > 1024))
     | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
     | extend timestamp = TimeGenerated, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName
 entityMappings:
@@ -36,5 +36,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Fix condition about ports and protocol used, this rule has never triggered according to latest AWS specification.

   Reason for Change(s):
   - According to (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkaclentry.html) if the protocol specified is -1 all the protocols and ports are considered, and thus the property portRange is ignored, it will show "from 0" "to 0", the port range would never be > 1024.
   The condition ```aclProtocol == '-1' and (total_ports > 1024)``` will **never** evaluate to ```true```.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes