### PR TITLE
Updated HQ descriptions to fit new limits

### DIFF
--- a/Solutions/Web Shells Threat Protection/Hunting Queries/Possible webshell drop.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/Possible webshell drop.yaml
@@ -1,7 +1,7 @@
 id: 8f2a256f-c9f1-4f0a-941a-a5a131d4bf3b
 name: Possible webshell drop
 description: |
-  This query searches for files with common web page content extensions created by IIS or Apache that could run arbitrary code. It includes a throttling mechanism to reduce false positive detections for WebDAV or other web-based content management running under the webserver process. The MaxFileOperations can be increased or set to -1 to disable this feature. Additional extensions of interest are listed after ExtensionList. Consider including or excluding these based on your organization's tolerance for false positives
+  This query searches for files with common web page content extensions created by IIS or Apache that could run arbitrary code. It includes a throttling mechanism to reduce false positive detections for web-based content management.
 description-detailed: |
   This query looks for files created by IIS or Apache matching common web page content extensions which
   can be used to execute arbitrary code.

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/Possible webshell drop.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/Possible webshell drop.yaml
@@ -1,6 +1,8 @@
 id: 8f2a256f-c9f1-4f0a-941a-a5a131d4bf3b
 name: Possible webshell drop
 description: |
+  This query searches for files with common web page content extensions created by IIS or Apache that could run arbitrary code. It includes a throttling mechanism to reduce false positive detections for WebDAV or other web-based content management running under the webserver process. The MaxFileOperations can be increased or set to -1 to disable this feature. Additional extensions of interest are listed after ExtensionList. Consider including or excluding these based on your organization's tolerance for false positives
+description-detailed: |
   This query looks for files created by IIS or Apache matching common web page content extensions which
   can be used to execute arbitrary code.
   The query uses a throtlling mechanism in an attempt to avoid false positive detections for WebDAV or
@@ -34,3 +36,4 @@ query: |
   | summarize count() by DeviceId, TimeBin
   | where MaxFileOperations == -1 or count_ < MaxFileOperations
   | join kind=rightsemi PossibleShells on DeviceId, TimeBin
+version: 1.0.0

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/PotentialWebshell.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/PotentialWebshell.yaml
@@ -1,7 +1,7 @@
 id: cc087e7c-4db0-4bf9-9e48-287a9c9c3fbc
 name: Webshell Detection
 description: | 
-  Web shells are scripts that allow remote administration when uploaded to a web server. Attackers use them to gain unauthorized access, escalate privileges, and compromise the environment. This query can detect web shells using GET requests by searching for keywords in URL strings. However, there may be false positives from web pages containing OS commands in their URLs, such as wikis.
+  Web shells are scripts that allow remote administration when uploaded to a web server. This query can detect web shells using GET requests by searching for keywords in URL strings.
 description-detailed: |
   'Web shells are script that when uploaded to a web server can be used for remote administration. 
   Attackers often use web shells to obtain unauthorized access, escalate //privilege as well as further compromise the environment. 

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/PotentialWebshell.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/PotentialWebshell.yaml
@@ -1,6 +1,8 @@
 id: cc087e7c-4db0-4bf9-9e48-287a9c9c3fbc
-name: Web shell Detection
-description: |
+name: Webshell Detection
+description: | 
+  Web shells are scripts that allow remote administration when uploaded to a web server. Attackers use them to gain unauthorized access, escalate privileges, and compromise the environment. This query can detect web shells using GET requests by searching for keywords in URL strings. However, there may be false positives from web pages containing OS commands in their URLs, such as wikis.
+description-detailed: |
   'Web shells are script that when uploaded to a web server can be used for remote administration. 
   Attackers often use web shells to obtain unauthorized access, escalate //privilege as well as further compromise the environment. 
   The query detects web shells that use GET requests by keyword searches in URL strings. 

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/SpringshellWebshellUsage.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/SpringshellWebshellUsage.yaml
@@ -1,6 +1,8 @@
 id: 6911d1df-4204-43b2-a64c-3cb102551ddd
 name: Possible Webshell usage attempt related to SpringShell(CVE-2022-22965)
 description: |
+  This query searches Azure Web Application Firewall data for potential Webshell usage related to the SpringShell RCE vulnerability (CVE-2022-22965). For more information on detecting and protecting against this vulnerability, refer to Microsoft's security blog.
+description-detailed: |
   'This hunting query looks in Azure Web Application Firewall data to find possible Webshell usage attempts related to SpringShell RCE vulnerability (CVE-2022-22965).
    The Spring Framework is one of the most widely used lightweight open-source framework for Java. The vulnerability in Spring Core can be exploited when an attacker 
    sends a specially crafted query to a web server running the Spring Core framework to create a backdoor shell.

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/SpringshellWebshellUsage.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/SpringshellWebshellUsage.yaml
@@ -1,7 +1,7 @@
 id: 6911d1df-4204-43b2-a64c-3cb102551ddd
 name: Possible Webshell usage attempt related to SpringShell(CVE-2022-22965)
 description: |
-  This query searches Azure Web Application Firewall data for potential Webshell usage related to the SpringShell RCE vulnerability (CVE-2022-22965). For more information on detecting and protecting against this vulnerability, refer to Microsoft's security blog.
+  This query searches Azure Web Application Firewall data for potential Webshell usage related to the SpringShell RCE vulnerability (CVE-2022-22965). For more information refer to Microsoft's security blog.
 description-detailed: |
   'This hunting query looks in Azure Web Application Firewall data to find possible Webshell usage attempts related to SpringShell RCE vulnerability (CVE-2022-22965).
    The Spring Framework is one of the most widely used lightweight open-source framework for Java. The vulnerability in Spring Core can be exploited when an attacker 

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/WebShellActivity.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/WebShellActivity.yaml
@@ -1,6 +1,8 @@
 id: e0c947c3-fe83-46ff-bbda-a43224a785fd
 name: Web Shell Activity
 description: |
+  This query detects web shells by analyzing the distribution of commonly-used scripts against regular scripts for public client IPs with no W3CIIS activity in a fixed lookback period. Results include public client IPs, user agents, and script distribution between start and end times.
+description-detailed: |
   'Web shells are scripts that, when uploaded to a web server, can be used to provide a backdoor to a compromised network.
   Attackers can use this entry point to leave malicious implants, such as obtaining unauthorized access, escalating privilege, and further compromising the environment.
 

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/WebShellActivity.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/WebShellActivity.yaml
@@ -1,7 +1,7 @@
 id: e0c947c3-fe83-46ff-bbda-a43224a785fd
 name: Web Shell Activity
 description: |
-  This query detects web shells by analyzing the distribution of commonly-used scripts against regular scripts for public client IPs with no W3CIIS activity in a fixed lookback period. Results include public client IPs, user agents, and script distribution between start and end times.
+  This query detects web shells by analyzing the distribution of commonly-used scripts against regular scripts for public client IPs with no W3CIIS activity in a fixed lookback period.
 description-detailed: |
   'Web shells are scripts that, when uploaded to a web server, can be used to provide a backdoor to a compromised network.
   Attackers can use this entry point to leave malicious implants, such as obtaining unauthorized access, escalating privilege, and further compromising the environment.

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/exchange-iis-worker-dropping-webshell.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/exchange-iis-worker-dropping-webshell.yaml
@@ -1,6 +1,8 @@
 id: 42e7df5b-80f6-49a5-946a-08026ec24807
-name: exchange-iis-worker-dropping-webshell
-description: |
+name: Exchange IIS Worker Dropping Webshells
+description: | 
+  In March 2021, Microsoft released patches for four zero-day vulnerabilities that were being exploited in coordinated attacks on Microsoft Exchange Server. The CVEs are: CVE-2021-26855, CVE-2021-26857, CVE-2021-26858, and CVE-2021-27065. This query checks for the IIS worker process dropping files that resemble web shells and other artifacts seen in known attacks. More related queries can be found in the "See also" section of the page. Reference: https://msrc-blog.microsoft.com/2021/03/02/multiple-security-updates-released-for-exchange-server
+description_detailed: |
   This query was originally published in the threat analytics report, "Exchange Server zero-days exploited in the wild".
   In early March 2021, Microsoft released patches for four different zero-day vulnerabilities affecting Microsoft Exchange Server. The vulnerabilities were being used in a coordinated attack. For more information on the vulnerabilities, visit the following links:
   1. CVE-2021-26855

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/exchange-iis-worker-dropping-webshell.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/exchange-iis-worker-dropping-webshell.yaml
@@ -1,7 +1,7 @@
 id: 42e7df5b-80f6-49a5-946a-08026ec24807
 name: Exchange IIS Worker Dropping Webshells
 description: | 
-  In March 2021, Microsoft released patches for four zero-day vulnerabilities that were being exploited in coordinated attacks on Microsoft Exchange Server. The CVEs are: CVE-2021-26855, CVE-2021-26857, CVE-2021-26858, and CVE-2021-27065. This query checks for the IIS worker process dropping files that resemble web shells and other artifacts seen in known attacks. More related queries can be found in the "See also" section of the page. Reference: https://msrc-blog.microsoft.com/2021/03/02/multiple-security-updates-released-for-exchange-server
+  This query checks for the IIS worker process dropping files that resemble web shells and other artifacts seen in known attacks. Reference: https://msrc-blog.microsoft.com/2021/03/02/multiple-security-updates-released-for-exchange-server
 description_detailed: |
   This query was originally published in the threat analytics report, "Exchange Server zero-days exploited in the wild".
   In early March 2021, Microsoft released patches for four different zero-day vulnerabilities affecting Microsoft Exchange Server. The vulnerabilities were being used in a coordinated attack. For more information on the vulnerabilities, visit the following links:

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/umworkerprocess-creating-webshell.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/umworkerprocess-creating-webshell.yaml
@@ -1,6 +1,8 @@
 id: 60d15bd4-1fad-4a70-bc3b-094dc1c5e554
-name: umworkerprocess-creating-webshell
+name: UMWorkerProcess Creating Webshell
 description: |
+  This query detects unusual file content created by UMWorkerProcess, indicating exploitation of CVE-2021-26858 to generate a web shell. Microsoft released patches in March 2021 for four zero-day vulnerabilities affecting Exchange Server, which were being used in coordinated attacks. More related queries can be found on the Microsoft Security Response Center blog.
+description-detailed: |
   This query was originally published in the threat analytics report, "Exchange Server zero-days exploited in the wild".
   In early March 2021, Microsoft released patches for four different zero-day vulnerabilities affecting Microsoft Exchange Server. The vulnerabilities were being used in a coordinated attack. For more information on the vulnerabilities, visit the following links:
   1. CVE-2021-26855

--- a/Solutions/Web Shells Threat Protection/Hunting Queries/umworkerprocess-creating-webshell.yaml
+++ b/Solutions/Web Shells Threat Protection/Hunting Queries/umworkerprocess-creating-webshell.yaml
@@ -1,7 +1,7 @@
 id: 60d15bd4-1fad-4a70-bc3b-094dc1c5e554
 name: UMWorkerProcess Creating Webshell
 description: |
-  This query detects unusual file content created by UMWorkerProcess, indicating exploitation of CVE-2021-26858 to generate a web shell. Microsoft released patches in March 2021 for four zero-day vulnerabilities affecting Exchange Server, which were being used in coordinated attacks. More related queries can be found on the Microsoft Security Response Center blog.
+  This query detects unusual file content created by UMWorkerProcess, indicating exploitation of CVE-2021-26858 to generate a web shell. More related queries can be found on the Microsoft Security Response Center blog.
 description-detailed: |
   This query was originally published in the threat analytics report, "Exchange Server zero-days exploited in the wild".
   In early March 2021, Microsoft released patches for four different zero-day vulnerabilities affecting Microsoft Exchange Server. The vulnerabilities were being used in a coordinated attack. For more information on the vulnerabilities, visit the following links:


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated Hunting Queries in the Webshell Solution to have descriptions that meet the 255 character limit.
  - Moved longer descriptions to the new description-detailed field.


   Reason for Change(s):
   - Required to ensure correct deployment of new Webshell solution is possible.

   Version Updated:
   - Y

   Testing Completed:
   - Y

   Checked that the validations are passing and have addressed any issues that are present:
   -Y