### PR TITLE
Re-add active TI indicator filter to IPEntity_AzureKeyVault

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_AzureKeyVault.yaml
@@ -28,6 +28,7 @@ query: |
   // Fetch threat intelligence indicators related to IP addresses
   let IP_Indicators = ThreatIntelligenceIndicator
     | summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId
+    | where Active == true
     | where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP)
     | where LatestIndicatorTime >= ago(ioc_lookBack) and ExpirationDateTime > now()
     | extend TI_ipEntity = iff(isnotempty(NetworkIP), NetworkIP, NetworkDestinationIP)
@@ -63,5 +64,5 @@ entityMappings:
     fieldMappings:
       - identifier: ResourceId
         columnName: ResourceId
-version: 1.3.1
+version: 1.3.2
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Re-added condition to limit to active indicators for `IPEntity_AzureKeyVault` (`TI map IP entity to Azure Key Vault logs`)

   Reason for Change(s):
   - The `where Active == true` filter was removed in https://github.com/Azure/Azure-Sentinel/commit/c22b48b7b823deb9f8a7ccb130edeed0c0cf154c - it looks like this was accidental based on the commit message and the fact other TI rules still have the filter in place

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

