### PR TITLE
Addinf metadata for DoD Zero workbook 

### DIFF
--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -6645,6 +6645,20 @@
     "title": "DoD Zero Trust Strategy Workbook",
     "templateRelativePath": "DoDZeroTrustWorkbook.json",
     "subtitle": "",
-    "provider": "Microsoft"
+    "provider": "Microsoft",
+    "support": {
+      "tier": "Microsoft"
+    },
+    "author": {
+      "name": "Lili Davoudian, Chhorn Lim, Jay Pelletier, Michael Crane"
+    },
+    "source": {
+      "kind": "Community"
+    },
+    "categories": {
+      "domains": [
+        "IT Operations"
+      ]
+}
 }
 ]


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added workbook metadata 

   Reason for Change(s):
   - Workbook was not visible in the content hub

   Version Updated:
   - no