### PR TITLE
Fix Source IP aggregation for Firewall

### DIFF
--- a/Solutions/Azure Firewall/Analytic Rules/Azure Firewall - Multiple Sources Affected by the Same TI Destination.yaml
+++ b/Solutions/Azure Firewall/Analytic Rules/Azure Firewall - Multiple Sources Affected by the Same TI Destination.yaml
@@ -26,7 +26,7 @@ query: |
   let RunTime = 1d; 
   let StartRunTime = 1d; 
   let EndRunTime = StartRunTime - RunTime; 
-  let MinAffectedThershold = 5; 
+  let MinAffectedThreshold = 5;
   union isfuzzy=true
   (AzureDiagnostics 
   | where TimeGenerated  between (ago(StartRunTime) .. ago(EndRunTime))
@@ -34,8 +34,8 @@ query: |
   | parse msg_s with * "from " SourceIp ":" SourcePort:int " to " Fqdn ":" DestinationPort:int  "." * "Action: Deny. " ThreatDescription),
   (AZFWThreatIntel
   | where TimeGenerated between (ago(StartRunTime) .. ago(EndRunTime)))
-  | summarize TiTrafficCount = count(), dCountSourceIps = dcount(SourceIp), AffectedIps = make_set(SourceIp, 10000) by Fqdn, ThreatDescription,SourceIp 
-  | where array_length(AffectedIps) > MinAffectedThershold | order by TiTrafficCount desc
+  | summarize TiTrafficCount = count(), dCountSourceIps = dcount(SourceIp), AffectedIps = make_set(SourceIp, 10000) by Fqdn, ThreatDescription
+  | where array_length(AffectedIps) > MinAffectedThreshold | order by TiTrafficCount desc
 entityMappings:
   - entityType: IP
     fieldMappings:
@@ -45,5 +45,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: Fqdn
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled


### PR DESCRIPTION

   Change(s):
   - Fix source IP aggregation for Azure Firewall analytics rules "Multiple Sources Affected by the Same TI Destination"

   Reason for Change(s):
   - Undo a change from a recent commit (a7132b0) and restore the "Multiple Sources Affected by the Same TI Destination" Firewall analytics rule source IP aggregation. Currently the rule summarizes by the source IP, which results in the query returning zero results unless the "MinAffectedThreshold" is set to 0, thereby making the parameter useless.
   - Fix a typo for the "MinAffectedThreshold" parameter

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
