### PR TITLE
UpdatingCustomTablesforDataConnectorsKQLValidations

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/ProjectActivity.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ProjectActivity.json
@@ -1,0 +1,93 @@
+{
+  "Name":"ProjectActivity",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "EventOriginalUid",
+    "Type": "string"
+  },
+  {
+    "Name": "RecordType",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "DateTime"
+  },
+  {
+    "Name": "EventOriginalType",
+    "Type": "string"
+  },
+  {
+    "Name": "OrganizationId",
+    "Type": "string"
+  },
+  {
+    "Name": "UserType",
+    "Type": "string"
+  },
+  {
+    "Name": "ActorUserType",
+    "Type": "string"
+  },
+  {
+    "Name": "ActorUserId",
+    "Type": "string"
+  },
+  {
+    "Name": "Workload",
+    "Type": "string"
+  },
+  {
+    "Name": "EventResult",
+    "Type": "string"
+  },
+  {
+    "Name": "ObjectId",
+    "Type": "string"
+  },
+  {
+    "Name": "ActorName",
+    "Type": "string"
+  },
+  {
+    "Name": "SrcIpAddr",
+    "Type": "string"
+  },
+  {
+    "Name": "Scope",
+    "Type": "string"
+  },
+  {
+    "Name": "ProjectEntity",
+    "Type": "string"
+  },
+  {
+    "Name": "ProjectAction",
+    "Type": "string"
+  },
+  {
+    "Name": "OnBehalfOfResId",
+    "Type": "string"
+  },
+  {
+    "Name": "EventProduct",
+    "Type": "string"
+  },
+  {
+    "Name": "EventVendor",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/ProofPointTAPClicksBlocked_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ProofPointTAPClicksBlocked_CL.json
@@ -1,0 +1,101 @@
+{
+  "Name":"ProofPointTAPClicksBlocked_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "String"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "String"
+  },
+  {
+    "Name": "MG",
+    "Type": "String"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "String"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "DateTime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "String"
+  },
+  {
+    "Name": "RawData",
+    "Type": "String"
+  },
+  {
+    "Name": "clickTime_t",
+    "Type": "DateTime"
+  },
+  {
+    "Name": "sender_s",
+    "Type": "String"
+  },
+  {
+    "Name": "recipient_s",
+    "Type": "String"
+  },
+  {
+    "Name": "senderIP_s",
+    "Type": "String"
+  },
+  {
+    "Name": "messageID_s",
+    "Type": "String"
+  },
+  {
+    "Name": "clickIP_s",
+    "Type": "real"
+  },
+  {
+    "Name": "GUID_s",
+    "Type": "String"
+  },
+  {
+    "Name": "url_s",
+    "Type": "String"
+  },
+  {
+    "Name": "classification_s",
+    "Type": "String"
+  },
+  {
+    "Name": "threatTime_t",
+    "Type": "DateTime"
+  },
+  {
+    "Name": "userAgent_s",
+    "Type": "String"
+  },
+  {
+    "Name": "campaignId_s",
+    "Type": "String"
+  },
+  {
+    "Name": "threatID_s",
+    "Type": "String"
+  },
+  {
+    "Name": "threatURL_s",
+    "Type": "String"
+  },
+  {
+    "Name": "threatStatus_s",
+    "Type": "String"
+  },
+  {
+    "Name": "Type",
+    "Type": "String"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "String"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/ProofPointTAPMessagesBlocked_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ProofPointTAPMessagesBlocked_CL.json
@@ -1,0 +1,153 @@
+{
+  "Name":"ProofPointTAPMessagesBlocked_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "String"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "String"
+  },
+  {
+    "Name": "MG",
+    "Type": "String"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "String"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "DateTime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "String"
+  },
+  {
+    "Name": "RawData",
+    "Type": "String"
+  },
+  {
+    "Name": "spamScore_d",
+    "Type": "real"
+  },
+  {
+    "Name": "threatsInfoMap_s",
+    "Type": "String"
+  },
+  {
+    "Name": "messageTime_t",
+    "Type": "DateTime"
+  },
+  {
+    "Name": "subject_s",
+    "Type": "String"
+  },
+  {
+    "Name": "quarantineRule_s",
+    "Type": "String"
+  },
+  {
+    "Name": "replyToAddress_s",
+    "Type": "String"
+  },
+  {
+    "Name": "toAddresses_s",
+    "Type": "String"
+  },
+  {
+    "Name": "QID_s",
+    "Type": "String"
+  },
+  {
+    "Name": "sender_s",
+    "Type": "String"
+  },
+  {
+    "Name": "recipient_s",
+    "Type": "String"
+  },
+  {
+    "Name": "senderIP_s",
+    "Type": "String"
+  },
+  {
+    "Name": "messageID_s",
+    "Type": "String"
+  },
+  {
+    "Name": "messageParts_s",
+    "Type": "String"
+  },
+  {
+    "Name": "headerReplyTo_s",
+    "Type": "String"
+  },
+  {
+    "Name": "impostorScore_d",
+    "Type": "real"
+  },
+  {
+    "Name": "malwareScore_d",
+    "Type": "real"
+  },
+  {
+    "Name": "messageSize_d",
+    "Type": "real"
+  },
+  {
+    "Name": "headerFrom_s",
+    "Type": "String"
+  },
+  {
+    "Name": "phishScore_d",
+    "Type": "real"
+  },
+  {
+    "Name": "policyRoutes_s",
+    "Type": "String"
+  },
+  {
+    "Name": "modulesRun_s",
+    "Type": "String"
+  },
+  {
+    "Name": "GUID_s",
+    "Type": "String"
+  },
+  {
+    "Name": "cluster_s",
+    "Type": "String"
+  },
+  {
+    "Name": "quarantineFolder_s",
+    "Type": "String"
+  },
+  {
+    "Name": "fromAddress_s",
+    "Type": "String"
+  },
+  {
+    "Name": "ccAddresses_s",
+    "Type": "String"
+  },
+  {
+    "Name": "xmailer_s",
+    "Type": "String"
+  },
+  {
+    "Name": "completelyRewritten_b",
+    "Type": "Boolean"
+  },
+  {
+    "Name": "Type",
+    "Type": "String"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "String"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/ProofpointPOD.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ProofpointPOD.json
@@ -560,6 +560,10 @@
         {
             "Name": "SmCtladdr",
             "Type": "String"
+        },
+        {
+            "Name": "TimeGenerated",
+            "Type": "DateTime"
         }
     ]
 }

--- a/.script/tests/KqlvalidationsTests/CustomTables/ProofpointPOD_maillog_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ProofpointPOD_maillog_CL.json
@@ -120,6 +120,10 @@
        {
           "Name":"sm_ctladdr_s",
           "Type":"String"
-       }
+       },
+       {
+         "Name": "TimeGenerated",
+         "Type": "DateTime"
+     }
     ]
  }

--- a/.script/tests/KqlvalidationsTests/CustomTables/ProofpointPOD_message_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ProofpointPOD_message_CL.json
@@ -436,6 +436,10 @@
        {
           "Name":"filter_modules_urldefense_counts_noRewriteIsExcludedDomain_d",
           "Type":"Double"
+       },
+       {
+         "Name": "TimeGenerated",
+         "Type": "DateTime"
        }
     ]
  }

--- a/.script/tests/KqlvalidationsTests/CustomTables/QualysKB.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/QualysKB.json
@@ -1,0 +1,125 @@
+{
+  "Name":"QualysKB",
+  "Properties":[
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "Qid",
+    "Type": "string"
+  },
+  {
+    "Name": "Title",
+    "Type": "string"
+  },
+  {
+    "Name": "Category",
+    "Type": "string"
+  },
+  {
+    "Name": "Consquence",
+    "Type": "string"
+  },
+  {
+    "Name": "Diagnosis",
+    "Type": "string"
+  },
+  {
+    "Name": "LastServiceModificationDateTime",
+    "Type": "string"
+  },
+  {
+    "Name": "Patchable",
+    "Type": "string"
+  },
+  {
+    "Name": "CveId",
+    "Type": "string"
+  },
+  {
+    "Name": "CveUrl",
+    "Type": "string"
+  },
+  {
+    "Name": "VendorReferenceId",
+    "Type": "string"
+  },
+  {
+    "Name": "VendorReferenceUrl",
+    "Type": "string"
+  },
+  {
+    "Name": "PciFlag",
+    "Type": "string"
+  },
+  {
+    "Name": "PublishedDateTime",
+    "Type": "string"
+  },
+  {
+    "Name": "Severity",
+    "Type": "string"
+  },
+  {
+    "Name": "SoftwareProduct",
+    "Type": "string"
+  },
+  {
+    "Name": "SoftwareVendor",
+    "Type": "string"
+  },
+  {
+    "Name": "Solution",
+    "Type": "string"
+  },
+  {
+    "Name": "VulnType",
+    "Type": "string"
+  },
+  {
+    "Name": "DiscoveryAdditionalInfo",
+    "Type": "string"
+  },
+  {
+    "Name": "DiscoveryRemote",
+    "Type": "string"
+  },
+  {
+    "Name": "DiscoverAuthType",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/RSASecurIDAMEvent.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/RSASecurIDAMEvent.json
@@ -1,0 +1,277 @@
+{
+  "Name":"RSASecurIDAMEvent",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "EventTime",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Facility",
+    "Type": "string"
+  },
+  {
+    "Name": "HostName",
+    "Type": "string"
+  },
+  {
+    "Name": "SeverityLevel",
+    "Type": "string"
+  },
+  {
+    "Name": "ProcessID",
+    "Type": "int"
+  },
+  {
+    "Name": "HostIP",
+    "Type": "string"
+  },
+  {
+    "Name": "ProcessName",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "EventVendor",
+    "Type": "string"
+  },
+  {
+    "Name": "EventProduct",
+    "Type": "string"
+  },
+  {
+    "Name": "EventSchemaVersion",
+    "Type": "string"
+  },
+  {
+    "Name": "EventCount",
+    "Type": "long"
+  },
+  {
+    "Name": "EventType",
+    "Type": "string"
+  },
+  {
+    "Name": "EventSeverity",
+    "Type": "string"
+  },
+  {
+    "Name": "EventOriginalUid",
+    "Type": "string"
+  },
+  {
+    "Name": "ImsServerInstance",
+    "Type": "string"
+  },
+  {
+    "Name": "SrcIpAddr",
+    "Type": "string"
+  },
+  {
+    "Name": "DstIpAddr",
+    "Type": "string"
+  },
+  {
+    "Name": "DvcAction",
+    "Type": "string"
+  },
+  {
+    "Name": "EventIdCode",
+    "Type": "string"
+  },
+  {
+    "Name": "EventResult",
+    "Type": "string"
+  },
+  {
+    "Name": "EventResultDetails",
+    "Type": "string"
+  },
+  {
+    "Name": "ActorSessionId",
+    "Type": "string"
+  },
+  {
+    "Name": "BatchId",
+    "Type": "string"
+  },
+  {
+    "Name": "UserId",
+    "Type": "string"
+  },
+  {
+    "Name": "UserIdentitySrcId",
+    "Type": "string"
+  },
+  {
+    "Name": "UserSecurityDomainId",
+    "Type": "string"
+  },
+  {
+    "Name": "SrcUserName",
+    "Type": "string"
+  },
+  {
+    "Name": "SrcUserFirstName",
+    "Type": "string"
+  },
+  {
+    "Name": "SrcUserLastName",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument1",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument2",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument3",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument4",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument5",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument6",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument7",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument8",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument9",
+    "Type": "string"
+  },
+  {
+    "Name": "Argument10",
+    "Type": "string"
+  },
+  {
+    "Name": "Cause",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject1Type",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject1Id",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject1IdentitySourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject1SecurityDomainId",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject1Name",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject2Type",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject2Id",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject2IdentitySourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "DomainObject2SecurityDomainId",
+    "Type": "string"
+  },
+  {
+    "Name": "AgentId",
+    "Type": "string"
+  },
+  {
+    "Name": "AgentSecurityDomainId",
+    "Type": "string"
+  },
+  {
+    "Name": "DvcIpAddr",
+    "Type": "string"
+  },
+  {
+    "Name": "DvcHostname",
+    "Type": "string"
+  },
+  {
+    "Name": "AgentType",
+    "Type": "string"
+  },
+  {
+    "Name": "PolicyMethodId",
+    "Type": "string"
+  },
+  {
+    "Name": "PolicyMethodName",
+    "Type": "string"
+  },
+  {
+    "Name": "PolicyId",
+    "Type": "string"
+  },
+  {
+    "Name": "PolicyExpression",
+    "Type": "string"
+  },
+  {
+    "Name": "EventId",
+    "Type": "string"
+  },
+  {
+    "Name": "EventMessage",
+    "Type": "string"
+  },
+  {
+    "Name": "AgentTypeDescription",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Rubrik_Anomaly_Data_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Rubrik_Anomaly_Data_CL.json
@@ -1,0 +1,85 @@
+{
+  "Name":"Rubrik_Anomaly_Data_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_clusterId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "summary_s",
+    "Type": "string"
+  },
+  {
+    "Name": "source_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "class_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_status_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Rubrik_Ransomware_Data_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Rubrik_Ransomware_Data_CL.json
@@ -1,0 +1,85 @@
+{
+  "Name":"Rubrik_Ransomware_Data_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "summary_s",
+    "Type": "string"
+  },
+  {
+    "Name": "source_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "class_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_status_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_clusterId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Rubrik_ThreatHunt_Data_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Rubrik_ThreatHunt_Data_CL.json
@@ -1,0 +1,101 @@
+{
+  "Name":"Rubrik_ThreatHunt_Data_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_seriesId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_clusterId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "summary_s",
+    "Type": "string"
+  },
+  {
+    "Name": "source_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "class_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_objectType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_status_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_errorId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_errorCode_s",
+    "Type": "string"
+  },
+  {
+    "Name": "custom_details_errorReason_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SalesforceServiceCloud_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SalesforceServiceCloud_CL.json
@@ -800,6 +800,10 @@
         {
             "Name": "analytics_mode_s",
             "Type": "String"
+        },
+        {
+            "Name": "TimeGenerated",
+            "Type": "DateTime"
         }
     ]
 }

--- a/.script/tests/KqlvalidationsTests/CustomTables/SecurityScorecardFactor_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SecurityScorecardFactor_CL.json
@@ -1,0 +1,97 @@
+{
+  "Name":"SecurityScorecardFactor_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "body_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Factor_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Factor_Name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "subject_s",
+    "Type": "string"
+  },
+  {
+    "Name": "dateYesterday_s",
+    "Type": "string"
+  },
+  {
+    "Name": "dateToday_s",
+    "Type": "string"
+  },
+  {
+    "Name": "scoreYesterday_d",
+    "Type": "real"
+  },
+  {
+    "Name": "scoreToday_d",
+    "Type": "real"
+  },
+  {
+    "Name": "scoreChange_d",
+    "Type": "real"
+  },
+  {
+    "Name": "factorDescription_s",
+    "Type": "string"
+  },
+  {
+    "Name": "industry_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SecurityScorecardIssues_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SecurityScorecardIssues_CL.json
@@ -1,0 +1,105 @@
+{
+  "Name":"SecurityScorecardIssues_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "body_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Factor_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventID_s",
+    "Type": "string"
+  },
+  {
+    "Name": "subject_s",
+    "Type": "string"
+  },
+  {
+    "Name": "date_t",
+    "Type": "string"
+  },
+  {
+    "Name": "issueType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "findingsCount_d",
+    "Type": "string"
+  },
+  {
+    "Name": "groupStatus_s",
+    "Type": "string"
+  },
+  {
+    "Name": "issueName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "totalScoreImpact_d",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_value_s",
+    "Type": "string"
+  },
+  {
+    "Name": "detail_url_s",
+    "Type": "string"
+  },
+  {
+    "Name": "industry_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SecurityScorecardRatings_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SecurityScorecardRatings_CL.json
@@ -1,0 +1,101 @@
+{
+  "Name":"SecurityScorecardRatings_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "portfolioId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "body_s",
+    "Type": "string"
+  },
+  {
+    "Name": "src_s",
+    "Type": "string"
+  },
+  {
+    "Name": "subject_s",
+    "Type": "string"
+  },
+  {
+    "Name": "dateYesterday_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "dateToday_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "scoreYesterday_d",
+    "Type": "real"
+  },
+  {
+    "Name": "scoreToday_d",
+    "Type": "real"
+  },
+  {
+    "Name": "scoreChange_d",
+    "Type": "real"
+  },
+  {
+    "Name": "industry_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioId_g",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "portfolioId_g_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SenservaPro_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SenservaPro_CL.json
@@ -64,6 +64,11 @@
     {
       "Name": "TimeGenerated",
       "Type": "DateTime"
+    },
+    {
+      "Name": "Severity",
+      "Type": "String"
     }
   ]
+  
 }

--- a/.script/tests/KqlvalidationsTests/CustomTables/SentinelOne_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SentinelOne_CL.json
@@ -1,0 +1,393 @@
+{
+  "Name":"SentinelOne_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "accountId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "accountName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "activityType_d",
+    "Type": "real"
+  },
+  {
+    "Name": "createdAt_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "data_accountName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_fullScopeDetails_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_role_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_scopeLevel_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_scopeName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_siteName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_source_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_userScope_s",
+    "Type": "string"
+  },
+  {
+    "Name": "data_username_s",
+    "Type": "string"
+  },
+  {
+    "Name": "id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "primaryDescription_s",
+    "Type": "string"
+  },
+  {
+    "Name": "siteId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "siteName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "updatedAt_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "userId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "event_name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "activeDirectory_computerDistinguishedName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "activeDirectory_computerMemberOf_s",
+    "Type": "string"
+  },
+  {
+    "Name": "activeDirectory_lastUserDistinguishedName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "activeDirectory_lastUserMemberOf_s",
+    "Type": "string"
+  },
+  {
+    "Name": "activeThreats_d",
+    "Type": "real"
+  },
+  {
+    "Name": "agentVersion_s",
+    "Type": "string"
+  },
+  {
+    "Name": "allowRemoteShell_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "appsVulnerabilityStatus_s",
+    "Type": "string"
+  },
+  {
+    "Name": "computerName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "consoleMigrationStatus_s",
+    "Type": "string"
+  },
+  {
+    "Name": "coreCount_d",
+    "Type": "real"
+  },
+  {
+    "Name": "cpuCount_d",
+    "Type": "real"
+  },
+  {
+    "Name": "cpuId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "domain_s",
+    "Type": "string"
+  },
+  {
+    "Name": "encryptedApplications_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "externalId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "externalIp_s",
+    "Type": "string"
+  },
+  {
+    "Name": "firewallEnabled_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "groupId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "groupIp_s",
+    "Type": "string"
+  },
+  {
+    "Name": "groupName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "inRemoteShellSession_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "infected_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "installerType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "isActive_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "isDecommissioned_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "isPendingUninstall_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "isUninstalled_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "isUpToDate_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "lastActiveDate_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "lastIpToMgmt_s",
+    "Type": "string"
+  },
+  {
+    "Name": "lastLoggedInUserName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "licenseKey_s",
+    "Type": "string"
+  },
+  {
+    "Name": "locationEnabled_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "locationType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "locations_s",
+    "Type": "string"
+  },
+  {
+    "Name": "machineType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "mitigationMode_s",
+    "Type": "string"
+  },
+  {
+    "Name": "mitigationModeSuspicious_s",
+    "Type": "string"
+  },
+  {
+    "Name": "modelName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "networkInterfaces_s",
+    "Type": "string"
+  },
+  {
+    "Name": "networkQuarantineEnabled_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "networkStatus_s",
+    "Type": "string"
+  },
+  {
+    "Name": "operationalState_s",
+    "Type": "string"
+  },
+  {
+    "Name": "osArch_s",
+    "Type": "string"
+  },
+  {
+    "Name": "osName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "osRevision_s",
+    "Type": "string"
+  },
+  {
+    "Name": "osStartTime_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "osType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "rangerStatus_s",
+    "Type": "string"
+  },
+  {
+    "Name": "rangerVersion_s",
+    "Type": "string"
+  },
+  {
+    "Name": "registeredAt_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "remoteProfilingState_s",
+    "Type": "string"
+  },
+  {
+    "Name": "scanFinishedAt_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "scanStartedAt_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "scanStatus_s",
+    "Type": "string"
+  },
+  {
+    "Name": "threatRebootRequired_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "totalMemory_d",
+    "Type": "real"
+  },
+  {
+    "Name": "userActionsNeeded_s",
+    "Type": "string"
+  },
+  {
+    "Name": "uuid_g",
+    "Type": "string"
+  },
+  {
+    "Name": "creator_s",
+    "Type": "string"
+  },
+  {
+    "Name": "creatorId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "inherits_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "isDefault_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "registrationToken_s",
+    "Type": "string"
+  },
+  {
+    "Name": "totalAgents_d",
+    "Type": "real"
+  },
+  {
+    "Name": "type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SlackAudit_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SlackAudit_CL.json
@@ -1,0 +1,125 @@
+{
+  "Name":"SlackAudit_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "date_create_d",
+    "Type": "real"
+  },
+  {
+    "Name": "action_s",
+    "Type": "string"
+  },
+  {
+    "Name": "actor_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "actor_user_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "actor_user_name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "actor_user_email_s",
+    "Type": "string"
+  },
+  {
+    "Name": "actor_user_team_s",
+    "Type": "string"
+  },
+  {
+    "Name": "entity_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "entity_file_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "entity_file_name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "entity_file_filetype_s",
+    "Type": "string"
+  },
+  {
+    "Name": "entity_file_title_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_location_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_location_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_location_name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_location_domain_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_ua_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_ip_address_s",
+    "Type": "string"
+  },
+  {
+    "Name": "context_session_id_d",
+    "Type": "real"
+  },
+  {
+    "Name": "action_description_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Snowflake_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Snowflake_CL.json
@@ -1,0 +1,305 @@
+{
+  "Name":"Snowflake_CL",
+  "Properties":[
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "BYTES_DELETED_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_READ_FROM_RESULT_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_SCANNED_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_SENT_OVER_THE_NETWORK_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_SPILLED_TO_LOCAL_STORAGE_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_SPILLED_TO_REMOTE_STORAGE_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_WRITTEN_d",
+    "Type": "real"
+  },
+  {
+    "Name": "BYTES_WRITTEN_TO_RESULT_d",
+    "Type": "real"
+  },
+  {
+    "Name": "CLIENT_IP_s",
+    "Type": "string"
+  },
+  {
+    "Name": "CLUSTER_NUMBER_d",
+    "Type": "real"
+  },
+  {
+    "Name": "COMPILATION_TIME_d",
+    "Type": "real"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "CREDITS_USED_CLOUD_SERVICES_d",
+    "Type": "real"
+  },
+  {
+    "Name": "DATABASE_ID_d",
+    "Type": "real"
+  },
+  {
+    "Name": "DATABASE_NAME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "END_TIME_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "ERROR_CODE_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ERROR_MESSAGE_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EVENT_ID_d",
+    "Type": "real"
+  },
+  {
+    "Name": "EVENT_TIMESTAMP_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "EVENT_TYPE_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXECUTION_STATUS_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXECUTION_TIME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXTERNAL_FUNCTION_TOTAL_INVOCATIONS_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXTERNAL_FUNCTION_TOTAL_RECEIVED_BYTES_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXTERNAL_FUNCTION_TOTAL_RECEIVED_ROWS_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXTERNAL_FUNCTION_TOTAL_SENT_BYTES_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EXTERNAL_FUNCTION_TOTAL_SENT_ROWS_s",
+    "Type": "string"
+  },
+  {
+    "Name": "FIRST_AUTHENTICATION_FACTOR_s",
+    "Type": "string"
+  },
+  {
+    "Name": "INBOUND_DATA_TRANSFER_BYTES_s",
+    "Type": "string"
+  },
+  {
+    "Name": "IS_CLIENT_GENERATED_STATEMENT_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "IS_SUCCESS_s",
+    "Type": "string"
+  },
+  {
+    "Name": "LIST_EXTERNAL_FILES_TIME_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "OUTBOUND_DATA_TRANSFER_BYTES_d",
+    "Type": "real"
+  },
+  {
+    "Name": "PARTITIONS_SCANNED_s",
+    "Type": "string"
+  },
+  {
+    "Name": "PARTITIONS_TOTAL_d",
+    "Type": "real"
+  },
+  {
+    "Name": "PERCENTAGE_SCANNED_FROM_CACHE_d",
+    "Type": "real"
+  },
+  {
+    "Name": "QUERY_ID_g",
+    "Type": "string"
+  },
+  {
+    "Name": "QUERY_LOAD_PERCENT_d",
+    "Type": "real"
+  },
+  {
+    "Name": "QUERY_TAG_s",
+    "Type": "string"
+  },
+  {
+    "Name": "QUERY_TEXT_s",
+    "Type": "string"
+  },
+  {
+    "Name": "QUERY_TYPE_s",
+    "Type": "string"
+  },
+  {
+    "Name": "QUEUED_OVERLOAD_TIME_d",
+    "Type": "real"
+  },
+  {
+    "Name": "QUEUED_PROVISIONING_TIME_d",
+    "Type": "real"
+  },
+  {
+    "Name": "QUEUED_REPAIR_TIME_d",
+    "Type": "real"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "RELATED_EVENT_ID_s",
+    "Type": "string"
+  },
+  {
+    "Name": "RELEASE_VERSION_s",
+    "Type": "string"
+  },
+  {
+    "Name": "REPORTED_CLIENT_TYPE_s",
+    "Type": "string"
+  },
+  {
+    "Name": "REPORTED_CLIENT_VERSION_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ROLE_NAME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ROWS_DELETED_d",
+    "Type": "real"
+  },
+  {
+    "Name": "ROWS_INSERTED_d",
+    "Type": "real"
+  },
+  {
+    "Name": "ROWS_PRODUCED_d",
+    "Type": "real"
+  },
+  {
+    "Name": "ROWS_UNLOADED_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ROWS_UPDATED_s",
+    "Type": "string"
+  },
+  {
+    "Name": "SCHEMA_ID_s",
+    "Type": "string"
+  },
+  {
+    "Name": "SCHEMA_NAME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "SESSION_ID_d",
+    "Type": "real"
+  },
+  {
+    "Name": "source_table_s",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "START_TIME_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "TOTAL_ELAPSED_TIME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "TRANSACTION_BLOCKED_TIME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "USER_NAME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "WAREHOUSE_ID_s",
+    "Type": "string"
+  },
+  {
+    "Name": "WAREHOUSE_NAME_s",
+    "Type": "string"
+  },
+  {
+    "Name": "WAREHOUSE_SIZE_s",
+    "Type": "string"
+  },
+  {
+    "Name": "WAREHOUSE_TYPE_s",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SophosEP_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SophosEP_CL.json
@@ -1,0 +1,169 @@
+{
+  "Name":"SophosEP_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_processPath_s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_processId_s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_processName_s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_parentProcessId_s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_parentProcessPath_s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "user_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "customer_id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "created_at_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "source_info_ip_s",
+    "Type": "string"
+  },
+  {
+    "Name": "threat_s",
+    "Type": "string"
+  },
+  {
+    "Name": "endpoint_id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "endpoint_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "origin_s",
+    "Type": "string"
+  },
+  {
+    "Name": "when_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "amsi_threat_data_processPath_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_processId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_processName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_parentProcessId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "amsi_threat_data_parentProcessPath_s",
+    "Type": "string"
+  },
+  {
+    "Name": "source_s",
+    "Type": "string"
+  },
+  {
+    "Name": "type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "location_s",
+    "Type": "string"
+  },
+  {
+    "Name": "id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "group_s",
+    "Type": "string"
+  },
+  {
+    "Name": "datastream_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EventVendor_s",
+    "Type": "string"
+  },
+  {
+    "Name": "EventProduct_s",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SymantecICDx_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SymantecICDx_CL.json
@@ -1,0 +1,50 @@
+{
+  "Name":"SymantecICDx_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "connection_src_ip_s",
+    "Type": "string"
+  },
+  {
+    "Name": "threat_id_d",
+    "Type": "string"
+  }
+  
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Talon_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Talon_CL.json
@@ -1,0 +1,181 @@
+{
+  "Name": "Talon_CL",
+  "Properties": [
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_loginUsername_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_matchedURL_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_categories_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_reasons_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_failedAttempts_d",
+    "Type": "real"
+  },
+  {
+    "Name": "eventDetails_engine_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_activity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_printerName_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_fromURL_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_installSource_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_version_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_path_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventCategory_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventType_s",
+    "Type": "string"
+  },
+  {
+    "Name": "url_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "action_s",
+    "Type": "string"
+  },
+  {
+    "Name": "userEmail_s",
+    "Type": "string"
+  },
+  {
+    "Name": "deviceHostname_s",
+    "Type": "string"
+  },
+  {
+    "Name": "IPAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "browserVersion_s",
+    "Type": "string"
+  },
+  {
+    "Name": "userAgent_s",
+    "Type": "string"
+  },
+  {
+    "Name": "osPlatform_s",
+    "Type": "string"
+  },
+  {
+    "Name": "osVersion_s",
+    "Type": "string"
+  },
+  {
+    "Name": "mitreTechniques_s",
+    "Type": "string"
+  },
+  {
+    "Name": "policyRule_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_protocol_s",
+    "Type": "string"
+  },
+  {
+    "Name": "eventDetails_method_s",
+    "Type": "string"
+  },
+  {
+    "Name": "type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "time_s",
+    "Type": "string"
+  },
+  {
+    "Name": "description_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Tenable_IO_Assets_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Tenable_IO_Assets_CL.json
@@ -1,0 +1,177 @@
+{
+  "Name":"Tenable_IO_Assets_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "has_agent_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "has_plugin_results_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "created_at_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "updated_at_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "first_seen_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "last_seen_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "first_scan_time_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "last_scan_time_s",
+    "Type": "string"
+  },
+  {
+    "Name": "last_licensed_scan_date_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "last_scan_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "last_schedule_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "agent_names_s",
+    "Type": "string"
+  },
+  {
+    "Name": "installed_software_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ipv4s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ipv6s_s",
+    "Type": "string"
+  },
+  {
+    "Name": "fqdns_s",
+    "Type": "string"
+  },
+  {
+    "Name": "mac_addresses_s",
+    "Type": "string"
+  },
+  {
+    "Name": "netbios_names_s",
+    "Type": "string"
+  },
+  {
+    "Name": "operating_systems_s",
+    "Type": "string"
+  },
+  {
+    "Name": "system_types_s",
+    "Type": "string"
+  },
+  {
+    "Name": "hostnames_s",
+    "Type": "string"
+  },
+  {
+    "Name": "ssh_fingerprints_s",
+    "Type": "string"
+  },
+  {
+    "Name": "qualys_asset_ids_s",
+    "Type": "string"
+  },
+  {
+    "Name": "qualys_host_ids_s",
+    "Type": "string"
+  },
+  {
+    "Name": "manufacturer_tpm_ids_s",
+    "Type": "string"
+  },
+  {
+    "Name": "symantec_ep_hardware_keys_s",
+    "Type": "string"
+  },
+  {
+    "Name": "sources_s",
+    "Type": "string"
+  },
+  {
+    "Name": "tags_s",
+    "Type": "string"
+  },
+  {
+    "Name": "network_interfaces_s",
+    "Type": "string"
+  },
+  {
+    "Name": "acr_score_s",
+    "Type": "string"
+  },
+  {
+    "Name": "exposure_score_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "azure_resource_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "azure_vm_id_g",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Tenable_IO_Vuln_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Tenable_IO_Vuln_CL.json
@@ -1,0 +1,265 @@
+{
+  "Name":"Tenable_IO_Vuln_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_fqdn_s",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_hostname_s",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_uuid_g",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_ipv4_s",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_operating_system_s",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_network_id_g",
+    "Type": "string"
+  },
+  {
+    "Name": "asset_tracked_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "output_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cve_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_base_score_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_cvss_temporal_score_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_cvss_temporal_vector_exploitability_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_temporal_vector_remediation_level_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_temporal_vector_report_confidence_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_temporal_vector_raw_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_access_complexity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_access_vector_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_authentication_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_confidentiality_impact_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_integrity_impact_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_availability_impact_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_cvss_vector_raw_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_description_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_family_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_family_id_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_has_patch_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "plugin_id_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_name_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_risk_factor_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_see_also_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_solution_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_synopsis_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_vpr_score_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_vpr_drivers_age_of_vuln_lower_bound_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_vpr_drivers_age_of_vuln_upper_bound_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_vpr_drivers_exploit_code_maturity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_vpr_drivers_cvss_impact_score_predicted_b",
+    "Type": "bool"
+  },
+  {
+    "Name": "plugin_vpr_drivers_cvss3_impact_score_d",
+    "Type": "real"
+  },
+  {
+    "Name": "plugin_vpr_drivers_threat_intensity_last28_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_vpr_drivers_threat_sources_last28_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_vpr_drivers_product_coverage_s",
+    "Type": "string"
+  },
+  {
+    "Name": "plugin_vpr_updated_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "port_port_d",
+    "Type": "real"
+  },
+  {
+    "Name": "port_protocol_s",
+    "Type": "string"
+  },
+  {
+    "Name": "scan_completed_at_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "scan_schedule_uuid_s",
+    "Type": "string"
+  },
+  {
+    "Name": "scan_started_at_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "scan_uuid_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_s",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_id_d",
+    "Type": "real"
+  },
+  {
+    "Name": "severity_default_id_d",
+    "Type": "real"
+  },
+  {
+    "Name": "severity_modification_type_s",
+    "Type": "string"
+  },
+  {
+    "Name": "first_found_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "last_found_t",
+    "Type": "datetime"
+  },
+  {
+    "Name": "indexed_at_s",
+    "Type": "string"
+  },
+  {
+    "Name": "state_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/Tenable_ad_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/Tenable_ad_CL.json
@@ -1,0 +1,41 @@
+{
+  "Name":"Tenable_ad_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/TheomAlerts_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/TheomAlerts_CL.json
@@ -88,6 +88,12 @@
     {
       "Name": "deepLink_s",
       "Type": "String"
+    },
+    {
+      "Name": "TimeGenerated",
+      "Type": "Datetime"
     }
+    
+    
   ]
 }

--- a/.script/tests/KqlvalidationsTests/CustomTables/TrendMicroCAS_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/TrendMicroCAS_CL.json
@@ -128,6 +128,10 @@
       {
          "Name":"message_triggered_dlp_template_d",
          "Type":"Double"
-      }
+      },
+      {
+         "Name": "TimeGenerated",
+         "Type": "DateTime"
+     }
    ]
 }

--- a/.script/tests/KqlvalidationsTests/CustomTables/TrendMicroDeepSecurity.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/TrendMicroDeepSecurity.json
@@ -1,0 +1,89 @@
+{
+  "Name":"TrendMicroDeepSecurity",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "DeepSecurityHostID",
+    "Type": "string"
+  },
+  {
+    "Name": "DeepSecurityModuleName",
+    "Type": "string"
+  },
+  {
+    "Name": "actionReason",
+    "Type": "string"
+  },
+  {
+    "Name": "LIDescription",
+    "Type": "string"
+  },
+  {
+    "Name": "FragmentationBits",
+    "Type": "string"
+  },
+  {
+    "Name": "TCPFlags",
+    "Type": "string"
+  },
+  {
+    "Name": "InfectedResource",
+    "Type": "string"
+  },
+  {
+    "Name": "ResourceType",
+    "Type": "string"
+  },
+  {
+    "Name": "RiskLevel",
+    "Type": "string"
+  },
+  {
+    "Name": "DPIStreamPosition",
+    "Type": "string"
+  },
+  {
+    "Name": "DPIFlags",
+    "Type": "string"
+  },
+  {
+    "Name": "DPIPacketPosition",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/TrendMicroTippingPoint.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/TrendMicroTippingPoint.json
@@ -1,0 +1,597 @@
+{
+  "Name": "TrendMicroTippingPoint",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "DeviceVendor",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceProduct",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceVersion",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceEventClassID",
+    "Type": "string"
+  },
+  {
+    "Name": "Activity",
+    "Type": "string"
+  },
+  {
+    "Name": "LogSeverity",
+    "Type": "string"
+  },
+  {
+    "Name": "OriginalLogSeverity",
+    "Type": "string"
+  },
+  {
+    "Name": "AdditionalExtensions",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceAction",
+    "Type": "string"
+  },
+  {
+    "Name": "ApplicationProtocol",
+    "Type": "string"
+  },
+  {
+    "Name": "EventCount",
+    "Type": "int"
+  },
+  {
+    "Name": "DestinationDnsDomain",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationServiceName",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationTranslatedAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationTranslatedPort",
+    "Type": "int"
+  },
+  {
+    "Name": "CommunicationDirection",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceDnsDomain",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceExternalID",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceFacility",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceInboundInterface",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceNtDomain",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceOutboundInterface",
+    "Type": "string"
+  },
+  {
+    "Name": "DevicePayloadId",
+    "Type": "string"
+  },
+  {
+    "Name": "ProcessName",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceTranslatedAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationHostName",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationMACAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationNTDomain",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationProcessId",
+    "Type": "int"
+  },
+  {
+    "Name": "DestinationUserPrivileges",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationProcessName",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationPort",
+    "Type": "int"
+  },
+  {
+    "Name": "DestinationIP",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceTimeZone",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationUserID",
+    "Type": "string"
+  },
+  {
+    "Name": "DestinationUserName",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceName",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceMacAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "ProcessID",
+    "Type": "int"
+  },
+  {
+    "Name": "EndTime",
+    "Type": "datetime"
+  },
+  {
+    "Name": "ExternalID",
+    "Type": "int"
+  },
+  {
+    "Name": "ExtID",
+    "Type": "string"
+  },
+  {
+    "Name": "FileCreateTime",
+    "Type": "string"
+  },
+  {
+    "Name": "FileHash",
+    "Type": "string"
+  },
+  {
+    "Name": "FileID",
+    "Type": "string"
+  },
+  {
+    "Name": "FileModificationTime",
+    "Type": "string"
+  },
+  {
+    "Name": "FilePath",
+    "Type": "string"
+  },
+  {
+    "Name": "FilePermission",
+    "Type": "string"
+  },
+  {
+    "Name": "FileType",
+    "Type": "string"
+  },
+  {
+    "Name": "FileName",
+    "Type": "string"
+  },
+  {
+    "Name": "FileSize",
+    "Type": "int"
+  },
+  {
+    "Name": "ReceivedBytes",
+    "Type": "long"
+  },
+  {
+    "Name": "Message",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFileCreateTime",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFileHash",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFileID",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFileModificationTime",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFileName",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFilePath",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFilePermission",
+    "Type": "string"
+  },
+  {
+    "Name": "OldFileSize",
+    "Type": "int"
+  },
+  {
+    "Name": "OldFileType",
+    "Type": "string"
+  },
+  {
+    "Name": "SentBytes",
+    "Type": "long"
+  },
+  {
+    "Name": "EventOutcome",
+    "Type": "string"
+  },
+  {
+    "Name": "Protocol",
+    "Type": "string"
+  },
+  {
+    "Name": "Reason",
+    "Type": "string"
+  },
+  {
+    "Name": "RequestURL",
+    "Type": "string"
+  },
+  {
+    "Name": "RequestClientApplication",
+    "Type": "string"
+  },
+  {
+    "Name": "RequestContext",
+    "Type": "string"
+  },
+  {
+    "Name": "RequestCookies",
+    "Type": "string"
+  },
+  {
+    "Name": "RequestMethod",
+    "Type": "string"
+  },
+  {
+    "Name": "ReceiptTime",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceHostName",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceMACAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceNTDomain",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceDnsDomain",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceServiceName",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceTranslatedAddress",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceTranslatedPort",
+    "Type": "int"
+  },
+  {
+    "Name": "SourceProcessId",
+    "Type": "int"
+  },
+  {
+    "Name": "SourceUserPrivileges",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceProcessName",
+    "Type": "string"
+  },
+  {
+    "Name": "SourcePort",
+    "Type": "int"
+  },
+  {
+    "Name": "SourceIP",
+    "Type": "string"
+  },
+  {
+    "Name": "StartTime",
+    "Type": "datetime"
+  },
+  {
+    "Name": "SourceUserID",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceUserName",
+    "Type": "string"
+  },
+  {
+    "Name": "EventType",
+    "Type": "int"
+  },
+  {
+    "Name": "DeviceEventCategory",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomIPv6Address1",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomIPv6Address2",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomIPv6Address3",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomIPv6Address4",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomIPv6Address4Label",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint1",
+    "Type": "real"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint1Label",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint2",
+    "Type": "real"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint2Label",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint3",
+    "Type": "real"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint3Label",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint4",
+    "Type": "real"
+  },
+  {
+    "Name": "DeviceCustomFloatingPoint4Label",
+    "Type": "string"
+  },
+  {
+    "Name": "TippingPointVLAN",
+    "Type": "int"
+  },
+  {
+    "Name": "FieldDeviceCustomNumber1",
+    "Type": "long"
+  },
+  {
+    "Name": "TippingPointTaxonomy",
+    "Type": "int"
+  },
+  {
+    "Name": "FieldDeviceCustomNumber2",
+    "Type": "long"
+  },
+  {
+    "Name": "TippingPointPacketTrace",
+    "Type": "int"
+  },
+  {
+    "Name": "FieldDeviceCustomNumber3",
+    "Type": "long"
+  },
+  {
+    "Name": "TippingPointProfileName",
+    "Type": "string"
+  },
+  {
+    "Name": "TippingPointPolicyUUID",
+    "Type": "string"
+  },
+  {
+    "Name": "TippingPointSignatureUUID",
+    "Type": "string"
+  },
+  {
+    "Name": "TippingPointZoneNames",
+    "Type": "string"
+  },
+  {
+    "Name": "TippingPointSMSName",
+    "Type": "string"
+  },
+  {
+    "Name": "TippingPointFilterMessageParms",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomDate1",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomDate1Label",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomDate2",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceCustomDate2Label",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexDate1",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexDate1Label",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexNumber1",
+    "Type": "int"
+  },
+  {
+    "Name": "FlexNumber1Label",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexNumber2",
+    "Type": "int"
+  },
+  {
+    "Name": "FlexNumber2Label",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexString1",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexString1Label",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexString2",
+    "Type": "string"
+  },
+  {
+    "Name": "FlexString2Label",
+    "Type": "string"
+  },
+  {
+    "Name": "RemoteIP",
+    "Type": "string"
+  },
+  {
+    "Name": "RemotePort",
+    "Type": "string"
+  },
+  {
+    "Name": "MaliciousIP",
+    "Type": "string"
+  },
+  {
+    "Name": "ThreatSeverity",
+    "Type": "int"
+  },
+  {
+    "Name": "IndicatorThreatType",
+    "Type": "string"
+  },
+  {
+    "Name": "ThreatDescription",
+    "Type": "string"
+  },
+  {
+    "Name": "ThreatConfidence",
+    "Type": "string"
+  },
+  {
+    "Name": "ReportReferenceLink",
+    "Type": "string"
+  },
+  {
+    "Name": "MaliciousIPLongitude",
+    "Type": "real"
+  },
+  {
+    "Name": "MaliciousIPLatitude",
+    "Type": "real"
+  },
+  {
+    "Name": "MaliciousIPCountry",
+    "Type": "string"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "SimplifiedDeviceAction",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "cat",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/ZimperiumMitigationLog_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ZimperiumMitigationLog_CL.json
@@ -1,0 +1,73 @@
+{
+  "Name": "ZimperiumMitigationLog_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "threat_uuid",
+    "Type": "string"
+  },
+  {
+    "Name": "event_id_s",
+    "Type": "string"
+  },
+  {
+    "Name": "zdevice_id",
+    "Type": "string"
+  },
+  {
+    "Name": "device_os_s",
+    "Type": "string"
+  },
+  {
+    "Name": "event_timestamp_s",
+    "Type": "string"
+  },
+  {
+    "Name": "account_id",
+    "Type": "string"
+  },
+  {
+    "Name": "detection_app_instance_id",
+    "Type": "string"
+  },
+  {
+    "Name": "mitigated",
+    "Type": "bool"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/ZimperiumThreatLog_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/ZimperiumThreatLog_CL.json
@@ -1,0 +1,293 @@
+{
+  "Name": "ZimperiumThreatLog_CL",
+  "Properties":[
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "systemtoken",
+    "Type": "string"
+  },
+  {
+    "Name": "threatdetail",
+    "Type": "string"
+  },
+  {
+    "Name": "account_id",
+    "Type": "string"
+  },
+  {
+    "Name": "severity_name",
+    "Type": "string"
+  },
+  {
+    "Name": "event_id",
+    "Type": "string"
+  },
+  {
+    "Name": "threat_name",
+    "Type": "string"
+  },
+  {
+    "Name": "threat_uuid",
+    "Type": "string"
+  },
+  {
+    "Name": "threat_vector_s",
+    "Type": "string"
+  },
+  {
+    "Name": "devicetime",
+    "Type": "datetime"
+  },
+  {
+    "Name": "device_id",
+    "Type": "string"
+  },
+  {
+    "Name": "device_model",
+    "Type": "string"
+  },
+  {
+    "Name": "device_jailbroken",
+    "Type": "bool"
+  },
+  {
+    "Name": "zdevice_id",
+    "Type": "string"
+  },
+  {
+    "Name": "detection_app_instance_id",
+    "Type": "string"
+  },
+  {
+    "Name": "detection_app_version",
+    "Type": "string"
+  },
+  {
+    "Name": "device_os_s",
+    "Type": "string"
+  },
+  {
+    "Name": "device_os_version",
+    "Type": "string"
+  },
+  {
+    "Name": "device_owner_id",
+    "Type": "string"
+  },
+  {
+    "Name": "device_owner_email",
+    "Type": "string"
+  },
+  {
+    "Name": "device_owner_first_name",
+    "Type": "string"
+  },
+  {
+    "Name": "device_owner_last_name",
+    "Type": "string"
+  },
+  {
+    "Name": "device_ip",
+    "Type": "string"
+  },
+  {
+    "Name": "device_mac",
+    "Type": "string"
+  },
+  {
+    "Name": "gateway_ip",
+    "Type": "string"
+  },
+  {
+    "Name": "gateway_mac",
+    "Type": "string"
+  },
+  {
+    "Name": "basetation_mnc",
+    "Type": "real"
+  },
+  {
+    "Name": "basetation_psc",
+    "Type": "real"
+  },
+  {
+    "Name": "basetationtype",
+    "Type": "string"
+  },
+  {
+    "Name": "basetation_cid",
+    "Type": "real"
+  },
+  {
+    "Name": "basetation_mcc",
+    "Type": "real"
+  },
+  {
+    "Name": "basetation_lac",
+    "Type": "real"
+  },
+  {
+    "Name": "attacker_ip",
+    "Type": "string"
+  },
+  {
+    "Name": "attacker_mac",
+    "Type": "string"
+  },
+  {
+    "Name": "attacker_bssid",
+    "Type": "string"
+  },
+  {
+    "Name": "attackersid",
+    "Type": "string"
+  },
+  {
+    "Name": "network",
+    "Type": "string"
+  },
+  {
+    "Name": "network_bssid",
+    "Type": "string"
+  },
+  {
+    "Name": "network_interface",
+    "Type": "string"
+  },
+  {
+    "Name": "jailbreak_reasons",
+    "Type": "string"
+  },
+  {
+    "Name": "process",
+    "Type": "string"
+  },
+  {
+    "Name": "sideloaded_appeveloper",
+    "Type": "string"
+  },
+  {
+    "Name": "sideloaded_app_name",
+    "Type": "string"
+  },
+  {
+    "Name": "sideloaded_app_package",
+    "Type": "string"
+  },
+  {
+    "Name": "event",
+    "Type": "string"
+  },
+  {
+    "Name": "file_name",
+    "Type": "string"
+  },
+  {
+    "Name": "file_hash",
+    "Type": "string"
+  },
+  {
+    "Name": "file_path",
+    "Type": "string"
+  },
+  {
+    "Name": "suspected_url",
+    "Type": "string"
+  },
+  {
+    "Name": "malware_list",
+    "Type": "string"
+  },
+  {
+    "Name": "package_name",
+    "Type": "string"
+  },
+  {
+    "Name": "malware_family",
+    "Type": "string"
+  },
+  {
+    "Name": "installerource",
+    "Type": "string"
+  },
+  {
+    "Name": "actionriggered",
+    "Type": "string"
+  },
+  {
+    "Name": "profile_name",
+    "Type": "string"
+  },
+  {
+    "Name": "profileype",
+    "Type": "string"
+  },
+  {
+    "Name": "profile_identifier",
+    "Type": "string"
+  },
+  {
+    "Name": "subnet_mask",
+    "Type": "string"
+  },
+  {
+    "Name": "network_encryption",
+    "Type": "string"
+  },
+  {
+    "Name": "external_ip",
+    "Type": "string"
+  },
+  {
+    "Name": "certificate",
+    "Type": "string"
+  },
+  {
+    "Name": "basetation",
+    "Type": "string"
+  },
+  {
+    "Name": "stagefright_vulnerability_report",
+    "Type": "string"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "event_timestamp_s",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/secRMM_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/secRMM_CL.json
@@ -1,0 +1,153 @@
+{
+  "Name":"secRMM_CL",
+  "Properties":[
+  {
+    "Name": "_ResourceId",
+    "Type": "string"
+  },
+  {
+    "Name": "AdditionalProgramInfo",
+    "Type": "string"
+  },
+  {
+    "Name": "Computer",
+    "Type": "string"
+  },
+  {
+    "Name": "ConfigurationTarget",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceDescription",
+    "Type": "string"
+  },
+  {
+    "Name": "Drive",
+    "Type": "string"
+  },
+  {
+    "Name": "Event",
+    "Type": "string"
+  },
+  {
+    "Name": "InternalID",
+    "Type": "string"
+  },
+  {
+    "Name": "ManagementGroupName",
+    "Type": "string"
+  },
+  {
+    "Name": "Message",
+    "Type": "string"
+  },
+  {
+    "Name": "MG",
+    "Type": "string"
+  },
+  {
+    "Name": "Model",
+    "Type": "string"
+  },
+  {
+    "Name": "PreviousPropertyValue",
+    "Type": "string"
+  },
+  {
+    "Name": "ProgramName",
+    "Type": "string"
+  },
+  {
+    "Name": "ProgramPID_d",
+    "Type": "real"
+  },
+  {
+    "Name": "PropertyAction",
+    "Type": "string"
+  },
+  {
+    "Name": "PropertyName",
+    "Type": "string"
+  },
+  {
+    "Name": "PropertyOperationStatus",
+    "Type": "string"
+  },
+  {
+    "Name": "PropertyValue",
+    "Type": "string"
+  },
+  {
+    "Name": "RawData",
+    "Type": "string"
+  },
+  {
+    "Name": "SerialNumber_g",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceFile",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceFileLastWrite",
+    "Type": "string"
+  },
+  {
+    "Name": "SourceFileSize_d",
+    "Type": "real"
+  },
+  {
+    "Name": "SourceSystem",
+    "Type": "string"
+  },
+  {
+    "Name": "TargetFile",
+    "Type": "string"
+  },
+  {
+    "Name": "TenantId",
+    "Type": "string"
+  },
+  {
+    "Name": "TimeGenerated",
+    "Type": "datetime"
+  },
+  {
+    "Name": "Type",
+    "Type": "string"
+  },
+  {
+    "Name": "User",
+    "Type": "string"
+  },
+  {
+    "Name": "UserSID",
+    "Type": "string"
+  },
+  {
+    "Name": "Volume",
+    "Type": "string"
+  },
+  {
+    "Name": "Event_s",
+    "Type": "string"
+  },
+  {
+    "Name": "User_s",
+    "Type": "string"
+  },
+  {
+    "Name": "DeviceDescription_s",
+    "Type": "string"
+  },
+  {
+    "Name": "Drive_s",
+    "Type": "string"
+  },
+  {
+    "Name": "AdditionalProgramInfo_s",
+    "Type": "string"
+  }
+]
+}

--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -2979,93 +2979,13 @@
     "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
   },
   {
-    "id": "ProofpointPOD",
-    "templateName": "ProofpointPOD_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "ProofpointTAP",
-    "templateName": "ProofpointTAP_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "QualysKB",
-    "templateName": "QualysKB_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "RSASecurIDAM",
-    "templateName": "RSASecurID.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "RubrikSecurityCloudAzureFunctions",
-    "templateName": "RubrikWebhookEvents_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SalesforceServiceCloud",
-    "templateName": "SalesforceServiceCloud_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
     "id": "SecurePractice_MailRisk",
     "templateName": "SecurePractice_MailRisk.json",
     "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
   },
   {
-    "id": "SecurityScorecardFactorAzureFunctions",
-    "templateName": "SecurityScorecardFactor_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
     "id": "SecurityScorecardIssueAzureFunctions",
     "templateName": "SecurityScorecardIssue_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SecurityScorecardRatingsAzureFunctions",
-    "templateName": "SecurityScorecardRatings_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SenservaPro",
-    "templateName": "SenservaPro.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SentinelOne",
-    "templateName": "SentinelOne_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SlackAuditAPI",
-    "templateName": "SlackAudit_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SnowflakeDataConnector",
-    "templateName": "Snowflake_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SophosEP",
-    "templateName": "SophosEP_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "SquadraTechnologiesSecRMM",
-    "templateName": "SquadraTechnologies.SecRMM.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "Symantec",
-    "templateName": "SymantecICDX.JSON",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "TalonLogs",
-    "templateName": "TalonLogs.json",
     "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
   },
   {
@@ -3094,53 +3014,13 @@
     "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
   },
   {
-    "id": "Office365Project",
-    "templateName": "template_Office365Project.JSON",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
     "id": "OfficePowerBI",
     "templateName": "template_OfficePowerBI.JSON",
     "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
   },
   {
-    "id": "Tenable.ad",
-    "templateName": "Tenable.ad.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "TenableIOAPI",
-    "templateName": "TenableIO.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "TrendMicroCAS",
-    "templateName": "TerndMicroCAS_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "Theom",
-    "templateName": "Theom.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "TrendMicro",
-    "templateName": "TrendMicroDeepSecurity.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "TrendMicroTippingPoint",
-    "templateName": "TrendMicroTippingPoint.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
     "id": "VMwareCarbonBlack",
     "templateName": "VMwareCarbonBlack_API_FunctionApp.json",
-    "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
-  },
-  {
-    "id": "ZimperiumMtdAlerts",
-    "templateName": "Zimperium MTD Alerts.json",
     "validationFailReason": "Temporarily Added for Data Connector KQL Queries validation"
   },
   {


### PR DESCRIPTION
   Required items, please complete.
   
   Change(s):
   - Adding new custom tables and updating existing ones.

   Reason for Change(s):
   - We have some data connectors' KQL queries failing validation tests due to missing custom tables which is being referred in 
     these queries or some column missing in any of the existing custom tables, so we referred to the sample data added by 
     authors for these tables and made updates in tables accordingly.

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below
