### PR TITLE
Hunting queries corrections

### DIFF
--- a/Hunting Queries/AzureActivity/Azure-CloudShell-Usage.yaml
+++ b/Hunting Queries/AzureActivity/Azure-CloudShell-Usage.yaml
@@ -15,13 +15,13 @@ relevantTechniques:
 query: |
 
    AzureActivity
-      | where ActivityStatusValue == "Succeeded"
+      | where ActivityStatusValue =~ "Success"
       | where ResourceGroup has "cloud-shell-storage"
-      | where OperationNameValue == "Microsoft.Storage/storageAccounts/listKeys/action"
+      | where OperationNameValue =~ "Microsoft.Storage/storageAccounts/listKeys/action"
       // Change the timekey scope below to get activity for a longer window 
       | summarize by Caller, timekey= bin(TimeGenerated, 1h)
       | join (AzureActivity | where TimeGenerated >= ago(1d)
-      | where OperationNameValue != "Microsoft.Storage/storageAccounts/listKeys/action"
+      | where OperationNameValue !~ "Microsoft.Storage/storageAccounts/listKeys/action"
       | where isnotempty(OperationName)
        // Change the timekey scope below to get activity for a longer window 
       | summarize make_set(OperationName) by Caller, timekey=bin(TimeGenerated, 1h)) on Caller, timekey

--- a/Hunting Queries/AzureActivity/Azure-CloudShell-Usage.yaml
+++ b/Hunting Queries/AzureActivity/Azure-CloudShell-Usage.yaml
@@ -22,9 +22,9 @@ query: |
       | summarize by Caller, timekey= bin(TimeGenerated, 1h)
       | join (AzureActivity | where TimeGenerated >= ago(1d)
       | where OperationNameValue !~ "Microsoft.Storage/storageAccounts/listKeys/action"
-      | where isnotempty(OperationName)
+      | where isnotempty(OperationNameValue)
        // Change the timekey scope below to get activity for a longer window 
-      | summarize make_set(OperationName) by Caller, timekey=bin(TimeGenerated, 1h)) on Caller, timekey
+      | summarize make_set(OperationNameValue) by Caller, timekey=bin(TimeGenerated, 1h)) on Caller, timekey
       | extend timestamp = timekey, AccountCustomEntity = Caller
 
 entityMappings:

--- a/Hunting Queries/Microsoft 365 Defender/Initial access/SuspiciousUrlClicked.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Initial access/SuspiciousUrlClicked.yaml
@@ -1,8 +1,8 @@
 id: 959f8d6a-53b8-488f-a628-999b3410702e
 name: SuspiciousUrlClicked
 description: |
-  This query correlates Office 365 Advanced Threat Protection (ATP) signals and Azure Active Directory (Azure AD) identity data to find the relevant endpoint event BrowerLaunchedToOpen in Microsoft Defender ATP.
-  This event reflects relevant clicks on the malicious URL in the spear-phishing email recognized by Office 365 ATP.
+  This query correlates Microsoft Defender for Office 365 signals and Azure Active Directory (Azure AD) identity data to find the relevant endpoint event BrowerLaunchedToOpen in Microsoft Defender ATP.
+  This event reflects relevant clicks on the malicious URL in the spear-phishing email recognized by Microsoft Defender for Office 365.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
@@ -17,7 +17,7 @@ query: |
   // Some URL are wrapped with a safelink
   // Let's get the the unwrapped url and clicks 
   AlertInfo
-  | where ServiceSource == "Office 365 ATP"
+  | where ServiceSource =~ "Microsoft Defender for Office 365"
   | join (
           AlertEvidence
           | where EntityType =="Url"

--- a/Hunting Queries/Microsoft 365 Defender/Lateral Movement/ImpersonatedUserFootprint.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Lateral Movement/ImpersonatedUserFootprint.yaml
@@ -1,7 +1,7 @@
 id: aeb65be9-7a40-409e-a227-56ebbcf33de4
 name: ImpersonatedUserFootprint
 description: |
-  Azure ATP raises alert on suspicious Kerberos ticket, pointing to a potential overpass-the-hash attack.
+  Microsoft Defender for Identity raises alert on suspicious Kerberos ticket, pointing to a potential overpass-the-hash attack.
   Once attackers gain credentials for a user with higher privileges, they will use the stolen credentials to sign into other devices and move laterally.
   This query finds related sign-in events following overpass-the-hash attack to trace the footprint of the impersonated user.
 requiredDataConnectors:
@@ -14,7 +14,7 @@ tactics:
 - Lateral movement
 query: |
   AlertInfo
-  | where ServiceSource == "Azure ATP"
+  | where ServiceSource =~ "Microsoft Defender for Identity"
   | where Title == "Suspected overpass-the-hash attack (Kerberos)"
   | extend AlertTime = Timestamp 
   | join 


### PR DESCRIPTION
These changes corrects some out-of-the-box hunting queries.

   Change(s):
   - Updated/corrected static string comparisons and column name for 3 Hunting Queries.

   Reason for Change(s):
   - These rules are not functional out-of-the-box otherwise.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Not locally