### PR TITLE
Fix issue in checkSkipPackagingInfo file

### DIFF
--- a/.script/package-automation/checkSkipPackagingInfo.ps1
+++ b/.script/package-automation/checkSkipPackagingInfo.ps1
@@ -44,31 +44,49 @@ try
             # WHEN CHANGES ARE IN SOLUTION PACKAGE FOLDER THEN WE SHOULD SKIP PACKAGING 
             $diff = git diff --diff-filter=d --name-only HEAD^ HEAD
             Write-Host "List of files changed in PR: $diff"
-            $filteredFiles = $diff | Where-Object {$_ -like "Solutions/$solutionName/Package/*" } | Where-Object { $_ -match ([regex]::Escape(".json")) }
 
-            $isPackagingRequired = $false
-            if ($filteredFiles.Count -le 0)
+            $changesInPackageFolder = $diff | Where-Object {$_ -like "Solutions/$solutionName/Package/*" }
+            Write-Host "List of files changed in Package folder:  $changesInPackageFolder"
+
+            if ($changesInPackageFolder.Count -gt 0)
             {
-                # WE NEED PACKAGING
-                $isPackagingRequired = $true
-                $customProperties['isPackagingRequired'] =
-                Write-Output "isPackagingRequired=$true" >> $env:GITHUB_OUTPUT
+                # changes are in Package folder so skip packaging
+                Write-Output "isPackagingRequired=$false" >> $env:GITHUB_OUTPUT
+                Write-Host "Skip packaging as changes are in Package folder!"
             }
-
-            $customProperties['isPackagingRequired'] = $isPackagingRequired
-            Write-Host "isPackagingRequired set to $isPackagingRequired"
-            Write-Output "isPackagingRequired=$isPackagingRequired" >> $env:GITHUB_OUTPUT
-
-            if ($instrumentationKey -ne '')
+            else
             {
-                Send-AppInsightsTraceTelemetry -InstrumentationKey $instrumentationKey -Message "CheckPackagingSkipStatus started, Job Run Id : $runId" -Severity Information -CustomProperties $customProperties
+                # IDENTIFY EXCLUSIONS AND IF THERE ARE NO FILES AFTER EXCLUSION THEN SKIP WORKFLOW RUN
+                $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$", ".md$", "system_generated_metadata.json$")
+
+                $filteredFiles = $diff | Where-Object {$_ -match "Solutions/"} | Where-Object {$_ -notlike "Solutions/$solutionName/Package/*" } | Where-Object {$_ -notlike "Solutions/Images/*"}  
+
+                $changesInSolutionFolder = $filteredFiles | Where-Object { $_ -notmatch ($exclusionList -join '|')  }
+                Write-Hose "List of files changed in Solution folder: $changesInSolutionFolder"
+                # there are no changes in package folder but check if changes in pr are valid and not from exclusion list
+                if ($changesInSolutionFolder.Count -gt 0)
+                {
+                    
+                    # has changes in Solution folder and valid files
+                    # WE NEED PACKAGING
+                    $customProperties['isPackagingRequired'] = $true
+                    Write-Output "isPackagingRequired=$true" >> $env:GITHUB_OUTPUT
+
+                    if ($instrumentationKey -ne '')
+                    {
+                        Send-AppInsightsTraceTelemetry -InstrumentationKey $instrumentationKey -Message "CheckPackagingSkipStatus started, Job Run Id : $runId" -Severity Information -CustomProperties $customProperties
+                    }
+                }
+                else {
+                    Write-Output "isPackagingRequired=$false" >> $env:GITHUB_OUTPUT
+                }
             }
         }
     }
 }
 catch
 {
-    Write-Output "isPackagingRequired=$true" >> $env:GITHUB_OUTPUT
+    Write-Output "isPackagingRequired=$false" >> $env:GITHUB_OUTPUT
     
     if ($instrumentationKey -ne '')
     {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Based on bug raised in ADO [Link](https://dev.azure.com/SentinelThirdPartyEcosystem/Sentinel%20TCS/_workitems/edit/7637). I have fixed this issue by adding additional checks to checkSkipPackagingInfo.ps1 file
   
   Reason for Change(s):
   - See guidance below

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Below are the screenshots from private repo:**
When changes are in package folder:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/dc95ff95-9ddc-4f4d-839b-7cfb511adfc1)

When only change is done on ReleaseNotes:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/ef34ad07-8bcb-43b3-961b-7fbd35306e32)
