### PR TITLE
Fixed RemoteIP field parsing in FailedLogonAttempts_UnknownUser.yaml

### DIFF
--- a/Solutions/Syslog/Analytic Rules/FailedLogonAttempts_UnknownUser.yaml
+++ b/Solutions/Syslog/Analytic Rules/FailedLogonAttempts_UnknownUser.yaml
@@ -52,5 +52,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Syslog/Analytic Rules/FailedLogonAttempts_UnknownUser.yaml
+++ b/Solutions/Syslog/Analytic Rules/FailedLogonAttempts_UnknownUser.yaml
@@ -26,7 +26,7 @@ query: |
   Syslog
   | where Facility =~ "authpriv"
   | where SyslogMessage has "authentication failure" and SyslogMessage has " uid=0"
-  | parse SyslogMessage with * "rhost=" RemoteIP
+  | extend RemoteIP = extract(@".*?rhost=([\d.]+).*?", 1,SyslogMessage)
   | project TimeGenerated, Computer, ProcessName, HostIP, RemoteIP, ProcessID
   | join kind=innerunique (
       // Below pulls messages from syslog-authpriv logs that show each instance an unknown user tried to logon. 


### PR DESCRIPTION
The `parse` operator is incorrectly parsing the events that has more fields after `rhost=` as given below:

https://github.com/Azure/Azure-Sentinel/blob/3aee076f46e4c1baf1cb75bae59b84ce18ed6098/Solutions/Syslog/Analytic%20Rules/FailedLogonAttempts_UnknownUser.yaml#L29

```csv
SyslogMessage
------------------------------------------------
pam_sss(sshd:auth): authentication   failure  logname= uid=0 euid=0 tty=ssh   ruser= rhost=10.65.17.140 user=factory
pam_unix(sshd:auth): authentication   failure  logname= uid=0 euid=0 tty=ssh   ruser= rhost=10.65.17.130
pam_sss(sshd:auth): authentication   failure  logname= uid=0 euid=0 tty=ssh   ruser= rhost=10.65.17.122 user=USERID
pam_unix(sshd:auth): authentication   failure  logname= uid=0 euid=0 tty=ssh   ruser= rhost=10.65.17.110
pam_sss(sshd:auth): authentication   failure  logname= uid=0 euid=0 tty=ssh   ruser= rhost=10.65.17.120 user=admin
pam_unix(sshd:auth): authentication   failure  logname= uid=0 euid=0 tty=ssh   ruser= rhost=10.65.17.150
``` 

## Current Output:
```
RemoteIP
--------------------------
10.65.17.140 user=factory
10.65.17.130
10.65.17.122 user=USERID
10.65.17.110
10.65.17.120 user=admin
10.65.17.140
```


## Output After Change (Fixed by using `extract` function)
```csv
RemoteIP
------------
10.65.17.140
10.65.17.130
10.65.17.122
10.65.17.110
10.65.17.120
10.65.17.150
```


   Required items, please complete
   
   Change(s):
   - See guidance below

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


# Guidance <- remove section before submitting
-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for XYZ.yaml

   Reason for Change(s):
   - New schema used for XYZ.yaml
   - Resolves ISSUE #1234

   Version updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

_Note: If updating a detection, you must update the version field._

> Before the submission has been made, please look at running the KQL and Yaml Validation Checks locally.
> https://github.com/Azure/Azure-Sentinel#run-kql-validation-locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
