### PR TITLE
Bugfix DomainEntity_SecurityAlert.yaml

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_SecurityAlert.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_SecurityAlert.yaml
@@ -88,5 +88,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: Url
-version: 1.4.0
+version: 1.4.1
 kind: Scheduled

--- a/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_SecurityAlert.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/DomainEntity_SecurityAlert.yaml
@@ -53,7 +53,7 @@ query: |
       | extend MSTI = case(AlertName has "TI map" and VendorName == "Microsoft" and ProductName == 'Azure Sentinel', true, false)
       | where MSTI == false
       // Extract domain patterns from message
-      | extend domain = todynamic(dynamic_to_json(extract_all(@"(((xn--)?[a-z0-9\-]+\.)+([a-z]+|(xn--[a-z0-9]+)))", dynamic([1]), tolower(Entities))))
+      | extend domain = todynamic(dynamic_to_json(extract_all(@"(((xn--)?[a-z0-9\-]+\.)+([a-z]+|(xn--[a-z0-9]+)))", dynamic([1,1]), tolower(Entities))))
       | mv-expand domain
       | extend domain = tostring(domain[0])
       | extend parts = split(domain, '.')


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   -Changed dymanic([1]) to dymanic([1,1]) to make result array of array consistent

   Reason for Change(s):
   - **extract_all**  sometimes produce an array of array and sometimes a single dimension array, which breaks the later commands. Making dynamic ([1]) with dynamic ([1,1]), always produces an array of array.
   - For more details, [ICM](https://portal.microsofticm.com/imp/v3/incidents/details/411416882/home)

   Version Updated:
   - Yes, 1.4.1

   Testing Completed:
   - Yes