### PR TITLE
Add condition continue-on-error in workflow

### DIFF
--- a/.github/workflows/package-command.yaml
+++ b/.github/workflows/package-command.yaml
@@ -202,6 +202,7 @@ jobs:
       pull-requests: write
       contents: write
     needs: [solutionNameDetails, neworexistingsolution, createpackage, getPullRequestInfo]
+    continue-on-error: true
     env:
       BLOBNAME: "${{ needs.createpackage.outputs.blobName }}"
       IS_CREATE_PACKAGE: ${{ needs.createpackage.outputs.isCreatePackage }}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Currently we are getting error "GitHub Actions is not permitted to create or approve pull requests." when we update existing pr from github action. Instead of failing the action this way we are adding a condition so that it shows success. We saw that even if it is failing it is adding all required files to the pr so its ok to show success in this case.

   Reason for Change(s):
   - Skip success for package files committed to existing pr 

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
