### PR TITLE
Add operation in Analytic Rule AWS_RDSInstancePubliclyExposed.yaml

### DIFF
--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_RDSInstancePubliclyExposed.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_RDSInstancePubliclyExposed.yaml
@@ -18,7 +18,7 @@ relevantTechniques:
   - T1537
 query: |
     AWSCloudTrail
-    | where  EventName == "ModifyDBInstance" and isempty(ErrorCode) and isempty(ErrorMessage)
+    | where  EventName in ("CreateDBInstance", "ModifyDBInstance") and isempty(ErrorCode) and isempty(ErrorMessage)
     | where tostring(parse_json(RequestParameters).publiclyAccessible) == "true"
     | extend UserIdentityUserName = iff(isnotempty(UserIdentityUserName), UserIdentityUserName, tostring(split(UserIdentityArn,'/')[-1]))
     | extend timestamp = TimeGenerated, IPCustomEntity = SourceIpAddress, AccountCustomEntity = UserIdentityUserName


### PR DESCRIPTION
   Change(s):
   - Add operation where a database is created with public access from the beginning.

   Reason for Change(s):
   - I believe that if the modification of DB is monitored, the creation of DB should be monitored too.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes