### PR TITLE
Added new filters in SentinelOne FileEvent vim parser

### DIFF
--- a/Parsers/ASimFileEvent/Parsers/vimFileEventSentinelOne.yaml
+++ b/Parsers/ASimFileEvent/Parsers/vimFileEventSentinelOne.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: File Event Parser for SentinelOne
   Version: '0.1.0'
-  LastUpdated: Sep 18, 2023
+  LastUpdated: Oct 26, 2023
 Product:
   Name: SentinelOne
 Normalization:
@@ -19,143 +19,200 @@ Description: |
 ParserName: vimFileEventSentinelOne
 EquivalentBuiltInParser: _Im_FileEvent_SentinelOne
 ParserParams:
+  - Name: starttime
+    Type: datetime
+    Default: datetime(null)
+  - Name: endtime
+    Type: datetime
+    Default: datetime(null)
+  - Name: eventtype_in
+    Type: dynamic
+    Default: dynamic([])
+  - Name: srcipaddr_has_any_prefix
+    Type: dynamic
+    Default: dynamic([])
+  - Name: actorusername_has_any
+    Type: dynamic
+    Default: dynamic([])
+  - Name: targetfilepath_has_any
+    Type: dynamic
+    Default: dynamic([])
+  - Name: srcfilepath_has_any
+    Type: dynamic
+    Default: dynamic([])
+  - Name: hashes_has_any
+    Type: dynamic
+    Default: dynamic([])
+  - Name: dvchostname_has_any
+    Type: dynamic
+    Default: dynamic([])
   - Name: disabled
     Type: bool
     Default: false
 ParserQuery: |
-  let GetWindowsFilenamePart = (path: string) { tostring(split(path, @'\')[-1]) };
-  let GetLinuxFilenamePart = (path: string) { tostring(split(path, @'/')[-1]) };
-  let EventTypeLookup = datatable (alertInfo_eventType_s: string, EventType: string)
-      [
-      "FILECREATION", "FileCreated",
-      "FILEMODIFICATION", "FileModified",
-      "FILEDELETION", "FileDeleted",
-      "FILERENAME", "FileRenamed"
-  ];
-  let ThreatConfidenceLookup_undefined = datatable(
-      alertInfo_analystVerdict_s: string,
-      ThreatConfidence_undefined: int
-  )
-      [
-      "FALSE_POSITIVE", 5,
-      "Undefined", 15,
-      "SUSPICIOUS", 25,
-      "TRUE_POSITIVE", 33 
-  ];
-  let ThreatConfidenceLookup_suspicious = datatable(
-      alertInfo_analystVerdict_s: string,
-      ThreatConfidence_suspicious: int
-  )
-      [
-      "FALSE_POSITIVE", 40,
-      "Undefined", 50,
-      "SUSPICIOUS", 60,
-      "TRUE_POSITIVE", 67 
-  ];
-  let ThreatConfidenceLookup_malicious = datatable(
-      alertInfo_analystVerdict_s: string,
-      ThreatConfidence_malicious: int
-  )
-      [
-      "FALSE_POSITIVE", 75,
-      "Undefined", 80,
-      "SUSPICIOUS", 90,
-      "TRUE_POSITIVE", 100 
-  ];
-  let parser = (disabled: bool=false) {
-      let allFileData = SentinelOne_CL
-          | where not(disabled)
-              and event_name_s == "Alerts."
-              and alertInfo_eventType_s in ('FILECREATION', 'FILEMODIFICATION', 'FILEDELETION', 'FILERENAME');
-      let windowsFileData = allFileData
-          | where agentDetectionInfo_osFamily_s == "windows"
-          | extend
-              TargetFilePathType = "Windows Local",
-              TargetFileName = GetWindowsFilenamePart(targetProcessInfo_tgtFilePath_s),
-              SrcFileName = GetWindowsFilenamePart(targetProcessInfo_tgtFileOldPath_s);
-      let otherFileData = allFileData
-          | where agentDetectionInfo_osFamily_s != "windows"
-          | extend
-              TargetFilePathType = "Unix",
-              TargetFileName = GetLinuxFilenamePart(targetProcessInfo_tgtFilePath_s),
-              SrcFileName = GetLinuxFilenamePart(targetProcessInfo_tgtFileOldPath_s);
-      let parseddata = union windowsFileData, otherFileData
-          | lookup EventTypeLookup on alertInfo_eventType_s;
-      let undefineddata = parseddata
-          | where ruleInfo_treatAsThreat_s == "UNDEFINED"
-          | lookup ThreatConfidenceLookup_undefined on alertInfo_analystVerdict_s;
-      let suspiciousdata = parseddata
-          | where ruleInfo_treatAsThreat_s == "Suspicious"
-          | lookup ThreatConfidenceLookup_suspicious on alertInfo_analystVerdict_s;
-      let maaliciousdata = parseddata
-          | where ruleInfo_treatAsThreat_s == "Malicious"
-          | lookup ThreatConfidenceLookup_malicious on alertInfo_analystVerdict_s;
-      union undefineddata, suspiciousdata, maaliciousdata
-      | extend
-          ThreatConfidence = coalesce(ThreatConfidence_undefined, ThreatConfidence_suspicious, ThreatConfidence_malicious),
-          EventSeverity = iff(ruleInfo_severity_s == "Critical", "High", ruleInfo_severity_s),
-          EventVendor = "SentinelOne",
-          EventProduct = "SentinelOne",
-          EventResult = "Success",
-          EventSchema = "FileEvent",
-          EventSchemaVersion = "0.2.1",
-          EventCount = toint(1),
-          DvcAction = "Allowed",
-          ActorUsername = sourceProcessInfo_user_s
-      | project-rename
-          EventStartTime = sourceProcessInfo_pidStarttime_t,
-          EventOriginalSeverity = ruleInfo_severity_s,
-          EventUid = _ItemId,
-          ActingProcessCommandLine = sourceProcessInfo_commandline_s,
-          ActingProcessGuid = sourceProcessInfo_uniqueId_g,
-          ActingProcessId = sourceProcessInfo_pid_s,
-          ActingProcessName = sourceProcessInfo_name_s,
-          DvcId = agentDetectionInfo_uuid_g,
-          DvcOs = agentDetectionInfo_osName_s,
-          DvcOsVersion = agentDetectionInfo_osRevision_s,
-          EventOriginalType = alertInfo_eventType_s,
-          EventOriginalUid = alertInfo_dvEventId_s,
-          RuleName = ruleInfo_name_s,
-          TargetFileCreationTime = targetProcessInfo_tgtFileCreatedAt_t,
-          SrcFilePath = targetProcessInfo_tgtFileOldPath_s,
-          TargetFilePath = targetProcessInfo_tgtFilePath_s,
-          TargetFileSHA1 = targetProcessInfo_tgtFileHashSha1_s,
-          TargetFileSHA256 = targetProcessInfo_tgtFileHashSha256_s,
-          ThreatOriginalConfidence = ruleInfo_treatAsThreat_s
-      | invoke _ASIM_ResolveDvcFQDN('agentDetectionInfo_name_s')
-      | extend
-          Dvc = coalesce(DvcHostname, DvcId, EventProduct),
-          EventEndTime = EventStartTime,
-          Rule = RuleName,
-          FileName = TargetFileName,
-          FilePath = TargetFilePath,
-          Process = ActingProcessName,
-          User = ActorUsername,
-          Hash = coalesce(TargetFileSHA256, TargetFileSHA1)
-      | extend
-          ActorUsernameType = _ASIM_GetUsernameType(ActorUsername),
-          ActorUserType = _ASIM_GetUserType(ActorUsername, ""),
-          DvcIdType = iff(isnotempty(DvcId), "Other", ""),
-          HashType = case(
+    let GetWindowsFilenamePart = (path: string) { tostring(split(path, @'\')[-1]) };
+    let GetLinuxFilenamePart = (path: string) { tostring(split(path, @'/')[-1]) };
+    let EventTypeLookup = datatable (alertInfo_eventType_s: string, EventType: string)
+        [
+        "FILECREATION", "FileCreated",
+        "FILEMODIFICATION", "FileModified",
+        "FILEDELETION", "FileDeleted",
+        "FILERENAME", "FileRenamed"
+    ];
+    let ThreatConfidenceLookup_undefined = datatable(
+        alertInfo_analystVerdict_s: string,
+        ThreatConfidence_undefined: int
+    )
+        [
+        "FALSE_POSITIVE", 5,
+        "Undefined", 15,
+        "SUSPICIOUS", 25,
+        "TRUE_POSITIVE", 33 
+    ];
+    let ThreatConfidenceLookup_suspicious = datatable(
+        alertInfo_analystVerdict_s: string,
+        ThreatConfidence_suspicious: int
+    )
+        [
+        "FALSE_POSITIVE", 40,
+        "Undefined", 50,
+        "SUSPICIOUS", 60,
+        "TRUE_POSITIVE", 67 
+    ];
+    let ThreatConfidenceLookup_malicious = datatable(
+        alertInfo_analystVerdict_s: string,
+        ThreatConfidence_malicious: int
+    )
+        [
+        "FALSE_POSITIVE", 75,
+        "Undefined", 80,
+        "SUSPICIOUS", 90,
+        "TRUE_POSITIVE", 100 
+    ];
+    let parser = (
+        starttime: datetime=datetime(null), 
+        endtime: datetime=datetime(null), 
+        eventtype_in: dynamic=dynamic([]), 
+        srcipaddr_has_any_prefix: dynamic=dynamic([]), 
+        actorusername_has_any: dynamic=dynamic([]), 
+        targetfilepath_has_any: dynamic=dynamic([]), 
+        srcfilepath_has_any: dynamic=dynamic([]), 
+        hashes_has_any: dynamic=dynamic([]), 
+        dvchostname_has_any: dynamic=dynamic([]), 
+        disabled: bool=false
+        ) {
+        let allFileData = SentinelOne_CL
+            | where not(disabled)
+            | where ((isnull(starttime) or TimeGenerated >= starttime) and (isnull(endtime) or TimeGenerated <= endtime))
+                and event_name_s == "Alerts."
+                and alertInfo_eventType_s in ('FILECREATION', 'FILEMODIFICATION', 'FILEDELETION', 'FILERENAME')
+            | where array_length(srcipaddr_has_any_prefix) == 0
+                and (array_length(actorusername_has_any) == 0 or sourceProcessInfo_user_s has_any (actorusername_has_any))
+                and (array_length(targetfilepath_has_any) == 0 or targetProcessInfo_tgtFilePath_s has_any (targetfilepath_has_any))
+                and (array_length(srcfilepath_has_any) == 0 or targetProcessInfo_tgtFileOldPath_s has_any (srcfilepath_has_any))
+                and (array_length(hashes_has_any) == 0 or targetProcessInfo_tgtFileHashSha1_s has_any (hashes_has_any) or targetProcessInfo_tgtFileHashSha256_s has_any (hashes_has_any))
+                and (array_length(dvchostname_has_any) == 0 or agentDetectionInfo_name_s has_any (dvchostname_has_any))
+            | lookup EventTypeLookup on alertInfo_eventType_s
+            | where (array_length(eventtype_in) == 0 or EventType has_any (eventtype_in));
+        let windowsFileData = allFileData
+            | where agentDetectionInfo_osFamily_s == "windows"
+            | extend
+                TargetFilePathType = "Windows Local",
+                TargetFileName = GetWindowsFilenamePart(targetProcessInfo_tgtFilePath_s),
+                SrcFileName = GetWindowsFilenamePart(targetProcessInfo_tgtFileOldPath_s);
+        let otherFileData = allFileData
+            | where agentDetectionInfo_osFamily_s != "windows"
+            | extend
+                TargetFilePathType = "Unix",
+                TargetFileName = GetLinuxFilenamePart(targetProcessInfo_tgtFilePath_s),
+                SrcFileName = GetLinuxFilenamePart(targetProcessInfo_tgtFileOldPath_s);
+        let parseddata = union windowsFileData, otherFileData;
+        let undefineddata = parseddata
+            | where ruleInfo_treatAsThreat_s == "UNDEFINED"
+            | lookup ThreatConfidenceLookup_undefined on alertInfo_analystVerdict_s;
+        let suspiciousdata = parseddata
+            | where ruleInfo_treatAsThreat_s == "Suspicious"
+            | lookup ThreatConfidenceLookup_suspicious on alertInfo_analystVerdict_s;
+        let maaliciousdata = parseddata
+            | where ruleInfo_treatAsThreat_s == "Malicious"
+            | lookup ThreatConfidenceLookup_malicious on alertInfo_analystVerdict_s;
+        union undefineddata, suspiciousdata, maaliciousdata
+        | extend
+            ThreatConfidence = coalesce(ThreatConfidence_undefined, ThreatConfidence_suspicious, ThreatConfidence_malicious),
+            EventSeverity = iff(ruleInfo_severity_s == "Critical", "High", ruleInfo_severity_s),
+            EventVendor = "SentinelOne",
+            EventProduct = "SentinelOne",
+            EventResult = "Success",
+            EventSchema = "FileEvent",
+            EventSchemaVersion = "0.2.1",
+            EventCount = toint(1),
+            DvcAction = "Allowed",
+            ActorUsername = sourceProcessInfo_user_s
+        | project-rename
+            EventStartTime = sourceProcessInfo_pidStarttime_t,
+            EventOriginalSeverity = ruleInfo_severity_s,
+            EventUid = _ItemId,
+            ActingProcessCommandLine = sourceProcessInfo_commandline_s,
+            ActingProcessGuid = sourceProcessInfo_uniqueId_g,
+            ActingProcessId = sourceProcessInfo_pid_s,
+            ActingProcessName = sourceProcessInfo_name_s,
+            DvcId = agentDetectionInfo_uuid_g,
+            DvcOs = agentDetectionInfo_osName_s,
+            DvcOsVersion = agentDetectionInfo_osRevision_s,
+            EventOriginalType = alertInfo_eventType_s,
+            EventOriginalUid = alertInfo_dvEventId_s,
+            RuleName = ruleInfo_name_s,
+            TargetFileCreationTime = targetProcessInfo_tgtFileCreatedAt_t,
+            SrcFilePath = targetProcessInfo_tgtFileOldPath_s,
+            TargetFilePath = targetProcessInfo_tgtFilePath_s,
+            TargetFileSHA1 = targetProcessInfo_tgtFileHashSha1_s,
+            TargetFileSHA256 = targetProcessInfo_tgtFileHashSha256_s,
+            ThreatOriginalConfidence = ruleInfo_treatAsThreat_s
+        | invoke _ASIM_ResolveDvcFQDN('agentDetectionInfo_name_s')
+        | extend
+            Dvc = coalesce(DvcHostname, DvcId, EventProduct),
+            EventEndTime = EventStartTime,
+            Rule = RuleName,
+            FileName = TargetFileName,
+            FilePath = TargetFilePath,
+            Process = ActingProcessName,
+            User = ActorUsername,
+            Hash = coalesce(TargetFileSHA256, TargetFileSHA1)
+        | extend
+            ActorUsernameType = _ASIM_GetUsernameType(ActorUsername),
+            ActorUserType = _ASIM_GetUserType(ActorUsername, ""),
+            DvcIdType = iff(isnotempty(DvcId), "Other", ""),
+            HashType = case(
                 isnotempty(Hash) and isnotempty(TargetFileSHA256),
                 "TargetFileSHA256",
                 isnotempty(Hash) and isnotempty(TargetFileSHA1),
                 "TargetFileSHA1",
                 ""
             ) 
-      | project-away 
-          *_d,
-          *_s,
-          *_g,
-          *_t,
-          *_b,
-          _ResourceId,
-          Computer,
-          MG,
-          ManagementGroupName,
-          RawData,
-          SourceSystem,
-          TenantId,
-          ThreatConfidence_*
-  };
-  parser(disabled = disabled)
+        | project-away 
+            *_d,
+            *_s,
+            *_g,
+            *_t,
+            *_b,
+            _ResourceId,
+            Computer,
+            MG,
+            ManagementGroupName,
+            RawData,
+            SourceSystem,
+            TenantId,
+            ThreatConfidence_*
+    };
+    parser(
+        starttime=starttime, 
+        endtime=endtime, 
+        eventtype_in=eventtype_in, 
+        srcipaddr_has_any_prefix=srcipaddr_has_any_prefix, 
+        actorusername_has_any=actorusername_has_any, 
+        targetfilepath_has_any=targetfilepath_has_any, 
+        srcfilepath_has_any=srcfilepath_has_any, 
+        hashes_has_any=hashes_has_any, 
+        dvchostname_has_any=dvchostname_has_any, 
+        disabled=disabled
+    )

--- a/Parsers/ASimFileEvent/test/SentinelOne_vimFileEvent_DataTest.csv
+++ b/Parsers/ASimFileEvent/test/SentinelOne_vimFileEvent_DataTest.csv
@@ -1,5 +1,4 @@
 ﻿Result
-"(0) Error: 1 invalid value(s) (up to 10 listed) in 10004 records (100.0%) for field [EventProduct] of type [Enumerated]: [""SentinelOne""] (Schema:FileEvent)"
 "(0) Error: 1 invalid value(s) (up to 10 listed) in 10004 records (100.0%) for field [EventVendor] of type [Enumerated]: [""SentinelOne""] (Schema:FileEvent)"
 "(1) Warning: Empty value in 9932 records (99.28%)  in mandatory field [ActorUsername] (Schema:FileEvent)"
 "(2) Info: Empty value in 2048 records (20.47%)  in optional field [TargetFileSHA1] (Schema:FileEvent)"


### PR DESCRIPTION
Change(s):

Added new filters in SentinelOne FileEvent vim parser.
Reason for Change(s):

New filters are suggested for FileEvent parser so added in SnetinelOne FileEvent vim parser.
Version Updated:

No.
Testing Completed:

Yes
Checked that the validations are passing and have addressed any issues that are present:

Yes