### PR TITLE
Singleton orchestration pattern

### DIFF
--- a/Solutions/AbnormalSecurity/Data Connectors/SentinelFunctionsOrchestrator/__init__.py
+++ b/Solutions/AbnormalSecurity/Data Connectors/SentinelFunctionsOrchestrator/__init__.py
@@ -30,17 +30,16 @@ if(not match):
     raise Exception("Invalid Log Analytics Uri.")
 
 def orchestrator_function(context: df.DurableOrchestrationContext):
-    logging.info(f"Executing orchestrator function version 1.1 orchestration_id: {context.instance_id}")
+    logging.info(f"Executing orchestrator function version 1.1")
     datetimeEntityId = df.EntityId("SoarDatetimeEntity", "latestDatetime")
-    stored_datetime = yield context.call_entity(datetimeEntityId, "get", ("", context.instance_id))
-    logging.info(f"Retrieved stored datetime: {stored_datetime} orchestration_id: {context.instance_id}")
+    stored_datetime = yield context.call_entity(datetimeEntityId, "get")
+    logging.info(f"Retrieved stored datetime: {stored_datetime}")
 
     current_datetime = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-    logging.info(f"The current datetime is {current_datetime} orchestration id; {context.instance_id}")
+    logging.info(f"The current datetime is {current_datetime}")
     asyncio.run(transfer_abnormal_data_to_sentinel(stored_datetime, current_datetime))
-    logging.info(f"Finished api calls for orchestration_id: {context.instance_id}")
     context.signal_entity(datetimeEntityId, "set", (current_datetime, context.instance_id))
-    logging.info(f"Set last_datetime to {current_datetime} orchestration_id: {context.instance_id}")
+    logging.info(f"Set last_datetime to {current_datetime}")
 
 async def transfer_abnormal_data_to_sentinel(stored_datetime, current_datetime):
     context = {"gte_datetime": stored_datetime, "lte_datetime": current_datetime}

--- a/Solutions/AbnormalSecurity/Data Connectors/SentinelFunctionsOrchestrator/__init__.py
+++ b/Solutions/AbnormalSecurity/Data Connectors/SentinelFunctionsOrchestrator/__init__.py
@@ -30,17 +30,17 @@ if(not match):
     raise Exception("Invalid Log Analytics Uri.")
 
 def orchestrator_function(context: df.DurableOrchestrationContext):
-    logging.info(f"Executing orchestrator function version 1.1")
+    logging.info(f"Executing orchestrator function version 1.1 orchestration_id: {context.instance_id}")
     datetimeEntityId = df.EntityId("SoarDatetimeEntity", "latestDatetime")
-    stored_datetime = yield context.call_entity(datetimeEntityId, "get")
-    logging.info(f"retrieved stored datetime: {stored_datetime}")
+    stored_datetime = yield context.call_entity(datetimeEntityId, "get", ("", context.instance_id))
+    logging.info(f"Retrieved stored datetime: {stored_datetime} orchestration_id: {context.instance_id}")
 
     current_datetime = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    logging.info(f"The current datetime is {current_datetime} orchestration id; {context.instance_id}")
     asyncio.run(transfer_abnormal_data_to_sentinel(stored_datetime, current_datetime))
-
-    context.signal_entity(datetimeEntityId, "set", current_datetime)
-    logging.info(f"set last_datetime to {current_datetime}")
-
+    logging.info(f"Finished api calls for orchestration_id: {context.instance_id}")
+    context.signal_entity(datetimeEntityId, "set", (current_datetime, context.instance_id))
+    logging.info(f"Set last_datetime to {current_datetime} orchestration_id: {context.instance_id}")
 
 async def transfer_abnormal_data_to_sentinel(stored_datetime, current_datetime):
     context = {"gte_datetime": stored_datetime, "lte_datetime": current_datetime}

--- a/Solutions/AbnormalSecurity/Data Connectors/SentinelTimerTrigger/__init__.py
+++ b/Solutions/AbnormalSecurity/Data Connectors/SentinelTimerTrigger/__init__.py
@@ -13,6 +13,12 @@ import azure.durable_functions as df
 async def main(mytimer: func.TimerRequest, starter: str):
     logging.info("Executing SentinelTimerTrigger function")
     client = df.DurableOrchestrationClient(starter)
+    instance_id = "singleton_instance"
+    existing_instance = await client.get_status(instance_id)
+    if existing_instance is None or str(existing_instance.runtime_status) in [None, "OrchestrationRuntimeStatus.Completed", "OrchestrationRuntimeStatus.Failed", "OrchestrationRuntimeStatus.Terminated"]:
+        instance_id = await client.start_new("SentinelFunctionsOrchestrator", instance_id)
+        logging.info(f"Starting new orchestration - the runtime status is: {str(existing_instance.runtime_status)}")
+    else:
+        logging.info(f"Skipped orchestration - runtime status is : {str(existing_instance.runtime_status)}") 
 
-    instance_id = await client.start_new("SentinelFunctionsOrchestrator")
-    logging.info(f"Started orchestration with ID = '{instance_id}'.")
+        


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Implemented singleton orchestration pattern as per https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-singletons?tabs=python. 
   - Added more logs

   Reason for Change(s):
   - We are seeing a bug where concurrent instances of the orchestration modify the SoarDatetimeEntity's state simultaneously, and results in undesired behavior. We rely on the state of this entity to determine the `startTime` filter parameter for API requests that are made to our REST API. Upon investigating our internal logs we can see that the `startTime` is not being set properly. A scenario where this becomes evident is the following: SentinelTimerTrigger triggers at T0, SentinelFunctionsOrchestrator (A) is kicked off at T1 (request takes 5 minutes due to timing out), SentinelTimerTrigger triggers at T5 (its on a 5 minute chron schedule), SentinelFunctionsOrchestrator (B) is kicked off at T6  ... here we can see the problem. SentinelFunctionsOrchestrator (A) has not finished executing and as a result has not updated the SoarDatetimeEntity with the appropriate date, so SentinelFunctionsOrchestrator (B) will be reading from a stale state. This change aims to ensure that only 1 instance of the orchestrator can run from start to finish to avoid multiple orchestrators modifying the SoardatetimeEntity's state. 

   Version Updated:
   -No

   Testing Completed:
   - Deployed functions to Azure environment and inspected logs to verify that only 1 instance of the orchestration was running at any given time, and verified that the SentinelTimerTrigger skipped the creation of new orchestrations when there was one already running.  

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


# Guidance <- remove section before submitting
-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for XYZ.yaml

   Reason for Change(s):
   - New schema used for XYZ.yaml
   - Resolves ISSUE #1234

   Version updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

_Note: If updating a detection, you must update the version field._

> Before the submission has been made, please look at running the KQL and Yaml Validation Checks locally.
> https://github.com/Azure/Azure-Sentinel#run-kql-validation-locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
