### PR TITLE
Add automated comment on Github Issue only when its created

### DIFF
--- a/.github/workflows/IssueComment.yml
+++ b/.github/workflows/IssueComment.yml
@@ -1,6 +1,8 @@
 name: IssueComment
 
-on: [issues]
+on: 
+  issues:
+    types: opened
 
 jobs:
   commenting:


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Change in existing issue comment workflow to run workflow only when issue is opened.

   Reason for Change(s):
   - When a new issue is created in Github an automated comment is added to the issue. This automated comment is added when anyone do any change to the issue, so this PR will restrict and add comment only for the first time i.e. when PR is opened.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
