### PR TITLE
Switch sign-in and deletion time comparison, and add ResultType sign-in filter for SuspiciousLoginfromDeletedExternalIdentities

### DIFF
--- a/Detections/MultipleDataSources/SuspiciousLoginfromDeletedExternalIdentities.yaml
+++ b/Detections/MultipleDataSources/SuspiciousLoginfromDeletedExternalIdentities.yaml
@@ -38,11 +38,12 @@ query: |
   | join kind=inner (
       SigninLogs
       | where TimeGenerated > ago(query_period)
+      | where ResultType == 0
       | summarize take_any(*) by UserPrincipalName
       | extend ParsedUserPrincipalName = translate("@", "_", UserPrincipalName)
       | project SigninLogs_TimeGenerated = TimeGenerated, UserPrincipalName, UserDisplayName, ResultType, ResultDescription, IPAddress, LocationDetails, AppDisplayName, ResourceDisplayName, ClientAppUsed, UserAgent, DeviceDetail, UserId, UserType, OriginalRequestId, ParsedUserPrincipalName
       ) on $left.ParsedDeletedUserPrincipalName == $right.ParsedUserPrincipalName
-  | where Delete_TimeGenerated > SigninLogs_TimeGenerated
+  | where SigninLogs_TimeGenerated > Delete_TimeGenerated
   | project-away ParsedDeletedUserPrincipalName, ParsedUserPrincipalName
   | extend
       AccountName = tostring(split(UserPrincipalName, "@")[0]),
@@ -58,7 +59,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
   Change(s):
   - For rule `SuspiciousLoginfromDeletedExternalIdentities` (`Suspicious Login from deleted guest account`):
       - added a filter for successful sign-ins
       - flipped the comparison for the sign-in and deletion times around

   Reason for Change(s):
   - The rule intends to detect successful sign-ins, but it does not limit results based on sign-in success or failure.  As per [SigninLogs](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/signinlogs), a `ResultType` of `0` indicates a successful sign-in, so checking for this will limit results to sign-in success only
   - The rule intends to detect when a successful sign-in occurs ***after*** the account was deleted; however, the current logic actually checks that the deletion occurs after the sign-in
       - (See below for examples of the issue vs. proposed solution)

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

_Work done in collaboration with @kstew-chorus and @smant-chorus_

---
## `Delete_` and `SigninLogs_TimeGenerated` Check
### Issue with Current Logic
#### Example Query
```kql
let Delete_TimeGenerated = datetime(2023-08-30T14:00:00.000Z);  // Deletion at 14:00 on 30th August 2023
let SigninLogs_TimeGenerated = datetime(2023-08-30T15:00:00.000Z);  // Sign-in at 15:00 on 30th August 2023 (i.e. 1 hour after deletion)
print SignInAfterDeletion = Delete_TimeGenerated > SigninLogs_TimeGenerated
```
#### Results
![image](https://github.com/Azure/Azure-Sentinel/assets/138881774/6d0a67ad-6e04-488d-a127-3adfb90de740)

Even though the sign-in occurs after the deletion, the check returns `false` because `Delete_TimeGenerated > SigninLogs_TimeGenerated` corresponds to "return true when the deletion occurs after the sign-in".  As the purpose of the detection is to identify sign-ins that occur from deleted accounts, the current logic is **resulting in a false negative condition for this activity**.

### Proposed Solution
#### Example Query
```kql
let Delete_TimeGenerated = datetime(2023-08-30T14:00:00.000Z);  // Deletion at 14:00 on 30th August 2023
let SigninLogs_TimeGenerated = datetime(2023-08-30T15:00:00.000Z);  // Sign-in at 15:00 on 30th August 2023 (i.e. 1 hour after deletion)
print SignInAfterDeletion = SigninLogs_TimeGenerated > Delete_TimeGenerated
```
#### Results
![image](https://github.com/Azure/Azure-Sentinel/assets/138881774/7b1f2b7d-3834-4aa7-ba85-40c6177c2604)

By switching the check around to `SigninLogs_TimeGenerated > Delete_TimeGenerated`, it is now correctly checking if the sign-in occurs after the deletion.
