### PR TITLE
Add Locations to SuccessThenFail_DiffIP_SameUserandApp.yaml

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
@@ -1,9 +1,7 @@
 id: 02ef8d7e-fc3a-4d86-a457-650fa571d8d2
 name: Successful logon from IP and failure from a different IP
 description: |
-  'Identifies when a user account successfully logs onto an Azure App from one IP and within 10 mins failed to logon to the same App via a different IP.
-  This may indicate a malicious attempt at password guessing based on knowledge of the users account. This query has also been updated to include UEBA 
-  logs IdentityInfo and BehaviorAnalytics for contextual information around the results.'
+  'Identifies when a user account successfully logs onto an Azure App from one IP and within 10 mins failed to logon to the same App via a different IP (may indicate a malicious attempt at password guessing with known account). UEBA added for context.'
 severity: Medium 
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -53,6 +51,9 @@ query: |
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
   union isfuzzy=true aadSignin, aadNonInt
+  Identifies when a user account successfully logs onto an Azure App from one IP and within 10 mins failed to logon to the same App via a different IP (may indicate a malicious attempt at password guessing with known account). UEBA added for context.
+  | extend 
+  // UEBA context below - make sure you have these 2 datatypes, otherwise the query will not work. If so, comment all that is below.
   | join kind=leftouter (
       IdentityInfo
       | summarize LatestReportTime = arg_max(TimeGenerated, *) by AccountUPN
@@ -98,5 +99,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: FailedIPAddress
-version: 2.1.4
+version: 2.1.5
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
@@ -51,8 +51,7 @@ query: |
   let aadSignin = aadFunc("SigninLogs");
   let aadNonInt = aadFunc("AADNonInteractiveUserSignInLogs");
   union isfuzzy=true aadSignin, aadNonInt
-  Identifies when a user account successfully logs onto an Azure App from one IP and within 10 mins failed to logon to the same App via a different IP (may indicate a malicious attempt at password guessing with known account). UEBA added for context.
-  | extend 
+  | extend Name = tostring(split(UserPrincipalName,'@',0)[0]), UPNSuffix = tostring(split(UserPrincipalName,'@',1)[0])
   // UEBA context below - make sure you have these 2 datatypes, otherwise the query will not work. If so, comment all that is below.
   | join kind=leftouter (
       IdentityInfo
@@ -99,5 +98,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: FailedIPAddress
-version: 2.1.5
+version: 2.1.6
 kind: Scheduled

--- a/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/SuccessThenFail_DiffIP_SameUserandApp.yaml
@@ -34,16 +34,20 @@ query: |
   let logonDiff = 10m; let aadFunc = (tableName:string){ table(tableName)
   | where ResultType == "0"
   | where AppDisplayName !in ("Office 365 Exchange Online", "Skype for Business Online") // To remove false-positives, add more Apps to this array
-  | project SuccessLogonTime = TimeGenerated, UserPrincipalName, SuccessIPAddress = IPAddress, AppDisplayName, SuccessIPBlock = iff(IPAddress contains ":", strcat(split(IPAddress, ":")[0], ":", split(IPAddress, ":")[1]), strcat(split(IPAddress, ".")[0], ".", split(IPAddress, ".")[1])), Type
+  // ---------- Fix for SuccessBlock to also consider IPv6
+  | extend SuccessIPv6Block = strcat(split(IPAddress, ":")[0], ":", split(IPAddress, ":")[1], ":", split(IPAddress, ":")[2], ":", split(IPAddress, ":")[3])
+  | extend SuccessIPv4Block = strcat(split(IPAddress, ".")[0], ".", split(IPAddress, ".")[1])
+  // ------------------
+  | project SuccessLogonTime = TimeGenerated, UserPrincipalName, SuccessIPAddress = IPAddress, SuccessLocation = Location, AppDisplayName, SuccessIPBlock = iff(IPAddress contains ":", strcat(split(IPAddress, ":")[0], ":", split(IPAddress, ":")[1]), strcat(split(IPAddress, ".")[0], ".", split(IPAddress, ".")[1])), Type
   | join kind= inner (
       table(tableName)
       | where ResultType !in ("0", "50140")
       | where ResultDescription !~ "Other"
       | where AppDisplayName !in ("Office 365 Exchange Online", "Skype for Business Online")
-      | project FailedLogonTime = TimeGenerated, UserPrincipalName, FailedIPAddress = IPAddress, AppDisplayName, ResultType, ResultDescription, Type 
+      | project FailedLogonTime = TimeGenerated, UserPrincipalName, FailedIPAddress = IPAddress, FailedLocation = Location, AppDisplayName, ResultType, ResultDescription, Type 
   ) on UserPrincipalName, AppDisplayName
   | where SuccessLogonTime < FailedLogonTime and FailedLogonTime - SuccessLogonTime <= logonDiff and FailedIPAddress !startswith SuccessIPBlock
-  | summarize FailedLogonTime = max(FailedLogonTime), SuccessLogonTime = max(SuccessLogonTime) by UserPrincipalName, SuccessIPAddress, AppDisplayName, FailedIPAddress, ResultType, ResultDescription, Type
+  | summarize FailedLogonTime = max(FailedLogonTime), SuccessLogonTime = max(SuccessLogonTime) by UserPrincipalName, SuccessIPAddress, SuccessLocation, AppDisplayName, FailedIPAddress, FailedLocation, ResultType, ResultDescription, Type
   | extend timestamp = SuccessLogonTime
   | extend UserPrincipalName = tolower(UserPrincipalName)};
   let aadSignin = aadFunc("SigninLogs");
@@ -94,5 +98,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: FailedIPAddress
-version: 2.1.3
+version: 2.1.4
 kind: Scheduled


### PR DESCRIPTION
Added Success and Failed Locations
Fixed SuccessIPBlock to also consider IPV6

   Required items, please complete
   
   Change(s):
   - Added Success and Failed Locations
   - Fixed SuccessIPBlock to consider IPv6

   Reason for Change(s):
   - Locations are very useful for whitelisting known activity
   - IPv6 are now more used than before, so it makes sense to have that into account

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes