### PR TITLE
Update Workbook Dns.json

### DIFF
--- a/Workbooks/Dns.json
+++ b/Workbooks/Dns.json
@@ -88,7 +88,7 @@
               "additionalResourceOptions": [
                 "value::all"
               ],
-              "selectAllValue": ""
+              "selectAllValue": "*"
             },
             "timeContext": {
               "durationMs": 0


### PR DESCRIPTION
   
   Change(s):
   - Updated "selectAllValue" value from empty string to "*".

   Reason for Change(s):
   - https://github.com/Azure/Azure-Sentinel/issues/8376
   - In case of empty string, Ip list was forming a large string and when used in query, it was exceeding the max query length.

   Version Updated:
   - No

   Testing Completed:
   - Yes, functional testing and deployment testing
