### PR TITLE
Compress only files instead of complete folder in package

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -2788,7 +2788,12 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
         else {
             $zipPackageName = "$calculatedBuildPipelinePackageVersion" + ".zip"
         }
-        Compress-Archive -Path "$solutionFolder/*" -DestinationPath "$solutionFolder/$zipPackageName" -Force
+
+        $compress = @{
+            Path = "$solutionFolder/createUiDefinition.json", "$solutionFolder/mainTemplate.json"
+            DestinationPath = "$solutionFolder/$zipPackageName"
+        }
+        Compress-Archive @compress -Force
     }
 
     function global:GetContentTemplateDefaultValues()


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Made change in "commonFunctions.ps1" file

   Reason for Change(s):
   - When a package i.e. zip is created then instead of zipping only createUiDefinition and mainTemplate it also adds old zip files in the package so this PR solves this issue.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Below is the zip package content of Azure Active Directory:**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/3cc7acfc-b7dd-4cee-bbbf-e5af89649536)

![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/a9b85006-5e6d-4056-9336-f48f203badea)
