### PR TITLE
Update Regex for AccessLog

### DIFF
--- a/Solutions/Tomcat/Parsers/TomcatEvent.txt
+++ b/Solutions/Tomcat/Parsers/TomcatEvent.txt
@@ -3,7 +3,7 @@
 // Reference : Using functions in Azure monitor log queries : https://docs.microsoft.com/azure/azure-monitor/log-query/functions
 let tomcat_accesslog_events =() {
 Tomcat_CL
-| where RawData matches regex @'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*\[.*\]\s\"(GET|POST).*?\"\s([1-5][0-9]{2})\s(\d+)\s\"(.*?)\"\s\"(.*?)\".*'
+| where RawData matches regex @'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*\[.*\]\s\"(GET|POST).*?\"\s([1-5][0-9]{2})\s(\d+|-)(?:\s\"(.*?)\")?(?:\s\"(.*?)\")?.*'
 | extend EventProduct = 'Tomcat'
 | extend EventType = 'AccessLog'
 | extend EventData = split(RawData, '"')
@@ -13,7 +13,7 @@ Tomcat_CL
 | extend SrcIpAddr = tostring(SubEventData0[0])
 | extend ClientIdentity = SubEventData0[1]
 | extend SrcUserName = SubEventData0[2]
-| extend EventStartTime = todatetime(replace(@'\/', @'-', replace(@'(\d{2}\/\w{3}\/\d{4}):(\d{2}\:\d{2}\:\d{2})', @'\1 \2', extract(@'\[(.*?)\+\d+\]', 1, RawData))))
+| extend EventStartTime = todatetime(replace(@'\/', @'-', replace(@'(\d{2}\/\w{3}\/\d{4}):(\d{2}\:\d{2}\:\d{2})', @'\1 \2', extract(@'\[(.*?)[-+]\d+\]', 1, RawData))))
 | extend HttpRequestMethod = SubEventData1[0]
 | extend UrlOriginal = SubEventData1[1]
 | extend HttpVersion = SubEventData1[2]


### PR DESCRIPTION
Fixed regex parser to handle cases where Bytes, Referer and User-agent fields are empty.

Change(s):
- Updated the regex parser to handle cases where Bytes, User-agent, and Referrer fields are empty.

Reason for Change(s):
- To ensure the regex parser can handle log lines with Bytes as `-`, and empty User-agent and Referrer fields.
- To handle negative timezone offset ex: -0400

Version Updated:
- N/A

Testing Completed:
- Tested the updated regex parser with sample log lines containing empty fields.
- Verified that the regex parser correctly captures all required fields even when some fields are empty.
- Checked the validity of the parsed log data against the log line structure.

Checked that the validations are passing and have addressed any issues that are present:
- Yes. The regex parser now handles empty fields without any issues.

Sample logs
```
123.45.60.78 - - [26/Jun/2023:06:32:27 -0600] "GET null null" 400 -
9.10.11.12 - - [25/Jun/2023:14:48:40 -0600] "GET /DummyPortal/tema/imagenes/business_bg.png HTTP/1.1" 404 1051
13.14.15.16 - - [25/Jun/2023:15:16:59 -0600] "GET /DummyPortal/tema/imagenes/business_bg.png HTTP/1.1" 404 1061 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
17.18.19.20 - - [25/Jun/2023:15:16:59 -0600] "GET /DummyPortal/tema/imagenes/business_bg.png HTTP/1.1" 404 1061 "http://www.example.com/previous-page" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
21.22.23.24 - - [25/Jun/2023:23:16:32 -0600] "POST /DummyPortal/diag_Form?images/ HTTP/1.1" 404 -
```