### PR TITLE
[feedly] fix function app settings

### DIFF
--- a/Solutions/Feedly/Data Connectors/azuredeploy_Connector_Feedly_AzureFunction.json
+++ b/Solutions/Feedly/Data Connectors/azuredeploy_Connector_Feedly_AzureFunction.json
@@ -188,7 +188,7 @@
             "FeedlyApiKey": "[parameters('FeedlyApiKey')]",
             "FeedlyStreamIds": "[parameters('FeedlyStreamIds')]",
             "DaysToBackfill": "[parameters('DaysToBackfill')]",
-            "WEBSITE_RUN_FROM_PACKAGE": "<add link to zip>"
+            "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinel-Feedly-functionapp",
           }
         }
       ]

--- a/Solutions/Feedly/Data Connectors/azuredeploy_Connector_Feedly_AzureFunction.json
+++ b/Solutions/Feedly/Data Connectors/azuredeploy_Connector_Feedly_AzureFunction.json
@@ -188,7 +188,7 @@
             "FeedlyApiKey": "[parameters('FeedlyApiKey')]",
             "FeedlyStreamIds": "[parameters('FeedlyStreamIds')]",
             "DaysToBackfill": "[parameters('DaysToBackfill')]",
-            "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinel-Feedly-functionapp",
+            "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinel-Feedly-functionapp"
           }
         }
       ]


### PR DESCRIPTION
   
   Change(s):
   - Fix `WEBSITE_RUN_FROM_PACKAGE` in the function app

   Reason for Change(s):
   - `WEBSITE_RUN_FROM_PACKAGE` was unset

   Version Updated:
   - I'm unsure if and where I need to update the version

   Testing Completed:
   - N/A

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A

--- 

I have some questions for this change:
- Is there any version / zipped content that needs to be updated to reflect those changes?
- What will be the process to make this change live once the PR is merged?
