### PR TITLE
Updating the Query of SigninAttemptsByIPviaDisabledAccounts.yaml

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/SigninAttemptsByIPviaDisabledAccounts.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SigninAttemptsByIPviaDisabledAccounts.yaml
@@ -30,36 +30,35 @@ relevantTechniques:
   - T1098
 query: |
   let aadFunc = (tableName: string) {
-  table(tableName)
+  let failed_signins = table(tableName)
   | where ResultType == "50057"
-  | where ResultDescription == "User account is disabled. The account has been disabled by an administrator."
+  | where ResultDescription == "User account is disabled. The account has been disabled by an administrator.";
+  let disabled_users = failed_signins | summarize by UserPrincipalName;
+  table(tableName)
+    | where ResultType == 0
+    | where isnotempty(UserPrincipalName)
+    | where UserPrincipalName !in (disabled_users)
+  | summarize
+          successfulAccountsTargettedCount = dcount(UserPrincipalName),
+          successfulAccountSigninSet = make_set(UserPrincipalName, 100),
+          successfulApplicationSet = make_set(AppDisplayName, 100)
+      by IPAddress, Type
+      // Assume IPs associated with sign-ins from 100+ distinct user accounts are safe
+      | where successfulAccountsTargettedCount < 50
+      | where isnotempty(successfulAccountsTargettedCount)
+    | join kind=inner (failed_signins
   | summarize
       StartTime = min(TimeGenerated),
       EndTime = max(TimeGenerated),
-      disabledAccountLoginAttempts = count(),
-      disabledAccountsTargeted = dcount(UserPrincipalName),
+      totalDisabledAccountLoginAttempts = count(),
+      disabledAccountsTargettedCount = dcount(UserPrincipalName),
       applicationsTargeted = dcount(AppDisplayName),
-      disabledAccountSet = make_set(UserPrincipalName),
-      applicationSet = make_set(AppDisplayName)
+      disabledAccountSet = make_set(UserPrincipalName, 100),
+      disabledApplicationSet = make_set(AppDisplayName, 100)
   by IPAddress, Type
-  | order by disabledAccountLoginAttempts desc
-  | join kind= leftouter ( 
-      // Consider these IPs suspicious - and alert any related successful sign-ins
-      table(tableName)
-      | where ResultType == 0
-      | summarize
-          successfulAccountSigninCount = dcount(UserPrincipalName),
-          successfulAccountSigninSet = make_set(UserPrincipalName, 15)
-      by IPAddress, Type
-      // Assume IPs associated with sign-ins from 100+ distinct user accounts are safe
-      | where successfulAccountSigninCount < 100
-  ) on IPAddress 
-  // IPs from which attempts to authenticate as disabled user accounts originated, and had a non-zero success rate for some other account
-  | where isnotempty(successfulAccountSigninCount)
-  | project StartTime, EndTime, IPAddress, disabledAccountLoginAttempts, disabledAccountsTargeted, disabledAccountSet, applicationSet, successfulAccountSigninCount, successfulAccountSigninSet, Type
-  | order by disabledAccountLoginAttempts
-  | extend timestamp = StartTime, IPCustomEntity = IPAddress
-  };
+  | order by totalDisabledAccountLoginAttempts desc) on IPAddress
+  | project StartTime, EndTime, IPAddress, totalDisabledAccountLoginAttempts, disabledAccountsTargettedCount, disabledAccountSet, disabledApplicationSet, successfulApplicationSet, successfulAccountsTargettedCount, successfulAccountSigninSet, Type
+  | order by totalDisabledAccountLoginAttempts};
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
   union isfuzzy=true aadSignin, aadNonInt
@@ -70,17 +69,19 @@ query: |
       | project UsersInsights, DevicesInsights, ActivityInsights, InvestigationPriority, SourceIPAddress, UserPrincipalName
       | project-rename IPAddress = SourceIPAddress
       | summarize
-          Users = make_set(UserPrincipalName, 1000),
-          UsersInsights = make_set(UsersInsights, 1000),
-          DevicesInsights = make_set(DevicesInsights, 1000),
+          Users = make_set(UserPrincipalName, 100),
+          UsersInsights = make_set(UsersInsights, 100),
+          DevicesInsights = make_set(DevicesInsights, 100),
           IPInvestigationPriority = sum(InvestigationPriority)
       by IPAddress
   ) on IPAddress
+  | extend SFRatio = toreal(toreal(disabledAccountsTargettedCount)/toreal(successfulAccountsTargettedCount))
+  | where SFRatio >= 0.5
   | sort by IPInvestigationPriority desc
 entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 2.1.2
+version: 2.1.3
 kind: Scheduled


### PR DESCRIPTION
Change(s):
Added a SFRatio check to the rule SigninAttemptsByIPviaDisabledAccounts.yaml to stop false positive of re-enabled accounts.

Reason for Change(s):
Re-enabling disabled accounts was causing false positive.

Resolves Issue# https://github.com/Azure/Azure-Sentinel/issues/8409

Version Updated:
Yes

Testing Completed:
Yes
![image](https://github.com/Azure/Azure-Sentinel/assets/99784106/a7f671e2-5093-48de-bd4f-ff64567c7e9f)


Checked that the validations are passing and have addressed any issues that are present: Yes