### PR TITLE
verify github webhook signature

### DIFF
--- a/Solutions/GitHub/Data Connectors/GithubWebhook/GithubWebhookConnector/__init__.py
+++ b/Solutions/GitHub/Data Connectors/GithubWebhook/GithubWebhookConnector/__init__.py
@@ -11,6 +11,7 @@ import re
 
 sentinel_customer_id = os.environ.get('WorkspaceID')
 sentinel_shared_key = os.environ.get('WorkspaceKey')
+github_webhook_secret = os.environ.get('GithubWebhookSecret')
 sentinel_log_type =  'githubscanaudit'
 logging.info("Sentinel Logtype:{}".format(sentinel_log_type))
 logAnalyticsUri = os.environ.get('LogAnaltyicsUri')
@@ -31,6 +32,23 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
      logging.info('Info:Current retry count:{}'.format(context.retry_context.retry_count))   
      logging.info('Info:Github webhook data connector started')  
      logging.info("Sentinel Logtype:{}".format(sentinel_log_type))  
+
+     # check webhook signature if GitHubWebhookSecret exists
+     if ((github_webhook_secret not in (None, '') and not str(github_webhook_secret).isspace())):    
+        hash_object = hmac.new(github_webhook_secret.encode('utf-8'), msg=req.get_body(), digestmod=hashlib.sha256)
+        expected_signature = "sha256=" + hash_object.hexdigest()
+        if 'x-hub-signature-256' not in req.headers:
+            return func.HttpResponse(
+             "Github webhook signature header is missing.",
+             status_code=403
+        )
+        signature_header = req.headers['x-hub-signature-256']
+        if not hmac.compare_digest(expected_signature, signature_header):
+            return func.HttpResponse(
+             "Github webhook signature verification failed.",
+             status_code=403
+        )
+
      req_body = req.get_json()
      body = json.dumps(customizeJson(json.dumps(req_body)))
      logging.info("Info:Converted input json to dict and further to json")


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Currently this connector ain't supporting any authentication of incoming webhooks. Github provides a [mechanism of webhook authentication with HMAC signature](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks) of request's body. I added validation of `x-hub-signature` header following [Github's guildlines](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github). Connector is still working without presence of signature header for backward compatibility. Secret on Connector side is stored the same way as WorkspaceKey:

```
     sentinel_shared_key = os.environ.get('WorkspaceKey')
     github_webhook_secret = os.environ.get('GithubWebhookSecret')
```

   Also i have updated presented zip archive with azure function accordingly. After this PR will be accepted i'm going to create PR in Azure Docs describing steps required to store secret on both Azure and Github sides.

   Reason for Change(s):
   - Enhancing security of webhook calls.

   Version Updated:
   - N/A

   Testing Completed:
   - Yes, i have tested it my organization's Azure environment.

   Checked that the validations are passing and have addressed any issues that are present:
   - No schema-related changes was made.
