### PR TITLE
Change runtime of GuestAccountsAddedinAADGroupsOtherThanTheOnesSpecified to 2h

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/GuestAccountsAddedinAADGroupsOtherThanTheOnesSpecified.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/GuestAccountsAddedinAADGroupsOtherThanTheOnesSpecified.yaml
@@ -7,8 +7,8 @@ requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
       - AuditLogs
-queryFrequency: 1d
-queryPeriod: 1d
+queryFrequency: 2h
+queryPeriod: 2h
 triggerOperator: gt
 triggerThreshold: 0
 status: Available
@@ -63,5 +63,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatedByIPAdress
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION

Change queryFrequency and queryPeriod from 1d to 2h. This will improve the MTTD (Mean time to Detect)

   Required items, please complete
   
   Change(s):
   - Changed queryFrequency and queryPeriod from 1d to 2h

   Reason for Change(s):
   - Improve the MTTD (Mean time to Detect). Older version could take almost 1 day after the event occurred to trigger.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes