### PR TITLE
Disable GitHub Workflow Call from Azure pipeline which creates Auto Package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,4 +26,3 @@ jobs:
 - template: .azure-pipelines/playbooksValidations.yaml
 - template: .azure-pipelines/sampleDataValidator.yaml
 - template: .azure-pipelines/contentValidations.yaml
-- template: .azure-pipelines/callGithubWorkflow.yaml


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - From azurepipeline.yaml file removed callGithubWorkflow file, so that it will not run auto packaging.

   Reason for Change(s):
   - We are disabling auto packaging for now and we will be rethinking on whether to move it after merge of the pr. As when package is added and if there reviewer approves the pr but auto package added commit to the same pr then it dismisses the pr approval by saying stale review discussed. 

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - Yes
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
