### PR TITLE
MainTemplate Generation should use ParserId instead of ParserName

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
@@ -2339,7 +2339,7 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
                                 apiVersion = "2022-01-01-preview";
                                 name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Parser-', last(split(variables('_parserId$parserCounter'),'/'))))]";
                                 dependsOn  =  @(
-                                    "[variables('_parserName$parserCounter')]"
+                                    "[variables('_parserId$parserCounter')]"
                                 );
                                 properties = [PSCustomObject]@{
                                     parentId  = "[resourceId('Microsoft.OperationalInsights/workspaces/savedSearches', parameters('workspace'), variables('parserName$parserCounter'))]"

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -3074,7 +3074,7 @@ function addTemplateSpecParserResource($content,$yaml,$isyaml, $contentResourceD
             apiVersion = $contentResourceDetails.commonResourceMetadataApiVersion; #"2022-01-01-preview";
             name       = "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('Parser-', last(split(variables('_parserId$global:parserCounter'),'/'))))]";
             dependsOn  =  @(
-                "[variables('_parserName$global:parserCounter')]"
+                "[variables('_parserId$global:parserCounter')]"
             );
             properties = [PSCustomObject]@{
                 parentId  = "[resourceId('Microsoft.OperationalInsights/workspaces/savedSearches', parameters('workspace'), variables('parserName$global:parserCounter'))]"


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Changes in CommonFunctions and V2 powershell script files

   Reason for Change(s):
   - In Content and Metadata DependOn is referring to parserName instead it should be parserId.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

