### PR TITLE
Skip packaging for dependabot PRs

### DIFF
--- a/.github/workflows/package-command.yaml
+++ b/.github/workflows/package-command.yaml
@@ -18,13 +18,13 @@ on:
     types: [package-command, Package-command, PACKAGE-command]
 jobs:
   solutionNameDetails:
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/getSolutionName.yaml
     secrets: inherit
 
   # BELOW JOB WILL CHECK IF WE NEED TO SKIP PACKAGE CREATION OR NOT
   checkSkipPackagingDetails:
-    if: ${{ needs.solutionNameDetails.outputs.solutionName != '' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.actor != 'dependabot[bot]' && needs.solutionNameDetails.outputs.solutionName != '' && !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/checkSkipPackagingInfo.yaml
     secrets: inherit
     needs: solutionNameDetails
@@ -34,7 +34,7 @@ jobs:
   neworexistingsolution:
     needs: [solutionNameDetails, checkSkipPackagingDetails]
     uses: ./.github/workflows/neworexistingsolution.yaml
-    if: ${{ needs.solutionNameDetails.outputs.solutionName != '' && needs.checkSkipPackagingDetails.outputs.isPackagingRequired == 'True' }} 
+    if: ${{ github.actor != 'dependabot[bot]' && needs.solutionNameDetails.outputs.solutionName != '' && needs.checkSkipPackagingDetails.outputs.isPackagingRequired == 'True' }} 
     with: 
       solutionName: "${{ needs.solutionNameDetails.outputs.solutionName }}"
     secrets: inherit

--- a/.github/workflows/package-on-merge.yaml
+++ b/.github/workflows/package-on-merge.yaml
@@ -21,17 +21,17 @@ on:
       - closed
 jobs:
   checkAutomatedPR:
-    if: ${{ github.event.pull_request.merged && !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.merged && !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/checkAutomatedPR.yaml
 
   solutionNameDetails:
-    if: ${{ github.event.pull_request.merged && !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.merged && !github.event.pull_request.head.repo.fork }}
     needs: checkAutomatedPR
     uses: ./.github/workflows/getSolutionName.yaml
     secrets: inherit
 
   checkSkipPackagingDetails:
-    if: ${{ github.event.pull_request.merged && !github.event.pull_request.head.repo.fork && needs.solutionNameDetails.outputs.solutionName != ''  }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.merged && !github.event.pull_request.head.repo.fork && needs.solutionNameDetails.outputs.solutionName != ''  }}
     uses: ./.github/workflows/checkSkipPackagingInfo.yaml
     secrets: inherit
     needs: solutionNameDetails
@@ -41,7 +41,7 @@ jobs:
   neworexistingsolution:
     needs: [solutionNameDetails, checkSkipPackagingDetails]
     uses: ./.github/workflows/neworexistingsolution.yaml
-    if: ${{ needs.solutionNameDetails.outputs.solutionName != '' && needs.checkSkipPackagingDetails.outputs.isPackagingRequired == 'True' }} 
+    if: ${{ github.actor != 'dependabot[bot]' && needs.solutionNameDetails.outputs.solutionName != '' && needs.checkSkipPackagingDetails.outputs.isPackagingRequired == 'True' }} 
     with: 
       solutionName: "${{ needs.solutionNameDetails.outputs.solutionName }}"
     secrets: inherit


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added check to skip if pr is triggered by dependabot where the package is getting generated.

   Reason for Change(s):
   - We need to skip package for dependabot PR's

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

