### PR TITLE
Removed token from slash command

### DIFF
--- a/.github/workflows/slash-command-dispatch.yaml
+++ b/.github/workflows/slash-command-dispatch.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@67dfeb76529b35541a7c536976cba367cd2d364b
         with:
-          token: ${{ env.GITHUB_TOKEN }}
           commands: package
           repository: ${{env.REPO_OWNER}}/${{env.REPO_NAME}}
           issue-type: pull-request


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Removed token from slash command to run our workflow

   Reason for Change(s):
   - we are facing issue in running workflow when adding slash command to pr

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

