### PR TITLE
Update getModifiedASimSchemas.ps1

### DIFF
--- a/.script/getModifiedASimSchemas.ps1
+++ b/.script/getModifiedASimSchemas.ps1
@@ -1,19 +1,19 @@
 function getModifiedAsimSchemas() {
     $schemas = ("ASimDns", "ASimWebSession", "ASimNetworkSession", "ASimProcessEvent", "ASimAuditEvent", "ASimAuthentication", "ASimFileEvent", "ASimRegistryEvent")
-    $midifiedSchemas = @()
+    $modifiedSchemas = @()
     foreach ($schema in $schemas) {
         $filesThatWereChanged= Invoke-Expression "git diff origin/master  --name-only -- $($PSScriptRoot)/../Parsers/$($schema)/Parsers"
         if ($filesThatWereChanged) {
             Write-Host Files that were changed under Azure-Sentinel/Parsers/$schema/ARM:
 			Write-Host  - $filesThatWereChanged
-            $midifiedSchemas += $schema
+            $modifiedSchemas += $schema
         }
         else {
             Write-Host "No files were changed under Azure-Sentinel/Parsers/$schema/"
         }
     }
 
-    return $midifiedSchemas
+    return $modifiedSchemas
 }
 
 getModifiedAsimSchemas


### PR DESCRIPTION
fixed typo in variable from `$midifiedSchemas` to `$modifiedSchemas`

   Required items, please complete
   
   Change(s):
   - Changed file getModifiedASimSchemas.ps1

   Reason for Change(s):
   - Typo in variable

   Version Updated:
   - N/A

   Testing Completed:
   - Yes, locally
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
