### PR TITLE
adding _ASIM_GetSourceBySourceType table

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/_ASIM_GetSourceBySourceType.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/_ASIM_GetSourceBySourceType.json
@@ -8,6 +8,10 @@
         {
             "Name": "Source",
             "Type": "String"
-        }
+        },
+        {
+            "Name": "print_0",
+            "Type": "dynamic"
+          }
     ]
 }

--- a/.script/tests/KqlvalidationsTests/CustomTables/_ASIM_GetSourceBySourceType.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/_ASIM_GetSourceBySourceType.json
@@ -1,0 +1,13 @@
+{
+    "Name": "_ASIM_GetSourceBySourceType",
+    "Properties": [
+        {
+            "Name": "SourceType",
+            "Type": "string"
+        },
+        {
+            "Name": "Source",
+            "Type": "String"
+        }
+    ]
+}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - adding custom table _ASIM_GetSourceBySourceType

   Reason for Change(s):
   - We were getting validation error as name does not refer to known table. We were using this function in ASIM parsers to filter logs based on specific computer or sources.

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - NA

-----------------------------------------------------------------------------------------------------------
