### PR TITLE
Fix version for IPEntity_AzureActivity

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureActivity.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureActivity.yaml
@@ -76,5 +76,5 @@ entityMappings:
     fieldMappings:
       - identifier: ResourceId
         columnName: ResourceId
-version: 1.3.2
+version: 1.4.0
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Updated version of rule `IPEntity_AzureActivity` (`TI Map IP Entity to AzureActivity`)

   Reason for Change(s):
   - The version was accidentally downgraded due to a syncing issue between `master` branches, overwriting the intended version bump
   - The intended version for the rule in the previous PR (https://github.com/Azure/Azure-Sentinel/pull/8283) was 1.4.0
   - (See the version history timeline below)

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

## Version History Timeline
### 24th May 2023
#### Commit https://github.com/Azure/Azure-Sentinel/commit/652cf39b679e35e63f507f127c83ff46e4156a52
- File: [IPEntity_AzureActivity at 652cf39](https://github.com/Azure/Azure-Sentinel/blob/652cf39b679e35e63f507f127c83ff46e4156a52/Solutions/Threat%20Intelligence/Analytic%20Rules/IPEntity_AzureActivity.yaml#L90)
- Version: 1.3.3
- Merged to `Azure-Sentinel:master` in [#8112 · Azure/Azure-Sentinel](https://github.com/Azure/Azure-Sentinel/pull/8112/files#diff-e8904146aaed751be4b71fbb3a87eae7b01442eb55b1e22660bda6e2aa97bb30)

| **`master` Version: 1.3.3** |
| -----------------------------|

### 16th June 2023
#### Commit https://github.com/Azure/Azure-Sentinel/commit/482b6f4a2a4d5aef12ea31b3802b9e2e1a7bd0ec
- File: [IPEntity_AzureActivity at 482b6f4](https://github.com/Azure/Azure-Sentinel/blob/482b6f4a2a4d5aef12ea31b3802b9e2e1a7bd0ec/Solutions/Threat%20Intelligence/Analytic%20Rules/IPEntity_AzureActivity.yaml#L82)
- Version: 1.4.0

#### Commit https://github.com/Azure/Azure-Sentinel/commit/7ab70b69089435b4333e0581cfbe76025404ed25
- File: [IPEntity_AzureActivity at 7ab70b6](https://github.com/Azure/Azure-Sentinel/blob/7ab70b69089435b4333e0581cfbe76025404ed25/Solutions/Threat%20Intelligence/Analytic%20Rules/IPEntity_AzureActivity.yaml#L79)
- Version: 1.3.2
- Outdated version of `master` is merged into the working branch, resulting in the new proposed version (1.4.0) being overwritten by the outdated `master` one (1.3.2)

### 26th June 2023
#### Commit https://github.com/Azure/Azure-Sentinel/commit/844b41378e594fcf2cf822bbc3675c556b4527ca
- File: [IPEntity_AzureActivity at 844b413](https://github.com/Azure/Azure-Sentinel/blob/844b41378e594fcf2cf822bbc3675c556b4527ca/Solutions/Threat%20Intelligence/Analytic%20Rules/IPEntity_AzureActivity.yaml)
- Version: 1.3.2
- Merged to `Azure-Sentinel:master` in [#8283 · Azure/Azure-Sentinel](https://github.com/Azure/Azure-Sentinel/pull/8283/files#diff-e8904146aaed751be4b71fbb3a87eae7b01442eb55b1e22660bda6e2aa97bb30)

| **`master` Version: 1.3.2** |
|------------------------------|

Results in the following when comparing version for the rule template in the Sentinel rule wizard:
![image](https://github.com/Azure/Azure-Sentinel/assets/138881774/e4aef3af-d52c-4825-873e-463183f1bdb7)

**The intended version for the rule in https://github.com/Azure/Azure-Sentinel/pull/8283 was 1.4.0.**