### PR TITLE
Entity mapping added to UserAccountAddedToPrivlegeGroup_1h.yaml

### DIFF
--- a/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
+++ b/Detections/SecurityEvent/UserAccountAddedToPrivlegeGroup_1h.yaml
@@ -74,7 +74,13 @@ entityMappings:
     fieldMappings:
       - identifier: FullName
         columnName: Computer
-version: 1.3.5
+  - entityType: Security Group
+    fieldMappings:
+      - identifier: DistinguishedName
+        columnName: TargetUserName
+      - identifier: SID
+        columnName: TargetSid  
+version: 1.3.6
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
  
   Change(s):
    Entity mapping added: "Security Group"

   Reason for Change(s):
   More information available on alert preview. The most important WHAT user added to WHAT security group.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   -Yes
