### PR TITLE
Description containing double quotes via image tag

### DIFF
--- a/.github/workflows/checkAutomatedPR.yaml
+++ b/.github/workflows/checkAutomatedPR.yaml
@@ -30,7 +30,7 @@ jobs:
         id: ValidateAutomatedPR
 
         run: |
-          $prBodyContent = "${{ env.BODY }}"
+          $prBodyContent = '${{ env.BODY }}'
           $isAutomatedPR = $false
           if ($prBodyContent -like '*Automation have successfully*')
           {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - When a image tag is added then it has double quotes and in our workflow it was failing with assigning values. So we have made it single quote. This happens when we use slash command

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

