### PR TITLE
Update Incident-Assignment-Shift playbook with incorrect API-call

### DIFF
--- a/Solutions/SentinelSOARessentials/Playbooks/Incident-Assignment-Shifts/azuredeploy.json
+++ b/Solutions/SentinelSOARessentials/Playbooks/Incident-Assignment-Shifts/azuredeploy.json
@@ -307,7 +307,7 @@
                                                             "type": "ManagedServiceIdentity"
                                                         },
                                                         "method": "GET",
-                                                        "uri": "[uriComponentToString(uri(variables('azure'),'subscriptions/@{triggerBody()?[''workspaceInfo'']?[''SubscriptionId'']}/resourceGroups/@{triggerBody()?[''workspaceInfo'']?[''ResourceGroupName'']}/providers/Microsoft.OperationalInsights/workspaces/@{triggerBody()?[''workspaceInfo'']?[''WorkspaceName'']}/providers/Microsoft.SecurityInsights/Incidents?api-version=2020-01-01&$filter=(properties/owner/objectId eq ''@{items(''For_each_Shifts_list'')?[''userId'']}'' and properties/createdTimeUtc ge @{items(''For_each_Shifts_list'')?[''sharedShift'']?[''startDateTime'']})&$top=2000'))]"
+                                                        "uri": "[uriComponentToString(uri(variables('azure'),'subscriptions/@{triggerBody()?[''workspaceInfo'']?[''SubscriptionId'']}/resourceGroups/@{triggerBody()?[''workspaceInfo'']?[''ResourceGroupName'']}/providers/Microsoft.OperationalInsights/workspaces/@{triggerBody()?[''workspaceInfo'']?[''WorkspaceName'']}/providers/Microsoft.SecurityInsights/Incidents?api-version=2020-01-01&$filter=(properties/owner/objectId eq ''@{items(''For_each_Shifts_list'')?[''userId'']}'' and properties/createdTimeUtc ge @{items(''For_each_Shifts_list'')?[''sharedShift'']?[''startDateTime'']})&$top=1000'))]"
                                                     }
                                                 },
                                                 "Parse_JSON_-_HTTP": {


### PR DESCRIPTION
Change:
- Update  SecurtyInsights API call with top-request from 2000 to 1000.
 
Reason for Change(s):
- There are limitations of SecurityInsights API, you can't request API-call with more 1000 objects.

Version Updated:
- No

Testing Completed:
 - Yes


-----------------------------------------------------------------------------------------------------------
