### PR TITLE
Tool Changes for CreateSolutionV3

### DIFF
--- a/.script/package-automation/catelogAPI.ps1
+++ b/.script/package-automation/catelogAPI.ps1
@@ -1,0 +1,190 @@
+function GetCatelogDetails($offerId) 
+{
+    if ($null -eq $offerId -or $offerId -eq '')
+    {
+        Write-Host "Provided OfferId for CatelogAPI details is blank! Please provide valid OfferId!";
+        return $null;
+    }
+    else {
+        try {
+            $formatUri = 'https://catalogapi.azure.com/offers?api-version=2018-08-01-beta&$filter=(categoryIds/any(cat:+cat+eq+''AzureSentinelSolution'')+or+keywords/any(key:+contains(key,''f1de974b-f438-4719-b423-8bf704ba2aef'')))+and+(offerId+eq+%27'+ $offerId +'%27)'
+            $response = Invoke-RestMethod -Uri $formatUri -Method 'GET' -Headers $headers -Body $body
+            
+            $offerDetails = $response.items | Where-Object offerId -eq $offerId
+
+            if ($null -eq $offerDetails)
+            {
+                # when not found by offerId then use planId
+                $offerDetails = $response.items | Where-Object planId -eq $offerId
+            }
+
+            if ($null -eq $offerDetails)
+            {
+                # DETAILS NOT FOUND
+                Write-Host "CatelogAPI Details not found for offerId $offerId"
+                return $null;
+            }
+            else {
+                Write-Host "CatelogAPI Details found for offerId $offerId"
+                return $offerDetails;
+            }
+        }
+        catch {
+            Write-Host "Error occured in CatelogAPI. Error Details : $_";
+            return $null;
+        }
+    }
+}
+
+function CompareVersionStrings([string]$Version1, [string]$Version2) {
+
+    $v1 = $Version1.Split('.') -replace '^0', '0.'
+    $v2 = $Version2.Split('.') -replace '^0', '0.'   
+
+    [Array]::Resize( [ref] $v1, 4 )
+    [Array]::Resize( [ref] $v2, 4 )
+
+    for ($i=0; $i-lt 4; $i++) {      
+        switch (($v1[$i].length).CompareTo(($v2[$i].length))) {
+            {$_ -lt 0} { $v1[$i] = $v1[$i].PadRight($v2[$i].Length,'0') }
+            {$_ -gt 0} { $v2[$i] = $v2[$i].PadRight($v1[$i].Length,'0') }
+        }
+    }
+    
+    $v1f = $v1 | % {[float]$_}
+    $v2f = $v2 | % {[float]$_}
+
+    return [Collections.StructuralComparisons]::StructuralComparer.Compare( $v1f, $v2f )  
+}
+
+function GetNewVersion($packageVersionAttribute, $dataFileContentObject, $defaultPackageVersion, $templateSpecAttribute, $isNewSolution)
+{
+    $templateSpecDefaultVersion = '2.0.0'
+    if($packageVersionAttribute)
+    {
+        if ($null -eq $dataFileContentObject.Version -or $dataFileContentObject.Version -eq '')
+        {
+            return $templateSpecAttribute ? ($templateSpecDefaultVersion, $true) : ($defaultPackageVersion, $true)
+        }
+        else 
+        {
+            return ($dataFileContentObject.Version, $false)
+        }
+    }
+    else 
+    {
+        return $templateSpecAttribute ? ($templateSpecDefaultVersion, $true) : ($defaultPackageVersion, $true)
+    }
+}
+
+function GetIncrementedVersion($version)
+{
+    $major,$minor,$build,$revision = $version.split(".")
+    $newBuildVersion = [int]$build +  1
+    return "$major.$minor.$newBuildVersion"
+}
+
+function GetOfferVersion($offerId, $mainTemplateUrl) 
+{
+    if ($null -eq $mainTemplateUrl -or $mainTemplateUrl -eq '')
+    {
+        Write-Host "Provided MainTemplateUrl for GetOfferVersion details is blank! Please provide valid MainTemplateUrl!";
+        return $null;
+    }
+    else 
+    {
+        try 
+        {
+            $response = Invoke-RestMethod -Uri $mainTemplateUrl -Method 'GET' -Headers $headers
+            $metadataDetails = $response.resources | Where-Object { ($_.name -eq "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('_solutionId'))]" -or $_.name -eq "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('_sourceId'))]") -and ($_.type -eq "Microsoft.OperationalInsights/workspaces/providers/metadata")};
+
+            if ($null -eq $metadataDetails -or $metadataDetails -eq '')
+            {
+                Write-Host "Offer Metadata Version details in MainTemplate is not found!"
+                return $null;
+            }
+            else 
+            {
+                Write-Host "Offer Metadata Version details in MainTemplate is found!"
+                return $metadataDetails.properties.version;
+            }
+        }
+        catch 
+        {
+            Write-Host "Error occured in CatelogAPI. Error Details11 : $_";
+            return $null;
+        }
+    }
+}
+
+function GetPackageVersion($defaultPackageVersion, $offerId, $offerDetails, $packageVersionAttribute, $userInputPackageVersion)
+{
+    if ($packageVersionAttribute)
+    {
+        $userInputMajor,$userInputMinor,$userInputBuild,$userInputRevision = $userInputPackageVersion.split(".")
+        $defaultMajor,$defaultMinor,$defaultBuild,$defaultRevision = $defaultPackageVersion.split(".")
+
+        if ($userInputMajor -ge '2' -and $userInputMinor -gt $defaultMinor)
+        {
+            #return as is value of package version as middle value is greater
+            return $userInputPackageVersion 
+        }
+    }
+
+    $defaultVersionMessage = "Package Version set to Default version $defaultPackageVersion"
+    if ($null -eq $offerDetails)
+    {
+        Write-Host "CatalogAPI Offer details not found for given offerId $offerId. $defaultVersionMessage"
+        return $defaultPackageVersion
+    }
+    else 
+    {
+        $mainTemplateDetails = $offerDetails.plans.artifacts | Where-Object {$_.type -eq "Template" -and $_.name -eq "DefaultTemplate"}
+
+        if ($null -eq $mainTemplateDetails)
+        {
+            # WE WILL TAKE WHATEVER VERSION IS SPECIFIED IN THE DATA INPUT FILE WITHOUT INCREMENTING IT
+            Write-Host "CatalogAPI mainTemplate details not found for given offerId $offerId. $defaultVersionMessage"
+            return $defaultPackageVersion
+        }
+        else
+        {
+            # CHECK IF CATELOG API HAS DETAILS AND IDENTIFY THE VERSION
+            $mainTemplateUri = $mainTemplateDetails.uri
+
+            if ($null -eq $mainTemplateUri)
+            {
+                Write-Host "CatalogAPI mainTemplate details missing URI for given offerId $offerId. $defaultVersionMessage"
+                return $defaultPackageVersion
+            }
+            else 
+            {
+                # OFFER DETAILS FOUND SO IDENTIFY THE VERSION IN MAINTEMPLATE FILE
+                $offerMetadataVersion = GetOfferVersion $offerId $mainTemplateUri
+                if ($null -eq $offerMetadataVersion -or $offerMetadataVersion -eq '')
+                {
+                    Write-Host "CatalogAPI mainTemplate details URI file is missing version or version is blank so $defaultVersionMessage"
+                    return $defaultPackageVersion
+                }
+                else 
+                {
+                    $identifiedOfferVersion = $offerMetadataVersion
+                    $catelogMajor,$catelogminor,$catelogbuild,$catelogrevision = $identifiedOfferVersion.split(".")
+                    $defaultMajor,$defaultminor,$defaultbuild,$defaultrevision = $defaultPackageVersion.split(".")
+
+                    if ($defaultMajor -gt $catelogMajor)
+                    {
+                        # eg: 3.0.0 > 2.0.1 ==> 3.0.0
+                        Write-Host "Default Package version is greater then the CatalogAPI version so $defaultVersionMessage"
+                        return $defaultPackageVersion
+                    }
+                    else 
+                    {
+                        $packageVersion = GetIncrementedVersion $identifiedOfferVersion
+                        return $packageVersion
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tools/Create-Azure-Sentinel-Solution/V2/README.md
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/README.md
@@ -4,7 +4,7 @@ Microsoft Sentinel Solutions provide an in-product experience for central discov
 
 The packaging tool detailed below provides an easy way to generate your solution package of choice in an automated manner and enables validation of the package generated as well. You can package different types of Microsoft Sentinel content that includes a combination of data connectors, parsers or Kusto Functions, workbooks, analytic rules, hunting queries, Azure Logic apps custom connectors, playbooks and watchlists.
 
-## To create solution package using V2 or V3 use 'createSolutionV3.ps1' file. Refer readme file [here](https://github.com/Azure/Azure-Sentinel/blob/master/Tools/Create-Azure-Sentinel-Solution/V3/README.md)
+## NOTE: Please use the latest version of packaging tool. For guidance on usage, refer to the ReadMe file [here](https://github.com/Azure/Azure-Sentinel/blob/master/Tools/Create-Azure-Sentinel-Solution/V3/README.md)
 
 ## Setup
 

--- a/Tools/Create-Azure-Sentinel-Solution/V2/README.md
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/README.md
@@ -4,6 +4,8 @@ Microsoft Sentinel Solutions provide an in-product experience for central discov
 
 The packaging tool detailed below provides an easy way to generate your solution package of choice in an automated manner and enables validation of the package generated as well. You can package different types of Microsoft Sentinel content that includes a combination of data connectors, parsers or Kusto Functions, workbooks, analytic rules, hunting queries, Azure Logic apps custom connectors, playbooks and watchlists.
 
+## To create solution package using V2 or V3 use 'createSolutionV3.ps1' file. Refer readme file [here](https://github.com/Azure/Azure-Sentinel/blob/master/Tools/Create-Azure-Sentinel-Solution/V3/README.md)
+
 ## Setup
 
 - Install PowerShell 7.1+

--- a/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
@@ -1,5 +1,6 @@
 Import-Module powershell-yaml
 
+Write-Host '====It is recommended to use createSolutionV3.ps1 file for packaging V2 and V3 version===='
 $jsonConversionDepth = 50
 $path = "$PSScriptRoot\input"
 $mainTemplateArtifact = [PSCustomObject]@{

--- a/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
@@ -1,6 +1,6 @@
 Import-Module powershell-yaml
 
-Write-Host '====It is recommended to use createSolutionV3.ps1 file for packaging V2 and V3 version===='
+Write-Host 'It is recommended to use createSolutionV3.ps1 file for solution packaging'
 $jsonConversionDepth = 50
 $path = "$PSScriptRoot\input"
 $mainTemplateArtifact = [PSCustomObject]@{
@@ -23,28 +23,42 @@ function handleEmptyInstructionProperties ($inputObj) {
     } { $obj }
     $outputObj
 }
-function removePropertiesRecursively ($resourceObj) {
+function removePropertiesRecursively ($resourceObj, $isWorkbook = $false) {
     foreach ($prop in $resourceObj.PsObject.Properties) {
         $key = $prop.Name
         $val = $prop.Value
         if ($null -eq $val) {
-            $resourceObj.$key = "[variables('blanks')]";
-                                            if (!$baseMainTemplate.variables.blanks) {
-                                    $baseMainTemplate.variables | Add-Member -NotePropertyName "blanks" -NotePropertyValue "[replace('b', 'b', '')]"
-                                }   
+            if ($isWorkbook)
+            {
+                $resourceObj.$key = ''
+            }
+            else
+            {
+                $resourceObj.$key = "[variables('blanks')]";
+                if (!$baseMainTemplate.variables.blanks) {
+                    $baseMainTemplate.variables | Add-Member -NotePropertyName "blanks" -NotePropertyValue "[replace('b', 'b', '')]"
+                }
+            }
         }
         elseif ($val -is [System.Object[]]) {
             if ($val.Count -eq 0) {
-                 #$resourceObj.PsObject.Properties.Remove($key)
-                 $resourceObj.$key = "[variables('TemplateEmptyArray')]";
-                                            if (!$baseMainTemplate.variables.TemplateEmptyArray) {
-                                    $baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyArray" -NotePropertyValue "[json('[]')]"
-                                            }
-        }
+                if ($isWorkbook)
+                {
+                    $resourceObj.$key = '[]'
+                }
+                else
+                {
+                    #$resourceObj.PsObject.Properties.Remove($key)
+                    $resourceObj.$key = "[variables('TemplateEmptyArray')]";
+                    if (!$baseMainTemplate.variables.TemplateEmptyArray) {
+                        $baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyArray" -NotePropertyValue "[json('[]')]"
+                    }
+                }
+            }
             else {
                 foreach ($item in $val) {
                     $itemIndex = $val.IndexOf($item)
-                    $resourceObj.$key[$itemIndex] = $(removePropertiesRecursively $val[$itemIndex])
+                    $resourceObj.$key[$itemIndex] = $(removePropertiesRecursively $val[$itemIndex] $isWorkbook)
                 }
             }
         }
@@ -54,7 +68,7 @@ function removePropertiesRecursively ($resourceObj) {
                     $resourceObj.PsObject.Properties.Remove($key)
                 }
                 else {
-                    $resourceObj.$key = $(removePropertiesRecursively $val)
+                    $resourceObj.$key = $(removePropertiesRecursively $val $isWorkbook)
                     if ($($resourceObj.$key.PsObject.Properties).Count -eq 0) {
                         $resourceObj.PsObject.Properties.Remove($key)
                     }
@@ -307,7 +321,7 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
                             # Serialize workbook data
                             $serializedData = $data |  ConvertFrom-Json -Depth $jsonConversionDepth
                             # Remove empty braces
-                            $serializedData = $(removePropertiesRecursively $serializedData) | ConvertTo-Json -Compress -Depth $jsonConversionDepth | Out-String
+                            $serializedData = $(removePropertiesRecursively $serializedData $true) | ConvertTo-Json -Compress -Depth $jsonConversionDepth | Out-String
                         }
                         catch {
                             Write-Host "Failed to serialize $file" -ForegroundColor Red
@@ -974,10 +988,8 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
                                 Write-Host $logicAppsPlaybookId;
                             }
 
-                            
-
                             $playbookResource =  $playbookResource
-                            $playbookResource = $(removePropertiesRecursively $playbookResource)
+                            $playbookResource = $(removePropertiesRecursively $playbookResource $false)
                             $playbookResource =  $(addInternalSuffixRecursively $playbookResource)
                             $playbookResource =  $(removeBlanksRecursively $playbookResource)
                             $playbookResources += $playbookResource;

--- a/Tools/Create-Azure-Sentinel-Solution/V3/README.md
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/README.md
@@ -1,0 +1,389 @@
+# Microsoft Sentinel Solutions Packaging Tool Guidance
+
+Microsoft Sentinel Solutions provide an in-product experience for central discoverability, single-step deployment, and enablement of end-to-end product and/or domain and/or vertical scenarios in Microsoft Sentinel. This experience is powered by Azure Marketplace for Solutions' discoverability, deployment and enablement and Microsoft Partner Center for Solutions’ authoring and publishing. Refer to details in [Microsoft Sentinel solutions documentation](https://aka.ms/azuresentinelsolutionsdoc). Detailed partner guidance for authoring and publishing solutions is covered in [building Microsoft Sentinel solutions guidance](https://aka.ms/sentinelsolutionsbuildguide).
+
+The packaging tool detailed below provides an easy way to generate your solution package of choice in an automated manner and enables validation of the package generated as well. You can package different types of Microsoft Sentinel content that includes a combination of data connectors, parsers or Kusto Functions, workbooks, analytic rules, hunting queries, Azure Logic apps custom connectors, playbooks and watchlists.
+
+## Setup
+
+- Install PowerShell 7.1+
+
+  - If you already have PowerShell 5.1, please follow this [upgrade guide](https://docs.microsoft.com/powershell/scripting/install/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.1).
+
+  - If you do not already have PowerShell, please follow this [installation guide](https://docs.microsoft.com/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-7.1).
+
+- Install Node.js
+
+  - The installation process can be started from [their website](https://nodejs.org/).
+
+- Install YAML Toolkit for Powershell
+
+  - `Install-Module powershell-yaml`
+
+- *For ease of editing, it's recommended to use VSCode with the 'Azure Resource Manager (ARM) Tools' extension installed*
+
+  - Install [VSCode](https://code.visualstudio.com/).
+
+  - Install the [Azure Resource Manager (ARM) Tools Extension](https://marketplace.visualstudio.com/items?itemName=msazurermtools.azurerm-vscode-tools).
+
+    - This extension provides language support, resource auto-completion, and automatic template validation within your IDE.
+
+## Creating Solution Package
+
+Clone the repository [Azure-Sentinel](https://github.com/Azure/Azure-Sentinel) to `C:\GitHub`.
+
+### Create Input File
+
+- Make sure to have a .json input data file inside of 'data' folder for your solution. 
+- There is NO need to place your data file inside of input folder as during package creation you will be asked to enter the data folder path from Solutions:
+eg: C:\Github\Azure-Sentinel\Solutions\Agari\Data
+
+#### **Input File Format:**
+
+```json
+/**
+ * Solution Automation Input File Json
+ * -----------------------------------------------------
+ * The purpose of this json is to provide detail on the various fields the input file can have.
+ * Name: Solution Name - Ex. "Symantec Endpoint Protection"
+ * Author: Author Name+Email of Solution - Ex. "Eli Forbes - v-eliforbes@microsoft.com"
+ * Logo: Link to the Logo used in createUiDefinition.json
+ * - NOTE: This field is only recommended for Azure Global Cloud. It is not recommended for solutions in Azure Government Cloud as the image will not be shown properly.
+ * Description: Solution Description used in createUiDefinition.json. Can include markdown.
+ * WorkbookDescription: Workbook description(s), generally from Workbooks' Metadata. This field can be a string if 1 description is used across all, and an array if multiple are used.
+ * PlaybookDescription: Playbook description(s), generally from Playbooks' Metadata. This field can be a string if 1 description is used across all, and an array if multiple are used.
+ * WatchlistDescription: Watchlist description(s), generally from Watchlists' Property data. This field can be a string if 1 description is used across all, and an array if multiple are used. This field is used if the description from the Watchlist resource is not desired in the Create-UI.
+ * Workbooks, Analytic Rules, Playbooks, etc.: These fields take arrays of paths relative to the repo  root, or BasePath if provided.
+ * SavedSearches: This input assumes a format of any of the following:
+ * -- Direct export via API (see https://docs.microsoft.com/rest/api/loganalytics/saved-searches/list-by-workspace)
+ * -- Array of SavedSearch resources
+ * -- Raw ARM template
+ *
+ * - NOTE: Playbooks field can take standard Playbooks, Custom Connectors, and Function Apps. Sequence of Playbooks should be FunctionApps, Custom Connector and then rest of the Playbooks. If FunctionApps and Custom Connector are not present then just specify Playbooks.
+ * BasePath: Optional base path to use. Either Internet URL or File Path. Default is repo root (https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/)
+ * Version: Optional Version to be used during package creation. We should use any version >= 2.0.0. This tool supports package creation for 2.x.x(Template Spec) and 3.x.x(contentPackages). Based on variable 'defaultPackageVersion' and given Version input. If the defaultPackageVersion is 3.0.0 and Data file input version is 2.0.1 then it package generated is of 3.0.0 i.e which ever is higher takes precedence. Here we are also verifying the catelogAPI to check version deployed in PartnerCenter. If 'defaultPackageVersion' is 2.0.0 and data input file version is 2.0.4 but in PartnerCenter catelogAPI version installed is 2.0.2 then package generated is of 2.0.3 i.e it will increment the package version based on catelogAPI.
+ * Metadata: Name of metadata file for the Solution, path is to be considered from BasePath.
+ * TemplateSpec: Optional Boolean value used to determine whether the package should be generated as a template spec
+ */
+{
+  "Name": "{SolutionName}",
+  "Author": "{AuthorName - Email}",
+  "Logo": "<img src=\"{LogoLink}\" width=\"75px\" height=\"75px\">",
+  "Description": "{Solution Description}",
+  "WorkbookDescription": ["{Description of workbook}"],
+  "Workbooks": [],
+  "WorkbookBladeDescription: string; //Description used in the CreateUiDefinition.json for Workbooks Blade
+  "AnalyticalRuleBladeDescription": "{//Description used in the CreateUiDefinition.json for Analytical Rule Blade"
+  "HuntingQueryBladeDescription": "//Description used in the CreateUiDefinition.json for Hunting Query Blade"
+  "PlaybooksBladeDescription": "//Description used in the CreateUiDefinition.json for Playbook Blade"
+  "Analytic Rules": [],
+  "Playbooks": [], //Please make sure if there is any CustomConnector in the solution then it's entry should be added prior to any other playbook.
+  "PlaybookDescription": ["{Description of playbook}"],
+  "Parsers": [],
+  "SavedSearches": [],
+  "Hunting Queries": [],
+  "Data Connectors": [],
+  "Watchlists": [],
+  "WatchlistDescription": [],
+  "BasePath": "{Path to Solution Content}",
+  "Version": "2.0.0", //Optional, If provided it will compare with defaultPackageVersion variable
+  "Metadata": "{Name of Solution Metadata file}",
+  "TemplateSpec": true,
+  "Is1PConnector": false
+}
+
+```
+
+#### **Example of Input File: Solution_McAfeePO.json**
+
+```json
+{
+  "Name": "Cisco Umbrella",
+  "Author": "Microsoft - support@microsoft.com",
+  "Logo": "<img src=\"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Logos/cisco-logo-72px.svg\" width=\"75px\" height=\"75px\">",
+  "Description": "The [Cisco Umbrella](https://umbrella.cisco.com/) solution for Microsoft Sentinel enables you to ingest [Cisco Umbrella events](https://docs.umbrella.com/deployment-umbrella/docs/log-formats-and-versioning) stored in Amazon S3 into Microsoft Sentinel using the Amazon S3 REST API.
+
+  **Underlying Microsoft Technologies used:**\n\nThis solution takes a dependency on the following technologies, and some of these dependencies either may be in [Preview](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) state or might result in additional ingestion or operational costs:
+  a. [Azure Monitor HTTP Data Collector API](https://docs.microsoft.com/azure/azure-monitor/logs/data-collector-api)
+  b. [Azure Functions](https://azure.microsoft.com/services/functions/#overview)  ",
+  "WorkbookBladeDescription": "This Microsoft Sentinel Solution installs workbooks. Workbooks provide a flexible canvas for data monitoring, analysis, and the creation of rich visual reports within the Azure portal. They allow you to tap into one or many data sources from Microsoft Sentinel and combine them into unified interactive experiences.",
+  "AnalyticalRuleBladeDescription": "This solution installs the following analytic rule templates. After installing the solution, create and enable analytic rules in Manage solution view. ",
+  "HuntingQueryBladeDescription": "This solution installs the following hunting queries. After installing the solution, run these hunting queries to hunt for threats in Manage solution view",
+  "PlaybooksBladeDescription": "This solution installs the following Playbook templates. After installing the solution, playbooks can be managed in the Manage solution view. ",
+  "Data Connectors": [
+    "DataConnectors/CiscoUmbrella/CiscoUmbrella_API_FunctionApp.json"
+  ],
+  "Parsers": [
+    "Solutions/CiscoUmbrella/Parsers/Cisco_Umbrella"
+  ],
+  "Hunting Queries": [
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaAnomalousFQDNsforDomain.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaBlockedUserAgents.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaDNSErrors.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaDNSRequestsUunreliableCategory.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaHighCountsOfTheSameBytesInSize.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaHighValuesOfUploadedData.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaPossibleConnectionC2.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaPossibleDataExfiltration.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaProxyAllowedUnreliableCategory.yaml",
+    "Solutions/CiscoUmbrella/Hunting Queries/CiscoUmbrellaRequestsUncategorizedURI.yaml"
+  ],
+  "Analytic Rules": [
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaConnectionNon-CorporatePrivateNetwork.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaConnectionToUnpopularWebsiteDetected.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaCryptoMinerUserAgentDetected.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaEmptyUserAgentDetected.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaHackToolUserAgentDetected.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaPowershellUserAgentDetected.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaRareUserAgentDetected.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaRequestAllowedHarmfulMaliciousURICategory.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaRequestBlocklistedFileType.yaml",
+    "Solutions/CiscoUmbrella/Analytic Rules/CiscoUmbrellaURIContainsIPAddress.yaml"
+  ],
+  "Workbooks": [
+    "Solutions/CiscoUmbrella/Workbooks/CiscoUmbrella.json"
+  ],
+  "Playbooks": [
+    "Playbooks/CiscoUmbrellaEnforcementAPIConnector/azuredeploy.json",
+    "Playbooks/CiscoUmbrellaInvestigateAPIConnector/azuredeploy.json",
+    "Playbooks/CiscoUmbrellaManagementAPIConnector/azuredeploy.json",
+    "Playbooks/CiscoUmbrellaNetworkDeviceManagementAPIConnector/azuredeploy.json",
+	"Playbooks/Playbooks/CiscoUmbrella-AddIpToDestinationList/azuredeploy.json",
+    "Playbooks/Playbooks/CiscoUmbrella-AssignPolicyToIdentity/azuredeploy.json",
+    "Playbooks/Playbooks/CiscoUmbrella-BlockDomain/azuredeploy.json",
+    "Playbooks/Playbooks/CiscoUmbrella-GetDomainInfo/azuredeploy.json"
+  ],
+  "BasePath": "C:\\GitHub\\Azure-Sentinel",
+  "Version": "2.0.0",
+  "Metadata": "SolutionMetadata.json",
+  "TemplateSpec": true,
+  "Is1PConnector": false
+}
+```
+
+### Create Solution Metadata File
+
+Create a  file and place it in the base path of solution `https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/McAfeeePO/`.
+* Refer to the [Microsoft Sentinel content and solutions categories documentation](https://aka.ms/sentinelcontentcategories) for a complete list of valid Microsoft Sentinel categories.
+* Refer to [Microsoft Sentinel content and support documentation](https://aka.ms/sentinelcontentsupportmodel) for information on valid support models.
+
+
+#### **Metadata File Format:**
+
+```json
+/**
+ * Solution Automation Metadata File Json
+ * -----------------------------------------------------
+ * The purpose of this json is to provide detail on the various fields the metadata solution can have. Refer to the metadata schema and example provided after the definitions for further context.
+ * publisherId: An identifier that's used by Partner Center to uniquely identify the publisher associated with a commercial marketplace account.- Ex. "azuresentinel", "CheckPoint", "semperis"
+ * offerId: Id of the Offer of Solution - Ex. "azure-sentinel-solution-ciscoaci", "azure-sentinel-solution-semperis-dsp"
+ * firstPublishDate: Solution first published date
+ * lastPublishDate: Latest published date of Solution
+ * providers: Provider of the solution. Specify one or many providers as a comma separated list as applicable for the solution - Ex. Cisco, Checkpoint, Microsoft
+ * categories: Domain and Vertical applicability of the solution. There can be multiple domain and/or vertical categories applicable to the same solution which can be represented as an array. For e.g. Domains - "Security - Network", "Application", etc. and Vertical - "Healthcare", "Finance". Refer to the [Microsoft Sentinel content and solutions categories documentation](https://aka.ms/sentinelcontentcategories) for a complete list of valid Microsoft Sentinel categories.
+ * support: Name, Email, Tier and Link for the solution support details.
+ * - NOTE: Additional metadata properties like Version, Author, etc. are used by the packaging tool based on the values provided in the input file. Format specified in the example below. Refer to [Microsoft
+ content and support documentation](https://aka.ms/sentinelcontentsupportmodel) for further information.
+ */
+{
+    "publisherId": {Id of Publisher},
+    "offerId": {Solution Offer Id},
+    "firstPublishDate": {Solution First Published Date},
+    "lastPublishDate": {Solution recent Published Date},
+    "providers": {Solution provider list},
+    "categories": {
+      "domains" : {Solution category domain list},
+      "verticals": {Solution category vertical list},
+     },
+    "support": {
+      "name": {Publisher ID},
+      "email": {Email for Solution Support},
+      "tier": {Support Tier},
+      "link": {Link of Support contacts for Solution},
+    }
+}
+
+```
+
+#### **Example of Input File: SolutionMetadata.json**
+
+```json
+{
+	"publisherId": "azuresentinel",
+	"offerId": "azure-sentinel-solution-mcafeeepo",
+	"firstPublishDate": "2021-03-26",
+	"lastPublishDate": "2021-08-09",
+	"providers": ["Cisco"],
+	"categories": {
+		"domains" : ["Security - Network"],
+		"verticals": []
+	},
+	"support": {
+	  "name": "Microsoft Corporation",
+	  "email": "support@microsoft.com",
+	  "tier": "Microsoft",
+	  "link": "https://support.microsoft.com"
+	}
+} 
+```
+
+### Generate Solution Package
+
+NOTE: It is now recommended to use 'createSolutionV3.ps1' file instead of 'createSolutionV2.ps1'. 'createSolutionV2.ps1' is not recommended going forward. 'createSolutionV4.ps1' file is used for GitHub pipeline and is not used for local use.
+
+To generate the solution package, run the `createSolutionV3.ps1` script in the automation folder, `Tools/Create-Azure-Sentinel-Solution/V3`.
+> Ex. From repository root, run: `./Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1`
+
+Executing above command with ask you to enter the data file path in the solution as 'Enter solution data file path'. Just specify the data folder path from Solutions. No need to specify data file path. This will generate and compress the solution package, and name the package using the version provided in the input file.
+eg: Enter solution data file path : C:\Github\Azure-Sentinel\Solutions\Agari\data
+
+In above example we have provided path of data folder only without file name. Also there is NO need to copy paste data input file to Tools/input folder.
+
+The package consists of the following files:
+
+* `createUIDefinition.json`: Template containing the definition for the Deployment Creation UI
+
+* `mainTemplate.json`: Template containing Deployable Resources
+
+These files will be created in the solution's `Package` folder with respect to the resources provided in the given input file. For every new modification to the files after the initial version of package, a new zip file should be created with an updated version name (2.0.1, 2.0.2, 3.0.0 etc.) containing modified `createUIDefinition.json` and `mainTemplate.json` files.
+
+Upon package creation, the automation will automatically import and run validation on the generated files using the Azure Toolkit / TTK CLI tool.
+
+### Azure Toolkit Validation
+
+The Azure Toolkit Validation is run automatically after package generation. However, if you make any manual edits to the template after the package is generated, you'll need to manually run the Azure Toolkit technical validation on your solution to check the end result.
+
+If you've already run the package creation tool in your current PowerShell instance, you should have the validation command imported and available, otherwise follow the steps below to install.
+
+#### Azure Toolkit Validation Setup
+
+- Clone the [arm-ttk repository](https://github.com/Azure/arm-ttk) to `C:\One`
+  - If `C:\One` does not exist, create the folder.
+  - You may also choose a different folder, but properly reference it in the Profile script.
+- Open your Powershell Profile script
+  - To find your Powershell Profile Script:
+    - Open Powershell.
+    - Type `$profile`, and hit enter.
+    - Your Powershell Profile script path will be output to the screen.
+    - Open the Profile script.
+- Add the following line of code to your Profile script.
+  - `Import-Module C:\One\arm-ttk\arm-ttk\arm-ttk.psd1`
+- Save and close your Profile script.
+- Refresh your profile.
+  - Run the following command in Powershell: `& $profile`
+  - Alternatively, you can close and re-open your PowerShell window.
+
+#### Azure Toolkit Validation Usage
+
+- Navigate to the directory of your solution.
+- Run: `Test-AzTemplate`
+
+### Manual Validation
+
+Once the package is created and Azure Toolkit technical validation is passing, one should manually validate that the package is created as desired.
+
+**1. Validate createUiDefinition.json:**
+
+* Open [CreateUISandbox](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/SandboxBlade).
+* Copy json content from createUiDefinition.json (in the recent version).
+* Clear that content in the editor and replace with copied content in step #2.
+* Click on preview
+* You should see the User Interface preview of data connector, workbook, etc., and descriptions you provided in input file.
+* Check the description and User Interface of solution preview.
+
+**2. Validate maintemplate.json:**
+
+Validate `mainTemplate.json` by deploying the template in portal.
+Follow these steps to deploy in portal:
+
+* Open up <https://aka.ms/AzureSentinelPrP> which launches the Azure portal with the needed private preview flags.
+* Go to "Deploy a Custom Template" on the portal
+* Select "Build your own template in Editor".
+* Copy json content from `mainTemplate.json` (in the recent version).
+* Clear that content in the editor and replace with copied content in step #3.
+* Click Save and then progress to selecting subscription, Sentinel-enabled resource group, and corresponding workspace, etc., to complete the deployment.
+* Click Review + Create to trigger deployment.
+* Check if the deployment successfully completes.
+* You should see the data connector, workbook, etc., deployed in the respective galleries and validate – let us know your feedback.
+
+### Known Failures
+
+#### VMSizes Must Match Template
+
+This will generally show as a warning but the test will be skipped. This will not be perceived as an error by the build.
+
+### Common Issues
+
+#### Template Should Not Contain Blanks
+
+This issue most commonly comes from the serialized workbook and playbooks, due to certain properties in the json having values of null, [], or {}. To fix this, remove these properties.
+
+#### IDs Should Be Derived from ResourceIDs
+
+Some IDs used, most commonly in resources of type `Microsoft.Web/connections`, tend to throw this error despite seeming to fit the expected format. To fix this define two variables, one which uses the problematic ID value, and another which references the first variable, then use this second variable as necessary in place of the ID value. See below for example of such a variable pair:
+
+```json
+"variables": {
+    "playbook-1-connection-1": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('workspace-location'), '/managedApis/microsoftgraphsecurity')]",
+    "_playbook-1-connection-1": "[variables('playbook-1-connection-1')]"
+  }
+```
+
+#### ApiVersions Should Be Recent
+
+Some resources, particularly playbook-related resources, come in with outdated `apiVersion` properties, and depending on the version it may not be picked up as outdated by the validation.
+
+Please ensure that resources of the following types use the corresponding versions:
+
+```json
+{
+    "type": "Microsoft.Web/connections",
+    "apiVersion": "2018-07-01-preview",
+}
+```
+
+```json
+{
+    "type": "Microsoft.Logic/workflows",
+    "apiVersion": "2019-05-01",
+}
+```
+
+#### Parameters Must Be Referenced
+
+It's possible some default parameters may go unused, especially if the solution consists mainly of playbooks. On failure this check will output the unused parameter(s) that exist within the `mainTemplate.json` file.
+
+To fix this, remove the unused parameter from the `parameters` section of `mainTemplate.json`, and check the following common issue "Outputs Must Be Present In Template Parameters".
+
+#### Outputs Must Be Present In Template Parameters
+
+In most cases, this error is a result of removing an unused parameter reference from `mainTemplate.json`. To fix the error in such a case, remove the problematic output variable from the `outputs` section of `createUiDefinition.json`.
+
+Otherwise, the parameter will need be added in the `parameters` section of `mainTemplate.json` and referenced as necessary.
+
+#### Main Template Encoding Issues
+
+If you generate your solution package using a version of PowerShell under 7.1, you'll likely face encoding errors which cause issues within the `mainTemplate.json` file.
+
+The main encoding issue here will be that single-quote characters `'` are encoded into `\u0027`, and due to function references relying on single-quotes, this will break the template.
+
+To resolve this issue, it's recommended that you install PowerShell 7.1+ and re-generate the package.
+
+See [Setup](#setup) to install PowerShell 7.1+.
+
+
+#### YAML Conversion Issues
+
+If the YAML Toolkit for PowerShell is not installed, you may experience errors related to converting `.yaml` files, for analytic rules or otherwise.
+
+To resolve this issue, it's recommended that you install the YAML Toolkit for Powershell.
+
+See [Setup](#setup) to install the YAML Toolkit for PowerShell.
+
+#### ARM-TTK failue for ContentProductId, Id Issues
+
+If you see arm-ttk error for 'contentProductId' and 'id' for 'Ids should be derived from ResourceIds' then you can ignore this error validations. 
+
+#### FILE EXTENSIONS
+
+Make sure to specify file extension in lower case and and not caps(eg: office365.JSON).

--- a/Tools/Create-Azure-Sentinel-Solution/V3/README.md
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/README.md
@@ -61,7 +61,7 @@ eg: C:\Github\Azure-Sentinel\Solutions\Agari\Data
  *
  * - NOTE: Playbooks field can take standard Playbooks, Custom Connectors, and Function Apps. Sequence of Playbooks should be FunctionApps, Custom Connector and then rest of the Playbooks. If FunctionApps and Custom Connector are not present then just specify Playbooks.
  * BasePath: Optional base path to use. Either Internet URL or File Path. Default is repo root (https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/)
- * Version: Optional Version to be used during package creation. We should use any version >= 2.0.0. This tool supports package creation for 2.x.x(Template Spec) and 3.x.x(contentPackages). Based on variable 'defaultPackageVersion' and given Version input. If the defaultPackageVersion is 3.0.0 and Data file input version is 2.0.1 then it package generated is of 3.0.0 i.e which ever is higher takes precedence. Here we are also verifying the catelogAPI to check version deployed in PartnerCenter. If 'defaultPackageVersion' is 2.0.0 and data input file version is 2.0.4 but in PartnerCenter catelogAPI version installed is 2.0.2 then package generated is of 2.0.3 i.e it will increment the package version based on catelogAPI.
+ * Version: Version to be used during package creation. Default version will be 3.0.0. This tool supports package creation for 2.x.x(Template Spec) and 3.x.x(contentPackages). Based on variable 'defaultPackageVersion' and given Version input. If the defaultPackageVersion is 3.0.0 and Data file input version is 2.0.1 then it package generated is of 3.0.0 i.e which ever is higher takes precedence. Here we are also verifying the catelogAPI to check version deployed in PartnerCenter. If 'defaultPackageVersion' is 2.0.0 and data input file version is 2.0.4 but in PartnerCenter catelogAPI version installed is 2.0.2 then package generated is of 2.0.3 i.e it will increment the package version based on catelogAPI.
  * Metadata: Name of metadata file for the Solution, path is to be considered from BasePath.
  * TemplateSpec: Optional Boolean value used to determine whether the package should be generated as a template spec
  */
@@ -86,7 +86,7 @@ eg: C:\Github\Azure-Sentinel\Solutions\Agari\Data
   "Watchlists": [],
   "WatchlistDescription": [],
   "BasePath": "{Path to Solution Content}",
-  "Version": "2.0.0", //Optional, If provided it will compare with defaultPackageVersion variable
+  "Version": "3.0.0", // Default version of 3.0.0. If you want create templateSpec package then change variable 'defaultPackageVersion' value in createSolutionV3.ps1 file 
   "Metadata": "{Name of Solution Metadata file}",
   "TemplateSpec": true,
   "Is1PConnector": false
@@ -154,7 +154,7 @@ eg: C:\Github\Azure-Sentinel\Solutions\Agari\Data
     "Playbooks/Playbooks/CiscoUmbrella-GetDomainInfo/azuredeploy.json"
   ],
   "BasePath": "C:\\GitHub\\Azure-Sentinel",
-  "Version": "2.0.0",
+  "Version": "3.0.0", // Default version of 3.0.0. If you want create templateSpec package then change variable 'defaultPackageVersion' value in createSolutionV3.ps1 file 
   "Metadata": "SolutionMetadata.json",
   "TemplateSpec": true,
   "Is1PConnector": false
@@ -229,7 +229,7 @@ Create a  file and place it in the base path of solution `https://raw.githubuser
 
 ### Generate Solution Package
 
-NOTE: It is now recommended to use 'createSolutionV3.ps1' file instead of 'createSolutionV2.ps1'. 'createSolutionV2.ps1' is not recommended going forward. 'createSolutionV4.ps1' file is used for GitHub pipeline and is not used for local use.
+NOTE: It is now recommended to use 'createSolutionV3.ps1' file instead of 'createSolutionV2.ps1'. 'createSolutionV2.ps1' is not recommended going forward. 'createSolutionV4.ps1' file is used for GitHub pipeline and is not used for local use. `'createSolutionV3.ps1' requires 'commonFunctions.ps1' file which is placed under 'Tools\Create-Azure-Sentinel-Solution\common' path and this file 'commonFunctions.ps1' has all core logic to create package.`
 
 To generate the solution package, run the `createSolutionV3.ps1` script in the automation folder, `Tools/Create-Azure-Sentinel-Solution/V3`.
 > Ex. From repository root, run: `./Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1`
@@ -245,7 +245,7 @@ The package consists of the following files:
 
 * `mainTemplate.json`: Template containing Deployable Resources
 
-These files will be created in the solution's `Package` folder with respect to the resources provided in the given input file. For every new modification to the files after the initial version of package, a new zip file should be created with an updated version name (2.0.1, 2.0.2, 3.0.0 etc.) containing modified `createUIDefinition.json` and `mainTemplate.json` files.
+These files will be created in the solution's `Package` folder with respect to the resources provided in the given input file. For every new modification to the files after the initial version of package, a new zip file should be created with an updated version name (3.0.0, 3.0.1 etc.) containing modified `createUIDefinition.json` and `mainTemplate.json` files.
 
 Upon package creation, the automation will automatically import and run validation on the generated files using the Azure Toolkit / TTK CLI tool.
 

--- a/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
@@ -1,0 +1,235 @@
+Write-Host '=======Starting Package Creation using V3========='
+$path = Read-Host "Enter solution data file path "
+$defaultPackageVersion = "3.0.0"
+Write-Host "Path $path, DefaultPackageVersion is $defaultPackageVersion"
+
+$path = $path.Replace('\', '/')
+$indexOfSolutions = $path.IndexOf('Solutions')
+
+if ($indexOfSolutions -le 0) {
+    Write-Host "Please provide data folder path from Solutions folder!"
+    exit 1
+}
+else {
+    $hasDataFolder = $path -like '*/data'
+    if ($hasDataFolder) {
+        # DATA FOLDER PRESENT
+        $dataFolderIndex = $path.IndexOf("/data", [StringComparison]"CurrentCultureIgnoreCase")
+
+        if ($dataFolderIndex -le 0) {
+            Write-Host "Given path is not from Solutions data folders. Please provide data file path from Solution"
+            exit 1
+        }
+        else {
+            $dataFolderName = $path.Substring($dataFolderIndex + 1)
+            $solutionName = $path.Substring($indexOfSolutions + 10, $dataFolderIndex - ($indexOfSolutions + 10))
+            $solutionFolderBasePath = $path.Substring(0, $dataFolderIndex)
+
+            # GET DATA FOLDER FILE NAME
+            $excluded = @("parameters.json", "parameter.json")
+            $dataFileName = Get-ChildItem -Path "$solutionFolderBasePath\$dataFolderName\" -recurse -exclude $excluded | ForEach-Object -Process { [System.IO.Path]::GetFileName($_) }
+
+            if ($dataFileName.Length -le 0) {
+                Write-Host "Data File not present in given folder path!"
+                exit 1
+            }
+        }
+    }
+    else {
+        Write-Host "Data File not present in given folder path!"
+        exit 1
+    }
+}
+
+$solutionBasePath = $path.Substring(0, $indexOfSolutions + 10)
+$repositoryBasePath = $path.Substring(0, $indexOfSolutions)
+Write-Host "SolutionBasePath is $solutionBasePath, Solution Name $solutionName" 
+
+$isPipelineRun = $false
+
+. "$repositoryBasePath/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1" # load common functions
+. "$repositoryBasePath.script/package-automation/catelogAPI.ps1"
+
+try {
+    foreach ($inputFile in $(Get-ChildItem -Path "$solutionFolderBasePath\$dataFolderName\$dataFileName")) {
+        #$inputJsonPath = Join-Path -Path $path -ChildPath "$($inputFile.Name)"
+        $contentToImport = Get-Content -Raw $inputFile | Out-String | ConvertFrom-Json
+
+        $basePath = $(if ($solutionBasePath) { $solutionBasePath } else { "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/" })
+        $metadataAuthor = $contentToImport.Author.Split(" - ");
+        if ($null -ne $metadataAuthor[1]) {
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "email" -NotePropertyValue $($metadataAuthor[1])
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_email" -NotePropertyValue "[variables('email')]"
+        }
+
+        $solutionName = $contentToImport.Name
+        #$metadataPath = "$PSScriptRoot/../../../Solutions/$($contentToImport.Name)/$($contentToImport.Metadata)"
+        $metadataPath = $solutionBasePath + "$($contentToImport.Name)/$($contentToImport.Metadata)"
+
+        $baseMetadata = Get-Content -Raw $metadataPath | Out-String | ConvertFrom-Json
+        if ($null -eq $baseMetadata) {
+            Write-Host "Please verify if the given path is correct and/or Solution folder name and Data file Name attribute value is correct!"
+            exit 1
+        }
+
+        #================START: IDENTIFY PACKAGE VERSION=============
+        $solutionOfferId = $baseMetadata.offerId
+        $offerId = "$solutionOfferId"
+        $offerDetails = GetCatelogDetails $offerId
+        $userInputPackageVersion = $contentToImport.version
+        $packageVersion = GetPackageVersion $defaultPackageVersion $offerId $offerDetails $true $userInputPackageVersion
+        if ($packageVersion -ne $contentToImport.version) {
+            $contentToImport.PSObject.Properties.Remove('version')
+            $contentToImport | Add-Member -MemberType NoteProperty -Name 'version' -Value $packageVersion 
+            Write-Host "Package version updated to $packageVersion"
+        }
+
+        $TemplateSpecAttribute = [bool]($contentToImport.PSobject.Properties.Name -match "TemplateSpec")
+        if (!$TemplateSpecAttribute) {
+            $contentToImport | Add-Member -MemberType NoteProperty -Name 'TemplateSpec' -Value $true
+        }
+
+        $major = $contentToImport.version.split(".")[0]
+        if ($TemplateSpecAttribute -and $contentToImport.TemplateSpec -eq $false -and $major -gt 1) {
+            $contentToImport.PSObject.Properties.Remove('TemplateSpec')
+            $contentToImport | Add-Member -MemberType NoteProperty -Name 'TemplateSpec' -Value $true
+        }
+        #================START: IDENTIFY PACKAGE VERSION=============
+
+        Write-Host "Package version identified is $packageVersion"
+
+        if ($contentToImport.version -eq '3.0.0') {
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutionName" -NotePropertyValue $solutionName
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutionVersion" -NotePropertyValue $contentToImport.version
+        }
+
+        $metadataAuthor = $contentToImport.Author.Split(" - ");
+
+        $global:solutionId = $baseMetadata.publisherId + "." + $baseMetadata.offerId
+        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "solutionId" -NotePropertyValue $global:solutionId
+        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutionId" -NotePropertyValue "[variables('solutionId')]"
+        
+        # VERIFY IF IT IS A CONTENTSPEC OR CONTENTPACKAGE RESOURCE TYPE BY VERIFYING VERSION FROM  DATA FILE
+        $contentResourceDetails = returnContentResources($contentToImport.Version)
+        if ($null -eq $contentResourceDetails) {
+            Write-Host "Not able to identify content resource details based on Version. Please verify if Version in data input file is correct!"
+            exit 1;
+        }
+
+        foreach ($objectProperties in $contentToImport.PsObject.Properties) {
+            if ($objectProperties.Value -is [System.Array]) {
+                foreach ($file in $objectProperties.Value) {
+                    $file = $file.Replace("$basePath/", "").Replace("Solutions/", "").Replace("$solutionName/", "") 
+                    $finalPath = $basePath + $solutionName + "/" + $file
+                    $rawData = $null
+                    try {
+                        Write-Host "Downloading $finalPath"
+                        $rawData = (New-Object System.Net.WebClient).DownloadString($finalPath)
+                    }
+                    catch {
+                        Write-Host "Failed to download $finalPath -- Please ensure that it exists in $([System.Uri]::EscapeUriString($basePath))" -ForegroundColor Red
+                        break;
+                    }
+
+                    try {
+                        $json = ConvertFrom-Json $rawData -ErrorAction Stop; # Determine whether content is JSON or YAML
+                        $validJson = $true;
+                    }
+                    catch {
+                        $validJson = $false;
+                    }
+                    
+                    if ($validJson) {
+                        # If valid JSON, must be Workbook or Playbook
+                        $objectKeyLowercase = $objectProperties.Name.ToLower()
+                        if ($objectKeyLowercase -eq "workbooks") {
+                            GetWorkbookDataMetadata -file $file -isPipelineRun $isPipelineRun -contentResourceDetails $contentResourceDetails -baseFolderPath $repositoryBasePath -contentToImport $contentToImport
+                        }
+                        elseif ($objectKeyLowercase -eq "playbooks") {
+                            GetPlaybookDataMetadata -file $file -contentToImport $contentToImport -contentResourceDetails $contentResourceDetails -json $json -isPipelineRun $isPipelineRun
+                        }
+                        elseif ($objectKeyLowercase -eq "data connectors" -or $objectKeyLowercase -eq "dataconnectors") {
+                            GetDataConnectorMetadata -file $file -contentResourceDetails $contentResourceDetails
+                        }
+                        elseif ($objectKeyLowercase -eq "savedsearches") {
+                            GenerateSavedSearches -json $json
+                        }
+                        elseif ($objectKeyLowercase -eq "watchlists") {
+                            GenerateWatchList -json $json -isPipelineRun $isPipelineRun
+                        }
+                    }
+                    else {
+                        if ($file -match "(\.yaml)$") {
+                            $objectKeyLowercase = $objectProperties.Name.ToLower()
+                            if ($objectKeyLowercase -eq "hunting queries") {
+                                GetHuntingDataMetadata -file $file -rawData $rawData -contentResourceDetails $contentResourceDetails
+                            }
+                            else {
+                                GenerateAlertRule -file $file -contentResourceDetails $contentResourceDetails
+                            }
+                        }
+                        else {
+                            GenerateParsersList -file $file -contentToImport $contentToImport -contentResourceDetails $contentResourceDetails
+                        }
+                    }
+                }
+            }
+            elseif ($objectProperties.Name.ToLower() -eq "metadata") {
+                try {
+                    $finalPath = $metadataPath
+                    $rawData = $null
+                    try {
+                        Write-Host "Downloading $finalPath"
+                        $rawData = (New-Object System.Net.WebClient).DownloadString($finalPath)
+                    }
+                    catch {
+                        Write-Host "Failed to download $finalPath -- Please ensure that it exists in $([System.Uri]::EscapeUriString($basePath))" -ForegroundColor Red
+                        break;
+                    }
+                        
+                    try {
+                        $json = ConvertFrom-Json $rawData -ErrorAction Stop; # Determine whether content is JSON or YAML
+                        $validJson = $true;
+                    }
+                    catch {
+                        $validJson = $false;
+                    }
+                    
+                    if ($validJson -and $json) {
+                        PrepareSolutionMetadata -solutionMetadataRawContent $json -contentResourceDetails $contentResourceDetails -defaultPackageVersion $defaultPackageVersion
+                    }
+                    else {
+                        Write-Host "Failed to load Metadata file $file -- Please ensure that it exists in $([System.Uri]::EscapeUriString($basePath))" -ForegroundColor Red
+                    }
+                }
+                catch {
+                    Write-Host "Failed to load Metadata file $file -- Please ensure that the SolutionMetadata file exists in $([System.Uri]::EscapeUriString($basePath))" -ForegroundColor Red
+                    break;
+                }
+            }
+        }
+        
+        $global:analyticRuleCounter -= 1
+		$global:workbookCounter -= 1
+		$global:playbookCounter -= 1
+		$global:connectorCounter -= 1
+		$global:parserCounter -= 1
+		$global:huntingQueryCounter -= 1
+		$global:watchlistCounter -= 1
+		updateDescriptionCount $global:connectorCounter                                "**Data Connectors:** "                     "{{DataConnectorCount}}"            $(checkResourceCounts $global:parserCounter, $global:analyticRuleCounter, $global:workbookCounter, $global:playbookCounter, $global:huntingQueryCounter, $global:watchlistCounter)
+		updateDescriptionCount $global:parserCounter                                   "**Parsers:** "                             "{{ParserCount}}"                   $(checkResourceCounts $global:analyticRuleCounter, $global:workbookCounter, $global:playbookCounter, $global:huntingQueryCounter, $global:watchlistCounter)
+		updateDescriptionCount $global:workbookCounter                                 "**Workbooks:** "                           "{{WorkbookCount}}"                 $(checkResourceCounts $global:analyticRuleCounter, $global:playbookCounter, $global:huntingQueryCounter, $global:watchlistCounter)
+		updateDescriptionCount $global:analyticRuleCounter                             "**Analytic Rules:** "                      "{{AnalyticRuleCount}}"             $(checkResourceCounts $global:playbookCounter, $global:huntingQueryCounter, $global:watchlistCounter)
+		updateDescriptionCount $global:huntingQueryCounter                             "**Hunting Queries:** "                     "{{HuntingQueryCount}}"             $(checkResourceCounts $global:playbookCounter, $global:watchlistCounter)
+		updateDescriptionCount $global:watchlistCounter                                "**Watchlists:** "                          "{{WatchlistCount}}"                $(checkResourceCounts @($global:playbookCounter))
+		updateDescriptionCount $global:customConnectorsList.Count                      "**Custom Azure Logic Apps Connectors:** "  "{{LogicAppCustomConnectorCount}}"  $(checkResourceCounts @($global:playbookCounter))
+		updateDescriptionCount $global:functionAppList.Count                           "**Function Apps:** "                       "{{FunctionAppsCount}}"             $(checkResourceCounts @($global:playbookCounter))
+        updateDescriptionCount ($global:playbookCounter - $global:customConnectorsList.Count - $global:functionAppList.Count)  "**Playbooks:** "   "{{PlaybookCount}}"       $false
+
+        GeneratePackage -solutionName $solutionName -contentToImport $contentToImport -calculatedBuildPipelinePackageVersion $contentToImport.Version;
+        RunArmTtkOnPackage -solutionName $solutionName -isPipelineRun $false;
+    }
+}
+catch {
+    Write-Host "Error occured in catch of createSolutionV3 file Error details are $_"
+}

--- a/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
@@ -159,7 +159,7 @@ try {
                         }
                     }
                     else {
-                        if ($file -match "(\.yaml)$") {
+                        if ($file -match "(\.yaml)$" -and $objectProperties.Name.ToLower() -ne "parsers") {
                             $objectKeyLowercase = $objectProperties.Name.ToLower()
                             if ($objectKeyLowercase -eq "hunting queries") {
                                 GetHuntingDataMetadata -file $file -rawData $rawData -contentResourceDetails $contentResourceDetails

--- a/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
@@ -1,6 +1,6 @@
-Write-Host '=======Starting Package Creation using V3========='
+Write-Host '=======Starting Package Creation using V3 tool========='
 $path = Read-Host "Enter solution data file path "
-$defaultPackageVersion = "3.0.0"
+$defaultPackageVersion = "3.0.0" # for templateSpec this will be 2.0.0
 Write-Host "Path $path, DefaultPackageVersion is $defaultPackageVersion"
 
 $path = $path.Replace('\', '/')

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -1,0 +1,3285 @@
+$jsonConversionDepth = 50
+$mainTemplateArtifact = [PSCustomObject]@{
+    name = "DefaultTemplate";
+    type = "Template"
+}
+
+# Base JSON Object Paths
+$baseMainTemplatePath = "$PSScriptRoot/templating/baseMainTemplate.json"
+$baseCreateUiDefinitionPath = "$PSScriptRoot/templating/baseCreateUiDefinition.json"
+
+$global:baseMainTemplate = Get-Content -Raw $baseMainTemplatePath | Out-String | ConvertFrom-Json
+$global:baseCreateUiDefinition = Get-Content -Raw $baseCreateUiDefinitionPath | Out-String | ConvertFrom-Json
+
+# Content Counters - (for adding numbering to each item)
+$global:analyticRuleCounter = 1
+$global:connectorCounter = 1
+$global:workbookCounter = 1
+$global:playbookCounter = 1
+$global:parserCounter = 1
+$global:savedSearchCounter = 1
+$global:huntingQueryCounter = 1
+$global:watchlistCounter = 1
+
+$global:DependencyCriteria = @();
+$global:customConnectorsList = @{};
+$global:functionAppList = @{};
+$ContentKindDict = [System.Collections.Generic.Dictionary[String,string]]::new()
+$ContentKindDict.Add("AnalyticsRule", "ar")
+$ContentKindDict.Add("AnalyticsRuleTemplate", "art")
+$ContentKindDict.Add("DataConnector", "dc")
+$ContentKindDict.Add("DataType", "dt")
+$ContentKindDict.Add("HuntingQuery", "hq")
+$ContentKindDict.Add("InvestigationQuery", "iq")
+$ContentKindDict.Add("Parser", "pr")
+$ContentKindDict.Add("Playbook", "pl")
+$ContentKindDict.Add("PlaybookTemplate", "plt")
+$ContentKindDict.Add("Workbook", "wb")
+$ContentKindDict.Add("WorkbookTemplate", "wbt")
+$ContentKindDict.Add("Watchlist", "wl")
+$ContentKindDict.Add("WatchlistTemplate", "wlt")
+$ContentKindDict.Add("Notebook", "nb")
+$ContentKindDict.Add("Solution", "sl")
+$ContentKindDict.Add("AzureFunction", "fa")
+$ContentKindDict.Add("LogicAppsCustomConnector", "lc")
+$ContentKindDict.Add("AutomationRule", "ar")
+$ContentKindDict.Add("ResourcesDataConnector", "rdc")
+$ContentKindDict.Add("Standalone", "sa")
+
+function handleEmptyInstructionProperties ($inputObj) {
+    $outputObj = $inputObj |
+    Get-Member -MemberType *Property |
+    Select-Object -ExpandProperty Name |
+    Sort-Object |
+    ForEach-Object -Begin { $obj = New-Object PSObject } {
+        if (($null -eq $inputObj.$_) -or ($inputObj.$_ -eq "") -or ($inputObj.$_.Count -eq 0)) {
+            Write-Host "Removing empty property $_"
+        }
+        else {
+            $obj | Add-Member -memberType NoteProperty -Name $_ -Value $inputObj.$_
+        }
+    } { $obj }
+    $outputObj
+}
+
+function removePropertiesRecursively ($resourceObj) {
+    foreach ($prop in $resourceObj.PsObject.Properties) {
+        $key = $prop.Name
+        $val = $prop.Value
+        if ($null -eq $val) {
+            $resourceObj.$key = "[variables('blanks')]";
+            if (!$global:baseMainTemplate.variables.blanks) {
+                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "blanks" -NotePropertyValue "[replace('b', 'b', '')]"
+            }
+        }
+        elseif ($val -is [System.Object[]]) {
+            if ($val.Count -eq 0) {
+                #$resourceObj.PsObject.Properties.Remove($key)
+                $resourceObj.$key = "[variables('TemplateEmptyArray')]";
+                if (!$global:baseMainTemplate.variables.TemplateEmptyArray) {
+                    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyArray" -NotePropertyValue "[json('[]')]"
+                }
+            }
+            else {
+                foreach ($item in $val) {
+                    $itemIndex = $val.IndexOf($item)
+                    $resourceObj.$key[$itemIndex] = $(removePropertiesRecursively $val[$itemIndex])
+                }
+            }
+        }
+        else {
+            if ($val -is [PSCustomObject]) {
+                if ($($val.PsObject.Properties).Count -eq 0) {
+                    $resourceObj.PsObject.Properties.Remove($key)
+                }
+                else {
+                    $resourceObj.$key = $(removePropertiesRecursively $val)
+                    if ($($resourceObj.$key.PsObject.Properties).Count -eq 0) {
+                        $resourceObj.PsObject.Properties.Remove($key)
+                    }
+                }
+            }
+        }
+    }
+    $resourceObj
+}
+
+function queryResourceExists () {
+    foreach ($resource in $global:baseMainTemplate.resources) {
+        if ($resource.type -eq "Microsoft.OperationalInsights/workspaces") {
+            return $true
+        }
+    }
+    return $false
+}
+
+function getQueryResourceLocation () {
+    for ($i = 0; $i -lt $global:baseMainTemplate.resources.Length; $i++) {
+        if ($global:baseMainTemplate.resources[$i].type -eq "Microsoft.OperationalInsights/workspaces") {
+            return $i
+        }
+    }
+}
+
+function getParserDetails($solutionName,$yaml,$isyaml)
+{
+    $API = 'https://catalogapi.azure.com/offers?api-version=2018-08-01-beta&$filter=categoryIds%2Fany(cat%3A%20cat%20eq%20%27AzureSentinelSolution%27)%20or%20keywords%2Fany(key%3A%20contains(key%2C%27f1de974b-f438-4719-b423-8bf704ba2aef%27))'
+    $SolutionDataItems = $(Invoke-WebRequest -URI $API | ConvertFrom-Json).items
+    $parserResourceType = [PSObject]@{
+        templateSpecParserType = "Microsoft.OperationalInsights/workspaces/savedSearches"
+        workspaceType = "Microsoft.OperationalInsights/workspaces"
+        normalParserType = "savedSearches"
+    }
+    $variableExpressionRegex = "\[\s?variables\(\'_([\w\W]+)\'\)\s?\]"
+    $parserDisplayDetails = New-Object PSObject
+
+    # =============new code from sarath=============
+    $functionAlias = ($isyaml -eq $true) ? $yaml.FunctionName : $(getFileNameFromPath $file)
+    $displayName = ($isyaml -eq $true) ? "$($yaml.Function.Title)" : "$($fileName)"
+    $name = ($isyaml -eq $true) ? "$($yaml.FunctionName)" : "$($fileName)"
+    $parserDisplayDetails | Add-Member -NotePropertyName "functionAlias" -NotePropertyValue $functionAlias
+    $parserDisplayDetails | Add-Member -NotePropertyName "displayName" -NotePropertyValue $displayName
+    $parserDisplayDetails | Add-Member -NotePropertyName "name" -NotePropertyValue $name
+    # ==============================================
+
+    $currentSolution = $SolutionDataItems | Where-Object { $_.legacyId -eq $solutionName }
+    if($currentSolution.length -gt 0)
+    {
+        $templateUrl = ($currentSolution.plans[0].artifacts | Where-Object { (($_.name -eq $mainTemplateArtifact.name) -and ($_.type -eq $mainTemplateArtifact.type)) }).uri
+        $templateContent = $(Invoke-WebRequest -URI $templateUrl) | ConvertFrom-Json
+        if ($templateContent.resources -and $templateContent.variables) {
+            $templateVariables = $templateContent.variables
+            $parserTemplate = $templateContent.resources | Where-Object { $_.type -eq $parserResourceType.templateSpecParserType -or $_.type -eq $parserResourceType.workspaceType }
+
+            if ($null -ne $parserTemplate) {
+                if($null -ne $parserTemplate.resources)
+                {
+                    $parserTemplate = $parserTemplate.resources | Where-Object {$_.properties.category -eq "Samples" -and $_.type -eq $parserResourceType.normalParserType }
+                }
+
+                $parserTemplate = $parserTemplate | Where-Object {$_.properties.functionAlias -eq $(getFileNameFromPath $file)}
+
+                if ($null -ne $parserTemplate) {
+                    $parserDisplayDetails.functionAlias = $parserTemplate.properties.functionAlias;
+                    $parserDisplayDetails.displayName = $parserTemplate.properties.displayName;
+                    $parserDisplayDetails.name = $parserTemplate.name.split('/')[-1];
+
+                    $suppressedOutput = $parserDisplayDetails.displayName -match $variableExpressionRegex
+                    if ($suppressedOutput -and $matches[1]) {
+                        $parserDisplayDetails.displayName = $templateVariables.$($matches[1])
+                    }
+
+                    $suppressedOutput = $parserDisplayDetails.name -match $variableExpressionRegex
+                    if ($suppressedOutput -and $matches[1]) {
+                        $parserDisplayDetails.name = $templateVariables.$($matches[1])
+                    }
+                }
+            }
+        }
+    }
+
+    return $parserDisplayDetails;
+}
+
+function Replace-SpecialChars {
+    param($InputString,$Type)
+    if ($Type.ToLower() -eq 'solutionname') {
+        $SpecialChars = '[#?\{\[\(\)\]\}]'
+        $Replacement  = ' '
+    }
+    elseif ($Type.ToLower() -eq 'filename') {
+        $SpecialChars = '[#?\{\[\(\)\]\}]'
+        $Replacement  = ''
+    }
+    else {
+        $SpecialChars = '[#?\{\[\(\)\]\}]'
+        $Replacement  = ''
+    }
+    return $InputString -replace $SpecialChars,$Replacement
+}
+
+function checkResourceCounts ($countList) {
+    if ($countList -isnot [System.Array]) { return $false }
+    else {
+        foreach ($count in $countList) { if ($count -gt 0) { return $true } }
+        return $false
+    }
+}
+
+function updateDescriptionCount($counter, $emplaceString, $replaceString, $countStringCondition) {
+    if ($counter -gt 0) {
+        $ruleCountSubstring = "$emplaceString$counter"
+        $ruleCountString = $(if ($countStringCondition) { "$ruleCountSubstring, " } else { $ruleCountSubstring })
+        $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace $replaceString, $ruleCountString
+    }
+    else {
+        $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace $replaceString, ""
+    }
+}
+
+function GetContentSchemaVersion($defaultPackageVersion, $dataInputVersion)
+{
+    # DEPENDING OF VERSION WE SHOULD SET THE CONTENTSCHEMAVERSION
+    if ($null -eq $defaultPackageVersion -or $null -eq $dataInputVersion)
+    {
+        # WHEN BOTH NULL
+        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
+    }
+    elseif ($null -ne $defaultPackageVersion -and ($dataInputVersion -ne $defaultPackageVersion))
+    {
+        # WHEN ONE IS NULL  
+        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "2.0.0";
+    }
+    elseif ($null -eq $defaultPackageVersion -and $null -eq $dataInputVersion) {
+        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
+        Write-Host "contentSchemaVersion set is 3.0.0 as both defaultPackageVersion and version field are null"
+    }
+    elseif ($null -ne $defaultPackageVersion -and $null -eq $dataInputVersion) {
+        $major = $defaultPackageVersion.split(".")[0]
+        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$major.0.0";
+        Write-Host "contentSchemaVersion set is $major inside of elseif where defaultPackageVersion is not null but input file version is null"
+    }
+    elseif ($null -eq $defaultPackageVersion -and $null -ne $dataInputVersion) {
+        $inputMajor,$inputMinor,$inputBuild,$inputRevision = $dataInputVersion.split(".")
+        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$inputMajor.0.0";
+        Write-Host "contentSchemaVersion inputMajor set is $inputMajor inside of elseif where defaultPackageVersion is null but input file version is not null"
+    }
+    elseif ($null -ne $defaultPackageVersion -and $null -ne $dataInputVersion -and 
+    $dataInputVersion -ne $defaultPackageVersion)
+    {
+        $inputMajor,$inputMinor,$inputBuild,$inputRevision = $dataInputVersion.split(".")
+        $defaultMajor,$defaultMinor,$defaultBuild,$defaultRevision = $defaultPackageVersion.split(".")
+            
+        if ($inputMajor -gt $defaultMajor -or $inputMajor -eq $defaultMajor)
+        {
+            $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$inputMajor.0.0";
+        }
+        elseif ($inputMajor -gt $defaultMajor)
+        {
+            $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$defaultMajor.0.0";
+        }
+    }
+    elseif ($defaultPackageVersion -eq $dataInputVersion)
+    {
+        # WHEN BOTH SAME
+        if ($null -eq $defaultPackageVersion)
+        {
+            $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
+        }
+        else {
+            $major = $defaultPackageVersion.split(".")[0]
+            $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$major.0.0";
+        }
+    }
+    else 
+    {
+        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
+    }
+
+    return $newMetadata
+}
+
+function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDetails, $defaultPackageVersion = $null)
+    {
+        Write-Host "Inside of PrepareSolutionMetadata"
+        $json = $solutionMetadataRawContent
+        # Create Metadata Resource Object
+        if ($json.support) {
+            $support = $json.support;
+        }
+        if ($json.categories) {
+            $categories = $json.categories;
+        }
+        
+        $Author = $contentToImport.Author.Split(" - ");
+        $newMetadata = [PSCustomObject]@{
+            type       = $contentResourceDetails.metadata #"Microsoft.OperationalInsights/workspaces/providers/metadata";
+            apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-01-01-preview";
+            location   = "[parameters('workspace-location')]";
+            properties = [PSCustomObject] @{
+                version = $contentToImport.Version;
+                kind    = "Solution";
+            };
+        };
+        
+        if($contentToImport.TemplateSpec)
+        {
+            $hasVersionAttribute = [bool]($contentToImport.PSobject.Properties.name -match "Version")
+            if ($hasVersionAttribute)
+            {
+                $newMetadata = GetContentSchemaVersion -defaultPackageVersion $defaultPackageVersion -dataInputVersion $contentToImport.Version
+            }
+            else {
+                $newMetadata = GetContentSchemaVersion -defaultPackageVersion $defaultPackageVersion -dataInputVersion $contentToImport.Version
+            }
+        }
+
+        if($contentResourceDetails.apiVersion -eq '3.0.0')
+        {
+            $newMetadata.Properties | Add-Member -Name 'displayName' -Type NoteProperty -Value $contentToImport.Name;
+            $newMetadata.Properties | Add-Member -Name 'publisherDisplayName' -Type NoteProperty -Value $(If ($support.psobject.properties["tier"].value.tolower() -eq "microsoft") {"Microsoft Sentinel, $($support.psobject.properties["name"].value)"} Else {$($support.psobject.properties["name"].value)})
+            $newMetadata.Properties | Add-Member -Name 'descriptionHtml' -Type NoteProperty -Value $contentToImport.Description;
+            $newMetadata.Properties | Add-Member -Name 'contentKind' -Type NoteProperty -Value "Solution";
+            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(substring(variables('_solutionId'),0, 50),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
+
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
+
+            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
+	    $newMetadata.Properties | Add-Member -Name 'contentProductId' -Type NoteProperty -Value "[variables('_solutioncontentProductId')]"
+            $newMetadata.Properties | Add-Member -Name 'id' -Type NoteProperty -Value "[variables('_solutioncontentProductId')]"
+            $newMetadata.Properties | Add-Member -Name 'icon' -Type NoteProperty -Value $contentToImport.Logo;
+        }
+        
+        $source = [PSCustomObject]@{
+            kind = "Solution";
+            name = "$solutionName";
+        };
+        $authorDetails = [PSCustomObject]@{
+            name  = $Author[0];
+        };
+
+        if($null -ne $Author[1])
+        {
+            $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+        }
+        if ($global:solutionId) 
+        {
+            $newMetadata | Add-Member -Name 'name' -Type NoteProperty -Value "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('_solutionId'))]";
+            $newMetadata.Properties | Add-Member -Name 'contentId' -Type NoteProperty -Value "[variables('_solutionId')]";
+            $newMetadata.Properties | Add-Member -Name 'parentId' -Type NoteProperty -Value "[variables('_solutionId')]";
+        
+            $source | Add-Member -Name 'sourceId' -Type NoteProperty -value "[variables('_solutionId')]";
+            $newMetadata.Properties | Add-Member -Name 'source' -Type NoteProperty -value $source;
+        }
+        
+        $newMetadata.Properties | Add-Member -Name 'author' -Type NoteProperty -value $authorDetails
+        
+        $supportDetails = New-Object psobject;
+        
+        if ($support -and $support.psobject.properties["name"] -and $support.psobject.properties["name"].value) {
+            $supportDetails | Add-Member -Name 'name' -Type NoteProperty -value $support.psobject.properties["name"].value;
+        }
+        
+        if ($support -and $support.psobject.properties["email"] -and $support.psobject.properties["email"].value) {
+            $supportDetails | Add-Member -Name 'email' -Type NoteProperty -value $support.psobject.properties["email"].value;
+        }
+        
+        if ($support -and $support.psobject.properties["tier"] -and $support.psobject.properties["tier"].value) {
+            $supportDetails | Add-Member -Name 'tier' -Type NoteProperty -value $support.psobject.properties["tier"].value;
+        }
+        
+        if ($support -and $support.psobject.properties["link"] -and $support.psobject.properties["link"].value) {
+            $supportDetails | Add-Member -Name 'link' -Type NoteProperty -value $support.psobject.properties["link"].value;
+        }
+        
+        if ($support.psobject.properties["name"] -or $support.psobject.properties["email"] -or $support.psobject.properties["tier"] -or $support.psobject.properties["link"]) 
+        {
+            $newMetadata.Properties | Add-Member -Name 'support' -Type NoteProperty -value $supportDetails;
+        }
+
+        $dependencies = [PSCustomObject]@{
+            operator = "AND";
+            criteria = $global:DependencyCriteria;
+        };
+        
+        $newMetadata.properties | Add-Member -Name 'dependencies' -Type NoteProperty -Value $dependencies;
+        
+        if ($json.firstPublishDate -and $json.firstPublishDate -ne "") 
+        {
+            $newMetadata.Properties | Add-Member -Name 'firstPublishDate' -Type NoteProperty -value $json.firstPublishDate;
+        }
+                    
+        if ($json.lastPublishDate -and $json.lastPublishDate -ne "") 
+        {
+            $newMetadata.Properties | Add-Member -Name 'lastPublishDate' -Type NoteProperty -value $json.lastPublishDate;
+        }
+        
+        if ($json.providers -and $json.providers -ne "") 
+        {
+            $newMetadata.Properties | Add-Member -Name 'providers' -Type NoteProperty -value $json.providers;
+        }
+        $categoriesDetails = New-Object psobject;
+        if ($categories -and $categories.psobject.properties['domains'] -and $categories.psobject.properties["domains"].Value.Length -gt 0) 
+        {
+            $categoriesDetails | Add-Member -Name 'domains' -Type NoteProperty -Value $categories.psobject.properties["domains"].Value;
+            $newMetadata.properties | Add-Member -Name 'categories' -Type NoteProperty -Value $categoriesDetails;
+        }
+        
+        if ($categories -and $categories.psobject.properties['verticals'] -and $categories.psobject.properties["verticals"].Value.Length -gt 0) 
+        {
+            $categoriesDetails | Add-Member -Name 'verticals' -Type NoteProperty -Value $categories.psobject.properties["verticals"].value;
+            $newMetadata.properties | Add-Member -Name 'categories' -Type NoteProperty -Value $categoriesDetails;
+        }
+        $global:baseMainTemplate.resources += $newMetadata;
+        ### Removing the Non-Sentinel Resources if there are any:
+        $newobject = $global:baseMainTemplate.resources | ? {$_.type -in $contentResourceDetails.resources}
+        $global:baseMainTemplate.resources = $newobject
+        ### TODO: CHECK IF ABOVE LINE IS NEEDED HERE OR WE SHOULD RETURN $newMetadata
+    }
+
+    function GetWorkbookDataMetadata($file, $isPipelineRun, $contentResourceDetails, $baseFolderPath, $contentToImport)
+    {
+        Write-Host "Generating Workbook using $file"
+        $solutionRename = Replace-SpecialChars -InputString $solutionName -Type 'solutionname'
+        $fileName = Split-Path $file -leafbase;
+
+        $indexOfOpenBraces = $fileName.IndexOf('(')
+        if ($indexOfOpenBraces -le 0)
+        {
+            $fileName = Replace-SpecialChars -InputString $fileName -Type 'filename'
+        }
+        $workbookKey = $fileName;
+        $fileName = $fileName + "Workbook";
+
+                        if ($global:workbookCounter -eq 1) {
+                            # Add workbook source variables
+                            if (!$contentToImport.TemplateSpec){
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workbook-source" -NotePropertyValue "[concat(resourceGroup().id, '/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'))]"
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbook-source" -NotePropertyValue "[variables('workbook-source')]"
+                            };
+                            $baseWorkbookStep = [PSCustomObject] @{
+                                name       = "workbooks";
+                                label      = "Workbooks";
+                                subLabel   = [PSCustomObject] @{
+                                    preValidation  = "Configure the workbooks";
+                                    postValidation = "Done";
+                                };
+                                bladeTitle = "Workbooks";
+                                elements   = @(
+                                    [PSCustomObject] @{
+                                        name    = "workbooks-text";
+                                        type    = "Microsoft.Common.TextBlock";
+                                        options = [PSCustomObject] @{
+                                            text =  $contentToImport.WorkbookBladeDescription ? $contentToImport.WorkbookBladeDescription : "This solution installs workbook(s) to help you gain insights into the telemetry collected in Microsoft Sentinel. After installing the solution, start using the workbook in Manage solution view.";
+                                        }
+                                    },
+                                    [PSCustomObject] @{
+                                        name    = "workbooks-link";
+                                        type    = "Microsoft.Common.TextBlock";
+                                        options = [PSCustomObject] @{
+                                            link=  [PSCustomObject] @{
+                                                label= "Learn more";
+                                                uri= "https://docs.microsoft.com/azure/sentinel/tutorial-monitor-your-data"
+                                            }
+                                            }
+                                    }
+                                )
+                            }
+
+                            $global:baseCreateUiDefinition.parameters.steps += $baseWorkbookStep
+                            if(!$contentToImport.TemplateSpec)
+                            {
+                                #Add formattedTimeNow parameter since workbooks exist
+                                $timeNowParameter = [PSCustomObject]@{
+                                    type         = "string";
+                                    defaultValue = "[utcNow('g')]";
+                                    metadata     = [PSCustomObject]@{
+                                        description = "Appended to workbook displayNames to make them unique";
+                                    }
+                                }
+                                $global:baseMainTemplate.parameters | Add-Member -MemberType NoteProperty -Name "formattedTimeNow" -Value $timeNowParameter
+                            }
+                        }
+
+                        # if ($isPipelineRun)
+                        # {
+                        #     $workbookFinalPath = $baseFolderPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';  #"https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/" #$workbookMetadataPathForPipelineRun 
+                        # }
+                        # else {
+                        #     $workbookFinalPath = $workbookMetadataPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';
+                        # }
+                        $workbookFinalPath = $baseFolderPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';  #"https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/" #$workbookMetadataPathForPipelineRun 
+                        
+                        # BELOW IS THE NEW CODE ADDED FROM AZURE SENTINEL REPO
+                        if($contentToImport.TemplateSpec) {
+                            #Getting Workbook Metadata dependencies from Github
+                            $workbookData = $null
+                            #$workbookFinalPath = $workbookMetadataPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';
+                            try {
+                                Write-Host "Downloading $workbookFinalPath"
+                                $workbookData = (New-Object System.Net.WebClient).DownloadString($workbookFinalPath)
+                                $dependencies = $workbookData | ConvertFrom-Json | Where-Object {($_.templateRelativePath.split('.')[0].ToLower() -eq $workbookKey.ToLower())}
+                                $WorkbookDependencyCriteria = @();
+                            }
+                            catch {
+                                Write-Host "TemplateSpec Workbook Metadata Dependencies errors occurred: $($_.Exception.Message)" -ForegroundColor Red
+                                break;
+                            }
+
+                            if($dependencies.source -and $dependencies.source.kind -and ($dependencies.source.kind -eq "Community" -or $dependencies.source.kind -eq "Standalone"))
+                            {
+                                throw "The file $fileName has metadata with source -> kind = Community | Standalone. Please remove it so that it can be packaged as a solution."
+                            }
+						}
+						$workbookUIParameter = [PSCustomObject] @{ name = "workbook$global:workbookCounter"; type = "Microsoft.Common.Section"; label = $dependencies.title; elements = @( [PSCustomObject] @{ name = "workbook$global:workbookCounter-text"; type = "Microsoft.Common.TextBlock"; options = @{ text = $dependencies.description; } } ) }
+                        $global:baseCreateUiDefinition.parameters.steps[$global:baseCreateUiDefinition.parameters.steps.Count - 1].elements += $workbookUIParameter
+
+                        try {
+                            $data = $rawData
+                            # Serialize workbook data
+                            $serializedData = $data |  ConvertFrom-Json -Depth $jsonConversionDepth
+                            # Remove empty braces
+                            $serializedData = $(removePropertiesRecursively $serializedData) | ConvertTo-Json -Compress -Depth $jsonConversionDepth | Out-String
+                        }
+                        catch {
+                            Write-Host "Failed to serialize $file" -ForegroundColor Red
+                            break;
+                        }
+                        $workbookDescriptionText = $(if ($contentToImport.WorkbookDescription -and $contentToImport.WorkbookDescription -is [System.Array]) { $contentToImport.WorkbookDescription[$global:workbookCounter - 1] } elseif ($contentToImport.WorkbookDescription -and $contentToImport.WorkbookDescription -is [System.String]) { $contentToImport.WorkbookDescription } else { "" })
+                        #creating parameters in mainTemplate
+                        $workbookIDParameterName = "workbook$global:workbookCounter-id"
+                        $workbookNameParameterName = "workbook$global:workbookCounter-name"
+
+                        $workbookIDParameter = [PSCustomObject] @{ type = "string"; defaultValue = "[newGuid()]"; minLength = 1; metadata = [PSCustomObject] @{ description = "Unique id for the workbook" }; }
+
+                        if(!$contentToImport.TemplateSpec)
+                        {
+                            $global:baseMainTemplate.parameters | Add-Member -MemberType NoteProperty -Name $workbookIDParameterName -Value $workbookIDParameter
+                        }
+
+                        # Create Workbook Resource Object
+                        $newWorkbook = [PSCustomObject]@{
+                            type       = "Microsoft.Insights/workbooks";
+                            name       = "[parameters('workbook$global:workbookCounter-id')]";
+                            location   = "[parameters('workspace-location')]";
+                            kind       = "shared";
+                            apiVersion = "2021-08-01";
+                            metadata   = [PSCustomObject]@{};
+                            properties = [PSCustomObject] @{
+                                displayName    = $contentToImport.Workbooks ? "[parameters('workbook$global:workbookCounter-name')]" : "[concat(parameters('workbook$global:workbookCounter-name'), ' - ', parameters('formattedTimeNow'))]";
+                                serializedData = $serializedData;
+                                version        = "1.0";
+                                sourceId       = $contentToImport.TemplateSpec? "[variables('workspaceResourceId')]" : "[variables('_workbook-source')]";
+                                category       = "sentinel"
+                            }
+                        }
+
+                        #$workbookMetadataPath = "$PSScriptRoot/../../../"
+                        if($contentToImport.TemplateSpec) {
+                            #Getting Workbook Metadata dependencies from Github
+                            $workbookData = $null
+                            #$workbookFinalPath = $workbookMetadataPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';
+                            #$workbookFinalPath = "https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json"
+                            
+                            # REPLACE BELOW WITH
+                            #https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json
+                            #$workbookFinalPath ="https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json?token=GHSAT0AAAAAACAH2TVHK4LEA4VCEPD7JR5SZB35H7A"
+                            
+                            try {
+                                Write-Host "Downloading $workbookFinalPath"
+                                $workbookData = (New-Object System.Net.WebClient).DownloadString($workbookFinalPath)
+                                $dependencies = $workbookData | ConvertFrom-Json | Where-Object {
+                                    $indexOfOpenBraces = $_.templateRelativePath.contains('(')
+                                    if ($indexOfOpenBraces)
+                                    {
+                                        $lastIndexOfDot = $_.templateRelativePath.LastIndexOf('.')
+                                        if($lastIndexOfDot -gt 0)
+                                        {
+                                            $value = $_.templateRelativePath.substring(0, $lastIndexOfDot)
+                                            if ($value.ToLower() -eq $workbookKey.ToLower())
+                                            {
+                                                return $_;
+                                            }
+                                        }
+                                    }
+                                    else {
+                                        if($_.templateRelativePath.split('.')[0].ToLower() -eq $workbookKey.ToLower())
+                                        {
+                                            return $_;
+                                        }
+                                    }
+                                }
+                                $WorkbookDependencyCriteria = @();
+                                foreach($dataTypesDependencies in $dependencies.dataTypesDependencies)
+                                {
+                                    $dataTypeObject = New-Object PSObject
+                                    $dataTypeObject | Add-Member -MemberType NoteProperty -Name "contentId" -Value "$dataTypesDependencies"
+                                    $dataTypeObject | Add-Member -MemberType NoteProperty -Name "kind" -Value "DataType"
+                                    $WorkbookDependencyCriteria += $dataTypeObject
+                                }
+                                foreach($dataConnectorsDependencies in $dependencies.dataConnectorsDependencies)
+                                {
+                                    $dataConnectorObject = New-Object PSObject
+                                    $dataConnectorObject | Add-Member -MemberType NoteProperty -Name "contentId" -Value "$dataConnectorsDependencies"
+                                    $dataConnectorObject | Add-Member -MemberType NoteProperty -Name "kind" -Value "DataConnector"
+                                    $WorkbookDependencyCriteria += $dataConnectorObject
+                                }
+                                if($null -ne $dataConnectorObject -or $null -ne $dataTypeObject){
+                                    $workbookDependencies = [PSCustomObject]@{
+                                        operator = "AND";
+                                        #criteria = $WorkbookDependencyCriteria;
+                                    };
+                                }
+
+                                if($WorkbookDependencyCriteria.Count -gt 0)
+                                {
+                                    $workbookDependencies | Add-Member -NotePropertyName "criteria" -NotePropertyValue $WorkbookDependencyCriteria                 
+                                }
+
+                                $newWorkbook.metadata | Add-Member -MemberType NoteProperty -Name "description" -Value "$($dependencies.description)"
+                            }
+                            catch {
+                                Write-Host "TemplateSpec Workbook Metadata Dependencies errors occurred: $($_.Exception.Message)" -ForegroundColor Red
+                                break;
+                            }
+
+                            $workbookNameParameter = [PSCustomObject] @{ type = "string"; defaultValue = $dependencies.title; minLength = 1; metadata = [PSCustomObject] @{ description = "Name for the workbook" }; }
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workbookVersion$global:workbookCounter" -NotePropertyValue "$($dependencies.version)"
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workbookContentId$global:workbookCounter" -NotePropertyValue "$($dependencies.workbookKey)"
+                            $global:baseMainTemplate.parameters | Add-Member -MemberType NoteProperty -Name $workbookNameParameterName -Value $workbookNameParameter
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workbookId$global:workbookCounter" -NotePropertyValue "[resourceId('Microsoft.Insights/workbooks', variables('workbookContentId$global:workbookCounter'))]"
+
+                            if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workbookTemplateSpecName$global:workbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-wb-',uniquestring(variables('_workbookContentId$global:workbookCounter'))),variables('workbookVersion$global:workbookCounter')))]"
+                            }
+                            else 
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workbookTemplateSpecName$global:workbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'-wb-',uniquestring(variables('_workbookContentId$global:workbookCounter')))]"
+                            }
+
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookContentId$global:workbookCounter" -NotePropertyValue "[variables('workbookContentId$global:workbookCounter')]"
+                            $global:DependencyCriteria += [PSCustomObject]@{
+                                kind      = "Workbook";
+                                contentId = "[variables('_workbookContentId$global:workbookCounter')]";
+                                version   = "[variables('workbookVersion$global:workbookCounter')]";
+                            };
+
+                            # Add workspace resource ID if not available
+                            if (!$global:baseMainTemplate.variables.workspaceResourceId) {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
+                            }
+
+                            if ($contentResourceDetails.contentSchemaVersion -ne '3.0.0')
+                            {
+                                # Add base templateSpec
+                                $baseWorkbookTemplateSpec = [PSCustomObject]@{
+                                    type       = $contentResourceDetails.resourcetype;  # "Microsoft.Resources/templateSpecs";
+                                    apiVersion = "2022-02-01";
+                                    name       = "[variables('workbookTemplateSpecName$global:workbookCounter')]";
+                                    location   = "[parameters('workspace-location')]";
+                                    tags       = [PSCustomObject]@{
+                                        "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                        "hidden-sentinelContentType" = "Workbook";
+                                    };
+                                    properties = [PSCustomObject]@{
+                                        description = "$($solutionName) Workbook with template";
+                                        displayName = "$($solutionName) workbook template";
+                                    }
+                                }
+                                $global:baseMainTemplate.resources += $baseWorkbookTemplateSpec
+                            }
+
+                            $newWorkbook.name = "[variables('workbookContentId$global:workbookCounter')]"
+                            $author = $contentToImport.Author.Split(" - ");
+                            $authorDetails = [PSCustomObject]@{
+                                name  = $author[0];
+                            };
+                            if($null -ne $author[1])
+                            {
+                                $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+                            }
+                            $workbookMetadata = [PSCustomObject]@{
+                                type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+                                apiVersion = "2022-01-01-preview";
+                                name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Workbook-', last(split(variables('workbookId$global:workbookCounter'),'/'))))]";
+                                properties = [PSCustomObject]@{
+                                    description = "$dependencies.description";
+                                    parentId  = "[variables('workbookId$global:workbookCounter')]"
+                                    contentId = "[variables('_workbookContentId$global:workbookCounter')]";
+                                    kind      = "Workbook";
+                                    version   = "[variables('workbookVersion$global:workbookCounter')]";
+                                    source    = [PSCustomObject]@{
+                                        kind     = "Solution";
+                                        name     = $contentToImport.Name;
+                                        sourceId = "[variables('_solutionId')]"
+                                    };
+                                    author    = $authorDetails;
+                                    support   = $baseMetadata.support;
+                                    #dependencies = $workbookDependencies;
+                                }
+                            }
+                            if($null -ne $workbookDependencies)
+                            {
+                                $workbookMetadata.properties | Add-Member -NotePropertyName "dependencies" -NotePropertyValue $workbookDependencies
+                            }
+                            if($workbookDescriptionText -ne "")
+                            {
+                                $workbookMetadata | Add-Member -NotePropertyName "description" -NotePropertyValue $workbookDescriptionText
+                            }
+
+                            # Add templateSpecs/versions resource to hold actual content
+                            $workbookTemplateSpecContent = [PSCustomObject]@{
+                                type       = $contentResourceDetails.subtype; # "Microsoft.Resources/templateSpecs/versions";
+                                apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-02-01";
+                                name       = $contentResourceDetails.apiVersion -eq '3.0.0' ? "[variables('workbookTemplateSpecName$global:workbookCounter')]" : "[concat(variables('workbookTemplateSpecName$global:workbookCounter'),'/',variables('workbookVersion$global:workbookCounter'))]";
+                                location   = "[parameters('workspace-location')]";
+                                tags       = [PSCustomObject]@{
+                                    "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                    "hidden-sentinelContentType" = "Workbook";
+                                };
+                                # dependsOn  = @(
+                                #     "[resourceId('Microsoft.Resources/templateSpecs', variables('workbookTemplateSpecName$global:workbookCounter'))]"
+                                # );
+                                dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
+                                "$($contentResourceDetails.dependsOn)") : @(
+                                    "$($contentResourceDetails.dependsOn), variables('workbookTemplateSpecName$global:workbookCounter'))]"
+                                );
+                                properties = [PSCustomObject]@{
+                                    description  = "$($fileName) Workbook with template version $($contentToImport.Version)";
+                                    mainTemplate = [PSCustomObject]@{
+                                        '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+                                        contentVersion = "[variables('workbookVersion$global:workbookCounter')]";
+                                        parameters     = [PSCustomObject]@{};
+                                        variables      = [PSCustomObject]@{};
+                                        resources      = @(
+                                            # workbook
+                                            $newWorkbook,
+                                            # Metadata
+                                            $workbookMetadata
+                                        )
+                                    };
+                                }
+                            }
+
+                            if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                            {
+                                $workbookTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $workbookTemplateSpecContent
+                                $workbookTemplateSpecContent.properties.contentId = "[variables('_workbookContentId$global:workbookCounter')]"
+                                $workbookTemplateSpecContent.properties.contentKind = "Workbook"
+                                $workbookTemplateSpecContent.properties.displayName = "[parameters('workbook$global:workbookCounter-name')]"
+                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
+
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
+
+                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
+				$workbookTemplateSpecContent.properties.contentProductId = "[variables('_workbookcontentProductId$global:workbookCounter')]"                                
+                                $workbookTemplateSpecContent.properties.id = "[variables('_workbookcontentProductId$global:workbookCounter')]"
+                                $workbookTemplateSpecContent.properties.version = "[variables('workbookVersion$global:workbookCounter')]"
+                                $workbookTemplateSpecContent.PSObject.Properties.Remove('tags')
+                            }
+                            $global:baseMainTemplate.resources += $workbookTemplateSpecContent
+                        }
+                        else 
+                        {
+                            if ($contentToImport.version -ne '3.0.0' )
+                            {
+                                $global:baseMainTemplate.resources += $newWorkbook
+                                if ($contentToImport.Metadata -or $isPipelineRun)
+                                {
+                                    $global:baseMainTemplate.variables | Add-Member -NotePropertyName $fileName -NotePropertyValue $fileName
+                                    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_$fileName" -NotePropertyValue "[variables('$fileName')]"
+                                    $global:DependencyCriteria += [PSCustomObject]@{
+                                        kind      = "Workbook";
+                                        contentId = "[variables('_$fileName')]";
+                                        version   = "[variables('workbookVersion$global:workbookCounter')]";
+                                    };
+                                }
+                            }
+                        }
+                        $global:workbookCounter += 1
+    }
+
+    function GetPlaybookDataMetadata($file, $contentToImport, $contentResourceDetails, $json, $isPipelineRun)
+    {
+        Write-Host "Generating Playbook using $file"
+                    $playbookData = $json
+                    $playbookName = $(if ($playbookData.parameters.PlaybookName) { $playbookData.parameters.PlaybookName.defaultValue }elseif ($playbookData.parameters."Playbook Name") { $playbookData.parameters."Playbook Name".defaultValue })
+
+                    $fileName = Split-path -Parent $file | Split-Path -leaf
+                    if($fileName.ToLower() -eq "incident-trigger" -or $fileName.ToLower() -eq "alert-trigger" -or $fileName.ToLower() -eq "entity-trigger")
+                    { 
+                        $parentPath = Split-Path $file -Parent; 
+                        $fileName = (Split-Path $parentPath -Parent | Split-Path -leaf) + "-" + $fileName; 
+                    }
+                    
+                    if($playbookData.metadata -and $playbookData.metadata.source -and $playbookData.metadata.source.kind -and ($playbookData.metadata.source.kind -eq "Community" -or $playbookData.metadata.source.kind -eq "Standalone"))
+                    {
+                        throw "The file $fileName has metadata with source -> kind = Community | Standalone. Please remove it so that it can be packaged as a solution."
+                    }
+
+                    if ($contentToImport.Metadata -or $isPipelineRun) {
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName $fileName -NotePropertyValue $fileName
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_$fileName" -NotePropertyValue "[variables('$fileName')]"
+                    }
+
+                    $IsLogicAppsCustomConnector = ($playbookData.resources | Where-Object {($_.type.ToLower() -eq "Microsoft.Web/customApis".ToLower())}) ? $true : $false;
+                    $IsFunctionAppResource = ($playbookData.resources | Where-Object {($_.type.ToLower() -eq "Microsoft.Web/sites".ToLower())}) ? $true : $false;  
+
+                    $global:DependencyCriteria += [PSCustomObject]@{
+                        kind      = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook";
+                        contentId = "[variables('_$fileName')]";
+                        version   = "[variables('playbookVersion$global:playbookCounter')]";
+                    };
+
+                    if($fileName.ToLower() -match "FunctionApp")
+                    {
+                        $functionAppsPlaybookId = $playbookData.parameters.FunctionAppName.defaultValue
+
+                        if ($null -eq $functionAppsPlaybookId)
+                        {
+                            $suffix = 'fa'
+                            if (!$playbookName) {
+                                $functionAppMessage = "FunctionAppname not found in FunctionApp file $fileName so setting default value to '" + $fileName + "fa'"
+                                Write-Host "$functionAppMessage"
+                                $functionAppsPlaybookId = $fileName + $suffix
+                            }
+                            else {
+                                $functionAppMessage = "FunctionAppname not found in FunctionApp file $fileName so setting default value to '" + $playbookName + "fa'"
+                                Write-Host "$functionAppMessage"
+                                $functionAppsPlaybookId = $playbookName + $suffix
+                            }
+                        }
+                    }
+
+                    if (!$playbookName) {
+                        $playbookName = $fileName;
+                    }
+
+                    if ($global:playbookCounter -eq 1) {
+                        # If a playbook exists, add CreateUIDefinition step before playbook elements while handling first playbook.
+                        $playbookStep = [PSCustomObject] @{
+                            name       = "playbooks";
+                            label      = "Playbooks";
+                            subLabel   = [PSCustomObject] @{
+                                preValidation  = "Configure the playbooks";
+                                postValidation = "Done";
+                            };
+                            bladeTitle = "Playbooks";
+                            elements   = @(
+                                [PSCustomObject] @{
+                                    name    = "playbooks-text";
+                                    type    = "Microsoft.Common.TextBlock";
+                                    options = [PSCustomObject] @{
+                                        text = $contentToImport.PlaybooksBladeDescription ? $contentToImport.PlaybooksBladeDescription : "This solution installs the Playbook templates to help implement your Security Orchestration, Automation and Response (SOAR) operations. After installing the solution, these will be deployed under Playbook Templates in the Automation blade in Microsoft Sentinel. They can be configured and managed from the Manage solution view in Content Hub.";
+                                    }
+                                },
+                                [PSCustomObject] @{
+                                    name    = "playbooks-link";
+                                    type    = "Microsoft.Common.TextBlock";
+                                    options = [PSCustomObject] @{
+                                        link = [PSCustomObject] @{
+                                            label = "Learn more";
+                                            uri   = "https://docs.microsoft.com/azure/sentinel/tutorial-respond-threats-playbook?WT.mc_id=Portal-Microsoft_Azure_CreateUIDef"
+                                    }
+                                }
+                            })
+                        }
+                        $global:baseCreateUiDefinition.parameters.steps += $playbookStep
+                    }
+                    $playbookDescriptionText = $(if ($contentToImport.PlaybookDescription -and $contentToImport.PlaybookDescription -is [System.Array]) { $contentToImport.PlaybookDescription[$global:playbookCounter - 1] } elseif ($contentToImport.PlaybookDescription -and $contentToImport.PlaybookDescription -is [System.String]) { $contentToImport.PlaybookDescription } else { "" })
+                    $playbookElement = [PSCustomObject] @{
+                        name     = "playbook$global:playbookCounter";
+                        type     = "Microsoft.Common.Section";
+                        label    = $playbookName;
+                        elements = @(
+                            [PSCustomObject] @{
+                                name    = "playbook$global:playbookCounter-text";
+                                type    = "Microsoft.Common.TextBlock";
+                                options = [PSCustomObject] @{ text = if ($playbookData.metadata -and $playbookData.metadata.comments) { $playbookData.metadata.comments } else { "This playbook ingests events from $solutionName into Log Analytics using the API." } }
+                            }
+                        )
+                    }
+                    $currentStepNum = $global:baseCreateUiDefinition.parameters.steps.Count - 1
+                    #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements += $playbookElement
+
+                    foreach ($param in $playbookData.parameters.PsObject.Properties) {
+                        $paramName = $param.Name
+                        $defaultParamValue = $(if ($playbookData.parameters.$paramName.defaultValue) { $playbookData.parameters.$paramName.defaultValue } else { "" })
+                        if ($param.Name.ToLower().contains("playbookname")) {
+                            $playbookNameObject = [PSCustomObject] @{
+                                name         = $contentToImport.TemplateSpec ? $paramName : "playbook$global:playbookCounter-$paramName";
+                                type         = "Microsoft.Common.TextBox";
+                                label        = "Playbook Name";
+                                defaultValue = $defaultParamValue;
+                                toolTip      = "Resource name for the logic app playbook.  No spaces are allowed";
+                                constraints  = [PSCustomObject] @{
+                                    required          = $true;
+                                    regex             = "[a-z0-9A-Z]{1,256}$";
+                                    validationMessage = "Please enter a playbook resource name"
+                                }
+                            }
+                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookNameObject
+                            if(!$contentToImport.TemplateSpec)
+                            {
+                                $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
+                                        defaultValue = $playbookName;
+                                        type         = "string";
+                                        minLength    = 1;
+                                        metadata     = [PSCustomObject] @{ description = "Resource name for the logic app playbook.  No spaces are allowed"; }
+                                    })
+                            }
+                        }
+                        elseif ($param.Name.ToLower().contains("username")) {
+                            $playbookUsernameObject = [PSCustomObject] @{
+                                name         = $contentToImport.TemplateSpec ? $paramName : "playbook$global:playbookCounter-$paramName";
+                                type         = "Microsoft.Common.TextBox";
+                                label        = "$solutionName Username";
+                                defaultValue = $defaultParamValue;
+                                toolTip      = "Username to connect to $solutionName API";
+                                constraints  = [PSCustomObject] @{
+                                    required          = $true;
+                                    regex             = "[a-z0-9A-Z]{1,256}$";
+                                    validationMessage = "Please enter a playbook username";
+                                }
+                            }
+                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookUsernameObject
+                            if(!$contentToImport.TemplateSpec){
+                            $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
+                                    defaultValue = $defaultParamValue;
+                                    type         = "string";
+                                    minLength    = 1;
+                                    metadata     = [PSCustomObject] @{ description = "Username to connect to $solutionName API" }
+                                })
+                            }
+                        }
+                        elseif ($param.Name.ToLower().contains("password")) {
+                            $playbookPasswordObject = [PSCustomObject] @{
+                                name        = $contentToImport.TemplateSpec ? $paramName : "playbook$global:playbookCounter-$paramName";
+                                type        = "Microsoft.Common.PasswordBox";
+                                label       = [PSCustomObject] @{ password = $defaultParamValue; };
+                                toolTip     = "Password to connect to $solutionName API";
+                                constraints = [PSCustomObject] @{ required = $true; };
+                                options     = [PSCustomObject] @{ hideConfirmation = $false; };
+                            }
+                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookPasswordObject
+                            if(!$contentToImport.TemplateSpec){
+                            $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
+                                    type      = "securestring";
+                                    minLength = 1;
+                                    metadata  = [PSCustomObject] @{ description = "Password to connect to $solutionName API"; }
+                                })
+                            }
+                        }
+                        elseif ($param.Name.ToLower().contains("apikey")) {
+                            $playbookPasswordObject = [PSCustomObject] @{
+                                name        = $contentToImport.TemplateSpec ? $paramName : "playbook$global:playbookCounter-$paramName";
+                                type        = "Microsoft.Common.PasswordBox";
+                                label       = [PSCustomObject] @{password = "ApiKey" };
+                                toolTip     = "ApiKey to connect to $solutionName API";
+                                constraints = [PSCustomObject] @{ required = $true; };
+                                options     = [PSCustomObject] @{ hideConfirmation = $true; };
+                            }
+                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookPasswordObject
+                            if(!$contentToImport.TemplateSpec)
+                            {
+                                $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
+                                        type      = "securestring";
+                                        minLength = 1;
+                                        metadata  = [PSCustomObject] @{ description = "ApiKey to connect to $solutionName API"; }
+                                    })
+                            }
+                        }
+                        else {
+                            function PascalSplit ($pascalStr) {
+                                foreach ($piece in $pascalStr) {
+                                    if ($piece -is [array]) {
+                                        foreach ($subPiece in $piece) { PascalSplit $subPiece }
+                                    }
+                                    else {
+                                        ($piece.ToString() -creplace '[A-Z]', ' $&').Trim().Split($null)
+                                    }
+                                }
+                            }
+
+                            $playbookParamObject = $(
+                                if ($playbookData.parameters.$paramName.allowedValues) {
+                                    [PSCustomObject] @{
+                                        name         = $contentToImport.TemplateSpec ? $paramName : "playbook$global:playbookCounter-$paramName";
+                                        type         = "Microsoft.Common.DropDown";
+                                        label        = "$(PascalSplit $paramName)";
+                                        placeholder  = "$($playbookData.parameters.$paramName.allowedValues[0])";
+                                        defaultValue = "$($playbookData.parameters.$paramName.allowedValues[0])";
+                                        toolTip      = "Please enter $(if($paramName.IndexOf("-") -ne -1){$paramName}else{PascalSplit $paramName})";
+                                        constraints  = [PSCustomObject] @{
+                                            allowedValues = $playbookData.parameters.$paramName.allowedValues | ForEach-Object {
+                                                [PSCustomObject] @{
+                                                    label = $_;
+                                                    value = $_;
+                                                }
+                                            }
+                                            required      = $true;
+                                        }
+                                        visible      = $true;
+                                    }
+                                }
+                                else {
+                                    [PSCustomObject] @{
+                                        name         = $contentToImport.TemplateSpec ? $paramName : "playbook$global:playbookCounter-$paramName";
+                                        type         = "Microsoft.Common.TextBox";
+                                        label        = "$(PascalSplit $paramName)";
+                                        defaultValue = $defaultParamValue;
+                                        toolTip      = "Please enter $(if($paramName.IndexOf("-") -ne -1){$paramName}else{PascalSplit $paramName})";
+                                        constraints  = [PSCustomObject] @{
+                                            required          = $true;
+                                            regex             = "[a-z0-9A-Z]{1,256}$";
+                                            validationMessage = "Please enter the $(PascalSplit $paramName)"
+                                        }
+                                    }
+                                }
+                            )
+                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookParamObject
+                            $defaultValue = $(if ($defaultParamValue) { $defaultParamValue } else { "" })
+                            if(!$contentToImport.TemplateSpec){
+                            $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
+                                    defaultValue = $defaultValue;
+                                    type         = "string";
+                                    minLength    = 1;
+                                })
+                            }
+                        }
+                        if(!$contentToImport.TemplateSpec){
+                            $global:baseCreateUiDefinition.parameters.outputs | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue "[steps('playbooks').playbook$global:playbookCounter.playbook$global:playbookCounter-$paramName]"
+                        }
+                    }
+
+                    foreach ($playbookVariable in $playbookData.variables.PsObject.Properties) {
+                        $variableName = $playbookVariable.Name
+                        $variableValue = $playbookVariable.Value
+                        if ($variableValue -is [System.String]) {
+                            $variableValue = $(node "$PSScriptRoot/templating/replacePlaybookParamNames.js" $variableValue $global:playbookCounter)
+                        }
+                        if($contentToImport.TemplateSpec -and $variableName.ToLower().Contains("connection"))
+                        {
+                            $variableValue = "[" + $variableValue ;
+                        }
+                        if (!$contentToImport.TemplateSpec -and $variableName.ToLower().contains("apikey")) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbook-$variableName" -NotePropertyValue "[$variableValue]"
+                        }
+                        elseif (!$contentToImport.TemplateSpec) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbook$global:playbookCounter-$variableName" -NotePropertyValue $variableValue
+                        }
+                    }
+
+                    $azureManagementUrlExists = $false
+                    $azureManagementUrl = "management.azure.com"
+
+                    function replaceQuotes ($inputStr) {
+                        $baseStr = $resourceObj.$key
+                        $outputStr = $baseStr.Replace("`"", "\`"")
+                        $outputStr
+                    }
+
+                    function removeBlanksRecursively($resourceObj) {
+                        if ($resourceObj.GetType() -ne [System.DateTime]) {
+                            foreach ($prop in $resourceObj.PsObject.Properties) {
+                                $key = $prop.Name
+                                if ($prop.Value -is [System.String]) {
+                                    #Write-Host "its a string $resourceObj.$key"
+                                    if($resourceObj.$key -eq "")
+                                    {
+                                        $resourceObj.$key = "[variables('blanks')]";
+
+                                        if (!$global:baseMainTemplate.variables.blanks) {
+                                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "blanks" -NotePropertyValue "[replace('b', 'b', '')]"
+                                        }
+                                    }
+                                }
+                                elseif ($prop.Value -is [System.Array]) {
+                                    foreach ($item in $prop.Value) {
+                                        $itemIndex = $prop.Value.IndexOf($item)
+                                        if ($null -ne $itemIndex) {
+                                            if ($item -is [System.String]) {
+                                                $resourceObj.$key[$itemIndex] = $item
+                                            }
+                                            elseif ($item -is [System.Management.Automation.PSCustomObject]) {
+                                                $resourceObj.$key[$itemIndex] = $(removeBlanksRecursively $item)
+                                            }
+                                        }
+                                    }
+                                }
+                                else {
+                                    if (($prop.Value -isnot [System.Int32]) -and ($prop.Value -isnot [System.Int64])) {
+                                        $resourceObj.$key = $(removeBlanksRecursively $resourceObj.$key)
+                                    }
+                                }
+                            }
+                        }
+                        $resourceObj
+                    }
+
+                    function addInternalSuffixRecursively($resourceObj) {
+                        if ($resourceObj.GetType() -ne [System.DateTime]) {
+                            foreach ($prop in $resourceObj.PsObject.Properties) {
+                                $key = $prop.Name
+                                if ($prop.Value -is [System.String]) {
+                                    $resourceObj.$key = $resourceObj.$key.Replace("resourceGroup().location", "variables('workspace-location-inline')")
+                                    if ($key -eq "operationId") {
+                                        $playbookData.variables | Add-Member -NotePropertyName "operationId-$($resourceobj.$key)" -NotePropertyValue $($resourceobj.$key)
+                                        $playbookData.variables | Add-Member -NotePropertyName "_operationId-$($resourceobj.$key)" -NotePropertyValue "[variables('operationId-$($resourceobj.$key)')]"
+                                        $resourceObj.$key = "[variables('_operationId-$($resourceobj.$key)')]"
+                                    }
+                                    if($contentToImport.TemplateSpec -and ($resourceObj.$key.StartsWith("[")) -and ($resourceObj.$key -ne "[variables('TemplateEmptyArray')]"))
+                                    {
+                                        $resourceObj.$key = "[" + $resourceObj.$key;
+                                    }
+                                }
+                                elseif ($prop.Value -is [System.Array]) {
+                                    foreach ($item in $prop.Value) {
+                                        $itemIndex = $prop.Value.IndexOf($item)
+                                        if ($null -ne $itemIndex) {
+                                            if ($item -is [System.String]) {
+                                                $item = $item.Replace("resourceGroup().location", "variables('workspace-location-inline')")
+                                                if($contentToImport.TemplateSpec -and ($item.StartsWith("[")))
+                                                {
+                                                    $item = "[" + $item;
+                                                }
+                                                $resourceObj.$key[$itemIndex] = $item
+                                            }
+                                            elseif ($item -is [System.Management.Automation.PSCustomObject]) {
+                                                $resourceObj.$key[$itemIndex] = $(addInternalSuffixRecursively $item)
+                                            }
+                                        }
+                                    }
+                                }
+                                else {
+                                    if (($prop.Value -isnot [System.Int32]) -and ($prop.Value -isnot [System.Int64])) {
+                                        $resourceObj.$key = $(addInternalSuffixRecursively $resourceObj.$key)
+                                    }
+                                }
+                            }
+                        }
+                        $resourceObj
+                    }
+
+                    function replaceVarsRecursively ($resourceObj) {
+                        if ($resourceObj.GetType() -ne [System.DateTime]) {
+                            foreach ($prop in $resourceObj.PsObject.Properties) {
+                                $key = $prop.Name
+                                if ($prop.Value -is [System.String]) {
+                                    $resourceObj.$key = $(node "$PSScriptRoot/templating/replacePlaybookParamNames.js" "$(replaceQuotes $resourceObj.$key)" $global:playbookCounter)
+                                    if($contentToImport.TemplateSpec -and ($resourceObj.$key.StartsWith("[") -and $resourceObj.$key.Contains("parameters(") -and !$resourceObj.$key.contains("parameters('workspace-location')")))
+                                    {
+                                        $resourceObj.$key = "[" + $resourceObj.$key;
+                                    }
+                                    if ($resourceObj.$key.StartsWith("[") -and $resourceObj.$key[$resourceObj.$key.Length - 1] -eq "]") {
+                                        $resourceObj.$key = $(node "$PSScriptRoot/templating/replacePlaybookVarNames.js" "$(replaceQuotes $resourceObj.$key)" $global:playbookCounter)
+                                    }
+                                    $resourceObj.$key = $(node "$PSScriptRoot/templating/replaceLocationValue.js" "$(replaceQuotes $resourceObj.$key)" $global:playbookCounter)
+                                    if ($resourceObj.$key.IndexOf($azureManagementUrl)) {
+                                        $resourceObj.$key = $resourceObj.$key.Replace($azureManagementUrl, "@{variables('azureManagementUrl')}")
+                                        $azureManagementUrlExists = $true
+                                    }
+                                    if ($key -eq "operationId") {
+                                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "operationId-$($resourceobj.$key)" -NotePropertyValue $($resourceobj.$key)
+                                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_operationId-$($resourceobj.$key)" -NotePropertyValue "[variables('operationId-$($resourceobj.$key)')]"
+                                        $resourceObj.$key = "[variables('_operationId-$($resourceobj.$key)')]"
+                                    }
+                                }
+                                elseif ($prop.Value -is [System.Array]) {
+                                    foreach ($item in $prop.Value) {
+                                        $itemIndex = $prop.Value.IndexOf($item)
+                                        if ($null -ne $itemIndex) {
+                                            if ($item -is [System.String]) {
+                                                $item = $(node "$PSScriptRoot/templating/replaceLocationValue.js" $item $global:playbookCounter)
+                                                $item = $(node "$PSScriptRoot/templating/replacePlaybookParamNames.js" $item $global:playbookCounter)
+                                                if($contentToImport.TemplateSpec -and ($item.StartsWith("[") -and $item.Contains("parameters(") -and !$item.contains("parameters('workspace-location')")))
+                                                {
+                                                    $item = "[" + $item;
+                                                }
+                                                if ($item.StartsWith("[") -and $item[$item.Length - 1] -eq "]") {
+                                                    $item = $(node "$PSScriptRoot/templating/replacePlaybookVarNames.js" $item $global:playbookCounter)
+                                                }
+                                                $resourceObj.$key[$itemIndex] = $item
+                                            }
+                                            elseif ($item -is [System.Management.Automation.PSCustomObject]) {
+                                                $resourceObj.$key[$itemIndex] = $(replaceVarsRecursively $item)
+                                            }
+                                        }
+                                    }
+                                }
+                                else {
+                                    if (($prop.Value -isnot [System.Int32]) -and ($prop.Value -isnot [System.Int64])) {
+                                        $resourceObj.$key = $(replaceVarsRecursively $resourceObj.$key)
+                                    }
+                                }
+                            }
+                        }
+                        $resourceObj
+                    }
+                    $connectionCounter = 1
+                    function getConnectionVariableName($connectionVariable) {
+                        foreach ($templateVar in $($global:baseMainTemplate.variables).PSObject.Properties) {
+                            if ($templateVar.Value -eq $connectionVariable) {
+                                return $templateVar.Name
+                            }
+                        }
+                        return $false
+                    }
+
+                    $playbookDependencies = @();
+                    $playbookResources = @();
+                    $playbookVersion = '1.0';
+                    $logicAppsPlaybookId = '';
+                    $global:contentShortName = '';
+                    $customConnectorContentId = '';
+                    $FunctionResource = @();
+                    foreach ($playbookResource in $playbookData.resources) {
+                        if ($playbookResource.type -eq "Microsoft.Web/connections") {
+                            if ($playbookResource.properties -and $playbookResource.properties.api -and $playbookResource.properties.api.id) {
+                                if ($playbookResource.properties.api.id.Contains("/providers/Microsoft.Web/customApis/")) {
+                                    $splits = $playbookResource.properties.api.id.Split(',');
+                                    $connectionKey = $splits[-1].Trim().Replace("parameters('","").Replace("'","").Replace(")","").Replace("]","");
+
+                                    foreach ($templateVar in $($playbookData.parameters).PSObject.Properties) {
+                                        if ($templateVar.Name -eq $connectionKey) {
+                                            $playbookDependencies += [PSCustomObject] @{
+                                                kind = "LogicAppsCustomConnector";
+                                                contentId = $global:customConnectorsList[$templateVar.Value.defaultValue].id;
+                                                version = $global:customConnectorsList[$templateVar.Value.defaultValue].version;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                $connectionVar = $playbookResource.properties.api.id
+                                $connectionVar = $connectionVar.Replace("resourceGroup().location", "variables('workspace-location-inline')")
+                                $variableReferenceString = "[variables"
+                                $varName = ""
+                                if ($connectionVar.StartsWith($variableReferenceString)) {
+                                    # Get value of variable
+                                    $varName = $($connectionVar.Split("'"))[1]
+                                    # Handle variable reference pairs
+                                    if ($playbookData.variables.$varName.StartsWith($variableReferenceString)) {
+                                        $varName = $($playbookData.variables.$varName.Split("'"))[1]
+                                    }
+                                    $connectionVar = $playbookData.variables.$varName
+                                    $connectionVar = $connectionVar.Replace("resourceGroup().location", "variables('workspace-location-inline')")
+
+                                }
+                                $foundConnection = getConnectionVariableName $connectionVar
+                                if ($foundConnection) {
+                                    $playbookResource.properties.api.id = "[variables('_$foundConnection')]"
+                                }
+                                else {
+                                    $playbookData.variables | Add-Member -NotePropertyName "connection-$connectionCounter" -NotePropertyValue $connectionVar
+                                    $playbookData.variables | Add-Member -NotePropertyName "_connection-$connectionCounter" -NotePropertyValue "[variables('connection-$connectionCounter')]"
+                                    $playbookResource.properties.api.id = "[variables('_connection-$connectionCounter')]"
+                                }
+                                if(($playbookResource.properties.parameterValues) -and ($null -ne $global:baseMainTemplate.variables.'playbook-ApiKey')) {
+                                    $playbookResource.properties.parameterValues.api_key = "[variables('playbook-ApiKey')]"
+                                }
+                            }
+                        }
+                        elseif ($contentToImport.TemplateSpec -and $playbookResource.type -eq "Microsoft.Logic/workflows") {
+                            if($null -eq $playbookResource.tags)
+                            {
+                                $playbookResource | Add-Member -NotePropertyName "tags" -NotePropertyValue ([PSCustomObject]@{});
+                            }
+                            $playbookResource.tags | Add-Member -NotePropertyName "hidden-SentinelWorkspaceId" -NotePropertyValue "[variables('workspaceResourceId')]";
+                            $playbookVersion = $playbookResource.tags.'hidden-SentinelTemplateVersion' ? $playbookResource.tags.'hidden-SentinelTemplateVersion' : $playbookVersion;
+                        } elseif ($contentToImport.TemplateSpec -and $playbookResource.type -eq "Microsoft.Web/customApis") {
+                            $logicAppsPlaybookId = $playbookResource.name.Replace("parameters('","").Replace("'","").Replace(")","").Replace("]","").Replace("[","");
+                            $customConnectorContentId = $playbookData.parameters.$logicAppsPlaybookId.defaultValue
+                            
+                        }
+
+
+                        $playbookResource =  $playbookResource
+                        $playbookResource = $(removePropertiesRecursively $playbookResource)
+                        $playbookResource =  $(addInternalSuffixRecursively $playbookResource)
+                        $playbookResource =  $(removeBlanksRecursively $playbookResource)
+                        $playbookResources += $playbookResource;
+                        $connectionCounter += 1
+                    }
+
+                    if(!$IsFunctionAppResource -and $rawData -like '*Microsoft.Web/sites*')
+                    {
+                        if ($null -ne $playbookData -and $null -ne $playbookData.parameters)
+                        {
+                            foreach($param in $playbookData.parameters.PsObject.Properties)
+                            {
+                                if($param.Value -match "defaultValue" -and $global:functionAppList.ContainsKey($param.Value.defaultValue))
+                                {
+                                    $playbookDependencies += [PSCustomObject] @{
+                                            kind = "AzureFunction";
+                                            contentId = $global:functionAppList[$param.Value.defaultValue].id;
+                                            version = $global:functionAppList[$param.Value.defaultValue].version;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if($contentToImport.TemplateSpec)
+                    {
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookVersion$global:playbookCounter" -NotePropertyValue $playbookVersion
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookContentId$global:playbookCounter" -NotePropertyValue $fileName
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookContentId$global:playbookCounter" -NotePropertyValue "[variables('playbookContentId$global:playbookCounter')]"
+
+                        if (!$IsLogicAppsCustomConnector -and !$IsFunctionAppResource) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookId$global:playbookCounter" -NotePropertyValue "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId$global:playbookCounter'))]"
+                        }
+
+                        #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue ($IsLogicAppsCustomConnector ? "[concat(parameters('workspace'),'-lc-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]" : "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]")
+
+                        if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                        {
+                            if ($IsLogicAppsCustomConnector) {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-lc-',uniquestring(variables('_playbookContentId$global:playbookCounter'))),variables('playbookVersion$global:playbookCounter')))]"
+                                $global:contentShortName  = 'lc'
+                            }
+                            elseif ($IsFunctionAppResource) {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-fa-',uniquestring(variables('_playbookContentId$global:playbookCounter'))),variables('playbookVersion$global:playbookCounter')))]"
+                                $global:contentShortName  = 'fa'
+                            }
+                            else {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue  "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId$global:playbookCounter'))),variables('playbookVersion$global:playbookCounter')))]"
+                                $global:contentShortName  = 'pl'
+                            } 
+                        }
+                        else
+                        {
+                        if ($IsLogicAppsCustomConnector) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'-lc-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]"
+                            $global:contentShortName  = 'lc'
+                        }
+                        elseif ($IsFunctionAppResource) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'-fa-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]"
+                            $global:contentShortName  = 'fa'
+                        }
+                        else {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]"
+                            $global:contentShortName  = 'pl'
+                        }
+                    }
+
+                        # $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue ($IsLogicAppsCustomConnector ? 
+                        # "[concat(parameters('workspace'),'-lc-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]" : 
+                        # $IsFunctionAppResource ? "[concat(parameters('workspace'),'-fa-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]" :
+                        # "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]")
+                        
+                        # Add workspace resource ID if not available
+                        if (!$global:baseMainTemplate.variables.workspaceResourceId) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
+                        }
+                        # Add base templateSpec
+                        if ($contentResourceDetails.contentSchemaVersion -ne '3.0.0')
+                        {
+                            $basePlaybookTemplateSpec = [PSCustomObject]@{
+                                type       = $contentResourceDetails.resourcetype; # "Microsoft.Resources/templateSpecs";
+                                apiVersion = "2022-02-01";
+                                name       = "[variables('playbookTemplateSpecName$global:playbookCounter')]";
+                                location   = "[parameters('workspace-location')]";
+                                tags       = [PSCustomObject]@{
+                                    "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                    "hidden-sentinelContentType" = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook";
+                                };
+                                # properties = [PSCustomObject]@{
+                                #     description = $IsLogicAppsCustomConnector ? $playbookName : "$($playbookName) playbook";
+                                #     displayName = $IsLogicAppsCustomConnector ? $playbookName : "$($playbookName) playbook";
+                                # }
+                                properties = [PSCustomObject]@{
+                                    description = $IsLogicAppsCustomConnector -or $IsFunctionAppResource ? $playbookName : "$($playbookName) playbook";
+                                    displayName = $IsLogicAppsCustomConnector -or $IsFunctionAppResource ? $playbookName : "$($playbookName) playbook";
+                                }
+                            }
+
+                            $global:baseMainTemplate.resources += $basePlaybookTemplateSpec
+                        }
+                        $author = $contentToImport.Author.Split(" - ");
+                        $authorDetails = [PSCustomObject]@{
+                            name  = $author[0];
+                        };
+                        if($null -ne $author[1])
+                        {
+                            $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+                        }
+                        if ($IsLogicAppsCustomConnector) {
+                            $global:customConnectorsList.add($customConnectorContentId, @{ id="[variables('_$filename')]"; version="[variables('playbookVersion$global:playbookCounter')]"});
+                        }
+                        if ($IsFunctionAppResource) {
+                            if ($null -ne $functionAppsPlaybookId)
+                            {
+                                $global:functionAppList.add($functionAppsPlaybookId, @{ id="[variables('_$filename')]"; version="[variables('playbookVersion$global:playbookCounter')]"});
+                            }
+                        }
+
+                        $playbookMetadata = [PSCustomObject]@{
+                            type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+                            apiVersion = "2022-01-01-preview";
+                            #name       = $IsLogicAppsCustomConnector ? "[[concat(variables('workspace-name'),'/Microsoft.SecurityInsights/',concat('LogicAppsCustomConnector-', last(split(variables('playbookId'),'/'))))]" : "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]";
+                            name       = $IsLogicAppsCustomConnector ? "[[concat(variables('workspace-name'),'/Microsoft.SecurityInsights/',concat('LogicAppsCustomConnector-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]" : 
+                            $IsFunctionAppResource ? "[[concat(variables('workspace-name'),'/Microsoft.SecurityInsights/',concat('AzureFunction-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]" :
+                            "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]";
+                            properties = [PSCustomObject]@{
+                                parentId  = $IsLogicAppsCustomConnector -or $IsFunctionAppResource ? "[[variables('playbookId$global:playbookCounter')]" : "[variables('playbookId$global:playbookCounter')]"
+                                contentId = "[variables('_playbookContentId$global:playbookCounter')]";
+                                kind      = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook";
+                                version   = "[variables('playbookVersion$global:playbookCounter')]";
+                                source    = [PSCustomObject]@{
+                                    kind     = "Solution";
+                                    name     = $contentToImport.Name;
+                                    sourceId = "[variables('_solutionId')]"
+                                };
+                                author    = $authorDetails;
+                                support   = $baseMetadata.support
+                            }
+                        }
+
+                        if ($playbookDependencies) {
+                            $criteria = [PSCustomObject]@{
+                                criteria = $playbookDependencies
+                            };
+                            $playbookMetadata.properties | Add-Member -NotePropertyName "dependencies" -NotePropertyValue $criteria
+                        }
+
+                        $playbookVariables = [PSCustomObject]@{};
+                        foreach($var in $playbookData.variables.PsObject.Properties)
+                        {
+                            $playbookVariables | Add-Member -NotePropertyName $var.Name -NotePropertyValue $(($contentToImport.TemplateSpec -and $var.Value.StartsWith("[")) ? "[" + $var.Value : $var.Value);
+                        }
+
+                        $playbookVariables | Add-Member -NotePropertyName "workspace-location-inline" -NotePropertyValue "[concat('[resourceGroup().locatio', 'n]')]";
+                        if ($IsLogicAppsCustomConnector) {
+                            $playbookVariables | Add-Member -NotePropertyName "playbookContentId$global:playbookCounter" -NotePropertyValue $fileName;
+                            $playbookVariables | Add-Member -NotePropertyName "playbookId$global:playbookCounter" -NotePropertyValue "[[resourceId('Microsoft.Web/customApis', parameters('$logicAppsPlaybookId'))]"
+                        }
+
+                        if ($IsFunctionAppResource) {
+                            $playbookVariables | Add-Member -NotePropertyName "playbookContentId$global:playbookCounter" -NotePropertyValue $fileName;
+                            $playbookVariables | Add-Member -NotePropertyName "playbookId$global:playbookCounter" -NotePropertyValue "[[resourceId('Microsoft.Logic/workflows', variables('playbookContentId$global:playbookCounter'))]"
+                        }
+
+                        $playbookVariables | Add-Member -NotePropertyName "workspace-name" -NotePropertyValue "[parameters('workspace')]"
+                        $playbookVariables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[[resourceId('microsoft.OperationalInsights/Workspaces', variables('workspace-name'))]"
+                        $playbookResources = $playbookResources + $playbookMetadata;
+
+                        $playbookMetadata = [PSCustomObject]@{};
+                        foreach($var in $playbookData.metadata.PsObject.Properties)
+                        {
+                            $playbookMetadata | Add-Member -NotePropertyName $var.Name -NotePropertyValue $var.Value;
+                        }
+
+                        # Add templateSpecs/versions resource to hold actual content
+                        $playbookTemplateSpecContent = [PSCustomObject]@{
+                            type       = $contentResourceDetails.subtype; # "Microsoft.Resources/templateSpecs/versions";
+                            apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-02-01";
+                            name       = $contentResourceDetails.apiVersion -eq '3.0.0' ? "[variables('playbookTemplateSpecName$global:playbookCounter')]" : "[concat(variables('playbookTemplateSpecName$global:playbookCounter'),'/',variables('playbookVersion$global:playbookCounter'))]";
+                            location   = "[parameters('workspace-location')]";
+                            tags       = [PSCustomObject]@{
+                                "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                "hidden-sentinelContentType" = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook";
+                            };
+                            # dependsOn  = @(
+                            #     "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName$global:playbookCounter'))]"
+                            # );
+                            dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
+                                "$($contentResourceDetails.dependsOn)") : @(
+                                "$($contentResourceDetails.dependsOn), variables('playbookTemplateSpecName$global:playbookCounter'))]"
+                            );
+                            properties = [PSCustomObject]@{
+                                description  = "$($playbookName) Playbook with template version $($contentToImport.Version)";
+                                mainTemplate = [PSCustomObject]@{
+                                    '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+                                    contentVersion = "[variables('playbookVersion$global:playbookCounter')]";
+                                    parameters     = $playbookData.parameters;
+                                    variables      = $playbookVariables;
+                                    resources      = $playbookResources;
+                                };
+                            }
+                        }
+                        if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                        {
+                            $playbookTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $playbookTemplateSpecContent
+                            $playbookTemplateSpecContent.properties.contentId = "[variables('_playbookContentId$global:playbookCounter')]"
+                            $playbookTemplateSpecContent.properties.contentKind = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook"
+                            $playbookTemplateSpecContent.properties.displayName = $playbookName
+                            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
+
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
+
+                            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
+			    $playbookTemplateSpecContent.properties.contentProductId = "[variables('_playbookcontentProductId$global:playbookCounter')]"
+                             $playbookTemplateSpecContent.properties.id = "[variables('_playbookcontentProductId$global:playbookCounter')]"
+                            $playbookTemplateSpecContent.properties.version = "[variables('playbookVersion$global:playbookCounter')]"
+                            $playbookTemplateSpecContent.PSObject.Properties.Remove('tags')
+                        }
+
+                        if (@($playbookMetadata.PsObject.Properties).Count -gt 0) {
+                            Write-Host "creating metadata for playbook"
+                            $playbookTemplateSpecContent.properties.mainTemplate | Add-Member -NotePropertyName "metadata" -NotePropertyValue ([PSCustomObject]@{});
+                            foreach($var in $playbookMetadata.PsObject.Properties) {
+                                if ($var.Name -ne "author" -and $var.Name -ne "support" -and $var.Name -ne "prerequisitesDeployTemplateFile") {
+                                    $playbookTemplateSpecContent.properties.mainTemplate.metadata | Add-Member -NotePropertyName $var.Name -NotePropertyValue $var.Value;
+                                }
+                            }
+                            if (!$playbookTemplateSpecContent.properties.mainTemplate.metadata.'lastUpdateTime') {
+                                $playbookTemplateSpecContent.properties.mainTemplate.metadata | Add-Member -NotePropertyName "lastUpdateTime" -NotePropertyValue (get-date -format "yyyy-MM-ddTHH:mm:ss.fffZ");
+                            }
+                        }
+                        if (!$playbookMetadata.releaseNotes -and $playbookTemplateSpecContent.properties.mainTemplate.metadata) {
+                            Write-Host "adding default release notes"
+                            $releaseNotes = [PSCustomObject]@{
+                                version = $playbookVersion;
+                                title      = "[variables('blanks')]";
+                                notes      = @("Initial version");
+                            }
+                            $playbookTemplateSpecContent.properties.mainTemplate.metadata | Add-Member -NotePropertyName 'releaseNotes' -NotePropertyValue $releaseNotes;
+                            if (!$global:baseMainTemplate.variables.blanks) {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "blanks" -NotePropertyValue "[replace('b', 'b', '')]"
+                            }
+                        }
+
+                        if ($null -ne $playbookTemplateSpecContent.properties.mainTemplate.metadata.entities -and
+                            $playbookTemplateSpecContent.properties.mainTemplate.metadata.entities.count -le 0)
+                        {
+                            $playbookTemplateSpecContent.properties.mainTemplate.metadata.PSObject.Properties.Remove("entities");
+                        }
+
+                        if ($null -ne $playbookTemplateSpecContent.properties.mainTemplate.metadata.tags -and
+                            $playbookTemplateSpecContent.properties.mainTemplate.metadata.tags.count -le 0)
+                        {
+                            $playbookTemplateSpecContent.properties.mainTemplate.metadata.PSObject.Properties.Remove("tags");
+                        }
+
+                        if ($null -ne $playbookTemplateSpecContent.properties.mainTemplate.metadata.prerequisites -and
+                        [string]::IsNullOrWhitespace($playbookTemplateSpecContent.properties.mainTemplate.metadata.prerequisites))
+                        {
+                            $playbookTemplateSpecContent.properties.mainTemplate.metadata.PSObject.Properties.Remove("prerequisites");
+                        }
+                        $global:baseMainTemplate.resources += $playbookTemplateSpecContent;
+                    }
+                    else
+                    {
+                        $global:baseMainTemplate.resources += $playbookResources;
+                    }
+
+                    if ($azureManagementUrlExists) {
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "azureManagementUrl" -NotePropertyValue $azureManagementUrl
+                    }
+
+                    $global:playbookCounter += 1
+    }
+
+    function GetDataConnectorMetadata($file, $contentResourceDetails)
+    {
+        Write-Host "Generating Data Connector using $file"
+                    try {
+                        $ccpPollingConfig = [PSCustomObject] @{}
+                        $ccpConnector = $false
+                        $connectorData = ConvertFrom-Json $rawData
+                        # If both ID and Title exist, is standard GenericUI data connector
+                        if ($connectorData.resources -and
+                        $connectorData.resources[0] -and
+                        $connectorData.resources[0].properties -and
+                        $connectorData.resources[0].properties.connectorUiConfig -and
+                        $connectorData.resources[0].properties.pollingConfig) {
+                            $ccpPollingConfig = $connectorData.resources[0].properties.pollingConfig
+                            $ccpConnector = $true
+                            $templateSpecConnectorData = $connectorData.resources[0].properties.connectorUiConfig
+                        }
+                        else
+                        {
+                            $ccpPollingConfig = $null
+                            $ccpConnector = $false
+                            $templateSpecConnectorData = $connectorData
+                        }
+                    }
+                    catch {
+                        Write-Host "Failed to deserialize $file" -ForegroundColor Red
+                        break;
+                    }
+                    # $connectorNameParamObj = [PSCustomObject] @{
+                    #     type         = "string";
+                    #      defaultValue = $(New-Guid).Guid
+                    # }
+                    #  $connectorId = $connectorData.id + 'Connector';
+                    # if ($contentToImport.Metadata -and !$contentToImport.TemplateSpec) {
+                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName $connectorId -NotePropertyValue $connectorId
+                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_$connectorId" -NotePropertyValue "[variables('$connectorId')]"
+                    # }
+                    #  if (!$contentToImport.TemplateSpec){
+                    #     $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "connector$global:connectorCounter-name" -NotePropertyValue $connectorNameParamObj
+                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName "connector$global:connectorCounter-source" -NotePropertyValue "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'),'/providers/Microsoft.SecurityInsights/dataConnectors/',parameters('connector$global:connectorCounter-name'))]"
+                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_connector$global:connectorCounter-source" -NotePropertyValue "[variables('connector$global:connectorCounter-source')]"
+                    #  };
+                    $global:DependencyCriteria += [PSCustomObject]@{
+                        kind      = "DataConnector";
+                        contentId = if ($contentToImport.TemplateSpec){"[variables('_dataConnectorContentId$global:connectorCounter')]"}else{"[variables('_$connectorId')]"};
+                        version   = if ($contentToImport.TemplateSpec){"[variables('dataConnectorVersion$global:connectorCounter')]"}else{$contentToImport.Version};
+                    };
+                    foreach ($step in $templateSpecConnectorData.instructionSteps) {
+                        # Remove empty properties from each instructionStep
+                        $stepIndex = $templateSpecConnectorData.instructionSteps.IndexOf($step)
+                        $templateSpecConnectorData.instructionSteps[$stepIndex] = handleEmptyInstructionProperties $step
+                    }
+
+                    if ($contentToImport.TemplateSpec) {
+                        $connectorName = $contentToImport.Name
+                        # Add workspace resource ID if not available
+                        if (!$global:baseMainTemplate.variables.workspaceResourceId) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
+                        }
+                        # If both ID and Title exist, is standard GenericUI data connector
+                        if ($templateSpecConnectorData.id -and $templateSpecConnectorData.title) {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "uiConfigId$global:connectorCounter" -NotePropertyValue $templateSpecConnectorData.id
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_uiConfigId$global:connectorCounter" -NotePropertyValue "[variables('uiConfigId$global:connectorCounter')]"
+                        }
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorContentId$global:connectorCounter" -NotePropertyValue $templateSpecConnectorData.id
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorContentId$global:connectorCounter" -NotePropertyValue "[variables('dataConnectorContentId$global:connectorCounter')]"
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorId$global:connectorCounter" -NotePropertyValue "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/dataConnectors', variables('_dataConnectorContentId$global:connectorCounter'))]"
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorId$global:connectorCounter" -NotePropertyValue "[variables('dataConnectorId$global:connectorCounter')]"
+
+                        if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                        {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorTemplateSpecName$global:connectorCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-dc-',uniquestring(variables('_dataConnectorContentId$global:connectorCounter'))),variables('dataConnectorVersion$global:connectorCounter')))]"
+                        }
+                        else 
+                        {
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorTemplateSpecName$global:connectorCounter" -NotePropertyValue "[concat(parameters('workspace'),'-dc-',uniquestring(variables('_dataConnectorContentId$global:connectorCounter')))]"
+                        }
+
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorVersion$global:connectorCounter" -NotePropertyValue (($null -ne $templateSpecConnectorData.metadata) ? "$($templateSpecConnectorData.metadata.version)" : "1.0.0")
+                        if (!$contentToImport.TemplateSpec){
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parentId" -NotePropertyValue $global:solutionId
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parentId" -NotePropertyValue "[variables('parentId')]"
+                        };
+
+                        if ($contentResourceDetails.contentSchemaVersion -ne '3.0.0')
+                        {
+                            # Add base templateSpec
+                            $baseDataConnectorTemplateSpec = [PSCustomObject]@{
+                                type       = $contentResourceDetails.resourcetype; # "Microsoft.Resources/templateSpecs";
+                                apiVersion = "2022-02-01";
+                                name       = "[variables('dataConnectorTemplateSpecName$global:connectorCounter')]";
+                                location   = "[parameters('workspace-location')]";
+                                tags       = [PSCustomObject]@{
+                                    "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                    "hidden-sentinelContentType" = "DataConnector";
+                                };
+                                properties = [PSCustomObject]@{
+                                    description = "$($connectorName) data connector with template";
+                                    displayName = "$($connectorName) template";
+                                }
+                            }
+                            $global:baseMainTemplate.resources += $baseDataConnectorTemplateSpec
+                        }
+                        if(!$contentToImport.Is1PConnector)
+                        {
+                            $existingFunctionApp = $false;
+                            $instructionArray = $templateSpecConnectorData.instructionSteps
+                            ($instructionArray | ForEach {if($_.description -and $_.description.IndexOf('[Deploy To Azure]') -gt 0){$existingFunctionApp = $true;}})
+                            if($existingFunctionApp)
+                            {
+                                $templateSpecConnectorData.title = ($templateSpecConnectorData.title.Contains("using Azure Functions")) ? $templateSpecConnectorData.title : $templateSpecConnectorData.title + " (using Azure Functions)"
+                                #$templateSpecConnectorData.title = $templateSpecConnectorData.title + " (using Azure Functions)";
+                            }
+                        }
+                        # Data Connector Content -- *Assumes GenericUI
+                        if($contentToImport.Is1PConnector)
+                        {
+                            $1pconnectorData = $templateSpecConnectorData
+                            $1pconnectorData = $1pconnectorData | Select-Object -Property id,title,publisher,descriptionMarkdown, graphQueries, connectivityCriterias,dataTypes
+                        }
+                        $templateSpecConnectorUiConfig = ($contentToImport.Is1PConnector -eq $true) ? $1pconnectorData : $templateSpecConnectorData
+                        $templateSpecConnectorUiConfig.id = "[variables('_uiConfigId$global:connectorCounter')]"
+                        if($contentToImport.Is1PConnector -eq $false)
+                        {
+                            $templateSpecConnectorUiConfig.availability.isPreview =  ($templateSpecConnectorUiConfig.availability.isPreview -eq $true) ? $false : $templateSpecConnectorUiConfig.availability.isPreview
+                        }
+                        $dataConnectorContent = [PSCustomObject]@{
+                            name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentId$global:connectorCounter'))]";
+                            apiVersion = "2021-03-01-preview";
+                            type       = "Microsoft.OperationalInsights/workspaces/providers/dataConnectors";
+                            location   = "[parameters('workspace-location')]";
+                            kind       = ($contentToImport.Is1PConnector -eq $true) ? "StaticUI" : (($ccpConnector -eq $true) ? $connectorData.resources[0].kind : "GenericUI");
+                            properties = [PSCustomObject]@{
+                                connectorUiConfig = $templateSpecConnectorUiConfig
+                            }
+                        }
+                        if($null -ne $ccpPollingConfig)
+                        {
+                            $dataConnectorContent.properties | Add-Member -NotePropertyName "pollingConfig" -NotePropertyValue $ccpPollingConfig
+                        }
+                        $author = $contentToImport.Author.Split(" - ");
+                        $authorDetails = [PSCustomObject]@{
+                            name  = $author[0];
+                        };
+                        if($null -ne $author[1])
+                        {
+                            $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+                        }
+                        $dataConnectorMetadata = [PSCustomObject]@{
+                            type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+                            apiVersion = "2022-01-01-preview";
+                            name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('DataConnector-', last(split(variables('_dataConnectorId$global:connectorCounter'),'/'))))]";
+                            properties = [PSCustomObject]@{
+                                parentId  = "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/dataConnectors', variables('_dataConnectorContentId$global:connectorCounter'))]";
+                                contentId = "[variables('_dataConnectorContentId$global:connectorCounter')]";
+                                kind      = "DataConnector";
+                                version   = "[variables('dataConnectorVersion$global:connectorCounter')]";
+                                source    = [PSCustomObject]@{
+                                    kind     = "Solution";
+                                    name     = $contentToImport.Name;
+                                    sourceId = "[variables('_solutionId')]"
+                                };
+                                author    = $authorDetails;
+                                support   = $baseMetadata.support
+                            }
+                        }
+                        #one removed check from here for apiVersion
+                        # Add templateSpecs/versions resource to hold actual content
+                        $dataConnectorTemplateSpecContent = [PSCustomObject]@{
+                            type       = $contentResourceDetails.subtype; # "Microsoft.Resources/templateSpecs/versions";
+                            apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-02-01";
+                            name       = $contentResourceDetails.apiVersion -eq '3.0.0' ? "[variables('dataConnectorTemplateSpecName$global:connectorCounter')]" : "[concat(variables('dataConnectorTemplateSpecName$global:connectorCounter'),'/',variables('dataConnectorVersion$global:connectorCounter'))]";
+                            location   = "[parameters('workspace-location')]";
+                            tags       = [PSCustomObject]@{
+                                "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                "hidden-sentinelContentType" = "DataConnector";
+                            };
+                            # dependsOn  = @(
+                            #     "[resourceId('Microsoft.Resources/templateSpecs', variables('dataConnectorTemplateSpecName$global:connectorCounter'))]"
+                            # );
+                            dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
+                                "$($contentResourceDetails.dependsOn)") : @(
+                                "$($contentResourceDetails.dependsOn), variables('dataConnectorTemplateSpecName$global:connectorCounter'))]"
+                            );
+                            properties = [PSCustomObject]@{
+                                description  = "$($connectorName) data connector with template version $($contentToImport.Version)";
+                                mainTemplate = [PSCustomObject]@{
+                                    '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+                                    contentVersion = "[variables('dataConnectorVersion$global:connectorCounter')]";
+                                    parameters     = [PSCustomObject]@{};
+                                    variables      = [PSCustomObject]@{};
+                                    resources      = @(
+                                        # Data Connector
+                                        $dataConnectorContent,
+                                        # Metadata
+                                        $dataConnectorMetadata
+                                    )
+                                };
+                            }
+                        }
+                        if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                        {
+                            $dataConnectorTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $dataConnectorTemplateSpecContent
+                            $dataConnectorTemplateSpecContent.properties.contentId = "[variables('_dataConnectorContentId$global:connectorCounter')]"
+                            $dataConnectorTemplateSpecContent.properties.contentKind = "DataConnector"
+                            
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorcontentProductId$global:connectorCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('_dataConnectorContentId$global:connectorCounter'),'-', variables('dataConnectorVersion$global:connectorCounter'))))]"
+
+                            # $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorcontentProductId$global:connectorCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('_dataConnectorContentId$global:connectorCounter'),'-', variables('dataConnectorVersion$global:connectorCounter'))))]"
+			                $dataConnectorTemplateSpecContent.properties.contentProductId = "[variables('_dataConnectorcontentProductId$global:connectorCounter')]"
+                            $dataConnectorTemplateSpecContent.properties.id = "[variables('_dataConnectorcontentProductId$global:connectorCounter')]"
+                            #GenerateIdHash -packageId "$($global:baseMainTemplate.variables."solutionId")" -contentKind "DataConnector" -contentId "$($global:baseMainTemplate.variables."dataConnectorContentId$global:connectorCounter")" -contentVersion "$($global:baseMainTemplate.variables."dataConnectorVersion$global:connectorCounter")"
+                            $dataConnectorTemplateSpecContent.properties.displayName = $templateSpecConnectorData.title
+                            $dataConnectorTemplateSpecContent.properties.version = "[variables('dataConnectorVersion$global:connectorCounter')]"
+                            $dataConnectorTemplateSpecContent.PSObject.Properties.Remove('tags')
+                        }
+                        $global:baseMainTemplate.resources += $dataConnectorTemplateSpecContent
+
+                        # Add content-metadata item, in addition to template spec metadata item
+                        $dataConnectorActiveContentMetadata = [PSCustomObject]@{
+                            type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+                            apiVersion = "2022-01-01-preview";
+                            name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('DataConnector-', last(split(variables('_dataConnectorId$global:connectorCounter'),'/'))))]";
+                            dependsOn  = @("[variables('_dataConnectorId$global:connectorCounter')]");
+                            location   = "[parameters('workspace-location')]";
+                            properties = [PSCustomObject]@{
+                                parentId  = "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/dataConnectors', variables('_dataConnectorContentId$global:connectorCounter'))]";
+                                contentId = "[variables('_dataConnectorContentId$global:connectorCounter')]";
+                                kind      = "DataConnector";
+                                version   = "[variables('dataConnectorVersion$global:connectorCounter')]";
+                                source    = [PSCustomObject]@{
+                                    kind     = "Solution";
+                                    name     = $contentToImport.Name;
+                                    sourceId = "[variables('_solutionId')]"
+                                };
+                                author    = $authorDetails;
+                                support   = $baseMetadata.support
+                            }
+                        }
+                        $global:baseMainTemplate.resources += $dataConnectorActiveContentMetadata
+                    }
+                    $connectorObj = [PSCustomObject]@{}
+                    # If direct title is available, assume standard connector format
+                    if ($connectorData.title) {
+                        $standardConnectorUiConfig = [PSCustomObject]@{
+                            title                 = $connectorData.title;
+                            publisher             = $connectorData.publisher;
+                            descriptionMarkdown   = $connectorData.descriptionMarkdown;
+                            graphQueries          = $connectorData.graphQueries;
+                            dataTypes             = $connectorData.dataTypes;
+                            connectivityCriterias = $connectorData.connectivityCriterias;
+                        }
+
+                        if(!$contentToImport.Is1PConnector)
+                        {
+                            $standardConnectorUiConfig | Add-Member -NotePropertyName "sampleQueries" -NotePropertyValue $connectorData.sampleQueries;
+                            $standardConnectorUiConfig | Add-Member -NotePropertyName "availability" -NotePropertyValue $connectorData.availability;
+                            $standardConnectorUiConfig | Add-Member -NotePropertyName "permissions" -NotePropertyValue $connectorData.permissions;
+                            $standardConnectorUiConfig | Add-Member -NotePropertyName "instructionSteps" -NotePropertyValue $connectorData.instructionSteps;
+                        }
+
+                        if($contentToImport.TemplateSpec){
+                            $standardConnectorUiConfig | Add-Member -NotePropertyName "id" -NotePropertyValue "[variables('_uiConfigId$global:connectorCounter')]"
+
+                        }
+
+                        $connectorObj = [PSCustomObject]@{
+                            name       = if ($contentToImport.TemplateSpec) { "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentId$global:connectorCounter'))]" }else { "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',parameters('connector$global:connectorCounter-name'))]" }
+                            apiVersion = "2021-03-01-preview";
+                            type       = "Microsoft.OperationalInsights/workspaces/providers/dataConnectors";
+                            location   = "[parameters('workspace-location')]";
+                            kind       = ($contentToImport.Is1PConnector -eq $true) ? "StaticUI" : "GenericUI";
+                            properties = [PSCustomObject]@{
+                                connectorUiConfig = $standardConnectorUiConfig
+                            }
+                        }
+
+                        if(!$contentToImport.TemplateSpec)
+                        {
+                            $connectorObj | Add-Member -NotePropertyName "id" -NotePropertyValue "[variables('_connector$global:connectorCounter-source')]";
+                        }
+                    }
+                    # This section is for CCP connectors
+                    elseif ($connectorData.resources -and
+                        $connectorData.resources[0] -and
+                        $connectorData.resources[0].properties -and
+                        $connectorData.resources[0].properties.connectorUiConfig -and
+                        $connectorData.resources[0].properties.pollingConfig) {
+                        # Else check if Polling connector
+                        $connectorData = $connectorData.resources[0]
+                        $connectorUiConfig = $connectorData.properties.connectorUiConfig
+                        # $connectorUiConfig.PSObject.Properties.Remove('id')
+                        $connectorUiConfig.id = if ($contentToImport.TemplateSpec) { "[variables('_uiConfigId$global:connectorCounter')]" }else { "[variables('_connector$global:connectorCounter-source')]" };
+
+                        $connectorObj = [PSCustomObject]@{
+                            # id         = if ($contentToImport.TemplateSpec) { "[variables('_uiConfigId$global:connectorCounter')]" }else { "[variables('_connector$global:connectorCounter-source')]" };
+                            name       = if ($contentToImport.TemplateSpec) { "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentId$global:connectorCounter'))]" }else { "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',parameters('connector$global:connectorCounter-name'))]" }
+                            apiVersion = "2021-03-01-preview";
+                            type       = "Microsoft.OperationalInsights/workspaces/providers/dataConnectors";
+                            location   = "[parameters('workspace-location')]";
+                            kind       = $connectorData.kind;
+                            properties = [PSCustomObject]@{
+                                connectorUiConfig = $connectorUiConfig;
+                                pollingConfig     = $connectorData.properties.pollingConfig;
+                            }
+                        }
+                    }
+                    if ($connectorData.additionalRequirementBanner) {
+                        $connectorObj.properties.connectorUiConfig | Add-Member -NotePropertyName "additionalRequirementBanner" -NotePropertyValue $connectorData.additionalRequirementBanner
+                    }
+
+                    $global:baseMainTemplate.resources += $connectorObj
+
+                    $syslog = "Syslog"
+                    $commonSecurityLog = "CommonSecurityLog"
+                    function getConnectorDataTypes($dataTypesArray) {
+                        $typeResult = "custom log"
+                        foreach ($dataType in $dataTypesArray) {
+                            if ($dataType.name.IndexOf($syslog) -ne -1) {
+                                $typeResult = $syslog
+                            }
+                            elseif ($dataType.name.IndexOf($commonSecurityLog) -ne -1) {
+                                $typeResult = $commonSecurityLog
+                            }
+                        }
+                        return $typeResult
+                    }
+                    function getAllDataTypeNames($dataTypesArray) {
+                        $typeResult = @()
+                        foreach ($dataType in $dataTypesArray) {
+                            $typeResult += $dataType.name
+                        }
+                        return $typeResult
+                    }
+                    $connectorDataType = $(getConnectorDataTypes $connectorData.dataTypes)
+                    $isParserAvailable = $($contentToImport.Parsers -and ($contentToImport.Parsers.Count -gt 0))
+                    $baseDescriptionText = "This Solution installs the data connector for $solutionName. You can get $solutionName $connectorDataType data in your Microsoft Sentinel workspace. Configure and enable this data connector in the Data Connector gallery after this Solution deploys."
+                    #$parserText = "The Solution installs a parser that transforms the ingested data into Microsoft Sentinel normalized format. The normalized format enables better correlation of different types of data from different data sources to drive end-to-end outcomes seamlessly in security monitoring, hunting, incident investigation and response scenarios in Microsoft Sentinel."
+                    $customLogsText = "$baseDescriptionText This data connector creates custom log table(s) $(getAllDataTypeNames $connectorData.dataTypes) in your Microsoft Sentinel / Azure Log Analytics workspace."
+                    $syslogText = "$baseDescriptionText The logs will be received in the Syslog table in your Microsoft Sentinel / Azure Log Analytics workspace."
+                    $commonSecurityLogText = "$baseDescriptionText The logs will be received in the CommonSecurityLog table in your Microsoft Sentinel / Azure Log Analytics workspace."
+                    #$connectorDescriptionText = $(if ($connectorDataType -eq $commonSecurityLog) { $commonSecurityLogText } elseif ($connectorDataType -eq $syslog) { $syslogText } else { $customLogsText })
+                    $connectorDescriptionText = "This Solution installs the data connector for $solutionName. You can get $solutionName $connectorDataType data in your Microsoft Sentinel workspace. After installing the solution, configure and enable this data connector by following guidance in Manage solution view."
+                    $parserText = "The Solution installs a parser that transforms the ingested data into Microsoft Sentinel normalized format. The normalized format enables better correlation of different types of data from different data sources to drive end-to-end outcomes seamlessly in security monitoring, hunting, incident investigation and response scenarios in Microsoft Sentinel."
+
+                    $baseDataConnectorStep = [PSCustomObject] @{
+                        name       = "dataconnectors";
+                        label      = "Data Connectors";
+                        bladeTitle = "Data Connectors";
+                        elements   = @();
+                    }
+                    $baseDataConnectorTextElement = [PSCustomObject] @{
+                        name    = "dataconnectors$global:connectorCounter-text";
+                        type    = "Microsoft.Common.TextBlock";
+                        options = [PSCustomObject] @{
+                            text = $connectorDescriptionText;
+                        }
+                    }
+
+                    if ($global:connectorCounter -eq 1) {
+                        $global:baseCreateUiDefinition.parameters.steps += $baseDataConnectorStep
+                    }
+                    $currentStepNum = $global:baseCreateUiDefinition.parameters.steps.Count - 1
+                    $global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements += $baseDataConnectorTextElement
+                    if ($global:connectorCounter -eq $contentToImport."Data Connectors".Count) {
+                        $parserTextElement = [PSCustomObject] @{
+                            name    = "dataconnectors-parser-text";
+                            type    = "Microsoft.Common.TextBlock";
+                            options = [PSCustomObject] @{
+                                text = $parserText;
+                            }
+                        }
+                        $connectDataSourcesLink = [PSCustomObject] @{
+                            name    = "dataconnectors-link2";
+                            type    = "Microsoft.Common.TextBlock";
+                            options = [PSCustomObject] @{
+                                link = [PSCustomObject] @{
+                                    label = "Learn more about connecting data sources";
+                                    uri   = "https://docs.microsoft.com/azure/sentinel/connect-data-sources";
+                                }
+                            }
+                        }
+                        if ($isParserAvailable) {
+                            $global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements += $parserTextElement
+                        }
+                        $global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements += $connectDataSourcesLink
+                    }
+
+                    # Update Connector Counter
+                    $global:connectorCounter += 1			
+    }
+
+    function GetHuntingDataMetadata($file, $rawData, $contentResourceDetails)
+    {
+        Write-Host "Generating Hunting Query using $file"
+                        $content = ''
+                        foreach ($line in $rawData) {
+                            $content = $content + "`n" + $line
+                        }
+                        try {
+                            $yaml = ConvertFrom-YAML $content
+                        }
+                        catch {
+                            Write-Host "Failed to deserialize $file" -ForegroundColor Red
+                            break;
+                        }
+
+                        $fileName = Split-Path $file -leafbase;
+                        $fileName = $fileName + "_HuntingQueries";
+
+                        
+                        $hasHuntingQueryVersion = [bool]($global:baseMainTemplate.variables.PSobject.Properties.Name -match "huntingQueryVersion$global:huntingQueryCounter")
+                        if ($hasHuntingQueryVersion)
+                        {
+                            $global:huntingQueryCounter += 1
+                        }
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "huntingQueryVersion$global:huntingQueryCounter" -NotePropertyValue (($null -ne $yaml.version) ? "$($yaml.version)" : "1.0.0")
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "huntingQuerycontentId$global:huntingQueryCounter" -NotePropertyValue $yaml.id
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentId$global:huntingQueryCounter" -NotePropertyValue "[variables('huntingQuerycontentId$global:huntingQueryCounter')]"
+                        $global:DependencyCriteria += [PSCustomObject]@{
+                            kind      = "HuntingQuery";
+                            contentId = "[variables('_huntingQuerycontentId$global:huntingQueryCounter')]";
+                            version   = "[variables('huntingQueryVersion$global:huntingQueryCounter')]";
+                        };
+
+                        if ($global:huntingQueryCounter -eq 1) {
+                            if (!$(queryResourceExists) -and !$contentToImport.TemplateSpec) {
+                                $baseHuntingQueryResource = [PSCustomObject] @{
+                                    type       = "Microsoft.OperationalInsights/workspaces";
+                                    apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2021-06-01";
+                                    name       = "[parameters('workspace')]";
+                                    location   = "[parameters('workspace-location')]";
+                                    resources  = @()
+                                }
+                                $global:baseMainTemplate.resources += $baseHuntingQueryResource
+                            }
+                            if (!$contentToImport.TemplateSpec -and $null -eq $global:baseMainTemplate.variables.'workspace-dependency') {
+                                #Add parser dependency variable once to ensure validation passes.
+                                $global:baseMainTemplate.variables | Add-Member -MemberType NoteProperty -Name "workspace-dependency" -Value "[concat('Microsoft.OperationalInsights/workspaces/', parameters('workspace'))]"
+                            }
+                            $huntingQueryBaseStep = [PSCustomObject] @{
+                                name       = "huntingqueries";
+                                label      = "Hunting Queries";
+                                bladeTitle = "Hunting Queries";
+                                elements   = @(
+                                    [PSCustomObject] @{
+                                        name    = "huntingqueries-text";
+                                        type    = "Microsoft.Common.TextBlock";
+                                        options = [PSCustomObject] @{
+                                                text = $contentToImport.HuntingQueryBladeDescription ? $contentToImport.HuntingQueryBladeDescription : "This solution installs the following hunting queries. After installing the solution, run these hunting queries to hunt for threats in Manage solution view. ";
+                                            }
+                                        },
+                                        [PSCustomObject] @{
+                                            name    = "huntingqueries-link";
+                                            type    = "Microsoft.Common.TextBlock";
+                                            options = [PSCustomObject] @{
+                                                link = [PSCustomObject] @{
+                                                    label = "Learn more";
+                                                    uri   = "https://docs.microsoft.com/azure/sentinel/hunting"
+                                                }
+                                            }
+                                        })
+                            }
+                            $global:baseCreateUiDefinition.parameters.steps += $huntingQueryBaseStep
+                        }
+
+                        if($yaml.metadata -and $yaml.metadata.source -and $yaml.metadata.source.kind -and ($yaml.metadata.source.kind -eq "Community" -or $yaml.metadata.source.kind -eq "Standalone"))
+                        {
+                            throw "The file $fileName has metadata with source -> kind = Community | Standalone. Please remove it so that it can be packaged as a solution."
+                        }
+
+                        $huntingQueryObj = [PSCustomObject] @{
+                            type       = $contentToImport.TemplateSpec ? "Microsoft.OperationalInsights/savedSearches" : "savedSearches";
+                            apiVersion = "2020-08-01";
+                            name       = $contentToImport.TemplateSpec ? "$($solutionName.Replace(' ', '_'))_Hunting_Query_$global:huntingQueryCounter" : "$solutionName Hunting Query $global:huntingQueryCounter";
+                            location   = "[parameters('workspace-location')]";
+                            properties = [PSCustomObject] @{
+                                eTag        = "*";
+                                displayName = $yaml.name;
+                                category    = "Hunting Queries";
+                                query       = $yaml.query;
+                                version     = $contentToImport.TemplateSpec ? 2 : 1;
+                                tags        = @();
+                            }
+                        }
+
+                        $huntingQueryDescription = ""
+                        if ($yaml.description) {
+                            $huntingQueryDescription = $yaml.description.substring(1, $yaml.description.length - 3)
+                            $descriptionObj = [PSCustomObject]@{
+                                name  = "description";
+                                value = $huntingQueryDescription
+                            }
+                            $huntingQueryObj.properties.tags += $descriptionObj
+                            $huntingQueryDescription = "$huntingQueryDescription "
+                        }
+                        if ($yaml.tactics -and $yaml.tactics.Count -gt 0) {
+                            $tacticsObj = [PSCustomObject]@{
+                                name  = "tactics";
+                                value = $yaml.tactics -join ","
+                            }
+                            if ($tacticsObj.value.ToString() -match ' ') {
+                                $tacticsObj.value = $tacticsObj.value -replace ' ', ''
+                            }
+                            $huntingQueryObj.properties.tags += $tacticsObj
+                        }
+
+                        if ($yaml.relevantTechniques -and $yaml.relevantTechniques.Count -gt 0) {
+                            $relevantTechniquesObj = [PSCustomObject]@{
+                                name  = "techniques";
+                                value = $yaml.relevantTechniques -join ","
+                            }
+                            if ($relevantTechniquesObj.value.ToString() -match ' ') {
+                                $relevantTechniquesObj.value = $relevantTechniquesObj.value -replace ' ', ''
+                            }
+                            $huntingQueryObj.properties.tags += $relevantTechniquesObj
+                        }
+
+                        if($contentToImport.TemplateSpec) {
+
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "huntingQueryId$global:huntingQueryCounter" -NotePropertyValue "[resourceId('Microsoft.OperationalInsights/savedSearches', variables('_huntingQuerycontentId$global:huntingQueryCounter'))]"
+
+                            if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "huntingQueryTemplateSpecName$global:huntingQueryCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-hq-',uniquestring(variables('_huntingQuerycontentId$global:huntingQueryCounter'))),variables('huntingQueryVersion$global:huntingQueryCounter')))]"
+                            }
+                            else 
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "huntingQueryTemplateSpecName$global:huntingQueryCounter" -NotePropertyValue "[concat(parameters('workspace'),'-hq-',uniquestring(variables('_huntingQuerycontentId$global:huntingQueryCounter')))]"
+                            }
+
+                            if (!$global:baseMainTemplate.variables.workspaceResourceId) {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
+                            }
+
+                            if ($contentResourceDetails.contentSchemaVersion -ne '3.0.0')
+                            {
+                                $baseHuntingQueryTemplateSpec = [PSCustomObject]@{
+                                    type       = $contentResourceDetails.resourcetype; # "Microsoft.Resources/templateSpecs";
+                                    apiVersion = "2022-02-01";
+                                    name       = "[variables('huntingQueryTemplateSpecName$global:huntingQueryCounter')]";
+                                    location   = "[parameters('workspace-location')]";
+                                    tags       = [PSCustomObject]@{
+                                        "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                        "hidden-sentinelContentType" = "HuntingQuery";
+                                    };
+                                    properties = [PSCustomObject]@{
+                                        description = "$($solutionName) Hunting Query $global:huntingQueryCounter with template";
+                                        displayName = "$($solutionName) Hunting Query template";
+                                    }
+                                }
+
+                                if($baseHuntingQueryTemplateSpec.properties.displayName.length -ge 64)
+                                {
+                                    $baseHuntingQueryTemplateSpec.properties.displayName = "$($solutionName) HQ template";
+                                }
+
+                                $global:baseMainTemplate.resources += $baseHuntingQueryTemplateSpec
+                            }
+                            
+                            $author = $contentToImport.Author.Split(" - ");
+                            $authorDetails = [PSCustomObject]@{
+                                name  = $author[0];
+                            };
+
+                            if($null -ne $author[1])
+                            {
+                                $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+                            }
+
+                            $huntingQueryMetadata = [PSCustomObject]@{
+                                type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+                                apiVersion = "2022-01-01-preview";
+                                name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('HuntingQuery-', last(split(variables('huntingQueryId$global:huntingQueryCounter'),'/'))))]";
+                                properties = [PSCustomObject]@{
+                                    description = "$($solutionName) Hunting Query $global:huntingQueryCounter";
+                                    parentId  = "[variables('huntingQueryId$global:huntingQueryCounter')]";
+                                    contentId = "[variables('_huntingQuerycontentId$global:huntingQueryCounter')]";
+                                    kind      = "HuntingQuery";
+                                    version   = "[variables('huntingQueryVersion$global:huntingQueryCounter')]";
+                                    source    = [PSCustomObject]@{
+                                        kind     = "Solution";
+                                        name     = $contentToImport.Name;
+                                        sourceId = "[variables('_solutionId')]"
+                                    };
+                                    author    = $authorDetails;
+                                    support   = $baseMetadata.support
+                                }
+                            }
+
+                            # Add templateSpecs/versions resource to hold actual content
+                            $huntingQueryTemplateSpecContent = [PSCustomObject]@{
+                                type       = $contentResourceDetails.subtype; # "Microsoft.Resources/templateSpecs/versions";
+                                apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-02-01";
+                                name       = $contentResourceDetails.apiVersion -eq '3.0.0' ? "[variables('huntingQueryTemplateSpecName$global:huntingQueryCounter')]" : "[concat(variables('huntingQueryTemplateSpecName$global:huntingQueryCounter'),'/',variables('huntingQueryVersion$global:huntingQueryCounter'))]";
+                                location   = "[parameters('workspace-location')]";
+                                tags       = [PSCustomObject]@{
+                                    "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                    "hidden-sentinelContentType" = "HuntingQuery";
+                                };
+                                # dependsOn  = @(
+                                #     "[resourceId('Microsoft.Resources/templateSpecs', variables('huntingQueryTemplateSpecName$global:huntingQueryCounter'))]"
+                                # );
+                                dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
+                                "$($contentResourceDetails.dependsOn)") : @(
+                                    "$($contentResourceDetails.dependsOn), variables('huntingQueryTemplateSpecName$global:huntingQueryCounter'))]"
+                                );
+                                properties = [PSCustomObject]@{
+                                    description  = "$($fileName) Hunting Query with template version $($contentToImport.Version)";
+                                    mainTemplate = [PSCustomObject]@{
+                                        '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+                                        contentVersion = "[variables('huntingQueryVersion$global:huntingQueryCounter')]";
+                                        parameters     = [PSCustomObject]@{};
+                                        variables      = [PSCustomObject]@{};
+                                        resources      = @(
+                                            # workbook
+                                            $huntingQueryObj,
+                                            # Metadata
+                                            $huntingQueryMetadata
+                                        )
+                                    };
+                                }
+                            }
+                            if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                            {
+                                $huntingQueryTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $huntingQueryTemplateSpecContent
+                                $huntingQueryTemplateSpecContent.properties.contentId = "[variables('_huntingQuerycontentId$global:huntingQueryCounter')]"
+                                $huntingQueryTemplateSpecContent.properties.contentKind = "HuntingQuery"
+                                $huntingQueryTemplateSpecContent.properties.displayName = $yaml.name
+                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
+
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
+
+                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
+				$huntingQueryTemplateSpecContent.properties.contentProductId = "[variables('_huntingQuerycontentProductId$global:huntingQueryCounter')]"
+                                $huntingQueryTemplateSpecContent.properties.id = "[variables('_huntingQuerycontentProductId$global:huntingQueryCounter')]"
+                                $huntingQueryTemplateSpecContent.properties.version = "[variables('huntingQueryVersion$global:huntingQueryCounter')]"
+                                $huntingQueryTemplateSpecContent.PSObject.Properties.Remove('tags')
+                            }
+                            $global:baseMainTemplate.resources += $huntingQueryTemplateSpecContent
+                        }
+                        else{
+                            if(!$contentToImport.TemplateSpec)
+                            {
+                                $dependsOn  = @(
+                                    "[variables('workspace-dependency')]"
+                                );
+
+                                $huntingQueryObj | Add-Member -NotePropertyName "dependsOn" -NotePropertyValue $dependsOn
+                            }
+                            $queryLocation = $(getQueryResourceLocation)
+                            if ($null -eq $queryLocation)
+                            {
+                                Write-Host "For Hunting queries getQueryResourceLocation function returned null for $file which is not valid!"
+                                return;
+                            }
+                            else {
+                                $global:baseMainTemplate.resources[$(getQueryResourceLocation)].resources += $huntingQueryObj
+                            }
+                        }
+                        $dependencyDescription = ""
+                        if ($yaml.requiredDataConnectors) {
+                            #$dependencyDescription = "It depends on the $($yaml.requiredDataConnectors.connectorId) data connector and $($($yaml.requiredDataConnectors.dataTypes)) data type and $($yaml.requiredDataConnectors.connectorId) parser."
+                            $dependencyDescription = "This hunting query depends on $($yaml.requiredDataConnectors.connectorId) data connector ($($($yaml.requiredDataConnectors.dataTypes)) Parser or Table)"
+                        }
+                        $huntingQueryElement = [PSCustomObject]@{
+                            name     = "huntingquery$global:huntingQueryCounter";
+                            type     = "Microsoft.Common.Section";
+                            label    = $yaml.name;
+                            elements = @()
+                        }
+                        $huntingQueryElementDescription = [PSCustomObject]@{
+                            name    = "huntingquery$global:huntingQueryCounter-text";
+                            type    = "Microsoft.Common.TextBlock";
+                            options = [PSCustomObject]@{
+                                text = "$($huntingQueryDescription)$dependencyDescription";
+                            }
+                        }
+                        if ($huntingQueryDescription -or $dependencyDescription) {
+                            $huntingQueryElement.elements += $huntingQueryElementDescription
+                        }
+                        $global:baseCreateUiDefinition.parameters.steps[$global:baseCreateUiDefinition.parameters.steps.Count - 1].elements += $huntingQueryElement
+
+                        # Update HuntingQuery Counter
+                        $global:huntingQueryCounter += 1
+    }
+
+    function GenerateAlertRule($file, $contentResourceDetails)
+    {
+        
+                        # If yaml and not hunting query, process as Alert Rule
+                        Write-Host "Generating Alert Rule using $file"
+                        if ($global:analyticRuleCounter -eq 1) {
+                            $baseAnalyticRuleStep = [PSCustomObject] @{
+                                name       = "analytics";
+                                label      = "Analytics";
+                                subLabel   = [PSCustomObject] @{
+                                    preValidation  = "Configure the analytics";
+                                    postValidation = "Done";
+                                };
+                                bladeTitle = "Analytics";
+                                elements   = @(
+                                    [PSCustomObject] @{
+                                        name    = "analytics-text";
+                                        type    = "Microsoft.Common.TextBlock";
+                                        options = [PSCustomObject] @{
+                                            text = $contentToImport.AnalyticalRuleBladeDescription ? $contentToImport.AnalyticalRuleBladeDescription : "This solution installs the following analytic rule templates. After installing the solution, create and enable analytic rules in Manage solution view.";
+                                        }
+                                    },
+                                    [PSCustomObject] @{
+                                        name    = "analytics-link";
+                                        type    = "Microsoft.Common.TextBlock";
+                                        options = [PSCustomObject] @{
+                                            link = [PSCustomObject] @{
+                                                label = "Learn more";
+                                                uri   = "https://docs.microsoft.com/azure/sentinel/tutorial-detect-threats-custom?WT.mc_id=Portal-Microsoft_Azure_CreateUIDef";
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                            $global:baseCreateUiDefinition.parameters.steps += $baseAnalyticRuleStep
+                        }
+                        $yamlPropertiesToCopyFrom = "name", "severity", "triggerThreshold", "query"
+                        $yamlPropertiesToCopyTo = "displayName", "severity", "triggerThreshold", "query"
+                        $alertRuleParameterName = "analytic$global:analyticRuleCounter-id"
+                        $alertRule = [PSCustomObject] @{ description = ""; displayName = ""; enabled = $false; query = ""; queryFrequency = ""; queryPeriod = ""; severity = ""; suppressionDuration = ""; suppressionEnabled = $false; triggerOperator = ""; triggerThreshold = 0; }
+                        $alertRuleParameter = [PSCustomObject] @{ type = "string"; defaultValue = "[newGuid()]"; minLength = 1; metadata = [PSCustomObject] @{ description = "Unique id for the scheduled alert rule" }; }
+                        $content = ''
+
+                        $fileName = Split-Path $file -leafbase;
+                        $fileName = $fileName + "_AnalyticalRules";
+                        foreach ($line in $rawData) {
+                            $content = $content + "`n" + $line
+                        }
+                        try {
+                            $yaml = ConvertFrom-YAML $content # Convert YAML to PSObject
+                        }
+                        catch {
+                            Write-Host "Failed to deserialize $file" -ForegroundColor Red
+                            break;
+                        }
+
+                        if($yaml.metadata -and $yaml.metadata.source -and $yaml.metadata.source.kind -and ($yaml.metadata.source.kind -eq "Community" -or $yaml.metadata.source.kind -eq "Standalone"))
+                        {
+                            throw "The file $fileName has metadata with source -> kind = Community | Standalone. Please remove it so that it can be packaged as a solution."
+                        }
+
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "analyticRuleVersion$global:analyticRuleCounter" -NotePropertyValue (($null -ne $yaml.version) ? "$($yaml.version)" : "1.0.0")
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "analyticRulecontentId$global:analyticRuleCounter" -NotePropertyValue "$($yaml.id)"
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentId$global:analyticRuleCounter" -NotePropertyValue "[variables('analyticRulecontentId$global:analyticRuleCounter')]"
+                        $global:DependencyCriteria += [PSCustomObject]@{
+                            kind      = "AnalyticsRule";
+                            contentId = "[variables('analyticRulecontentId$global:analyticRuleCounter')]";
+                            #post bug bash ,remove this below comments!
+                            version   = "[variables('analyticRuleVersion$global:analyticRuleCounter')]";
+                        };
+                        # Copy all directly transposable properties
+                        foreach ($yamlProperty in $yamlPropertiesToCopyFrom) {
+                            $index = $yamlPropertiesToCopyFrom.IndexOf($yamlProperty)
+                            $alertRule.$($yamlPropertiesToCopyTo[$index]) = $yaml.$yamlProperty
+                        }
+
+                        if($contentToImport.TemplateSpec)
+                        {
+                            $alertRule | Add-Member -NotePropertyName status -NotePropertyValue ($yaml.status ? $yaml.status : "Available") # Add requiredDataConnectors property if exists
+                        }
+
+                        if($yaml.requiredDataConnectors -and $yaml.requiredDataConnectors.count -gt 0)
+                        {
+                            $alertRule | Add-Member -NotePropertyName requiredDataConnectors -NotePropertyValue $yaml.requiredDataConnectors # Add requiredDataConnectors property if exists
+                            for($i=0; $i -lt $yaml.requiredDataConnectors.connectorId.count; $i++)
+                            {
+                                $alertRule.requiredDataConnectors[$i].connectorId = ($yaml.requiredDataConnectors[$i].connectorId.GetType().Name -is [object]) ? ($yaml.requiredDataConnectors[$i].connectorId -join ',') : $yaml.requiredDataConnectors[$i].connectorId;
+                            }
+                        }
+                        else
+                        {
+                            $alertRule | Add-Member -NotePropertyName requiredDataConnectors -NotePropertyValue "[variables('TemplateEmptyArray')]";
+                            if (!$global:baseMainTemplate.variables.TemplateEmptyArray) 
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyArray" -NotePropertyValue "[json('[]')]"
+                            }
+                        }
+
+                        if (!$yaml.severity) {
+                            $alertRule.severity = "Medium"
+                        }
+
+                        # Content Modifications
+                        $triggerOperators = [PSCustomObject] @{ gt = "GreaterThan" ; lt = "LessThan" ; eq = "Equal" ; ne = "NotEqual"; GreaterThan = "GreaterThan" ; LessThan = "LessThan" ; Equal = "Equal" ; NotEqual = "NotEqual" }
+                        $alertRule.triggerOperator = $triggerOperators.$($yaml.triggerOperator)
+                        if ($yaml.tactics -and ($yaml.tactics.Count -gt 0) ) {
+                            if ($yaml.tactics -match ' ') {
+                                $yaml.tactics = $yaml.tactics -replace ' ', ''
+                            }
+                            $alertRule | Add-Member -NotePropertyName tactics -NotePropertyValue $yaml.tactics # Add Tactics property if exists
+                        }
+                        if ($yaml.relevantTechniques -and ($yaml.relevantTechniques.Count -gt 0) ) {
+                            if ($yaml.relevantTechniques -match ' ') {
+                                $yaml.relevantTechniques = $yaml.relevantTechniques -replace ' ', ''
+                            }
+                            $alertRule | Add-Member -NotePropertyName techniques -NotePropertyValue ([array]($yaml.relevantTechniques | ForEach-Object { ($_ -split "\.")[0] })) # Add relevantTechniques property if exists
+                        }
+                        $alertRule.description = $yaml.description.TrimEnd() #remove newlines at the end of the string if there are any.
+                        if ($alertRule.description.StartsWith("'") -or $alertRule.description.StartsWith('"')) {
+                            # Remove surrounding single-quotes (') from YAML block literal string, in case the string starts with a single quote in Yaml.
+                            # This block is for backwards compatibility as YAML doesn't require having strings quotes by single (or double) quotes
+                            $alertRule.description = $alertRule.description.substring(1, $alertRule.description.length - 2)
+                        }
+
+                        # Check whether Day or Hour/Minut format need be used
+                        function checkISO8601Format($field) {
+                            if ($field.IndexOf("D") -ne -1) {
+                                return "P$field"
+                            }
+                            else {
+                                "PT$field"
+                            }
+                        }
+                        function Remove-EmptyArrays($Object) {
+                            (@($Object).GetEnumerator() | ? {
+                                if($_.GetType().fullname -eq "System.Collections.Hashtable"){
+                                    -not $_.Values
+                                }
+                                else
+                                {
+                                    -not $_.Value
+                                }
+                            }) |
+                            % {
+                                $Object.Remove($_.Name)
+                            }
+                            return $Object;
+                        }
+                        if($yaml.kind.ToUpper() -eq "Scheduled")
+                        {
+                            $alertRule.queryFrequency =  $(checkISO8601Format $yaml.queryFrequency.ToUpper())
+                            $alertRule.queryPeriod = $(checkISO8601Format $yaml.queryPeriod.ToUpper())
+                        }
+                        else {
+                            $alertRule.PSObject.Properties.Remove('queryFrequency');
+                            $alertRule.PSObject.Properties.Remove('queryPeriod');
+                            $alertRule.PSObject.Properties.Remove('triggerOperator');
+                            $alertRule.PSObject.Properties.Remove('triggerThreshold');
+                        }
+                        $alertRule.suppressionDuration = "PT1H"
+                        # Handle optional fields
+                        foreach ($yamlField in @("entityMappings", "eventGroupingSettings", "customDetails", "alertDetailsOverride", "incidentConfiguration", "sentinelEntitiesMappings")) {
+                            if ($yaml.$yamlField) {
+                                $alertRule | Add-Member -MemberType NoteProperty -Name $yamlField -Value $(Remove-EmptyArrays $yaml.$yamlField)
+
+                                if($yamlField -eq "entityMappings" -and $yaml.$yamlField.length -lt 2)
+                                {
+                                    $alertRule.entityMappings = @($alertRule.entityMappings);
+                                }
+                            }
+                        }
+                        # Create Alert Rule Resource Object
+                        $newAnalyticRule = [PSCustomObject]@{
+                            type       = $contentToImport.TemplateSpec ? "Microsoft.SecurityInsights/AlertRuleTemplates" : "Microsoft.OperationalInsights/workspaces/providers/alertRules";
+                            name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',parameters('analytic$global:analyticRuleCounter-id'))]";
+                            apiVersion = "2022-04-01-preview";
+                            kind       =  "$($yaml.kind)";
+                            location   = "[parameters('workspace-location')]";
+                            properties = $alertRule;
+                        }
+
+                        if($contentToImport.TemplateSpec) {
+
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "analyticRuleId$global:analyticRuleCounter" -NotePropertyValue "[resourceId('Microsoft.SecurityInsights/AlertRuleTemplates', variables('analyticRulecontentId$global:analyticRuleCounter'))]"
+
+                            if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "analyticRuleTemplateSpecName$global:analyticRuleCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-ar-',uniquestring(variables('_analyticRulecontentId$global:analyticRuleCounter'))),variables('analyticRuleVersion$global:analyticRuleCounter')))]"
+                            }
+                            else 
+                            {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "analyticRuleTemplateSpecName$global:analyticRuleCounter" -NotePropertyValue "[concat(parameters('workspace'),'-ar-',uniquestring(variables('_analyticRulecontentId$global:analyticRuleCounter')))]"
+                            }
+
+                            if (!$global:baseMainTemplate.variables.workspaceResourceId) {
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
+                            }
+                            
+                            if ($contentResourceDetails.contentSchemaVersion -ne '3.0.0')
+                            {
+                                $baseAnalyticRuleTemplateSpec = [PSCustomObject]@{
+                                    type       = $contentResourceDetails.resourcetype; # "Microsoft.Resources/templateSpecs";
+                                    apiVersion = "2022-02-01";
+                                    name       = "[variables('analyticRuleTemplateSpecName$global:analyticRuleCounter')]";
+                                    location   = "[parameters('workspace-location')]";
+                                    tags       = [PSCustomObject]@{
+                                        "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                        "hidden-sentinelContentType" = "AnalyticsRule";
+                                    };
+                                    properties = [PSCustomObject]@{
+                                        description = "$($solutionName) Analytics Rule $global:analyticRuleCounter with template";
+                                        displayName = "$($solutionName) Analytics Rule template";
+                                    }
+                                }
+
+                                if ($baseAnalyticRuleTemplateSpec.properties.displayName.length -ge 64)
+                                {
+                                    $baseAnalyticRuleTemplateSpec.properties.displayName = "$($solutionName) AR template";
+                                }
+                                $global:baseMainTemplate.resources += $baseAnalyticRuleTemplateSpec
+                            }
+
+                            $newAnalyticRule.name = "[variables('analyticRulecontentId$global:analyticRuleCounter')]"
+                            
+                            $author = $contentToImport.Author.Split(" - ");
+                            $authorDetails = [PSCustomObject]@{
+                                name  = $author[0];
+                            };
+
+                            if($null -ne $author[1])
+                            {
+                                $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+                            }
+
+                            $analyticRuleMetadata = [PSCustomObject]@{
+                                type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+                                apiVersion = "2022-01-01-preview";
+                                name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('AnalyticsRule-', last(split(variables('analyticRuleId$global:analyticRuleCounter'),'/'))))]";
+                                properties = [PSCustomObject]@{
+                                    description = "$($solutionName) Analytics Rule $global:analyticRuleCounter";
+                                    parentId  = "[variables('analyticRuleId$global:analyticRuleCounter')]";
+                                    contentId = "[variables('_analyticRulecontentId$global:analyticRuleCounter')]";
+                                    kind      = "AnalyticsRule";
+                                    # Need to remove the below assigned property for the yaml version after bug bash
+                                    version   = "[variables('analyticRuleVersion$global:analyticRuleCounter')]";
+                                    source    = [PSCustomObject]@{
+                                        kind     = "Solution";
+                                        name     = $contentToImport.Name;
+                                        sourceId = "[variables('_solutionId')]"
+                                    };
+                                    author    = $authorDetails;
+                                    support   = $baseMetadata.support
+                                }
+                            }
+
+                            # Add templateSpecs/versions resource to hold actual content
+                            $analyticRuleTemplateSpecContent = [PSCustomObject]@{
+                                type       = $contentResourceDetails.subtype; # "Microsoft.Resources/templateSpecs/versions";
+                                apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-02-01";
+                                name       = $contentResourceDetails.apiVersion -eq '3.0.0' ? "[variables('analyticRuleTemplateSpecName$global:analyticRuleCounter')]" : "[concat(variables('analyticRuleTemplateSpecName$global:analyticRuleCounter'),'/',variables('analyticRuleVersion$global:analyticRuleCounter'))]";
+                                location   = "[parameters('workspace-location')]";
+                                tags       = [PSCustomObject]@{
+                                    "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                                    "hidden-sentinelContentType" = "AnalyticsRule";
+                                };
+                                # dependsOn  = @(
+                                #     "[resourceId('Microsoft.Resources/templateSpecs', variables('analyticRuleTemplateSpecName$global:analyticRuleCounter'))]"
+                                # );
+                                dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
+                                "$($contentResourceDetails.dependsOn)") : @(
+                                    "$($contentResourceDetails.dependsOn), variables('analyticRuleTemplateSpecName$global:analyticRuleCounter'))]"
+                                );
+                                properties = [PSCustomObject]@{
+                                    description  = "$($fileName) Analytics Rule with template version $($contentToImport.Version)";
+                                    mainTemplate = [PSCustomObject]@{
+                                        '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+                                        contentVersion = "[variables('analyticRuleVersion$global:analyticRuleCounter')]";
+                                        parameters     = [PSCustomObject]@{};
+                                        variables      = [PSCustomObject]@{};
+                                        resources      = @(
+                                            # Analytics Rule
+                                            $newAnalyticRule,
+                                            # Metadata
+                                            $analyticRuleMetadata
+                                        )
+                                    };
+                                }
+                            }
+                            if ($contentResourceDetails.apiVersion -eq '3.0.0')
+                            {
+                                $analyticRuleTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $analyticRuleTemplateSpecContent
+                                $analyticRuleTemplateSpecContent.properties.contentId = "[variables('_analyticRulecontentId$global:analyticRuleCounter')]"
+                                $analyticRuleTemplateSpecContent.properties.contentKind = "AnalyticsRule"
+                                $analyticRuleTemplateSpecContent.properties.displayName = $yaml.name
+                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
+
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
+
+                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
+				$analyticRuleTemplateSpecContent.properties.contentProductId = "[variables('_analyticRulecontentProductId$global:analyticRuleCounter')]"
+                                $analyticRuleTemplateSpecContent.properties.id = "[variables('_analyticRulecontentProductId$global:analyticRuleCounter')]"
+                                $analyticRuleTemplateSpecContent.properties.version = "[variables('analyticRuleVersion$global:analyticRuleCounter')]"
+                                $analyticRuleTemplateSpecContent.PSObject.Properties.Remove('tags')
+                            }
+                            $global:baseMainTemplate.resources += $analyticRuleTemplateSpecContent
+                        }
+                        else {
+                            # Add Resource and Parameters to Template
+                            $global:baseMainTemplate.resources += $newAnalyticRule
+                        }
+
+                        if(!$contentToImport.TemplateSpec)
+                        {
+                            $global:baseMainTemplate.parameters | Add-Member -MemberType NoteProperty -Name $alertRuleParameterName -Value $alertRuleParameter
+                        }
+                        $alertRuleUIParameter = [PSCustomObject] @{ name = "analytic$global:analyticRuleCounter"; type = "Microsoft.Common.Section"; label = $alertRule.displayName; elements = @( [PSCustomObject] @{ name = "analytic$global:analyticRuleCounter-text"; type = "Microsoft.Common.TextBlock"; options = @{ text = $alertRule.description; } } ) }
+                        $global:baseCreateUiDefinition.parameters.steps[$global:baseCreateUiDefinition.parameters.steps.Count - 1].elements += $alertRuleUIParameter
+
+                        # Update Counter
+                        $global:analyticRuleCounter += 1
+                    
+    }
+
+    function GenerateWatchList($json, $isPipelineRun)
+    {
+        $watchlistData = $json.resources[0]
+
+                    $watchlistName = $watchlistData.properties.displayName;
+                    if ($contentToImport.Metadata -or $isPipelineRun) {
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName $watchlistName -NotePropertyValue $watchlistName
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_$watchlistName" -NotePropertyValue "[variables('$watchlistName')]"
+                    }
+
+                    $global:DependencyCriteria += [PSCustomObject]@{
+                        kind      = "Watchlist";
+                        contentId = "[variables('_$watchlistName')]";
+                        version   = $contentToImport.Version;
+                    };
+
+                    #Handle CreateUiDefinition Base Step
+                    if ($global:watchlistCounter -eq 1) {
+                        $baseWatchlistStep = [PSCustomObject]@{
+                            name       = "watchlists";
+                            label      = "Watchlists";
+                            subLabel   = [PSCustomObject]@{
+                                preValidation  = "Configure the watchlists";
+                                postValidation = "Done";
+                            }
+                            bladeTitle = "Watchlists";
+                            elements   = @(
+                                [PSCustomObject]@{
+                                    name    = "watchlists-text";
+                                    type    = "Microsoft.Common.TextBlock";
+                                    options = [PSCustomObject]@{
+                                        text = "Microsoft Sentinel watchlists enable the collection of data from external data sources for correlation with the events in your Microsoft Sentinel environment. Once created, you can use watchlists in your search, detection rules, threat hunting, and response playbooks. Watchlists are stored in your Microsoft Sentinel workspace as name-value pairs and are cached for optimal query performance and low latency. Once deployment is successful, the installed watchlists will be available in the Watchlists blade under 'My Watchlists'.";
+                                        link = [PSCustomObject]@{
+                                            label = "Learn more";
+                                            uri   = "https://aka.ms/sentinelwatchlists";
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                        $global:baseCreateUiDefinition.parameters.steps += $baseWatchlistStep
+                    }
+
+                    #Handle CreateUiDefinition Step Sub-Element
+                    $watchlistDescriptionText = $(if ($contentToImport.WatchlistDescription -and $contentToImport.WatchlistDescription -is [System.Array]) { $contentToImport.WatchlistDescription[$global:watchlistCounter - 1] } elseif ($contentToImport.WatchlistDescription -and $contentToImport.WatchlistDescription -is [System.String]) { $contentToImport.WatchlistDescription } else { $watchlistData.properties.description })
+                    $currentStepNum = $global:baseCreateUiDefinition.parameters.steps.Count - 1
+                    $watchlistStepElement = [PSCustomObject]@{
+                        name     = "watchlist$global:watchlistCounter";
+                        type     = "Microsoft.Common.Section";
+                        label    = $watchlistData.properties.displayName;
+                        elements = @(
+                            [PSCustomObject]@{
+                                name    = "watchlist$global:watchlistCounter-text";
+                                type    = "Microsoft.Common.TextBlock";
+                                options = [PSCustomObject]@{
+                                    text = $watchlistDescriptionText
+                                }
+                            }
+                        )
+                    }
+                    $global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements += $watchlistStepElement
+
+                    # Add Watchlist ID to MainTemplate parameters
+                    $watchlistIdParameterName = "watchlist$global:watchlistCounter-id"
+                    $watchlistIdParameter = [PSCustomObject] @{ type = "string"; defaultValue = "$($watchlistData.properties.watchlistAlias)"; minLength = 1; metadata = [PSCustomObject] @{ description = "Unique id for the watchlist" }; }
+                    $global:baseMainTemplate.parameters | Add-Member -MemberType NoteProperty -Name $watchlistIdParameterName -Value $watchlistIdParameter
+
+                    # Replace watchlist resource id
+                    $watchlistData.name = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',parameters('watchlist$global:watchlistCounter-id'))]"
+
+                    # Handle MainTemplate Resource
+                    $global:baseMainTemplate.resources += $watchlistData #Assume 1 watchlist per template
+
+                    # Update Watchlist Counter
+                    $global:watchlistCounter += 1
+    }
+
+
+    function GenerateSavedSearches($json)
+    {
+        $isStandardTemplate = $false
+                    $searchData = $json # Assume input is basic array of SavedSearches to start
+                    # Check if SavedSearch input file uses direct structure given by export
+                    if ($searchData -isnot [System.Array] -and $searchData.value) {
+                        $searchData = $searchData.value
+                    }
+                    # Check if SavedSearch input file uses standard template structure
+                    if ($searchData -isnot [System.Array] -and $searchData.resources) {
+                        $isStandardTemplate = $true
+                        $searchData = $searchData.resources
+                    }
+                    if ($searchData -is [System.Array] -and !$isStandardTemplate) {
+                        foreach ($search in $searchData) {
+                            $savedSearchIdParameterName = "savedsearch$global:savedSearchCounter-id"
+                            $savedSearchIdParameter = [PSCustomObject] @{ type = "string"; defaultValue = "[newGuid()]"; minLength = 1; metadata = [PSCustomObject] @{ description = "Unique id for the watchlist" }; }
+                            $global:baseMainTemplate.parameters | Add-Member -MemberType NoteProperty -Name $savedSearchIdParameterName -Value $savedSearchIdParameter
+
+                            $savedSearchResource = [PSCustomObject]@{
+                                type       = "Microsoft.OperationalInsights/workspaces/savedSearches";
+                                apiVersion = "2020-08-01";
+                                name       = "[concat(parameters('workspace'),'/',parameters('$savedSearchIdParameterName'))]";
+                                properties = [PSCustomObject]@{
+                                    category      = $search.properties.category;
+                                    displayName   = $search.properties.displayName;
+                                    query         = $search.properties.query;
+                                    functionAlias = $search.properties.functionAlias;
+                                    version       = $search.properties.version;
+                                };
+                            }
+                            $global:baseMainTemplate.resources += $savedSearchResource
+                            $global:savedSearchCounter++
+                        }
+                    }
+                    elseif ($isStandardTemplate) {
+                        $global:baseMainTemplate.resources += $searchData
+                    }
+    }
+
+    function GenerateParsersList($file, $contentToImport, $contentResourceDetails)
+    {
+        # Assume file is Parser due to parsers having inconsistent types. (.txt, .kql, or none)
+        Write-Host "Generating Data Parser using $file"
+        generateParserContent $file $contentToImport $contentResourceDetails
+    }
+
+    function RunArmTtkOnPackage
+    {
+        param(
+            [Parameter(Mandatory=$True)]
+            [string]$solutionName,
+            [Parameter(Mandatory=$True)]
+            [System.Boolean]$isPipelineRun
+        )
+        if ($isPipelineRun -eq $false)
+        {
+            #downloading and running arm-ttk on generated solution
+            $armTtkFolder = "$PSScriptRoot/../arm-ttk"
+            if (!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)) {
+                Write-Output "Missing arm-ttk validations. Downloading module..."
+                Invoke-Expression "$armTtkFolder/download-arm-ttk.ps1"
+            }
+            Invoke-Expression "$armTtkFolder/run-arm-ttk-in-automation.ps1 '$solutionName'"
+        }
+    }
+
+    function GeneratePackage($solutionName, $contentToImport, $calculatedBuildPipelinePackageVersion = '')
+    {
+        if ($contentToImport.Description) {
+            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionDescription}}", $contentToImport.Description
+        }
+        else {
+            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionDescription}}", ""
+        }
+        
+        # Update the descriptionHtml field and icon field only for the content templates 
+        #    and for resource type /contenttemplates
+        if ($contentResourceDetails.apiVersion -eq '3.0.0')
+        {
+            $updatecontentpackage = $baseMainTemplate.resources | Where-Object {$_.type -eq "Microsoft.OperationalInsights/workspaces/providers/contentPackages"}
+            $descriptionHtml = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{Logo}}\n\n", ""
+            $md = $descriptionHtml | ConvertFrom-Markdown
+            $updatecontentpackage.properties.descriptionHtml = $md.Html
+            $updatecontentpackage.properties.icon = $contentToImport.Logo
+        }
+        # Update Logo in CreateUiDefinition Description
+        if ($contentToImport.Logo) {
+            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{Logo}}", $contentToImport.Logo
+        }
+        else {
+            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{Logo}}\n\n", ""
+        }
+
+        # Update Metadata in MainTemplate
+        $baseMainTemplate.metadata.author = $(if ($contentToImport.Author) { $contentToImport.Author } else { "" })
+        $baseMainTemplate.metadata.comments = $baseMainTemplate.metadata.comments -replace "{{SolutionName}}", $solutionName
+
+        $repoRoot = $(git rev-parse --show-toplevel)
+        $solutionFolderName = $solutionName
+        $solutionFolder = "$repoRoot/Solutions/$solutionFolderName"
+        if (!(Test-Path -Path $solutionFolder)) {
+            New-Item -ItemType Directory $solutionFolder
+        }
+        $solutionFolder = "$solutionFolder/Package"
+        if (!(Test-Path -Path $solutionFolder)) {
+            New-Item -ItemType Directory $solutionFolder
+        }
+        $mainTemplateOutputPath = "$solutionFolder/mainTemplate.json"
+        $createUiDefinitionOutputPath = "$solutionFolder/createUiDefinition.json"
+
+        try {
+            $baseMainTemplate | ConvertTo-Json -Depth $jsonConversionDepth | Out-File $mainTemplateOutputPath -Encoding utf8
+        }
+        catch {
+            Write-Host "Failed to write output file $mainTemplateOutputPath" -ForegroundColor Red
+            break;
+        }
+        try {
+            # Sort UI Steps before writing to file
+            $createUiDefinitionOrder = "dataconnectors", "parsers", "workbooks", "analytics", "huntingqueries", "watchlists", "playbooks"
+            $global:baseCreateUiDefinition.parameters.steps = $global:baseCreateUiDefinition.parameters.steps | Sort-Object { $createUiDefinitionOrder.IndexOf($_.name) }
+            # Ensure single-step UI Definitions have proper type for steps
+            if ($($global:baseCreateUiDefinition.parameters.steps).GetType() -ne [System.Object[]]) {
+                $global:baseCreateUiDefinition.parameters.steps = @($global:baseCreateUiDefinition.parameters.steps)
+            }
+            $global:baseCreateUiDefinition | ConvertTo-Json -Depth $jsonConversionDepth | Out-File $createUiDefinitionOutputPath -Encoding utf8
+        }
+        catch {
+            Write-Host "Failed to write output file $createUiDefinitionOutputPath" -ForegroundColor Red
+            break;
+        }
+        
+        if ($calculatedBuildPipelinePackageVersion -eq '')
+        {
+            $zipPackageName = "$(if($contentToImport.Version){$contentToImport.Version}else{"newSolutionPackage"}).zip"
+        }
+        else {
+            $zipPackageName = "$calculatedBuildPipelinePackageVersion" + ".zip"
+        }
+        Compress-Archive -Path "$solutionFolder/*" -DestinationPath "$solutionFolder/$zipPackageName" -Force
+    }
+
+    function global:GetContentTemplateDefaultValues()
+    {
+        return @{
+            'packageKind' = "Solution"
+            'packageVersion' = "[variables('_solutionVersion')]"
+            'packageName' = "[variables('_solutionName')]"
+            'packageId' = "[variables('_solutionId')]"
+            'contentSchemaVersion' = '3.0.0'
+        }
+    }
+
+    function global:SetContentTemplateDefaultValuesToProperties($templateSpecResourceObj)
+    {
+        $contentTemplateDefaultValues = GetContentTemplateDefaultValues
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "packageKind" -Value $contentTemplateDefaultValues.packageKind
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "packageVersion" -Value $contentTemplateDefaultValues.packageVersion
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "packageName" -Value $contentTemplateDefaultValues.packageName
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "packageId" -Value $contentTemplateDefaultValues.packageId
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "contentSchemaVersion" -Value $contentTemplateDefaultValues.contentSchemaVersion
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "contentId" -Value ""
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "contentKind" -Value ""
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "displayName" -Value ""
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "contentProductId" -Value ""
+
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "id" -Value ""
+        
+        $templateSpecResourceObj.properties | Add-Member -MemberType NoteProperty -Name "version" -Value ""
+
+        return $templateSpecResourceObj
+    }
+# =================START: RESOURCE CONTENT BY VERSION=====================
+    function global:returnContentResources ($item)
+    {
+        try
+        {
+            $dict = $null;   
+            $version =  constructVersionNumber($item) 
+            if($version.Major -eq 3)
+            {    
+                $dict = @{
+                    #'resourcetype' = "Microsoft.OperationInsights/workspaces/providers/contentPackages"
+                    'subtype' = "Microsoft.OperationalInsights/workspaces/providers/contentTemplates"
+                    'dependsOn' = "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/contentPackages', variables('_solutionId'))]"
+                    'metadata' = "Microsoft.OperationalInsights/workspaces/providers/contentPackages"
+                    'contentSchemaVersion' = '3.0.0'
+                    'apiVersion' = '3.0.0'
+                    'resources' = @("Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
+                                    "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                                    "Microsoft.OperationalInsights/workspaces/savedSearches",
+                                    "Microsoft.OperationalInsights/workspaces/providers/Watchlists",
+                                    "Microsoft.OperationalInsights/workspaces/providers/contentTemplates",
+                                    "Microsoft.OperationalInsights/workspaces/providers/contentPackages")
+                    }
+            }
+            elseif ($version.Major -eq 2)
+            {
+                $dict = @{
+                    'resourcetype' = "Microsoft.Resources/templateSpecs"
+                    'subtype' = "Microsoft.Resources/templateSpecs/versions"
+                    'dependsOn' = "[resourceId('Microsoft.Resources/templateSpecs'"
+                    'metadata' = "Microsoft.OperationalInsights/workspaces/providers/metadata"
+                    'contentSchemaVersion' = '2.0.0'
+                    'apiVersion' = '2.0.0'
+                    'resources' = @("Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
+                                    "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                                    "Microsoft.OperationalInsights/workspaces/savedSearches",
+                                    "Microsoft.OperationalInsights/workspaces/providers/Watchlists",
+                                    "Microsoft.Resources/templateSpecs",
+                                    "Microsoft.Resources/templateSpecs/versions")
+                    }
+            }
+            else
+            {
+                Write-Host "Returning Empty dictionary object because the version information is given as null or empty" -ForegroundColor Red
+                return $dict 
+            } 
+
+            return $dict
+        }
+        catch 
+        {
+                Write-Host "Expected Version information is coming as null. Please correct the version number accordingly: $($_.Exception.Message)" -ForegroundColor Red
+                break;
+        }
+    }
+
+    function global:constructVersionNumber($version)
+    {
+        $major,$minor,$build,$revision = $version.split(".")    
+        $version = [version]::new($major,$minor,$build)
+        return $version
+    }
+# =================END: RESOURCE CONTENT BY VERSION=====================
+
+function ConvertHashTo-StringData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
+        [HashTable[]]$HashTable
+    )
+        $Parameters = ""
+        foreach ($item in $HashTable) {
+            if($Parameters -ne "")
+            {
+                $Parameters = $Parameters + ","
+            }
+            if($item.Type.StartsWith('table:'))
+            {
+                $Parameters = $Parameters + "{0}:{1}" -f $item.Name, $item.Type.split(":")[-1]
+            }
+            else
+            {
+                if($null -ne $item.Default)
+                {
+                    $Default = $item.Default
+                    if($item.Type.ToLower() -eq 'string')
+                    {
+                        $Default = "'$default'"
+                    }
+                    $Parameters = $Parameters + "{0}:{1}={2}" -f $item.Name, $item.Type,$Default
+                }
+                else {
+                    $Parameters = $Parameters + "{0}:{1}" -f $item.Name, $item.Type
+                }
+            }
+        }
+        return $Parameters
+        #($HashTable.GetEnumerator() | % {$($_.Type.StartsWith('table:')) ? "$($_.Name):$($_.Type.split(":",1)[1])" : "$($_.Name):$($_.Type)"}) -join ','
+}
+
+function global:GenerateIdHash($packageId, $contentKind, $contentId, $contentVersion)
+{
+    if ([string]::IsNullOrWhiteSpace($packageId) -or [string]::IsNullOrEmpty($contentId))
+    {
+            return [string]::Empty
+    }
+    $sb = [System.Text.StringBuilder]::new()
+    [int]$limit = 50
+    $sb.Append($packageId.Length -gt $limit ? $packageId.Substring(0, $limit) : $packageId).Append('-')
+    if ($ContentKindDict.ContainsKey($contentKind))
+    {
+            $sb.Append($ContentKindDict[$contentKind])
+    }
+    else
+    {
+            $sb.Append($contentKind.ToString().substring(0,2).tolower())
+    }
+    $sb.Append('-')
+    $str = "$packageId-$($contentKind.ToString())-$contentId";
+    if ([string]::IsNullOrEmpty($contentVersion))
+    {
+        $str += "-$contentVersion";
+    }
+    $val = HashLine -value $str
+    $sb.Append($val)
+    return $sb.ToString()
+}
+
+function HashLine($value)
+{
+        $val = [string](Base32Encode -charValue "$(ComputeSHA($value))")
+        return $val.ToString()
+}
+
+function  ComputeSHA {
+    Param (
+    [Parameter(Mandatory=$true)]
+    [string]
+    $ClearString
+    )
+    $hasher = [System.Security.Cryptography.HashAlgorithm]::Create('sha256')
+    $hash = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($ClearString))
+    $hashString = [System.BitConverter]::ToInt32($hash)
+    #$hashString = $hashString.replace('-','')
+    #[uint32]$newhashString = $hashString
+    return $hashString
+}
+
+function Base32Encode([uint32]$charValue)
+{  
+        $chars = "abcdefghijklmnopqrstuvwxyz234567"
+        $Charset = ($chars).ToCharArray()
+        #$Charset = [char[]]::new('abcdefghijklmnopqrstuvwxyz234567')
+        $sb = [System.Text.StringBuilder]::new()
+        for($index = 0; $index -lt 13; $index++)
+        {
+                $sb.Append($Charset[[int]($charValue -shr 59)])
+                $charValue -shl 5
+        }
+        return $sb.ToString()
+}
+
+function addTemplateSpecParserResource($content,$yaml,$isyaml)
+{
+        # Add workspace resource ID if not available
+        if (!$global:baseMainTemplate.variables.workspaceResourceId) {
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
+        }
+
+        if ($contentResourceDetails.contentSchemaVersion -ne '3.0.0')
+        {
+            # Add base templateSpec
+            $baseParserTemplateSpec = [PSCustomObject]@{
+                type       = "Microsoft.Resources/templateSpecs";
+                apiVersion = "2022-02-01";
+                name       = "[variables('parserTemplateSpecName$global:parserCounter')]";
+                location   = "[parameters('workspace-location')]";
+                tags       = [PSCustomObject]@{
+                    "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                    "hidden-sentinelContentType" = "Parser";
+                };
+                properties = [PSCustomObject]@{
+                    description = "$($fileName) Data Parser with template";
+                    displayName = "$($fileName) Data Parser template";
+                }
+            }
+            $global:baseMainTemplate.resources += $baseParserTemplateSpec
+        }
+        # Parser Content
+        $parserContent = [PSCustomObject]@{
+            name       = "[variables('_parserName$global:parserCounter')]";
+            apiVersion = "2020-08-01";
+            type       = "Microsoft.OperationalInsights/workspaces/savedSearches";
+            location   = "[parameters('workspace-location')]";
+            properties = [PSCustomObject]@{
+                eTag          = "*"
+                displayName   = "$($displayDetails.displayName)"
+                category      = $isyaml ? "$($yaml.Category)" : "Samples"
+                functionAlias = "$($displayDetails.functionAlias)"
+                query         = $isyaml ? "$($yaml.FunctionQuery)" : "$content"
+                functionParameters = $isyaml ? "$(ConvertHashTo-StringData $yaml.FunctionParams)" : ""
+                version       = $isyaml ? 2 : 1
+                tags          = @([PSCustomObject]@{
+                    "name"  = "description"
+                    "value" = $isyaml ? "$($yaml.Description)" : "$($displayDetails.displayName)"
+                    };
+                )
+            }
+        }
+        $author = $contentToImport.Author.Split(" - ");
+        $authorDetails = [PSCustomObject]@{
+            name  = $author[0];
+        };
+        if($null -ne $author[1])
+        {
+            $authorDetails | Add-Member -NotePropertyName "email" -NotePropertyValue "[variables('_email')]"
+        }
+        $parserMetadata = [PSCustomObject]@{
+            type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+            apiVersion = "2022-01-01-preview";
+            name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Parser-', last(split(variables('_parserId$global:parserCounter'),'/'))))]";
+            dependsOn  =  @(
+                "[variables('_parserName$global:parserCounter')]"
+            );
+            properties = [PSCustomObject]@{
+                parentId  = "[resourceId('Microsoft.OperationalInsights/workspaces/savedSearches', parameters('workspace'), variables('parserName$global:parserCounter'))]"
+                contentId = "[variables('_parserContentId$global:parserCounter')]";
+                kind      = "Parser";
+                version   = "[variables('parserVersion$global:parserCounter')]";
+                source    = [PSCustomObject]@{
+                    name     = $contentToImport.Name;
+                    kind     = "Solution";
+                    sourceId = "[variables('_solutionId')]"
+                };
+                author    = $authorDetails;
+                support   = $baseMetadata.support
+            }
+        }
+
+        # Add templateSpecs/versions resource to hold actual content
+        $parserTemplateSpecContent = [PSCustomObject]@{
+            type       =  $contentResourceDetails.subtype; #"Microsoft.Resources/templateSpecs/versions";
+            apiVersion = $contentResourceDetails.apiVersion -eq '3.0.0' ? "2023-04-01-preview" : "2022-02-01";
+            name       = $contentResourceDetails.apiVersion -eq '3.0.0' ? "[variables('parserTemplateSpecName$global:parserCounter')]" : "[concat(variables('parserTemplateSpecName$global:parserCounter'),'/',variables('parserVersion$global:parserCounter'))]";
+            location   = "[parameters('workspace-location')]";
+            tags       = [PSCustomObject]@{
+                "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
+                "hidden-sentinelContentType" = "Parser";
+            };
+            dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
+                                "$($contentResourceDetails.dependsOn)") : @(
+                "[resourceId('Microsoft.Resources/templateSpecs', variables('parserTemplateSpecName$global:parserCounter'))]"
+            );
+            properties = [PSCustomObject]@{
+                description  = "$($fileName) Data Parser with template version $($contentToImport.Version)";
+                mainTemplate = [PSCustomObject]@{
+                    '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+                    contentVersion = "[variables('parserVersion$global:parserCounter')]";
+                    parameters     = [PSCustomObject]@{};
+                    variables      = [PSCustomObject]@{};
+                    resources      = @(
+                        # Parser
+                        $parserContent,
+                        # Metadata
+                        $parserMetadata
+                    )
+                };
+                
+            }
+        }
+        if ($contentResourceDetails.apiVersion -eq '3.0.0')
+        {
+            $parserTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $parserTemplateSpecContent
+            $parserTemplateSpecContent.properties.contentId = "[variables('_parserContentId$global:parserCounter')]"
+            $parserTemplateSpecContent.properties.contentKind = "Parser"
+            $parserTemplateSpecContent.properties.displayName = "$($displayDetails.displayName)"
+            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
+
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
+
+            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
+	    $parserTemplateSpecContent.properties.contentProductId = "[variables('_parsercontentProductId$global:parserCounter')]"
+            $parserTemplateSpecContent.properties.id = "[variables('_parsercontentProductId$global:parserCounter')]"
+            $parserTemplateSpecContent.properties.version = "[variables('parserVersion$global:parserCounter')]"
+            $parserTemplateSpecContent.PSObject.Properties.Remove('tags')
+        }
+        
+        $global:baseMainTemplate.resources += $parserTemplateSpecContent
+
+        $parserObj = [PSCustomObject] @{
+            type       = "Microsoft.OperationalInsights/workspaces/savedSearches";
+            apiVersion = "2020-08-01";
+            name       = "[variables('_parserName$parserCounter')]";
+            location   = "[parameters('workspace-location')]";
+            properties = [PSCustomObject] @{
+                eTag          = "*"
+                displayName   = "$($displayDetails.displayName)"
+                category      = $isyaml ? "$($yaml.Category)" :"Samples"
+                functionAlias = "$($displayDetails.functionAlias)"
+                query         = $isyaml ? "$($yaml.FunctionQuery)" : "$content"
+                functionParameters = $isyaml ? "$(ConvertHashTo-StringData $yaml.FunctionParams)" : ""
+                version       = $isyaml ? 2 : 1
+                tags          = @([PSCustomObject]@{
+                    "name"  = "description"
+                    "value" = $isyaml ? "$($yaml.Description)" : "$($displayDetails.displayName)"
+                    };
+                )
+            }
+        }
+        $global:baseMainTemplate.resources += $parserObj
+
+        $parserMetadata = [PSCustomObject]@{
+            type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
+            apiVersion = "2022-01-01-preview";
+            location   = "[parameters('workspace-location')]";
+            name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Parser-', last(split(variables('_parserId$global:parserCounter'),'/'))))]";
+            dependsOn  =  @(
+                "[variables('_parserId$global:parserCounter')]"
+            );
+            properties = [PSCustomObject]@{
+                parentId  = "[resourceId('Microsoft.OperationalInsights/workspaces/savedSearches', parameters('workspace'), variables('parserName$global:parserCounter'))]"
+                contentId = "[variables('_parserContentId$global:parserCounter')]";
+                kind      = "Parser";
+                version   = "[variables('parserVersion$global:parserCounter')]";
+                source    = [PSCustomObject]@{
+                    kind     = "Solution";
+                    name     = $contentToImport.Name;
+                    sourceId = "[variables('_solutionId')]"
+                };
+                author    = $authorDetails;
+                support   = $baseMetadata.support
+            }
+        }
+
+        $global:baseMainTemplate.resources += $parserMetadata
+}
+
+function generateParserContent($file, $contentToImport, $contentResourceDetails)
+{
+    $solutionName = $contentToImport.name
+    if ($global:parserCounter -eq 1 -and $null -eq $global:baseMainTemplate.variables.'workspace-dependency' -and !$contentToImport.TemplateSpec) {
+        # Add parser dependency variable once to ensure validation passes.
+        $global:baseMainTemplate.variables | Add-Member -MemberType NoteProperty -Name "workspace-dependency" -Value "[concat('Microsoft.OperationalInsights/workspaces/', parameters('workspace'))]"
+    }
+
+    $fileName = Split-Path $file -leafbase;
+    function getFileNameFromPath ([string]$inputFilePath) {
+        # Split out path
+        $indexOfSlashInFile = $inputFilePath.IndexOf("/")
+        if ($indexOfSlashInFile -gt 0)
+        {
+            $output = $inputFilePath.Split("/")
+            Write-Host "input file path is $inputFilePath output $output"
+            $output = $output[$output.Length - 1]
+            Write-Host "updated output $output"
+            # Split out file type
+            $output = $output.Split(".")[0]
+            return $output
+        }
+        else {
+            # GET NAME OF THE FILE WITHOUT ANY EXTENSION
+            $output = $inputFilePath.Split(".")[0]
+            return $output
+        }
+    }
+    $content = ''
+    $yaml = $null
+    $isyaml = $false
+    $rawData = $rawData.Split("`n")
+    foreach ($line in $rawData) {
+        # Remove comment lines before condensing query
+        if (!$line.StartsWith("//")) {
+            $content = $content + "`n" + $line
+        }
+    }
+    if($file -match "(\.yaml)$")
+    {        
+        try {
+            $yaml = ConvertFrom-YAML $content
+            $isyaml = $true
+        }
+        catch {
+        Write-Host "Failed to deserialize while converting the Saved Search Function from Yaml $file" -ForegroundColor Red
+        break;
+        }
+    }
+    
+    $displayDetails = getParserDetails $global:solutionId $yaml $isyaml
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parserName$global:parserCounter" -NotePropertyValue "$($displayDetails.name)"
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parserName$global:parserCounter" -NotePropertyValue "[concat(parameters('workspace'),'/',variables('parserName$global:parserCounter'))]"
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parserId$global:parserCounter" -NotePropertyValue "[resourceId('Microsoft.OperationalInsights/workspaces/savedSearches', parameters('workspace'), variables('parserName$global:parserCounter'))]"
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parserId$global:parserCounter" -NotePropertyValue "[variables('parserId$global:parserCounter')]"
+
+    if ($contentResourceDetails.apiVersion -eq '3.0.0')
+    {
+        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parserTemplateSpecName$global:parserCounter" -NotePropertyValue "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat(concat(parameters('workspace'),'-pr-',uniquestring(variables('_parserContentId$global:parserCounter'))),variables('parserVersion$global:parserCounter')))]"
+    }
+    else 
+    {
+        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parserTemplateSpecName$global:parserCounter" -NotePropertyValue "[concat(parameters('workspace'),'-pr-',uniquestring(variables('_parserContentId$global:parserCounter')))]"
+    }
+
+    # Use File Name as Parser Name
+    $functionAlias = ($null -ne $yaml -and $yaml.Count -gt 0) ? $yaml.FunctionName : "$($displayDetails.functionAlias)"
+    $global:parserVersion = ($null -ne $yaml -and $yaml.Count -gt 0) ? ($null -eq $yaml.Function.Version ? "1.0.0" : $yaml.Function.Version) : "1.0.0"
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parserVersion$global:parserCounter" -NotePropertyValue $global:parserVersion
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "parserContentId$global:parserCounter" -NotePropertyValue "$($functionAlias)-Parser"
+    $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parserContentId$global:parserCounter" -NotePropertyValue "[variables('parserContentId$global:parserCounter')]"
+    $global:DependencyCriteria += [PSCustomObject]@{
+        kind      = "Parser";
+        contentId = "[variables('_parserContentId$global:parserCounter')]";
+        version   = "[variables('parserVersion$global:parserCounter')]";
+    };
+
+    if($contentToImport.TemplateSpec) {
+        # Adding the Parser respective TemplateSpec Resources and Active Parser and Metadata Resource
+        addTemplateSpecParserResource $content $yaml $isyaml
+    }
+    else {
+        if ($global:parserCounter -eq 1 -and $(queryResourceExists) -and !$contentToImport.TemplateSpec) {
+            $baseParserResource = [PSCustomObject] @{
+                type       = "Microsoft.OperationalInsights/workspaces";
+                apiVersion = "2020-08-01";
+                name       = "[parameters('workspace')]";
+                location   = "[parameters('workspace-location')]";
+                resources  = @(
+
+                )
+            }
+            $global:baseMainTemplate.resources += $baseParserResource
+        }
+        $parserObj = [PSCustomObject] @{
+            type       = "savedSearches";
+            apiVersion = "2020-08-01";
+            name       = "$solutionName Data Parser";
+            dependsOn  = @(
+                "[variables('workspace-dependency')]"
+            );
+            properties = [PSCustomObject] @{
+                eTag          = "*";
+                displayName   = "$solutionName Data Parser";
+                category      = "Samples";
+                functionAlias = "$functionAlias";
+                query         = $content;
+                version       = 1;
+            }
+        }
+        $queryLocation = $(getQueryResourceLocation)
+        if ($null -eq $queryLocation)
+        {
+            Write-Host  "For Parser, getQueryResourceLocation function returned null for $file which is not valid"
+            return;
+        }
+        else
+        {
+            $global:baseMainTemplate.resources[$queryLocation].resources += $parserObj
+        }
+    }
+    
+    $global:parserCounter += 1
+    #return $DependencyCriteria
+}

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -87,7 +87,6 @@ function removePropertiesRecursively ($resourceObj, $isWorkbook = $false) {
                 }
                 else
                 {
-                    #$resourceObj.PsObject.Properties.Remove($key)
                     $resourceObj.$key = "[variables('TemplateEmptyArray')]";
                     if (!$global:baseMainTemplate.variables.TemplateEmptyArray) {
                         $global:baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyArray" -NotePropertyValue "[json('[]')]"
@@ -147,14 +146,13 @@ function getParserDetails($solutionName,$yaml,$isyaml)
     $variableExpressionRegex = "\[\s?variables\(\'_([\w\W]+)\'\)\s?\]"
     $parserDisplayDetails = New-Object PSObject
 
-    # =============new code from sarath=============
     $functionAlias = ($isyaml -eq $true) ? $yaml.FunctionName : $(getFileNameFromPath $file)
     $displayName = ($isyaml -eq $true) ? "$($yaml.Function.Title)" : "$($fileName)"
     $name = ($isyaml -eq $true) ? "$($yaml.FunctionName)" : "$($fileName)"
     $parserDisplayDetails | Add-Member -NotePropertyName "functionAlias" -NotePropertyValue $functionAlias
     $parserDisplayDetails | Add-Member -NotePropertyName "displayName" -NotePropertyValue $displayName
     $parserDisplayDetails | Add-Member -NotePropertyName "name" -NotePropertyValue $name
-    # ==============================================
+
 
     $currentSolution = $SolutionDataItems | Where-Object { $_.legacyId -eq $solutionName }
     if($currentSolution.length -gt 0)
@@ -334,11 +332,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
             $newMetadata.Properties | Add-Member -Name 'publisherDisplayName' -Type NoteProperty -Value $(If ($support.psobject.properties["tier"].value.tolower() -eq "microsoft") {"Microsoft Sentinel, $($support.psobject.properties["name"].value)"} Else {$($support.psobject.properties["name"].value)})
             $newMetadata.Properties | Add-Member -Name 'descriptionHtml' -Type NoteProperty -Value $contentToImport.Description;
             $newMetadata.Properties | Add-Member -Name 'contentKind' -Type NoteProperty -Value "Solution";
-            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(substring(variables('_solutionId'),0, 50),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
 
-            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
-
-            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_solutioncontentProductId" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$($ContentKindDict.ContainsKey("Solution") ? $ContentKindDict["Solution"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]"
 	    $newMetadata.Properties | Add-Member -Name 'contentProductId' -Type NoteProperty -Value "[variables('_solutioncontentProductId')]"
             $newMetadata.Properties | Add-Member -Name 'id' -Type NoteProperty -Value "[variables('_solutioncontentProductId')]"
             $newMetadata.Properties | Add-Member -Name 'icon' -Type NoteProperty -Value $contentToImport.Logo;
@@ -428,7 +423,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
         ### Removing the Non-Sentinel Resources if there are any:
         $newobject = $global:baseMainTemplate.resources | ? {$_.type -in $contentResourceDetails.resources}
         $global:baseMainTemplate.resources = $newobject
-        ### TODO: CHECK IF ABOVE LINE IS NEEDED HERE OR WE SHOULD RETURN $newMetadata
     }
 
     function GetWorkbookDataMetadata($file, $isPipelineRun, $contentResourceDetails, $baseFolderPath, $contentToImport)
@@ -495,13 +489,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             }
                         }
 
-                        # if ($isPipelineRun)
-                        # {
-                        #     $workbookFinalPath = $baseFolderPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';  #"https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/" #$workbookMetadataPathForPipelineRun 
-                        # }
-                        # else {
-                        #     $workbookFinalPath = $workbookMetadataPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';
-                        # }
                         $workbookFinalPath = $baseFolderPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';  #"https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/" #$workbookMetadataPathForPipelineRun 
                         
                         # BELOW IS THE NEW CODE ADDED FROM AZURE SENTINEL REPO
@@ -568,17 +555,10 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             }
                         }
 
-                        #$workbookMetadataPath = "$PSScriptRoot/../../../"
                         if($contentToImport.TemplateSpec) {
                             #Getting Workbook Metadata dependencies from Github
                             $workbookData = $null
-                            #$workbookFinalPath = $workbookMetadataPath + 'Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json';
-                            #$workbookFinalPath = "https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json"
-                            
-                            # REPLACE BELOW WITH
-                            #https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json
-                            #$workbookFinalPath ="https://raw.githubusercontent.com/v-amolpatil/packagingrepo/master/Tools/Create-Azure-Sentinel-Solution/V2/WorkbookMetadata/WorkbooksMetadata.json?token=GHSAT0AAAAAACAH2TVHK4LEA4VCEPD7JR5SZB35H7A"
-                            
+
                             try {
                                 Write-Host "Downloading $workbookFinalPath"
                                 $workbookData = (New-Object System.Net.WebClient).DownloadString($workbookFinalPath)
@@ -732,9 +712,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
                                     "hidden-sentinelContentType" = "Workbook";
                                 };
-                                # dependsOn  = @(
-                                #     "[resourceId('Microsoft.Resources/templateSpecs', variables('workbookTemplateSpecName$global:workbookCounter'))]"
-                                # );
+
                                 dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
                                 "$($contentResourceDetails.dependsOn)") : @(
                                     "$($contentResourceDetails.dependsOn), variables('workbookTemplateSpecName$global:workbookCounter'))]"
@@ -762,11 +740,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 $workbookTemplateSpecContent.properties.contentId = "[variables('_workbookContentId$global:workbookCounter')]"
                                 $workbookTemplateSpecContent.properties.contentKind = "Workbook"
                                 $workbookTemplateSpecContent.properties.displayName = "[parameters('workbook$global:workbookCounter-name')]"
-                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
 
-                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
-
-                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_workbookcontentProductId$global:workbookCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','wb','-', uniqueString(concat(variables('_solutionId'),'-','Workbook','-',variables('_workbookContentId$global:workbookCounter'),'-', variables('workbookVersion$global:workbookCounter'))))]"
 				$workbookTemplateSpecContent.properties.contentProductId = "[variables('_workbookcontentProductId$global:workbookCounter')]"                                
                                 $workbookTemplateSpecContent.properties.id = "[variables('_workbookcontentProductId$global:workbookCounter')]"
                                 $workbookTemplateSpecContent.properties.version = "[variables('workbookVersion$global:workbookCounter')]"
@@ -830,20 +805,21 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                     {
                         $functionAppsPlaybookId = $playbookData.parameters.FunctionAppName.defaultValue
 
-                        if ($null -eq $functionAppsPlaybookId)
-                        {
-                            $suffix = 'fa'
-                            if (!$playbookName) {
-                                $functionAppMessage = "FunctionAppname not found in FunctionApp file $fileName so setting default value to '" + $fileName + "fa'"
-                                Write-Host "$functionAppMessage"
-                                $functionAppsPlaybookId = $fileName + $suffix
-                            }
-                            else {
-                                $functionAppMessage = "FunctionAppname not found in FunctionApp file $fileName so setting default value to '" + $playbookName + "fa'"
-                                Write-Host "$functionAppMessage"
-                                $functionAppsPlaybookId = $playbookName + $suffix
-                            }
-                        }
+                        # keeping this for furture use
+                        # if ($null -eq $functionAppsPlaybookId)
+                        # {
+                        #     $suffix = 'fa'
+                        #     if (!$playbookName) {
+                        #         $functionAppMessage = "FunctionAppname not found in FunctionApp file $fileName so setting default value to '" + $fileName + "fa'"
+                        #         Write-Host "$functionAppMessage"
+                        #         $functionAppsPlaybookId = $fileName + $suffix
+                        #     }
+                        #     else {
+                        #         $functionAppMessage = "FunctionAppname not found in FunctionApp file $fileName so setting default value to '" + $playbookName + "fa'"
+                        #         Write-Host "$functionAppMessage"
+                        #         $functionAppsPlaybookId = $playbookName + $suffix
+                        #     }
+                        # }
                     }
 
                     if (!$playbookName) {
@@ -895,7 +871,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                         )
                     }
                     $currentStepNum = $global:baseCreateUiDefinition.parameters.steps.Count - 1
-                    #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements += $playbookElement
 
                     foreach ($param in $playbookData.parameters.PsObject.Properties) {
                         $paramName = $param.Name
@@ -913,7 +888,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     validationMessage = "Please enter a playbook resource name"
                                 }
                             }
-                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookNameObject
+
                             if(!$contentToImport.TemplateSpec)
                             {
                                 $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
@@ -937,7 +912,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     validationMessage = "Please enter a playbook username";
                                 }
                             }
-                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookUsernameObject
+
                             if(!$contentToImport.TemplateSpec){
                             $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
                                     defaultValue = $defaultParamValue;
@@ -956,7 +931,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 constraints = [PSCustomObject] @{ required = $true; };
                                 options     = [PSCustomObject] @{ hideConfirmation = $false; };
                             }
-                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookPasswordObject
+
                             if(!$contentToImport.TemplateSpec){
                             $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
                                     type      = "securestring";
@@ -974,7 +949,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 constraints = [PSCustomObject] @{ required = $true; };
                                 options     = [PSCustomObject] @{ hideConfirmation = $true; };
                             }
-                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookPasswordObject
+
                             if(!$contentToImport.TemplateSpec)
                             {
                                 $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
@@ -1032,7 +1007,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     }
                                 }
                             )
-                            #$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements[$global:baseCreateUiDefinition.parameters.steps[$currentStepNum].elements.Length - 1].elements += $playbookParamObject
+
                             $defaultValue = $(if ($defaultParamValue) { $defaultParamValue } else { "" })
                             if(!$contentToImport.TemplateSpec){
                             $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "playbook$global:playbookCounter-$paramName" -NotePropertyValue ([PSCustomObject] @{
@@ -1079,7 +1054,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             foreach ($prop in $resourceObj.PsObject.Properties) {
                                 $key = $prop.Name
                                 if ($prop.Value -is [System.String]) {
-                                    #Write-Host "its a string $resourceObj.$key"
                                     if($resourceObj.$key -eq "")
                                     {
                                         $resourceObj.$key = "[variables('blanks')]";
@@ -1325,8 +1299,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookId$global:playbookCounter" -NotePropertyValue "[resourceId('Microsoft.Logic/workflows', variables('playbookContentId$global:playbookCounter'))]"
                         }
 
-                        #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue ($IsLogicAppsCustomConnector ? "[concat(parameters('workspace'),'-lc-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]" : "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]")
-
                         if ($contentResourceDetails.apiVersion -eq '3.0.0')
                         {
                             if ($IsLogicAppsCustomConnector) {
@@ -1358,11 +1330,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                         }
                     }
 
-                        # $global:baseMainTemplate.variables | Add-Member -NotePropertyName "playbookTemplateSpecName$global:playbookCounter" -NotePropertyValue ($IsLogicAppsCustomConnector ? 
-                        # "[concat(parameters('workspace'),'-lc-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]" : 
-                        # $IsFunctionAppResource ? "[concat(parameters('workspace'),'-fa-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]" :
-                        # "[concat(parameters('workspace'),'-pl-',uniquestring(variables('_playbookContentId$global:playbookCounter')))]")
-                        
                         # Add workspace resource ID if not available
                         if (!$global:baseMainTemplate.variables.workspaceResourceId) {
                             $global:baseMainTemplate.variables | Add-Member -NotePropertyName "workspaceResourceId" -NotePropertyValue "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]"
@@ -1379,10 +1346,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
                                     "hidden-sentinelContentType" = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook";
                                 };
-                                # properties = [PSCustomObject]@{
-                                #     description = $IsLogicAppsCustomConnector ? $playbookName : "$($playbookName) playbook";
-                                #     displayName = $IsLogicAppsCustomConnector ? $playbookName : "$($playbookName) playbook";
-                                # }
+
                                 properties = [PSCustomObject]@{
                                     description = $IsLogicAppsCustomConnector -or $IsFunctionAppResource ? $playbookName : "$($playbookName) playbook";
                                     displayName = $IsLogicAppsCustomConnector -or $IsFunctionAppResource ? $playbookName : "$($playbookName) playbook";
@@ -1403,16 +1367,18 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             $global:customConnectorsList.add($customConnectorContentId, @{ id="[variables('_$filename')]"; version="[variables('playbookVersion$global:playbookCounter')]"});
                         }
                         if ($IsFunctionAppResource) {
-                            if ($null -ne $functionAppsPlaybookId)
-                            {
-                                $global:functionAppList.add($functionAppsPlaybookId, @{ id="[variables('_$filename')]"; version="[variables('playbookVersion$global:playbookCounter')]"});
-                            }
+                            $global:functionAppList.add($functionAppsPlaybookId, @{ id="[variables('_$filename')]"; version="[variables('playbookVersion$global:playbookCounter')]"});
+
+                            # keeping it for furture use
+                            # if ($null -ne $functionAppsPlaybookId)
+                            # {
+                            #     $global:functionAppList.add($functionAppsPlaybookId, @{ id="[variables('_$filename')]"; version="[variables('playbookVersion$global:playbookCounter')]"});
+                            # }
                         }
 
                         $playbookMetadata = [PSCustomObject]@{
                             type       = "Microsoft.OperationalInsights/workspaces/providers/metadata";
                             apiVersion = "2022-01-01-preview";
-                            #name       = $IsLogicAppsCustomConnector ? "[[concat(variables('workspace-name'),'/Microsoft.SecurityInsights/',concat('LogicAppsCustomConnector-', last(split(variables('playbookId'),'/'))))]" : "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]";
                             name       = $IsLogicAppsCustomConnector ? "[[concat(variables('workspace-name'),'/Microsoft.SecurityInsights/',concat('LogicAppsCustomConnector-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]" : 
                             $IsFunctionAppResource ? "[[concat(variables('workspace-name'),'/Microsoft.SecurityInsights/',concat('AzureFunction-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]" :
                             "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Playbook-', last(split(variables('playbookId$global:playbookCounter'),'/'))))]";
@@ -1475,9 +1441,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
                                 "hidden-sentinelContentType" = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook";
                             };
-                            # dependsOn  = @(
-                            #     "[resourceId('Microsoft.Resources/templateSpecs', variables('playbookTemplateSpecName$global:playbookCounter'))]"
-                            # );
+
                             dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
                                 "$($contentResourceDetails.dependsOn)") : @(
                                 "$($contentResourceDetails.dependsOn), variables('playbookTemplateSpecName$global:playbookCounter'))]"
@@ -1499,11 +1463,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             $playbookTemplateSpecContent.properties.contentId = "[variables('_playbookContentId$global:playbookCounter')]"
                             $playbookTemplateSpecContent.properties.contentKind = $IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook"
                             $playbookTemplateSpecContent.properties.displayName = $playbookName
-                            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
 
-                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
-
-                            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_playbookcontentProductId$global:playbookCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$global:contentShortName','-', uniqueString(concat(variables('_solutionId'),'-','$($IsLogicAppsCustomConnector ? "LogicAppsCustomConnector" : $IsFunctionAppResource ? "AzureFunction" : "Playbook")','-',variables('_playbookContentId$global:playbookCounter'),'-', variables('playbookVersion$global:playbookCounter'))))]"
 			    $playbookTemplateSpecContent.properties.contentProductId = "[variables('_playbookcontentProductId$global:playbookCounter')]"
                              $playbookTemplateSpecContent.properties.id = "[variables('_playbookcontentProductId$global:playbookCounter')]"
                             $playbookTemplateSpecContent.properties.version = "[variables('playbookVersion$global:playbookCounter')]"
@@ -1594,20 +1555,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                         Write-Host "Failed to deserialize $file" -ForegroundColor Red
                         break;
                     }
-                    # $connectorNameParamObj = [PSCustomObject] @{
-                    #     type         = "string";
-                    #      defaultValue = $(New-Guid).Guid
-                    # }
-                    #  $connectorId = $connectorData.id + 'Connector';
-                    # if ($contentToImport.Metadata -and !$contentToImport.TemplateSpec) {
-                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName $connectorId -NotePropertyValue $connectorId
-                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_$connectorId" -NotePropertyValue "[variables('$connectorId')]"
-                    # }
-                    #  if (!$contentToImport.TemplateSpec){
-                    #     $global:baseMainTemplate.parameters | Add-Member -NotePropertyName "connector$global:connectorCounter-name" -NotePropertyValue $connectorNameParamObj
-                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName "connector$global:connectorCounter-source" -NotePropertyValue "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name,'/providers/Microsoft.OperationalInsights/workspaces/',parameters('workspace'),'/providers/Microsoft.SecurityInsights/dataConnectors/',parameters('connector$global:connectorCounter-name'))]"
-                    #     $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_connector$global:connectorCounter-source" -NotePropertyValue "[variables('connector$global:connectorCounter-source')]"
-                    #  };
+
                     $global:DependencyCriteria += [PSCustomObject]@{
                         kind      = "DataConnector";
                         contentId = if ($contentToImport.TemplateSpec){"[variables('_dataConnectorContentId$global:connectorCounter')]"}else{"[variables('_$connectorId')]"};
@@ -1677,7 +1625,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             if($existingFunctionApp)
                             {
                                 $templateSpecConnectorData.title = ($templateSpecConnectorData.title.Contains("using Azure Functions")) ? $templateSpecConnectorData.title : $templateSpecConnectorData.title + " (using Azure Functions)"
-                                #$templateSpecConnectorData.title = $templateSpecConnectorData.title + " (using Azure Functions)";
                             }
                         }
                         # Data Connector Content -- *Assumes GenericUI
@@ -1743,9 +1690,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
                                 "hidden-sentinelContentType" = "DataConnector";
                             };
-                            # dependsOn  = @(
-                            #     "[resourceId('Microsoft.Resources/templateSpecs', variables('dataConnectorTemplateSpecName$global:connectorCounter'))]"
-                            # );
+
                             dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
                                 "$($contentResourceDetails.dependsOn)") : @(
                                 "$($contentResourceDetails.dependsOn), variables('dataConnectorTemplateSpecName$global:connectorCounter'))]"
@@ -1771,13 +1716,11 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             $dataConnectorTemplateSpecContent = SetContentTemplateDefaultValuesToProperties -templateSpecResourceObj $dataConnectorTemplateSpecContent
                             $dataConnectorTemplateSpecContent.properties.contentId = "[variables('_dataConnectorContentId$global:connectorCounter')]"
                             $dataConnectorTemplateSpecContent.properties.contentKind = "DataConnector"
-                            
-                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorcontentProductId$global:connectorCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('_dataConnectorContentId$global:connectorCounter'),'-', variables('dataConnectorVersion$global:connectorCounter'))))]"
 
-                            # $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorcontentProductId$global:connectorCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('_dataConnectorContentId$global:connectorCounter'),'-', variables('dataConnectorVersion$global:connectorCounter'))))]"
+                            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_dataConnectorcontentProductId$global:connectorCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('_dataConnectorContentId$global:connectorCounter'),'-', variables('dataConnectorVersion$global:connectorCounter'))))]"
 			                $dataConnectorTemplateSpecContent.properties.contentProductId = "[variables('_dataConnectorcontentProductId$global:connectorCounter')]"
                             $dataConnectorTemplateSpecContent.properties.id = "[variables('_dataConnectorcontentProductId$global:connectorCounter')]"
-                            #GenerateIdHash -packageId "$($global:baseMainTemplate.variables."solutionId")" -contentKind "DataConnector" -contentId "$($global:baseMainTemplate.variables."dataConnectorContentId$global:connectorCounter")" -contentVersion "$($global:baseMainTemplate.variables."dataConnectorVersion$global:connectorCounter")"
+
                             $dataConnectorTemplateSpecContent.properties.displayName = $templateSpecConnectorData.title
                             $dataConnectorTemplateSpecContent.properties.version = "[variables('dataConnectorVersion$global:connectorCounter')]"
                             $dataConnectorTemplateSpecContent.PSObject.Properties.Remove('tags')
@@ -1857,11 +1800,9 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                         # Else check if Polling connector
                         $connectorData = $connectorData.resources[0]
                         $connectorUiConfig = $connectorData.properties.connectorUiConfig
-                        # $connectorUiConfig.PSObject.Properties.Remove('id')
                         $connectorUiConfig.id = if ($contentToImport.TemplateSpec) { "[variables('_uiConfigId$global:connectorCounter')]" }else { "[variables('_connector$global:connectorCounter-source')]" };
 
                         $connectorObj = [PSCustomObject]@{
-                            # id         = if ($contentToImport.TemplateSpec) { "[variables('_uiConfigId$global:connectorCounter')]" }else { "[variables('_connector$global:connectorCounter-source')]" };
                             name       = if ($contentToImport.TemplateSpec) { "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentId$global:connectorCounter'))]" }else { "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',parameters('connector$global:connectorCounter-name'))]" }
                             apiVersion = "2021-03-01-preview";
                             type       = "Microsoft.OperationalInsights/workspaces/providers/dataConnectors";
@@ -1903,11 +1844,9 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                     $connectorDataType = $(getConnectorDataTypes $connectorData.dataTypes)
                     $isParserAvailable = $($contentToImport.Parsers -and ($contentToImport.Parsers.Count -gt 0))
                     $baseDescriptionText = "This Solution installs the data connector for $solutionName. You can get $solutionName $connectorDataType data in your Microsoft Sentinel workspace. Configure and enable this data connector in the Data Connector gallery after this Solution deploys."
-                    #$parserText = "The Solution installs a parser that transforms the ingested data into Microsoft Sentinel normalized format. The normalized format enables better correlation of different types of data from different data sources to drive end-to-end outcomes seamlessly in security monitoring, hunting, incident investigation and response scenarios in Microsoft Sentinel."
                     $customLogsText = "$baseDescriptionText This data connector creates custom log table(s) $(getAllDataTypeNames $connectorData.dataTypes) in your Microsoft Sentinel / Azure Log Analytics workspace."
                     $syslogText = "$baseDescriptionText The logs will be received in the Syslog table in your Microsoft Sentinel / Azure Log Analytics workspace."
                     $commonSecurityLogText = "$baseDescriptionText The logs will be received in the CommonSecurityLog table in your Microsoft Sentinel / Azure Log Analytics workspace."
-                    #$connectorDescriptionText = $(if ($connectorDataType -eq $commonSecurityLog) { $commonSecurityLogText } elseif ($connectorDataType -eq $syslog) { $syslogText } else { $customLogsText })
                     $connectorDescriptionText = "This Solution installs the data connector for $solutionName. You can get $solutionName $connectorDataType data in your Microsoft Sentinel workspace. After installing the solution, configure and enable this data connector by following guidance in Manage solution view."
                     $parserText = "The Solution installs a parser that transforms the ingested data into Microsoft Sentinel normalized format. The normalized format enables better correlation of different types of data from different data sources to drive end-to-end outcomes seamlessly in security monitoring, hunting, incident investigation and response scenarios in Microsoft Sentinel."
 
@@ -2166,9 +2105,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
                                     "hidden-sentinelContentType" = "HuntingQuery";
                                 };
-                                # dependsOn  = @(
-                                #     "[resourceId('Microsoft.Resources/templateSpecs', variables('huntingQueryTemplateSpecName$global:huntingQueryCounter'))]"
-                                # );
+
                                 dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
                                 "$($contentResourceDetails.dependsOn)") : @(
                                     "$($contentResourceDetails.dependsOn), variables('huntingQueryTemplateSpecName$global:huntingQueryCounter'))]"
@@ -2195,11 +2132,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 $huntingQueryTemplateSpecContent.properties.contentId = "[variables('_huntingQuerycontentId$global:huntingQueryCounter')]"
                                 $huntingQueryTemplateSpecContent.properties.contentKind = "HuntingQuery"
                                 $huntingQueryTemplateSpecContent.properties.displayName = $yaml.name
-                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
 
-                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
-
-                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_huntingQuerycontentProductId$global:huntingQueryCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','hq','-', uniqueString(concat(variables('_solutionId'),'-','HuntingQuery','-',variables('_huntingQuerycontentId$global:huntingQueryCounter'),'-', variables('huntingQueryVersion$global:huntingQueryCounter'))))]"
 				$huntingQueryTemplateSpecContent.properties.contentProductId = "[variables('_huntingQuerycontentProductId$global:huntingQueryCounter')]"
                                 $huntingQueryTemplateSpecContent.properties.id = "[variables('_huntingQuerycontentProductId$global:huntingQueryCounter')]"
                                 $huntingQueryTemplateSpecContent.properties.version = "[variables('huntingQueryVersion$global:huntingQueryCounter')]"
@@ -2228,7 +2162,6 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                         }
                         $dependencyDescription = ""
                         if ($yaml.requiredDataConnectors) {
-                            #$dependencyDescription = "It depends on the $($yaml.requiredDataConnectors.connectorId) data connector and $($($yaml.requiredDataConnectors.dataTypes)) data type and $($yaml.requiredDataConnectors.connectorId) parser."
                             $dependencyDescription = "This hunting query depends on $($yaml.requiredDataConnectors.connectorId) data connector ($($($yaml.requiredDataConnectors.dataTypes)) Parser or Table)"
                         }
                         $huntingQueryElement = [PSCustomObject]@{
@@ -2518,9 +2451,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                     "hidden-sentinelWorkspaceId" = "[variables('workspaceResourceId')]";
                                     "hidden-sentinelContentType" = "AnalyticsRule";
                                 };
-                                # dependsOn  = @(
-                                #     "[resourceId('Microsoft.Resources/templateSpecs', variables('analyticRuleTemplateSpecName$global:analyticRuleCounter'))]"
-                                # );
+
                                 dependsOn  = $contentResourceDetails.apiVersion -eq '3.0.0' ? @(
                                 "$($contentResourceDetails.dependsOn)") : @(
                                     "$($contentResourceDetails.dependsOn), variables('analyticRuleTemplateSpecName$global:analyticRuleCounter'))]"
@@ -2547,11 +2478,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 $analyticRuleTemplateSpecContent.properties.contentId = "[variables('_analyticRulecontentId$global:analyticRuleCounter')]"
                                 $analyticRuleTemplateSpecContent.properties.contentKind = "AnalyticsRule"
                                 $analyticRuleTemplateSpecContent.properties.displayName = $yaml.name
-                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
 
-                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
-
-                                #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
+                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_analyticRulecontentProductId$global:analyticRuleCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','ar','-', uniqueString(concat(variables('_solutionId'),'-','AnalyticsRule','-',variables('_analyticRulecontentId$global:analyticRuleCounter'),'-', variables('analyticRuleVersion$global:analyticRuleCounter'))))]"
 				$analyticRuleTemplateSpecContent.properties.contentProductId = "[variables('_analyticRulecontentProductId$global:analyticRuleCounter')]"
                                 $analyticRuleTemplateSpecContent.properties.id = "[variables('_analyticRulecontentProductId$global:analyticRuleCounter')]"
                                 $analyticRuleTemplateSpecContent.properties.version = "[variables('analyticRuleVersion$global:analyticRuleCounter')]"
@@ -2932,7 +2860,6 @@ function ConvertHashTo-StringData {
             }
         }
         return $Parameters
-        #($HashTable.GetEnumerator() | % {$($_.Type.StartsWith('table:')) ? "$($_.Name):$($_.Type.split(":",1)[1])" : "$($_.Name):$($_.Type)"}) -join ','
 }
 
 function global:GenerateIdHash($packageId, $contentKind, $contentId, $contentVersion)
@@ -2978,8 +2905,6 @@ function  ComputeSHA {
     $hasher = [System.Security.Cryptography.HashAlgorithm]::Create('sha256')
     $hash = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($ClearString))
     $hashString = [System.BitConverter]::ToInt32($hash)
-    #$hashString = $hashString.replace('-','')
-    #[uint32]$newhashString = $hashString
     return $hashString
 }
 
@@ -2987,7 +2912,7 @@ function Base32Encode([uint32]$charValue)
 {  
         $chars = "abcdefghijklmnopqrstuvwxyz234567"
         $Charset = ($chars).ToCharArray()
-        #$Charset = [char[]]::new('abcdefghijklmnopqrstuvwxyz234567')
+
         $sb = [System.Text.StringBuilder]::new()
         for($index = 0; $index -lt 13; $index++)
         {
@@ -3111,11 +3036,8 @@ function addTemplateSpecParserResource($content,$yaml,$isyaml)
             $parserTemplateSpecContent.properties.contentId = "[variables('_parserContentId$global:parserCounter')]"
             $parserTemplateSpecContent.properties.contentKind = "Parser"
             $parserTemplateSpecContent.properties.displayName = "$($displayDetails.displayName)"
-            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, 50),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
 
-            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(substring(variables('_solutionId'), 0, if(greaterOrEquals(length(variables('_solutionId')), 50), 50, length(variables('_solutionId')))),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
-
-            #$global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
+            $global:baseMainTemplate.variables | Add-Member -NotePropertyName "_parsercontentProductId$global:parserCounter" -NotePropertyValue "[concat(take(variables('_solutionId'),50),'-','$($ContentKindDict.ContainsKey("Parser") ? $ContentKindDict["Parser"] : '')','-', uniqueString(concat(variables('_solutionId'),'-','Parser','-',variables('_parserContentId$global:parserCounter'),'-', variables('parserVersion$global:parserCounter'))))]"
 	    $parserTemplateSpecContent.properties.contentProductId = "[variables('_parsercontentProductId$global:parserCounter')]"
             $parserTemplateSpecContent.properties.id = "[variables('_parsercontentProductId$global:parserCounter')]"
             $parserTemplateSpecContent.properties.version = "[variables('parserVersion$global:parserCounter')]"
@@ -3295,5 +3217,4 @@ function generateParserContent($file, $contentToImport, $contentResourceDetails)
     }
     
     $global:parserCounter += 1
-    #return $DependencyCriteria
 }

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/SolutionAutomationInput.ts
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/SolutionAutomationInput.ts
@@ -1,0 +1,34 @@
+/**
+ * Solution Automation Input File Interface
+ * -----------------------------------------------------
+ * The purpose of this interface is to provide detail on
+ *  the various fields the input file can have.
+ */
+ interface SolutionAutomationInput {
+  Name: string;                //Solution Name      - Ex. "Symantec Endpoint Protection"
+  Author: string;              //Author of Solution - Ex. "Eli Forbes - v-eliforbes@microsoft.com"
+  Logo: string;                //Link to the Logo used in the CreateUiDefinition.json
+  Description: string;         //Solution Description used in the CreateUiDefinition.json
+  WorkbookDescription: string|string[]; //Workbook description(s) from ASI-Portal Workbooks Metadata
+  Version: string;             //Package version to be created
+  //The following fields take arrays of paths relative to the solutions folder.
+  //Ex. Workbooks: ["Workbooks/SymantecEndpointProtection.json"]
+  Workbooks?: string[];
+  WorkbookBladeDescription: string; //Description used in the CreateUiDefinition.json for Workbooks Blade
+  AnalyticalRuleBladeDescription: string; //Description used in the CreateUiDefinition.json for Analytical Rule Blade
+  HuntingQueryBladeDescription: string; //Description used in the CreateUiDefinition.json for Hunting Query Blade
+  PlaybooksBladeDescription: string; //Description used in the CreateUiDefinition.json for Playbook Blade
+  "Analytic Rules"?: string[];
+  Playbooks?: string[];
+  PlaybookDescription?: string|string[]; //Description used in the CreateUiDefinition.json
+  Parsers?: string[];
+  SavedSearches?: string[];
+  "Hunting Queries"?: string[];
+  "Data Connectors"?: string[];
+  Watchlists?: string[];
+  WatchlistDescription?: string|string[]; //Description used in the CreateUiDefinition.json
+  BasePath?: string; //Optional base path to use. Either Internet URL or File Path. Default = "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/""
+  Metadata: string; //Path to the SolutionMetadata file
+  TemplateSpec: true;
+  Is1PConnector: false;
+}

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/baseCreateUiDefinition.json
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/baseCreateUiDefinition.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Azure.CreateUIDef",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "config": {
+      "isWizard": false,
+      "basics": {
+        "description": "{{Logo}}\n\n**Note:** _There may be [known issues](https://aka.ms/sentinelsolutionsknownissues) pertaining to this Solution, please refer to them before installing._\n\n{{SolutionDescription}}\n\n{{DataConnectorCount}}{{ParserCount}}{{WorkbookCount}}{{AnalyticRuleCount}}{{HuntingQueryCount}}{{WatchlistCount}}{{LogicAppCustomConnectorCount}}{{FunctionAppsCount}}{{PlaybookCount}}\n\n[Learn more about Microsoft Sentinel](https://aka.ms/azuresentinel) | [Learn more about Solutions](https://aka.ms/azuresentinelsolutionsdoc)",
+        "subscription": {
+          "resourceProviders": [
+            "Microsoft.OperationsManagement/solutions",
+            "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "Microsoft.Insights/workbooks",
+            "Microsoft.Logic/workflows"
+          ]
+        },
+        "location": {
+          "metadata": {
+            "hidden": "Hiding location, we get it from the log analytics workspace"
+          },
+          "visible": false
+        },
+        "resourceGroup": {
+          "allowExisting": true
+        }
+      }
+    },
+    "basics": [
+      {
+        "name": "getLAWorkspace",
+        "type": "Microsoft.Solutions.ArmApiControl",
+        "toolTip": "This filters by workspaces that exist in the Resource Group selected",
+        "condition": "[greater(length(resourceGroup().name),0)]",
+        "request": {
+          "method": "GET",
+          "path": "[concat(subscription().id,'/providers/Microsoft.OperationalInsights/workspaces?api-version=2020-08-01')]"
+        }
+      },
+      {
+        "name": "workspace",
+        "type": "Microsoft.Common.DropDown",
+        "label": "Workspace",
+        "placeholder": "Select a workspace",
+        "toolTip": "This dropdown will list only workspace that exists in the Resource Group selected",
+        "constraints": {
+          "allowedValues": "[map(filter(basics('getLAWorkspace').value, (filter) => contains(toLower(filter.id), toLower(resourceGroup().name))), (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]",
+          "required": true
+        },
+        "visible": true
+      }
+    ],
+    "steps": [],
+    "outputs": {
+      "workspace-location": "[first(map(filter(basics('getLAWorkspace').value, (filter) => and(contains(toLower(filter.id), toLower(resourceGroup().name)),equals(filter.name,basics('workspace')))), (item) => item.location))]",
+      "location": "[location()]",
+      "workspace": "[basics('workspace')]"
+    }
+  }
+}

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/baseMainTemplate.json
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/baseMainTemplate.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "author": "{{author}}",
+        "comments": "Solution template for {{SolutionName}}"
+    },
+    "parameters": {
+        
+        "location": {
+            "type": "string",
+            "minLength": 1,
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Not used, but needed to pass arm-ttk test `Location-Should-Not-Be-Hardcoded`.  We instead use the `workspace-location` which is derived from the LA workspace"
+            }
+        },
+        "workspace-location": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "[concat('Region to deploy solution resources -- separate from location selection',parameters('location'))]"
+            }
+        },
+        "workspace": {
+            "defaultValue": "",
+            "type": "string",
+            "metadata": {
+                "description": "Workspace name for Log Analytics where Microsoft Sentinel is setup"
+            }
+        }
+    },
+    "variables": {},
+    "resources": [],
+    "outputs": {}
+}

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/replaceLocationValue.js
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/replaceLocationValue.js
@@ -1,0 +1,13 @@
+/** replacePlaybookVarNames.js
+ * This small script is utilized to perform a global replacement of playbook variables within a string.
+ * This is necessary due to PowerShell not providing global match/replacement capability.
+ */
+const regexStr = /(resourceGroup\(\)\.location)/g;
+const inputString = process.argv[2];
+const playbookNum = process.argv[3];
+
+if (inputString.match(regexStr)) {
+    console.log(inputString.replace(regexStr, "parameters('workspace-location')"))
+} else {
+    console.log(inputString);
+}

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/replacePlaybookParamNames.js
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/replacePlaybookParamNames.js
@@ -1,0 +1,13 @@
+/** replacePlaybookParamNames.js
+ * This small script is utilized to perform a global replacement of playbook parameter variables within a string.
+ * This is necessary due to PowerShell not providing global match/replacement capability.
+ */
+const regexStr = /parameters\(\'([\w\-\s]+)\'\)/g;
+const inputString = process.argv[2];
+const playbookNum = process.argv[3];
+
+if (inputString.match(regexStr)) {
+    console.log(inputString.replace(regexStr, `parameters('playbook${playbookNum}-$1')`))
+} else {
+    console.log(inputString);
+}

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/replacePlaybookVarNames.js
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/replacePlaybookVarNames.js
@@ -1,0 +1,13 @@
+/** replacePlaybookVarNames.js
+ * This small script is utilized to perform a global replacement of playbook variables within a string.
+ * This is necessary due to PowerShell not providing global match/replacement capability.
+ */
+const regexStr = /variables\(\'(\w+)\'\)/g;
+const inputString = process.argv[2];
+const playbookNum = process.argv[3];
+
+if (inputString.match(regexStr)) {
+    console.log(inputString.replace(regexStr, `variables('playbook${playbookNum}-$1')`))
+} else {
+    console.log(inputString);
+}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Tool changes to create package for templateSpec(2.x.x) and contentPackage(3.x.x)

   Reason for Change(s):
   - We need to be able to create V2 and V3 packages locally. So we introduced createSolutionV3.ps1 inside of Tools folder. createSolutionV2.ps1 is now not recommended for creating package going forward.

   Version Updated:
   - No

   Testing Completed:
   - Yes, locally tried to create package and is working.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**We see below error of version** 

![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/1fd00a0a-18c8-482d-b11b-6d3d3e569c7f)
