### PR TITLE
Adding DeviceInfo custom table

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/DeviceInfo.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/DeviceInfo.json
@@ -1,0 +1,141 @@
+{
+    "Name":"DeviceInfo",
+    "Properties":[
+    {
+      "Name": "Timestamp",
+      "Type": "datetime"
+    },
+    {
+      "Name": "DeviceId",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceName",
+      "Type": "string"
+    },
+    {
+      "Name": "ClientVersion",
+      "Type": "string"
+    },
+    {
+      "Name": "PublicIP",
+      "Type": "string"
+    },
+    {
+      "Name": "OSArchitecture",
+      "Type": "string"
+    },
+    {
+      "Name": "OSPlatform",
+      "Type": "string"
+    },
+    {
+      "Name": "OSBuild",
+      "Type": "string"
+    },
+    {
+      "Name": "IsAzureADJoined",
+      "Type": "bool"
+    },
+    {
+      "Name": "AadDeviceId",
+      "Type": "string"
+    },
+    {
+      "Name": "LoggedOnUsers",
+      "Type": "string"
+    },
+    {
+      "Name": "RegistryDeviceTag",
+      "Type": "string"
+    },
+    {
+      "Name": "OSVersion",
+      "Type": "string"
+    },
+    {
+      "Name": "MachineGroup",
+      "Type": "string"
+    },
+    {
+      "Name": "ReportId",
+      "Type": "string"
+    },
+    {
+      "Name": "OnboardingStatus",
+      "Type": "string"
+    },
+    {
+      "Name": "AdditionalFields",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceCategory",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceType",
+      "Type": "string"
+    },
+    {
+      "Name": "DeviceSubtype",
+      "Type": "string"
+    },
+    {
+      "Name": "Model",
+      "Type": "string"
+    },
+    {
+      "Name": "Vendor",
+      "Type": "string"
+    }, 
+    {
+    "Name": "OSDistribution",
+    "Type": "string"
+    },
+    {
+    "Name": "OSVersionInfo",
+    "Type": "string"
+    },
+    {
+    "Name": "MergedDeviceIds",
+    "Type": "string"
+    },
+    {
+    "Name": "MergedToDeviceId",
+    "Type": "string"
+    },
+    {
+    "Name": "SensorHealthState",
+    "Type": "string"
+    },
+    {
+    "Name": "IsExcluded",
+    "Type": "bool"
+    },
+    {
+    "Name": "ExclusionReason",
+    "Type": "string"
+    },
+    {
+    "Name": "AssetValue",
+    "Type": "string"
+    },
+    {
+    "Name": "ExposureLevel",
+    "Type": "string"
+    },
+    {
+    "Name": "IsInternetFacing",
+    "Type": "bool"
+    },
+    {
+    "Name": "DeviceManualTags",
+    "Type": "string"
+    },
+    {
+    "Name": "DeviceDynamicTags",
+    "Type": "string"
+    }
+  ]
+  }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Diana and Manny created a custom table for DeviceInfo

   Reason for Change(s):
   - To prevent merging problems from another PR which calls DeviceInfo in a detection query

   Version Updated:
   - No

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - No
