### PR TITLE
Skip Detection comment on fork PR for security reasons

### DIFF
--- a/.github/workflows/addCommentToRemindUpdatingTemplateVersion.yml
+++ b/.github/workflows/addCommentToRemindUpdatingTemplateVersion.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   add-comment:
     uses: ./.github/workflows/addComment.yaml
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     with:
       message: |
         **Hello how are you I am GitHub bot**


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In 'addCommentToRemindUpdatingTemplateVersion.yml' file we have added a condition to skip action run if the pr is from fork repo.
   
   Reason for Change(s):
   - When a fork pr is runs this action it fails as the token secret cannot be shared with the fork pr and can be a security risk so we are avoiding any job run for fork pr.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

