### PR TITLE
Fixed starttime to now()-1h

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/UserAssignedPrivilegedRole.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/UserAssignedPrivilegedRole.yaml
@@ -20,7 +20,7 @@ tags:
   - AADSecOpsGuide
 query: |
   // Define the start and end times based on input values
-  let starttime = now()-1d;
+  let starttime = now()-1h;
   let endtime = now();
   // Set a lookback period of 14 days
   let lookback = starttime - 14d;
@@ -78,5 +78,5 @@ entityMappings:
         columnName: InitiatorName
       - identifier: UPNSuffix
         columnName: InitiatorUPNSuffix
-version: 1.0.8
+version: 1.0.9
 kind: Scheduled


### PR DESCRIPTION
Fixed issue that was causing multiple triggers for the same event with now()-1d instead of now()-1h

   Required items, please complete
   
   Change(s):
   - Fixed issue that was causing multiple triggers for the same event with now()-1d instead of now()-1h

   Reason for Change(s):
   - Latest change was causing multiple triggers for the same event.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes