### PR TITLE
🐛 Fix incorrect field in TI analytic

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml
@@ -29,7 +29,7 @@ query: |
   let IP_Indicators = ThreatIntelligenceIndicator
     | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
     | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
-    | where TimeGenerated >= ago(ioc_lookBack) and ExpirationDateTime > now()
+    | where LatestIndicatorTime >= ago(ioc_lookBack) and ExpirationDateTime > now()
     | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
     | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(NetworkSourceIP), NetworkSourceIP, TI_ipEntity)
     | extend TI_ipEntity = iff(isempty(TI_ipEntity) and isnotempty(EmailSourceIpAddress), EmailSourceIpAddress, TI_ipEntity)
@@ -63,5 +63,5 @@ entityMappings:
     fieldMappings:
       - identifier: ResourceId
         columnName: ResourceId
-version: 1.3.0
+version: 1.3.1
 kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s): `Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml` was referring to an incorrect field. `TimeGenerated` was replaced with `LatestIndicatorTime`.

   Reason for Change(s):
   - Analytic does not run: `'where' operator: Failed to resolve column or scalar expression named 'TimeGenerated'`

   Version Updated: ✅

   Testing Completed: ☑️