### PR TITLE
Detect privileged role assignments ignoring PIM activations (#9218)

### DIFF
--- a/Solutions/Azure Active Directory/Analytic Rules/UserAssignedNewPrivilegedRole.yaml
+++ b/Solutions/Azure Active Directory/Analytic Rules/UserAssignedNewPrivilegedRole.yaml
@@ -1,0 +1,65 @@
+id: 746ddb63-f51b-4563-b449-a8b13cf302ec
+name: User Assigned New Privileged Role
+description: |
+  'Identifies when a new eligible or active privileged role is assigned to a user. Does not alert on PIM activations. Any account eligible for a role is now being given privileged access. If the assignment is unexpected or into a role that isn't the responsibility of the account holder, investigate.
+  Ref : https://docs.microsoft.com/azure/active-directory/fundamentals/security-operations-privileged-accounts#things-to-monitor-1'
+severity: High
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+queryFrequency: 2h
+queryPeriod: 2h
+triggerOperator: gt
+triggerThreshold: 0
+status: Available
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1078.004
+tags:
+  - AADSecOpsGuide
+query: |
+  AuditLogs
+  | where Category =~ "RoleManagement"
+  | where AADOperationType in ("Assign", "AssignEligibleRole", "CreateRequestGrantedRole", "CreateRequestPermanentEligibleRole", "CreateRequestPermanentGrantedRole")
+  | where ActivityDisplayName has_any ("Add eligible member to role", "Add member to role")
+  | mv-apply TargetResourceSubject = TargetResources on 
+    (
+        where TargetResourceSubject.type in~ ("User", "ServicePrincipal")
+        | extend Target = iff(TargetResourceSubject.type =~ "ServicePrincipal", tostring(TargetResourceSubject.displayName), tostring(TargetResourceSubject.userPrincipalName)),
+                 subjectProps = TargetResourceSubject.modifiedProperties
+    )
+  | mv-apply TargetResourceRole = TargetResources on 
+    (
+      // mimic modifiedProperties so we can use the same logic to get the role name regardless of where it comes from
+      where TargetResourceRole.type in~ ("Role")
+      | extend roleProps = pack_array(bag_pack("displayName","Role.DisplayName", "newValue", TargetResourceRole.displayName))
+    )
+  | mv-apply Property = iff(array_length(subjectProps) > 0, subjectProps, roleProps) on 
+    ( 
+      where Property.displayName =~ "Role.DisplayName"
+        | extend RoleName = trim('"',tostring(Property.newValue))
+    )
+  | where RoleName contains "Admin"
+  | extend InitiatingApp = tostring(InitiatedBy.app.displayName)
+  | extend Initiator = iif(isnotempty(InitiatingApp), InitiatingApp, tostring(InitiatedBy.user.userPrincipalName))
+  // Comment below to alert for PIM activations
+  | where Initiator != "MS-PIM"
+  | summarize by bin(TimeGenerated, 1h), OperationName,  RoleName, Target, Initiator, Result
+  | extend TargetName = tostring(split(Target,'@',0)[0]), TargetUPNSuffix = tostring(split(Target,'@',1)[0]), InitiatorName = tostring(split(Initiator,'@',0)[0]), InitiatorUPNSuffix = tostring(split(Initiator,'@',1)[0])
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: TargetName
+      - identifier: UPNSuffix
+        columnName: TargetUPNSuffix
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: InitiatorName
+      - identifier: UPNSuffix
+        columnName: InitiatorUPNSuffix
+version: 1.0.0
+kind: Scheduled


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Created new analytics rule that detects privileged role assignments while ignoring PIM activations

   Reason for Change(s):
   - The current rules are unable to detect eligible or active role assignments made within the context of PIM without also alerting on all PIM role activations. This results in a lot of noise.
   - See discussion for #9218 

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No


