### PR TITLE
Add unique strings behind function name for the Zoom connector arm templates

### DIFF
--- a/DataConnectors/Zoom/azuredeploy.json
+++ b/DataConnectors/Zoom/azuredeploy.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "FunctionName": {
-            "defaultValue": "ZoomLogs",
+            "defaultValue": "[concat('ZoomLogs',[uniqueString(subscription().subscriptionId)])]",
             "type": "string"
         },
         "customLogName": {

--- a/DataConnectors/Zoom/azuredeploy.json
+++ b/DataConnectors/Zoom/azuredeploy.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "FunctionName": {
-            "defaultValue": "[concat('ZoomLogs',[uniqueString(subscription().subscriptionId)])]",
+            "defaultValue": "[concat('ZoomLogs',uniqueString(subscription().subscriptionId))]",
             "type": "string"
         },
         "customLogName": {

--- a/DataConnectors/Zoom/azuredeploy_kv.json
+++ b/DataConnectors/Zoom/azuredeploy_kv.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "FunctionName": {
-            "defaultValue": "ZoomLogs",
+            "defaultValue": "[concat('ZoomLogs',[uniqueString(subscription().subscriptionId)])]",
             "type": "String"
         }
     },

--- a/DataConnectors/Zoom/azuredeploy_kv.json
+++ b/DataConnectors/Zoom/azuredeploy_kv.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "FunctionName": {
-            "defaultValue": "[concat('ZoomLogs',[uniqueString(subscription().subscriptionId)])]",
+            "defaultValue": "[concat('ZoomLogs',uniqueString(subscription().subscriptionId))]",
             "type": "String"
         }
     },


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated azuredeploy.json
   - Updated azuredeploy_kv.json

   Reason for Change(s):
   - Added `uniqueString` to parameter `FunctionName` to generate a unique and consistent name across all resources required for the Zoom connector. Without this change, the initial deployment will fail because the default value `ZoomLogs` used for the storage account name is not globally unique.

   Version Updated:
   - No

   Testing Completed:
   -  Yes
   
   Successfully deployed the Azure Function and Azure Key Vault via the updates templates

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   
  No change to anything beyond the arm template