### PR TITLE
Validate Workbook SerializedData in MainTemplate

### DIFF
--- a/.script/jsonFileValidator.ts
+++ b/.script/jsonFileValidator.ts
@@ -12,7 +12,7 @@ export async function IsValidJsonFile(filePath: string): Promise<ExitCode> {
     if (fileContent.includes('serializedData')) {
       let mainTemplateJsonObj = JSON.parse(fileContent);
 
-      mainTemplateJsonObj.filter((obj: { type: string; name: string | string[]; properties: { mainTemplate: { resources: any[]; }; }; }) => {
+      mainTemplateJsonObj.resources.filter((obj: { type: string; name: string | string[]; properties: { mainTemplate: { resources: any[]; }; }; }) => {
         if ((obj.type == "Microsoft.Resources/templateSpecs/versions" || obj.type == "Microsoft.OperationalInsights/workspaces/providers/contentTemplates") && obj.name.includes("workbook")) {
           obj.properties.mainTemplate.resources.filter((workbookObj: { type: string; properties: { serializedData: any; }; }) => {
             if (workbookObj.type == "Microsoft.Insights/workbooks") {

--- a/.script/jsonFileValidator.ts
+++ b/.script/jsonFileValidator.ts
@@ -17,13 +17,11 @@ export async function IsValidJsonFile(filePath: string): Promise<ExitCode> {
           obj.properties.mainTemplate.resources.filter((workbookObj: { type: string; properties: {
             displayName: string; serializedData: any; }; }) => {
             if (workbookObj.type == "Microsoft.Insights/workbooks") {
-              try
-              {
+              try {
                 JSON.parse(workbookObj.properties.serializedData);
               }
-              catch
-              {
-                console.log(`Invalid json content for Workbook, 'serializedData' attribute for 'displayName' ${workbookObj.properties.displayName}`);
+              catch {
+                throw Error(`In mainTemplate.json file, workbook with 'displayName'='${workbookObj.properties.displayName}' has invalid json string value for 'serializedData' attribute!`);
               }
             }
           });

--- a/.script/jsonFileValidator.ts
+++ b/.script/jsonFileValidator.ts
@@ -14,9 +14,17 @@ export async function IsValidJsonFile(filePath: string): Promise<ExitCode> {
 
       mainTemplateJsonObj.resources.filter((obj: { type: string; name: string | string[]; properties: { mainTemplate: { resources: any[]; }; }; }) => {
         if ((obj.type == "Microsoft.Resources/templateSpecs/versions" || obj.type == "Microsoft.OperationalInsights/workspaces/providers/contentTemplates") && obj.name.includes("workbook")) {
-          obj.properties.mainTemplate.resources.filter((workbookObj: { type: string; properties: { serializedData: any; }; }) => {
+          obj.properties.mainTemplate.resources.filter((workbookObj: { type: string; properties: {
+            displayName: string; serializedData: any; }; }) => {
             if (workbookObj.type == "Microsoft.Insights/workbooks") {
-              JSON.parse(workbookObj.properties.serializedData);
+              try
+              {
+                JSON.parse(workbookObj.properties.serializedData);
+              }
+              catch
+              {
+                console.log(`Invalid json content for Workbook, 'serializedData' attribute for 'displayName' ${workbookObj.properties.displayName}`);
+              }
             }
           });
         }

--- a/.script/jsonFileValidator.ts
+++ b/.script/jsonFileValidator.ts
@@ -28,12 +28,10 @@ export async function IsValidJsonFile(filePath: string): Promise<ExitCode> {
         }
       });
     }
-
-    return ExitCode.SUCCESS;
-  } else {
-    JSON.parse(fs.readFileSync(filePath, "utf8"));
-    return ExitCode.SUCCESS;
   }
+  
+  JSON.parse(fs.readFileSync(filePath, "utf8"));
+  return ExitCode.SUCCESS;
 }
 
 let fileTypeSuffixes = ["json"];

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,20 +11,20 @@ trigger:
 
 jobs:
 
-# - template: .azure-pipelines/solutionValidator.yaml
-# - template: .azure-pipelines/hyperLinkValidations.yaml
-# - template: .azure-pipelines/detectionsValidations.yaml
-# - template: .azure-pipelines/detectionTemplateSchemaValidation.yaml
-# - template: .azure-pipelines/kqlValidations.yaml
-# - template: .azure-pipelines/NonAsciiValidations.yaml
-# - template: .azure-pipelines/workbooksValidations.yaml
-# - template: .azure-pipelines/workbooksTemplateValidations.yaml
-# - template: .azure-pipelines/yamlFileValidator.yaml
+- template: .azure-pipelines/solutionValidator.yaml
+- template: .azure-pipelines/hyperLinkValidations.yaml
+- template: .azure-pipelines/detectionsValidations.yaml
+- template: .azure-pipelines/detectionTemplateSchemaValidation.yaml
+- template: .azure-pipelines/kqlValidations.yaml
+- template: .azure-pipelines/NonAsciiValidations.yaml
+- template: .azure-pipelines/workbooksValidations.yaml
+- template: .azure-pipelines/workbooksTemplateValidations.yaml
+- template: .azure-pipelines/yamlFileValidator.yaml
 - template: .azure-pipelines/jsonFileValidator.yaml
-# - template: .azure-pipelines/documentsLinkValidator.yaml
-# - template: .azure-pipelines/logoValidator.yaml
-# - template: .azure-pipelines/dataConnectorValidations.yaml
-# - template: .azure-pipelines/playbooksValidations.yaml
-# - template: .azure-pipelines/sampleDataValidator.yaml
-# - template: .azure-pipelines/contentValidations.yaml
-# - template: .azure-pipelines/callGithubWorkflow.yaml
+- template: .azure-pipelines/documentsLinkValidator.yaml
+- template: .azure-pipelines/logoValidator.yaml
+- template: .azure-pipelines/dataConnectorValidations.yaml
+- template: .azure-pipelines/playbooksValidations.yaml
+- template: .azure-pipelines/sampleDataValidator.yaml
+- template: .azure-pipelines/contentValidations.yaml
+- template: .azure-pipelines/callGithubWorkflow.yaml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,23 +7,24 @@ name: "Azure Sentinel Validations"
 
 trigger:
   - master
+  - validate-workbook-serializedData
 
 jobs:
 
-- template: .azure-pipelines/solutionValidator.yaml
-- template: .azure-pipelines/hyperLinkValidations.yaml
-- template: .azure-pipelines/detectionsValidations.yaml
-- template: .azure-pipelines/detectionTemplateSchemaValidation.yaml
-- template: .azure-pipelines/kqlValidations.yaml
-- template: .azure-pipelines/NonAsciiValidations.yaml
-- template: .azure-pipelines/workbooksValidations.yaml
-- template: .azure-pipelines/workbooksTemplateValidations.yaml
-- template: .azure-pipelines/yamlFileValidator.yaml
+# - template: .azure-pipelines/solutionValidator.yaml
+# - template: .azure-pipelines/hyperLinkValidations.yaml
+# - template: .azure-pipelines/detectionsValidations.yaml
+# - template: .azure-pipelines/detectionTemplateSchemaValidation.yaml
+# - template: .azure-pipelines/kqlValidations.yaml
+# - template: .azure-pipelines/NonAsciiValidations.yaml
+# - template: .azure-pipelines/workbooksValidations.yaml
+# - template: .azure-pipelines/workbooksTemplateValidations.yaml
+# - template: .azure-pipelines/yamlFileValidator.yaml
 - template: .azure-pipelines/jsonFileValidator.yaml
-- template: .azure-pipelines/documentsLinkValidator.yaml
-- template: .azure-pipelines/logoValidator.yaml
-- template: .azure-pipelines/dataConnectorValidations.yaml
-- template: .azure-pipelines/playbooksValidations.yaml
-- template: .azure-pipelines/sampleDataValidator.yaml
-- template: .azure-pipelines/contentValidations.yaml
-- template: .azure-pipelines/callGithubWorkflow.yaml
+# - template: .azure-pipelines/documentsLinkValidator.yaml
+# - template: .azure-pipelines/logoValidator.yaml
+# - template: .azure-pipelines/dataConnectorValidations.yaml
+# - template: .azure-pipelines/playbooksValidations.yaml
+# - template: .azure-pipelines/sampleDataValidator.yaml
+# - template: .azure-pipelines/contentValidations.yaml
+# - template: .azure-pipelines/callGithubWorkflow.yaml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,6 @@ name: "Azure Sentinel Validations"
 
 trigger:
   - master
-  - validate-workbook-serializedData
 
 jobs:
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In mainTemplate.json if there are any workbook which has attribute "serializedData" then workbook content is coming as a string in this field. It is observed that this "serializedData" attribute field value i.e json is invalid and fails when we open workbook view template. So this PR will validate if the "serializedData" attribute value is a valid json or not.

   Reason for Change(s):
   - To Validate if workbook, "serializedData" attribute value is a valid json format or not.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Testing Screenshot:**
**When mainTemplate has invalid json content in serializedData attribute as shown below:**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/c01bec9d-578c-4d31-964e-6dfe2149cc47)
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/7363eb1d-ed81-4547-abb8-518b8cf6f2c2)

**When mainTemplate has valid json content in serializedData attribute as shown below it will be success:**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/7d3b05f5-a4f4-4657-b7ab-eb5d0ec23bb8)
