### PR TITLE
slash command dispatch workflow change

### DIFF
--- a/.github/workflows/slash-command-dispatch.yaml
+++ b/.github/workflows/slash-command-dispatch.yaml
@@ -2,7 +2,7 @@ name: Slash Command Dispatch
 env:
     REPO_OWNER: "${{ vars.REPO_OWNER }}"
     REPO_NAME: "${{ vars.REPO_NAME }}"
-    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    GITHUB_TOKEN: "${{ secrets.PAT }}"
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Update token for slash command dispatch. We are not able to trigger github workflow when slash command due to permission restriction.

   Reason for Change(s):
   - slash command is not able to trigger packaging workflow so we have used read:org permission on token

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
