### PR TITLE
Updated mapping for M365 Analytic Rules Detections (Manny's half)

### DIFF
--- a/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
@@ -50,7 +50,6 @@ query: |
   | summarize TimeGenerated = make_list(TimeGenerated), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),
   UserAgents = make_list(UserAgent), OfficeIds = make_list(OfficeId), SourceRelativeUrls = make_list(SourceRelativeUrl), FileNames = make_list(SourceFileName)
   by OfficeWorkload, RecordType, Operation, UserType, UserKey, UserId, ClientIP, Site_Url, SiteUrlUserFolder, UserIdUserFolderFormat, UserIdDiffThanUserFolder
-  | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
   | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
   | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:

--- a/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
@@ -50,15 +50,14 @@ query: |
   | summarize TimeGenerated = make_list(TimeGenerated), StartTime = min(TimeGenerated), EndTime = max(TimeGenerated),
   UserAgents = make_list(UserAgent), OfficeIds = make_list(OfficeId), SourceRelativeUrls = make_list(SourceRelativeUrl), FileNames = make_list(SourceFileName)
   by OfficeWorkload, RecordType, Operation, UserType, UserKey, UserId, ClientIP, Site_Url, SiteUrlUserFolder, UserIdUserFolderFormat, UserIdDiffThanUserFolder
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
@@ -51,12 +51,15 @@ query: |
   UserAgents = make_list(UserAgent), OfficeIds = make_list(OfficeId), SourceRelativeUrls = make_list(SourceRelativeUrl), FileNames = make_list(SourceFileName)
   by OfficeWorkload, RecordType, Operation, UserType, UserKey, UserId, ClientIP, Site_Url, SiteUrlUserFolder, UserIdUserFolderFormat, UserIdDiffThanUserFolder
   | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
-
+  | extend Name = tostring(split(AccountCustomEntity, "@")[0]), DomainIndex = toint(indexof(AccountCustomEntity, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), AccountCustomEntity)
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
@@ -65,5 +68,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 2.0.1
+version: 2.0.2
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/Office_Uploaded_Executables.yaml
@@ -51,8 +51,8 @@ query: |
   UserAgents = make_list(UserAgent), OfficeIds = make_list(OfficeId), SourceRelativeUrls = make_list(SourceRelativeUrl), FileNames = make_list(SourceFileName)
   by OfficeWorkload, RecordType, Operation, UserType, UserKey, UserId, ClientIP, Site_Url, SiteUrlUserFolder, UserIdUserFolderFormat, UserIdDiffThanUserFolder
   | extend timestamp = StartTime, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
-  | extend Name = tostring(split(AccountCustomEntity, "@")[0]), DomainIndex = toint(indexof(AccountCustomEntity, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), AccountCustomEntity)
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -63,10 +63,10 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: URLCustomEntity
+        columnName: Site_Url
 version: 2.0.2
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -23,7 +23,6 @@ query: |
   | where Operation in~ ( "Add-MailboxPermission", "Add-MailboxFolderPermission", "Set-Mailbox", "New-ManagementRoleAssignment", "New-InboxRule", "Set-InboxRule", "Set-TransportRule")
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
   | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
-  | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIPOnly
   | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
   | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -24,15 +24,22 @@ query: |
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
   | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIPOnly
-
+  | extend Name = tostring(split(AccountCustomEntity, "@")[0]), DomainIndex = toint(indexof(AccountCustomEntity, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), AccountCustomEntity)
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.1
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: AppId
+        columnName: AppId
+version: 2.0.2
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -23,15 +23,14 @@ query: |
   | where Operation in~ ( "Add-MailboxPermission", "Add-MailboxFolderPermission", "Set-Mailbox", "New-ManagementRoleAssignment", "New-InboxRule", "Set-InboxRule", "Set-TransportRule")
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
   | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountName = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountName
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -24,8 +24,8 @@ query: |
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
   | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
   | extend timestamp = TimeGenerated, AccountCustomEntity = UserId, IPCustomEntity = ClientIPOnly
-  | extend Name = tostring(split(AccountCustomEntity, "@")[0]), DomainIndex = toint(indexof(AccountCustomEntity, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), AccountCustomEntity)
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -36,7 +36,7 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
   - entityType: CloudApplication
     fieldMappings:
       - identifier: AppId

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -23,14 +23,14 @@ query: |
   | where Operation in~ ( "Add-MailboxPermission", "Add-MailboxFolderPermission", "Set-Mailbox", "New-ManagementRoleAssignment", "New-InboxRule", "Set-InboxRule", "Set-TransportRule")
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
   | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
-  | extend Name = tostring(split(UserId, "@")[0]), AccountName = tostring(split(UserId, "@")[1])
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: UPNSuffix
         columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/RareOfficeOperations.yaml
@@ -23,12 +23,12 @@ query: |
   | where Operation in~ ( "Add-MailboxPermission", "Add-MailboxFolderPermission", "Set-Mailbox", "New-ManagementRoleAssignment", "New-InboxRule", "Set-InboxRule", "Set-TransportRule")
   and not(UserId has_any ('NT AUTHORITY\\SYSTEM (Microsoft.Exchange.ServiceHost)', 'NT AUTHORITY\\SYSTEM (w3wp)', 'devilfish-applicationaccount') and Operation in~ ( "Add-MailboxPermission", "Set-Mailbox"))
   | extend ClientIPOnly = tostring(extract_all(@'\[?(::ffff:)?(?P<IPAddress>(\d+\.\d+\.\d+\.\d+)|[^\]]+)\]?', dynamic(["IPAddress"]), ClientIP)[0][0])
-  | extend AccountName = tostring(split(UserId, "@")[0]), AccountName = tostring(split(UserId, "@")[1])
+  | extend Name = tostring(split(UserId, "@")[0]), AccountName = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: AccountName
+        columnName: Name
       - identifier: UPNSuffix
         columnName: AccountName
   - entityType: IP

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
@@ -62,10 +62,10 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: URLCustomEntity
+        columnName: Site_Url
 version: 2.0.3
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
@@ -48,7 +48,6 @@ query: |
   UserBehaviorAnalysis
   | where Deviation > threshold
   | project StartTimeUtc, EndTimeUtc, UserId, UserType, Operation, ClientIP, Site_Url, OfficeObjectId, OfficeWorkload, UserAgent, Deviation, Count=RecentCount
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
   | order by Count desc, ClientIP asc, Operation asc, UserId asc
   | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
   | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
@@ -49,15 +49,14 @@ query: |
   | where Deviation > threshold
   | project StartTimeUtc, EndTimeUtc, UserId, UserType, Operation, ClientIP, Site_Url, OfficeObjectId, OfficeWorkload, UserAgent, Deviation, Count=RecentCount
   | order by Count desc, ClientIP asc, Operation asc, UserId asc
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountName = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountName
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
@@ -50,11 +50,15 @@ query: |
   | project StartTimeUtc, EndTimeUtc, UserId, UserType, Operation, ClientIP, Site_Url, OfficeObjectId, OfficeWorkload, UserAgent, Deviation, Count=RecentCount
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP, URLCustomEntity = Site_Url
   | order by Count desc, ClientIP asc, Operation asc, UserId asc
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
@@ -63,5 +67,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: URLCustomEntity
-version: 2.0.2
+version: 2.0.3
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/SharePoint_Downloads_byNewIP.yaml
@@ -49,14 +49,14 @@ query: |
   | where Deviation > threshold
   | project StartTimeUtc, EndTimeUtc, UserId, UserType, Operation, ClientIP, Site_Url, OfficeObjectId, OfficeWorkload, UserAgent, Deviation, Count=RecentCount
   | order by Count desc, ClientIP asc, Operation asc, UserId asc
-  | extend AccountName = tostring(split(UserId, "@")[0]), AccountName = tostring(split(UserId, "@")[1])
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
         columnName: AccountName
       - identifier: UPNSuffix
-        columnName: AccountName
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
@@ -26,14 +26,18 @@ query: |
   | where AdminAuditLogEnabledValue =~ "False"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP, ResultStatus, Parameters, AdminAuditLogEnabledValue
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.1
+version: 2.0.2
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
@@ -25,15 +25,14 @@ query: |
   | extend AdminAuditLogEnabledValue = tostring(parse_json(tostring(parse_json(tostring(array_slice(parse_json(Parameters),3,3)))[0])).Value)
   | where AdminAuditLogEnabledValue =~ "False"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP, ResultStatus, Parameters, AdminAuditLogEnabledValue
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
@@ -25,7 +25,6 @@ query: |
   | extend AdminAuditLogEnabledValue = tostring(parse_json(tostring(parse_json(tostring(array_slice(parse_json(Parameters),3,3)))[0])).Value)
   | where AdminAuditLogEnabledValue =~ "False"
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP, ResultStatus, Parameters, AdminAuditLogEnabledValue
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
   | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
   | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:

--- a/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/exchange_auditlogdisabled.yaml
@@ -38,6 +38,6 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
 version: 2.0.2
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
@@ -57,6 +57,6 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ClientIP
 version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
@@ -44,15 +44,14 @@ query: |
   ClientIP
   )
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP = ClientIPOnly, Port, ResultStatus, Parameters
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
@@ -44,7 +44,6 @@ query: |
   ClientIP
   )
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP = ClientIPOnly, Port, ResultStatus, Parameters
-  | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
   | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
   | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:

--- a/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/office_policytampering.yaml
@@ -45,14 +45,18 @@ query: |
   )
   | summarize StartTimeUtc = min(TimeGenerated), EndTimeUtc = max(TimeGenerated), OperationCount = count() by Operation, UserType, UserId, ClientIP = ClientIPOnly, Port, ResultStatus, Parameters
   | extend timestamp = StartTimeUtc, AccountCustomEntity = UserId, IPCustomEntity = ClientIP
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: IPCustomEntity
-version: 2.0.0
+version: 2.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_above_threshold.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_above_threshold.yaml
@@ -25,15 +25,14 @@ query: |
   | summarize count_distinct_OfficeObjectId=dcount(OfficeObjectId), fileslist=make_set(OfficeObjectId) by UserId,ClientIP,bin(TimeGenerated, 15m)
   | where count_distinct_OfficeObjectId >= threshold
   | extend FileSample = iff(array_length(fileslist) == 1, tostring(fileslist[0]), strcat("SeeFilesListField","_", tostring(hash(tostring(fileslist)))))
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_above_threshold.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_above_threshold.yaml
@@ -25,11 +25,15 @@ query: |
   | summarize count_distinct_OfficeObjectId=dcount(OfficeObjectId), fileslist=make_set(OfficeObjectId) by UserId,ClientIP,bin(TimeGenerated, 15m)
   | where count_distinct_OfficeObjectId >= threshold
   | extend FileSample = iff(array_length(fileslist) == 1, tostring(fileslist[0]), strcat("SeeFilesListField","_", tostring(hash(tostring(fileslist)))))
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: UserId
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
@@ -52,5 +56,5 @@ incidentConfiguration:
     - Account
     groupByAlertDetails: []
     groupByCustomDetails: []
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_folders_above_threshold.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_folders_above_threshold.yaml
@@ -25,15 +25,14 @@ query: |
   | summarize count_distinct_SourceRelativeUrl=dcount(SourceRelativeUrl), dirlist=make_set(SourceRelativeUrl) by UserId,ClientIP,UserAgent,bin(TimeGenerated, 15m)
   | where count_distinct_SourceRelativeUrl >= threshold
   | extend DirSample = iff(array_length(dirlist) == 1, tostring(dirlist[0]), strcat("SeeDirListField","_", tostring(hash(tostring(dirlist)))))
-  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
-  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
+  | extend AccountName = tostring(split(UserId, "@")[0]), AccountUPNSuffix = tostring(split(UserId, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: Name
-      - identifier: NTDomain
-        columnName: Domain
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_folders_above_threshold.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/sharepoint_file_transfer_folders_above_threshold.yaml
@@ -25,11 +25,15 @@ query: |
   | summarize count_distinct_SourceRelativeUrl=dcount(SourceRelativeUrl), dirlist=make_set(SourceRelativeUrl) by UserId,ClientIP,UserAgent,bin(TimeGenerated, 15m)
   | where count_distinct_SourceRelativeUrl >= threshold
   | extend DirSample = iff(array_length(dirlist) == 1, tostring(dirlist[0]), strcat("SeeDirListField","_", tostring(hash(tostring(dirlist)))))
+  | extend Name = tostring(split(UserId, "@")[0]), DomainIndex = toint(indexof(UserId, '@'))
+  | extend Domain = iff(DomainIndex != -1, substring(UserId, DomainIndex + 1), UserId)
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: Name
-        columnName: UserId
+        columnName: Name
+      - identifier: NTDomain
+        columnName: Domain
   - entityType: IP
     fieldMappings:
       - identifier: Address
@@ -52,5 +56,5 @@ incidentConfiguration:
     - Account
     groupByAlertDetails: []
     groupByCustomDetails: []
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
Update mapping for 7 detections under M365 Analytic Rules

   Required items, please complete
   
   Change(s):
   - Diana and Manny updated the mapping for some detections, mainly splitting FullName into Name and NTDomain
   - A few detections had some other mappings added to them
   - We split up the work in half (8 detections each), for Manny's last detection there were no changes to be made.

   Reason for Change(s):
   - Updated mappings to have better correlations with Sentinel detections

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No