### PR TITLE
Skip Validation for Dependabots

### DIFF
--- a/.github/workflows/AddLabel.yaml
+++ b/.github/workflows/AddLabel.yaml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   solutionNameDetails:
-    if: ${{ !github.event.pull_request.head.repo.fork && !contains(github.event.pull_request.labels.*.name, 'P0')}}
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork && !contains(github.event.pull_request.labels.*.name, 'P0')}}
     uses: ./.github/workflows/getSolutionName.yaml
     secrets: inherit
 
   solutionPublisherDetail:
     needs: solutionNameDetails
-    if: ${{ needs.solutionNameDetails.outputs.solutionName != '' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.actor != 'dependabot[bot]' && needs.solutionNameDetails.outputs.solutionName != '' && !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/neworexistingsolution.yaml
     with: 
       solutionName: "${{ needs.solutionNameDetails.outputs.solutionName }}"
@@ -25,7 +25,7 @@ jobs:
   Labeler:
     runs-on: ubuntu-latest
     needs: solutionPublisherDetail
-    if: ${{ needs.solutionPublisherDetail.outputs.solutionPublisherId != '' && !contains(fromJson(vars.INTERNAL_PUBLISHERS),needs.solutionPublisherDetail.outputs.solutionPublisherId) }}
+    if: ${{ github.actor != 'dependabot[bot]' && needs.solutionPublisherDetail.outputs.solutionPublisherId != '' && !contains(fromJson(vars.INTERNAL_PUBLISHERS),needs.solutionPublisherDetail.outputs.solutionPublisherId) }}
     steps:
       - name: Add Label Notification
         uses: actions/github-script@v6


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - We should skip validation for dependabot. Currently it is failing for Labeller github action.

   Reason for Change(s):
   - We should skip validation for dependabot. Currently it is failing for Labeller github action.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

