### PR TITLE
Fix empty diff check for NRT_NewAppOrServicePrincipalCredential

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
@@ -39,7 +39,7 @@ query: |
     )
   | where old_value_set != "[]"
   | extend diff = set_difference(new_value_set, old_value_set)
-  | where isnotempty(diff)
+  | where diff != "[]"
   | parse diff with * "KeyIdentifier=" keyIdentifier:string ",KeyType=" keyType:string ",KeyUsage=" keyUsage:string ",DisplayName=" keyDisplayName:string "]" *
   | where keyUsage =~ "Verify"
   | mv-apply AdditionalDetail = AdditionalDetails on 
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.1
+version: 1.0.2
 kind: NRT


### PR DESCRIPTION
   Change(s):
   - Logic to check / filter on an empty `diff` for `NRT_NewAppOrServicePrincipalCredential` (`NRT New access credential added to Application or Service Principal`)

   Reason for Change(s):
   - `set_difference` returns an **array** datatype (i.e. `diff` is an array), but `isnotempty` takes a **scalar** datatype
   - This means `where isnotempty(diff)` does not work as intended and results in records with an empty `diff` (i.e. a removal has occurred instead of an addition) to trigger the rule 
   - Updating the check to `where diff != "[]"` also provides consistency with other empty array checks in the rule
   - (See below for examples of the issue vs. proposed solution)

   Version Updated:
   - Yes

   Testing Completed:
   - Yes 

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

## Query Logic Validation
Thanks to @smant-chorus for contributing to the validation queries below.

### Issue with Current Logic
**Example Query**
```kql
datatable(record_id: int, old_value_set: dynamic, new_value_set: dynamic) [
    1, dynamic(["[test_1]", "[test_2]", "[test_3]"]), dynamic(["[test_1]", "[test_3]"]),  // access credential test_2 removed
    2, dynamic(["[test_4]", "[test_5]", "[test_6]"]), dynamic(["[test_4]", "[test_5]", "[test_6]", "[test_7]"])  // access credential test_7 added
]
| extend diff = set_difference(new_value_set, old_value_set)
| extend diff_is_not_empty = isnotempty(diff)
| extend diff_array_length = array_length(diff)
| where isnotempty(diff)
```

**Results**
![image](https://github.com/Azure/Azure-Sentinel/assets/138881774/22b5b798-d863-48a8-bc2a-345fb11a5bd6)

The first record reflects an access credential being removed; the `diff` for this record is empty yet an `isnotempty(diff)` check will return `true`.  This is not the intended scope of the detection, which is meant to check for additions only.

### Proposed Solution
**Example Query**
```kql
datatable(record_id: int, old_value_set: dynamic, new_value_set: dynamic) [
    1, dynamic(["[test_1]", "[test_2]", "[test_3]"]), dynamic(["[test_1]", "[test_3]"]),  // access credential test_2 removed
    2, dynamic(["[test_4]", "[test_5]", "[test_6]"]), dynamic(["[test_4]", "[test_5]", "[test_6]", "[test_7]"])  // access credential test_7 added
]
| extend diff = set_difference(new_value_set, old_value_set)
| extend diff_is_not_empty = isnotempty(diff)
| extend diff_array_length = array_length(diff)
| where diff != "[]"
```
**Results**
![image](https://github.com/Azure/Azure-Sentinel/assets/138881774/5af108f0-dc0c-4128-868a-fc97b50cb634)

The `where diff != "[]"` now only returns `true` for the second record, i.e. the addition of an access credential.


-----------------------------------------------------------------------------------------------------------
