### PR TITLE
Added analytic rule for vulnerability of CVE-2023-4863

### DIFF
--- a/Solutions/Microsoft 365/Analytic Rules/PossibleWebpBufferOverflow.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/PossibleWebpBufferOverflow.yaml
@@ -1,0 +1,62 @@
+id: 26e81021-2de6-4442-a74a-a77885e96911
+name: Execution of software vulnerable to webp buffer overflow of CVE-2023-4863
+description: |
+    'This query looks at device, process, and network events from Defender for Endpoint that may be vulnerable to buffer overflow defined in CVE-2023-4863. Results are not an indicator of malicious activity.'
+severity: Informational
+status: Available
+kind: Scheduled
+queryFrequency: 1h
+queryPeriod: 1h
+triggerOperator: gt
+triggerThreshold: 0
+query: |-
+  //CVE-2023-4863 Process activity with .webp files on devices where CVE-2023-4863 is unpatched
+  //This query shows all process activity with .webp files on vulnerable machines and is not an indicator of malicious activity
+  let VulnDevices = DeviceTvmSoftwareVulnerabilities
+      | where CveId == "CVE-2023-4863"
+      | distinct DeviceId;
+  union DeviceProcessEvents, DeviceNetworkEvents, DeviceEvents
+  | where DeviceId in (VulnDevices) and InitiatingProcessCommandLine has(".webp") or ProcessCommandLine has(".webp")
+entityMappings:
+- entityType: Host
+  fieldMappings:
+  - identifier: HostName
+    columnName: DeviceName
+- entityType: Account
+  fieldMappings:
+  - identifier: FullName
+    columnName: AccountName
+- entityType: Process
+  fieldMappings:
+  - identifier: ProcessId
+    columnName: ProcessId
+- entityType: Process
+  fieldMappings:
+  - identifier: ProcessId
+    columnName: InitiatingProcessId
+- entityType: Process
+  fieldMappings:
+  - identifier: CommandLine
+    columnName: InitiatingProcessCommandLine
+- entityType: Process
+  fieldMappings:
+  - identifier: CommandLine
+    columnName: ProcessCommandLine
+suppressionEnabled: false
+incidentConfiguration:
+  createIncident: false
+  groupingConfiguration:
+    enabled: false
+    reopenClosedIncident: false
+    lookbackDuration: 5h
+    matchingMethod: Selected
+    groupByEntities:
+    - Account
+    groupByAlertDetails: []
+    groupByCustomDetails: []
+suppressionDuration: 5h
+alertDetailsOverride:
+  alertDisplayNameFormat: Possible exploitation of CVE-2023-4863
+  alertDynamicProperties: []
+eventGroupingSettings:
+  aggregationKind: SingleAlert


### PR DESCRIPTION
 
   Change(s):
   - Added analytic rule to Microsoft 365 solution for CVE-2023-4863

   Reason for Change(s):
   - Emerging threat

   Version Updated:
   - N/A (v1.0.0)

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
