### PR TITLE
HttpHost LogicalType Fix ASimTester.csv

### DIFF
--- a/ASIM/dev/ASimTester/ASimTester.csv
+++ b/ASIM/dev/ASimTester/ASimTester.csv
@@ -701,7 +701,7 @@ Hostname,string,Alias,WebSession,Hostname,,DstHostname
 HttpContentFormat,string,Optional,WebSession,,,
 HttpContentType,string,Optional,WebSession,,,
 HttpCookie,string,Optional,WebSession,,,
-HttpHost,string,Optional,WebSession,Hostname,,
+HttpHost,string,Optional,WebSession,,,
 HttpIsProxied,bool,Optional,WebSession,,,
 HttpReferrer,string,Optional,WebSession,,,
 HttpRequestBodyBytes,long,Optional,WebSession,,,


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Removed the hostname LogicalType at httpHost (websession)

   Reason for Change(s):
   - Removed the hostname LogicalType at httpHost (websession) as it was incorrect according to the documentation https://learn.microsoft.com/en-us/azure/sentinel/normalization-schema-web#:~:text=applicable.%0A%0AExample%3A%20800-,HttpHost,-Optional

   Version Updated:
   - No

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - NA

   