### PR TITLE
Update TargetResource logic for UserAssignedPrivilegedRole

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/UserAssignedPrivilegedRole.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/UserAssignedPrivilegedRole.yaml
@@ -26,9 +26,8 @@ query: |
   | where ActivityDisplayName has_any ("Add eligible member to role", "Add member to role")
   | mv-apply TargetResource = TargetResources on 
     (
-        where TargetResource.type =~ "User"
-        | extend Target = tostring(TargetResource.userPrincipalName)
-        | extend Target = iff(TargetResources.type == "ServicePrincipal", tostring(TargetResources.displayName), Target),
+        where TargetResource.type in~ ("User", "ServicePrincipal")
+        | extend Target = iff(TargetResource.type =~ "ServicePrincipal", tostring(TargetResource.displayName), tostring(TargetResource.userPrincipalName)),
                  props = TargetResource.modifiedProperties
     )
   | mv-apply Property = props on 
@@ -56,5 +55,5 @@ entityMappings:
         columnName: InitiatorName
       - identifier: UPNSuffix
         columnName: InitiatorUPNSuffix
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Condition to check if `TargetResource.type` is a User or Service Principal for `UserAssignedPrivilegedRole` (`User Assigned Privileged Role`)
   - Assignment of the `Target` variable based on whether the `TargetResource.type` is a User or Service Principal
        - update to a case-insensitive equality on the Service Principal to be consistent with the initial `type` filter

   Reason for Change(s):
   - The current logic of `where TargetResource.type =~ "User"` already filters the `type` by User, so the subsequent `extend Target = iff(TargetResources.type == "ServicePrincipal"` logic will never return `true`
   - `iff(TargetResources.type == "ServicePrincipal", tostring(TargetResources.displayName)` references `TargetResources` instead of `TargetResource`

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes