### PR TITLE
Filter out exclusion list so that package is not created

### DIFF
--- a/.script/package-automation/getSolutionName.ps1
+++ b/.script/package-automation/getSolutionName.ps1
@@ -17,6 +17,18 @@ try
     $filteredFiles = $diff | Where-Object {$_ -match "Solutions/"} | Where-Object {$_ -notlike "Solutions/Images/*"} | Where-Object {$_ -notlike "Solutions/*.md"} | Where-Object { $_ -notlike '*system_generated_metadata.json' }
     Write-Host "Filtered Files $filteredFiles"
 
+    # IDENTIFY EXCLUSIONS AND IF THERE ARE NO FILES AFTER EXCLUSION THEN SKIP WORKFLOW RUN
+    $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$")
+
+    $filterOutExclusionList = $filteredFiles | Where-Object { $_ -notmatch ($exclusionList -join '|')  }
+
+    if ($filterOutExclusionList.Count -le 0)
+    {
+        Write-Host "Skipping GitHub Action as changes in PR are not valid and contains only excluded files!"
+        Write-Output "solutionName=" >> $env:GITHUB_OUTPUT
+        exit 0
+    }
+
     if ($filteredFiles.Count -gt 0)
     {
         if ($instrumentationKey -ne '')

--- a/.script/package-automation/getSolutionName.ps1
+++ b/.script/package-automation/getSolutionName.ps1
@@ -18,7 +18,7 @@ try
     Write-Host "Filtered Files $filteredFiles"
 
     # IDENTIFY EXCLUSIONS AND IF THERE ARE NO FILES AFTER EXCLUSION THEN SKIP WORKFLOW RUN
-    $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$")
+    $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$", ".md$")
 
     $filterOutExclusionList = $filteredFiles | Where-Object { $_ -notmatch ($exclusionList -join '|')  }
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Filter out exclusion list so that package is not generated unnecessarily.

   Reason for Change(s):
   - Filter out exclusion list so that package is not generated unnecessarily.

   Version Updated:
   - NA

   Testing Completed:
   - 

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Changes in PR:**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/e6108b9b-8d80-4c80-8b3a-540cdc0f0b0c)

**It is not creating package when changes are from exclusion list**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/e9d41387-dceb-4ba0-8732-1dad835390c7)

**When PR contains only ReleaseNotes.md change then it will skip as shown in below screenshot:**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/dc019bd6-914b-4c7f-85cc-a5bc50e3d337)
