### PR TITLE
Fixed issue on hunting query text

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -1993,7 +1993,17 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
 
                         $huntingQueryDescription = ""
                         if ($yaml.description) {
-                            $huntingQueryDescription = $yaml.description.substring(1, $yaml.description.length - 3)
+                            #$huntingQueryDescription = $yaml.description.substring(1, $yaml.description.length - 3)
+                            $huntingQueryDescription = $yaml.description.Trim();
+                            if($huntingQueryDescription.StartsWith("'"))
+                            {
+                                $huntingQueryDescription = $huntingQueryDescription.substring(1, $huntingQueryDescription.length-1)
+                            }
+
+                            if($huntingQueryDescription.EndsWith("'"))
+                            {
+                                $huntingQueryDescription = $huntingQueryDescription.substring(0, $huntingQueryDescription.length-1)
+                            }
                             $descriptionObj = [PSCustomObject]@{
                                 name  = "description";
                                 value = $huntingQueryDescription


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - When Package is created then hunting query text was skipping 1 character from the string so we fixed this.
   Reason for Change(s):
   - See guidance below

   Version Updated:
   - NA

   Testing Completed:
   - Yes, done this locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

