### PR TITLE
Fix categories in Packaging tool

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -445,14 +445,18 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
         if ($categories -and $categories.psobject.properties['domains'] -and $categories.psobject.properties["domains"].Value.Length -gt 0) 
         {
             $categoriesDetails | Add-Member -Name 'domains' -Type NoteProperty -Value $categories.psobject.properties["domains"].Value;
-            $newMetadata.properties | Add-Member -Name 'categories' -Type NoteProperty -Value $categoriesDetails;
         }
         
         if ($categories -and $categories.psobject.properties['verticals'] -and $categories.psobject.properties["verticals"].Value.Length -gt 0) 
         {
             $categoriesDetails | Add-Member -Name 'verticals' -Type NoteProperty -Value $categories.psobject.properties["verticals"].value;
+        }
+
+        if ($null -ne $categoriesDetails)
+        {
             $newMetadata.properties | Add-Member -Name 'categories' -Type NoteProperty -Value $categoriesDetails;
         }
+
         $global:baseMainTemplate.resources += $newMetadata;
         ### Removing the Non-Sentinel Resources if there are any:
         $newobject = $global:baseMainTemplate.resources | ? {$_.type -in $contentResourceDetails.resources}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In SolutionMetadata.json file we have categories attribute array which contains domains and verticals. Current code was in V2 as well and it fails when we have both domains and verticals specified in this file. 
   - Currently, when we try to create a package it fails with an error as the property categories already exist in psobject. So I have moved code out in this PR so that we don't get error specified earlier.

   Reason for Change(s):
   - Identified issue for categories which is present in V2 and V3 packaging tool.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
