### PR TITLE
Added condition so that repo checkout doesn't happen

### DIFF
--- a/.azure-pipelines/callGithubWorkflow.yaml
+++ b/.azure-pipelines/callGithubWorkflow.yaml
@@ -47,6 +47,7 @@ jobs:
       eq(dependencies.YamlFileValidation.result, 'Succeeded')
     )
   steps:
+  - checkout: none
   - pwsh: |
       try
       {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Currently checkout is ran which is not request so added condition so that it gets skipped.

   Reason for Change(s):
   - Currently checkout is ran which is not request so added condition so that it gets skipped.

   Version Updated:
   - NA

   Testing Completed:
   - Yes
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

Below is the output after testing on Sarath's private repo:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/5c24c17a-dc94-4a4c-a9a2-5f88da666622)

