### PR TITLE
Azurekid - Bugfix DHCP Schema Duration field (ASIM)

### DIFF
--- a/ASIM/dev/ASimTester/ASimTester.csv
+++ b/ASIM/dev/ASimTester/ASimTester.csv
@@ -248,7 +248,7 @@ DstZone,string,Optional,WebSession,,,
 Duration,int,Alias,Dns,,,DnsNetworkDuration
 Duration,int,Alias,NetworkSession,,,NetworkDuration
 Duration,int,Alias,WebSession,,,NetworkDuration
-Duration,string,Alias,Dhcp,,,DhcpSessionDuration
+Duration,int,Alias,Dhcp,,,DhcpSessionDuration
 Dvc,string,Mandatory,AuditEvent,,,
 Dvc,string,Mandatory,Authentication,,,
 Dvc,string,Mandatory,Common,,,


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - `ASimTester.csv`

   Reason for Change(s):
   - The column `Duration` in the DHCP schema is incorrect.  
     The field `Duration` should be of type `int` because it an alias for `NetworkDuration` which also 
     has the `int` type

   Version Updated:
   - N/A

   Testing Completed:
   - Validated that the CSV format is still valid

   Checked that the validations are passing and have addressed any issues that are present:
   - Validated against the ASimSchemaTester function
