### PR TITLE
fixed issue on package version

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -232,35 +232,48 @@ function updateDescriptionCount($counter, $emplaceString, $replaceString, $count
 function GetContentSchemaVersion($defaultPackageVersion, $dataInputVersion)
 {
     # DEPENDING OF VERSION WE SHOULD SET THE CONTENTSCHEMAVERSION
-    if ($null -eq $defaultPackageVersion -or $null -eq $dataInputVersion)
+    if ($null -eq $defaultPackageVersion -and $null -eq $dataInputVersion)
     {
         # WHEN BOTH NULL
         $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
     }
-    elseif ($null -ne $defaultPackageVersion -and ($dataInputVersion -ne $defaultPackageVersion))
+    elseif ($null -ne $defaultPackageVersion -and $null -ne $dataInputVersion -and ($dataInputVersion -ne $defaultPackageVersion))
     {
-        # WHEN ONE IS NULL  
-        $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "2.0.0";
+        # when both has version
+        $inputMajor = $dataInputVersion.split(".")[0]
+        $defaultMajor = $defaultPackageVersion.split(".")[0]
+
+        if (($inputMajor -ge $defaultMajor -and $defaultMajor -ge 3) -or $defaultMajor -ge 3)
+        {
+            $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
+        }
+        else 
+        {
+            $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "2.0.0";
+        }
     }
     elseif ($null -eq $defaultPackageVersion -and $null -eq $dataInputVersion) {
+        # when both null
         $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "3.0.0";
         Write-Host "contentSchemaVersion set is 3.0.0 as both defaultPackageVersion and version field are null"
     }
     elseif ($null -ne $defaultPackageVersion -and $null -eq $dataInputVersion) {
+        # when data input is null and default is not null
         $major = $defaultPackageVersion.split(".")[0]
         $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$major.0.0";
         Write-Host "contentSchemaVersion set is $major inside of elseif where defaultPackageVersion is not null but input file version is null"
     }
     elseif ($null -eq $defaultPackageVersion -and $null -ne $dataInputVersion) {
-        $inputMajor,$inputMinor,$inputBuild,$inputRevision = $dataInputVersion.split(".")
+        # when data input is not null but default is null
+        $inputMajor = $dataInputVersion.split(".")[0]
         $newMetadata.Properties | Add-Member -Name 'contentSchemaVersion' -Type NoteProperty -Value "$inputMajor.0.0";
         Write-Host "contentSchemaVersion inputMajor set is $inputMajor inside of elseif where defaultPackageVersion is null but input file version is not null"
     }
     elseif ($null -ne $defaultPackageVersion -and $null -ne $dataInputVersion -and 
     $dataInputVersion -ne $defaultPackageVersion)
     {
-        $inputMajor,$inputMinor,$inputBuild,$inputRevision = $dataInputVersion.split(".")
-        $defaultMajor,$defaultMinor,$defaultBuild,$defaultRevision = $defaultPackageVersion.split(".")
+        $inputMajor = $dataInputVersion.split(".")[0]
+        $defaultMajor = $defaultPackageVersion.split(".")[0]
             
         if ($inputMajor -gt $defaultMajor -or $inputMajor -eq $defaultMajor)
         {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Made changes in commonFunctions.ps1 file to correctly show contentSchemaVersion.

   Reason for Change(s):
   - Fix issue on package version. When package already exist for 3.0.0 and create a new package for 3.0.1 then contentSchemaVersion is set to 2.0.0 instead of 3.0.0

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

