### PR TITLE
🐛 Fix incorrect case for Port Scan columnName

### DIFF
--- a/Solutions/Azure Firewall/Analytic Rules/Azure Firewall - Port Scan.yaml
+++ b/Solutions/Azure Firewall/Analytic Rules/Azure Firewall - Port Scan.yaml
@@ -2,16 +2,16 @@ id: b2c5907b-1040-4692-9802-9946031017e8
 name: Port Scan
 description: |
   'Identifies a source IP scanning multiple open ports on Azure Firewall. This can indicate malicious scanning of ports by an attacker, trying to reveal open ports in the organization that can be compromised for initial access.
-  
+
   Configurable Parameters:
-  
+
   - Port scan time - the time range to look for multiple ports scanned. Default is set to 30 seconds.
   - Minimum different ports threshold - alert only if more than this number of ports scanned. Default is set to 100.'
 severity: Medium
 status: Available
 requiredDataConnectors:
   - connectorId: AzureFirewall
-    dataTypes: 
+    dataTypes:
       - AzureDiagnostics
       - AZFWApplicationRule
       - AZFWNetworkRule
@@ -44,10 +44,10 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: SourceIP
+        columnName: SourceIp
   - entityType: URL
     fieldMappings:
       - identifier: Url
         columnName: Fqdn
-version: 1.1.0
+version: 1.1.1
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Use the correct case for the `SourceIp` columnName

   Reason for Change(s):
   - When deploying the existing rule an error occurs `Error in EntityMappings: The given column 'SourceIP' does not exist.`

   Version Updated: ✅

   Testing Completed: ✅
