### PR TITLE
Make Parser FunctionParams as optional

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -3018,7 +3018,7 @@ function addTemplateSpecParserResource($content,$yaml,$isyaml, $contentResourceD
                 category      = $isyaml ? "$($yaml.Category)" : "Samples"
                 functionAlias = "$($displayDetails.functionAlias)"
                 query         = $isyaml ? "$($yaml.FunctionQuery)" : "$content"
-                functionParameters = $isyaml ? "$(ConvertHashTo-StringData $yaml.FunctionParams)" : ""
+                functionParameters = $isyaml -and $null -ne $yaml.FunctionParams ? "$(ConvertHashTo-StringData $yaml.FunctionParams)" : ""
                 version       = $isyaml ? 2 : 1
                 tags          = @([PSCustomObject]@{
                     "name"  = "description"
@@ -3115,7 +3115,7 @@ function addTemplateSpecParserResource($content,$yaml,$isyaml, $contentResourceD
                 category      = $isyaml ? "$($yaml.Category)" :"Samples"
                 functionAlias = "$($displayDetails.functionAlias)"
                 query         = $isyaml ? "$($yaml.FunctionQuery)" : "$content"
-                functionParameters = $isyaml ? "$(ConvertHashTo-StringData $yaml.FunctionParams)" : ""
+                functionParameters = $isyaml -and $null -ne $yaml.FunctionParams ? "$(ConvertHashTo-StringData $yaml.FunctionParams)" : ""
                 version       = $isyaml ? 2 : 1
                 tags          = @([PSCustomObject]@{
                     "name"  = "description"


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - When FunctionParams attribute is not present in yaml based parser then package creation tool fails with an error. So we have make this functionparams check optional i.e if not specified then we dont calculate it and keep it as blank.

   Reason for Change(s):
   - Make FunctionParams as optional check

   Version Updated:
   - NA

   Testing Completed:
   - Yes, did testing by deploying the create ui using custom deploy. Also verified if maintemplate is getting deployed successfully using custom deploy

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

