### PR TITLE
AnalyticRules Entity Mapping Updates

### DIFF
--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOAgentPoolCreatedDeleted.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOAgentPoolCreatedDeleted.yaml
@@ -39,15 +39,18 @@ query: |
   | extend AgentPoolId = tostring(Data.AgentPoolId)
   | extend timekey = bin(TimeGenerated, timewindow)) on AgentPoolId, timekey
   | project-reorder TimeGenerated, ActorUPN, UserAgent, IpAddress, AuthenticationMechanism, OperationName, AgentPoolName, IsHosted, IsLegacy, Data
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOAuditStreamDisabled.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOAuditStreamDisabled.yaml
@@ -20,15 +20,18 @@ query: |
   | where OperationName =~ "AuditLog.StreamDisabledByUser"
   | extend StreamType = tostring(Data.ConsumerType)
   | project-reorder TimeGenerated, Details, ActorUPN, IpAddress, UserAgent, StreamType
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADONewExtensionAdded.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADONewExtensionAdded.yaml
@@ -22,15 +22,18 @@ query: |
   | extend PublisherName = tostring(Data.PublisherName)
   | where PublisherName !in (allowed_publishers)
   | project-reorder TimeGenerated, OperationName, ExtensionName, PublisherName, ActorUPN, IpAddress, UserAgent, ScopeDisplayName, Data
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOPATUsedWithBrowser.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOPATUsedWithBrowser.yaml
@@ -18,15 +18,17 @@ query: |
   | where AuthenticationMechanism startswith "PAT"
   // Look for useragents that include a redenring engine
   | where UserAgent has_any ("Gecko", "WebKit", "Presto", "Trident", "EdgeHTML", "Blink")
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOPipelineModifiedbyNewUser.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOPipelineModifiedbyNewUser.yaml
@@ -47,15 +47,18 @@ query: |
   | extend Alerts = iif(isnotempty(Alerts), Alerts, 0)
   // Uncomment the line below to only show results where the user as AADIdP alerts
   //| where Alerts > 0
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.3
+        columnName: IpAddress
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADORetentionReduced.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADORetentionReduced.yaml
@@ -20,15 +20,18 @@ query: |
   | where Data.SettingName in ("PurgeArtifacts", "PurgeRuns")
   | where Data.NewValue == 1 or Data.NewValue < Data.OldValue/2
   | project-reorder TimeGenerated, OperationName, ActorUPN, IpAddress, UserAgent, Data
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.2
+        columnName: IpAddress
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOSecretNotSecured.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOSecretNotSecured.yaml
@@ -25,15 +25,18 @@ query: |
   | where VariableGroupName has_any (keywords) or Data_Variables has_any (keywords)
   | where Type != "AzureKeyVault"
   | where Data_Variables !has "IsSecret"
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOVariableModifiedByNewUser.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ADOVariableModifiedByNewUser.yaml
@@ -36,15 +36,18 @@ query: |
   | where UserKey !in (historical_data)
   | project-away UserKey
   | project-reorder TimeGenerated, VariableGroupName, ActorUPN, IpAddress, UserAgent
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOAdminGroupAdditions.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOAdminGroupAdditions.yaml
@@ -28,15 +28,18 @@ query: |
   | where MonitorAllProjects == true or EntityName in (ProjectsToMonitor) or Level == 'Organization'
   | project TimeGenerated, Severity, Adder = ActorUPN, AddedIdentity, AddedIdentityId, AlertDetails, Level, EntityName, GroupName, ActorAuthType = AuthenticationMechanism,
     ActorIpAddress = IpAddress, ActorUserAgent = UserAgent, RawDetails = Details
-  | extend timestamp = TimeGenerated, AccountCustomEntity = Adder, IPCustomEntity = ActorIpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(Adder, "@")[0]), AccountUPNSuffix = tostring(split(Adder, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: ActorIpAddress
 version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOAdminGroupAdditions.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOAdminGroupAdditions.yaml
@@ -41,5 +41,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: ActorIpAddress
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricPrPolicyBypassing.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricPrPolicyBypassing.yaml
@@ -29,19 +29,22 @@ query: |
   | parse ScopeDisplayName with OrganizationName '(Organization)'
   | project TimeGenerated, ActorUPN, IpAddress, UserAgent, OrganizationName, ProjectName, RepoName = Data.RepoName, AlertDetails = Details, Branch = Data.Name,
     BypassReason = Data.BypassReason, PRLink = strcat('https://dev.azure.com/', OrganizationName, '/', ProjectName, '/_git/', Data.RepoName, '/pullrequest/', Data.PullRequestId)
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress, PullRequestLink = PRLink
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: IpAddress
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: PullRequestLink
-version: 1.0.3
+        columnName: PRLink
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricServiceConnectionAdds.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOHistoricServiceConnectionAdds.yaml
@@ -52,11 +52,14 @@ query: |
   | where CurrentCount >= HistoricCount + NewConnectionThreshold
   | project StartTime, OrganizationName, ProjectName, DefId, link, RecentDistinctServiceConnections = CurrentCount, HistoricDistinctServiceConnections = HistoricCount,
     RecentConnections = ConnectionNames, HistoricConnections = ConnectionNames1, ActorUPN
-  | extend timestamp = StartTime, AccountCustomEntity = ActorUPN
+  | extend timestamp = StartTime
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
-version: 1.0.2
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPatSessionMisuse.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPatSessionMisuse.yaml
@@ -31,15 +31,18 @@ query: |
   | where AuthenticationMechanism startswith "PAT" and (OperationName has_any (HasAnyBlocklist) or OperationName in (HasExactBlocklist))
     and ActorUPN !in (AllowlistedUpns)
   | project TimeGenerated, AuthenticationMechanism, ProjectName, ActorUPN, ActorDisplayName, IpAddress, UserAgent, OperationName, Details, Data
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.3
+        columnName: IpAddress
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPipelineCreatedDeletedOneDay.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPipelineCreatedDeletedOneDay.yaml
@@ -37,11 +37,11 @@ query: |
   | extend PipelineId = tostring(Data.PipelineId)
   | extend PipelineName = tostring(Data.PipelineName)
   // Rename some things to make the output clearer
-  | project-rename TimeDeleted = TimeGenerated, DeletingUserAgent = UserAgent, DeletingIP = IpAddress) on PipelineId, timekey
+  | project-rename TimeDeleted = TimeGenerated,DeletingUser = ActorUPN, DeletingUserAgent = UserAgent, DeletingIP = IpAddress) on PipelineId, timekey
   | project TimeCreated, TimeDeleted, PipelineName, PipelineId, CreatingUser, CreatingIP, CreatingUserAgent, DeletingUser, DeletingIP, DeletingUserAgent, ScopeDisplayName, ProjectName, Data, OperationName, OperationName1
   | extend timestamp = TimeCreated
   | extend CreatingUserAccountName = tostring(split(CreatingUser, "@")[0]), CreatingUserAccountUPNSuffix = tostring(split(CreatingUser, "@")[1])
-  | extend DeletingUserAccountName = tostring(split(ActorUPN, "@")[0]), DeletingUserAccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
+  | extend DeletingUserAccountName = tostring(split(DeletingUser, "@")[0]), DeletingUserAccountUPNSuffix = tostring(split(DeletingUser, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPipelineCreatedDeletedOneDay.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/AzDOPipelineCreatedDeletedOneDay.yaml
@@ -37,25 +37,31 @@ query: |
   | extend PipelineId = tostring(Data.PipelineId)
   | extend PipelineName = tostring(Data.PipelineName)
   // Rename some things to make the output clearer
-  | project-rename TimeDeleted = TimeGenerated, DeletingUser = ActorUPN, DeletingUserAgent = UserAgent, DeletingIP = IpAddress) on PipelineId, timekey
+  | project-rename TimeDeleted = TimeGenerated, DeletingUserAgent = UserAgent, DeletingIP = IpAddress) on PipelineId, timekey
   | project TimeCreated, TimeDeleted, PipelineName, PipelineId, CreatingUser, CreatingIP, CreatingUserAgent, DeletingUser, DeletingIP, DeletingUserAgent, ScopeDisplayName, ProjectName, Data, OperationName, OperationName1
-  | extend timestamp = TimeCreated, AccountCustomEntity = CreatingUser, IPCustomEntity = CreatingIP
+  | extend timestamp = TimeCreated
+  | extend CreatingUserAccountName = tostring(split(CreatingUser, "@")[0]), CreatingUserAccountUPNSuffix = tostring(split(CreatingUser, "@")[1])
+  | extend DeletingUserAccountName = tostring(split(ActorUPN, "@")[0]), DeletingUserAccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: CreatingUserAccountName
+      - identifier: UPNSuffix
+        columnName: CreatingUserAccountUPNSuffix
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: DeletingUser
+      - identifier: Name
+        columnName: DeletingUserAccountName
+      - identifier: UPNSuffix
+        columnName: DeletingUserAccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
+        columnName: CreatingIP
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: DeletingIP
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/ExternalUpstreamSourceAddedtoAzureDevOpsFeed.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/ExternalUpstreamSourceAddedtoAzureDevOpsFeed.yaml
@@ -36,15 +36,18 @@ query: |
   | extend SourceProtocol = tostring(UpstreamsAdded.Protocol)
   | extend SourceStatus = tostring(UpstreamsAdded.Status)
   | project-reorder TimeGenerated, OperationName, ScopeDisplayName, ProjectName, FeedName, SourceName, SourceLocation, SourceProtocol, ActorUPN, UserAgent, IpAddress
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity =  IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/NRT_ADOAuditStreamDisabled.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/NRT_ADOAuditStreamDisabled.yaml
@@ -16,15 +16,18 @@ query: |
   | where OperationName =~ "AuditLog.StreamDisabledByUser"
   | extend StreamType = tostring(Data.ConsumerType)
   | project-reorder TimeGenerated, Details, ActorUPN, IpAddress, UserAgent, StreamType
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.0
+        columnName: IpAddress
+version: 1.0.1
 kind: NRT

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/NewAgentAddedToPoolbyNewUserorofNewOS.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/NewAgentAddedToPoolbyNewUserorofNewOS.yaml
@@ -55,15 +55,18 @@ query: |
   | extend OsDescription = tostring(Data.OsDescription)
   | extend SystemDetails = Data.SystemCapabilities
   | project-reorder TimeGenerated, OperationName, ScopeDisplayName, AgentPoolName, AgentName, ActorUPN, IpAddress, UserAgent, OsDescription, SystemDetails, Data
-  | extend timestamp = TimeGenerated, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend timestamp = TimeGenerated
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.1
+        columnName: IpAddress
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/AzureDevOpsAuditing/Analytic Rules/NewPAPCAPCASaddedtoADO.yaml
+++ b/Solutions/AzureDevOpsAuditing/Analytic Rules/NewPAPCAPCASaddedtoADO.yaml
@@ -30,18 +30,24 @@ query: |
   | extend timekey = bin(TimeGenerated, 1h)) on timekey, ActorUserId
   | summarize ActionsWhenAdded = make_set(OperationName) by ActorUPN, AddingUser, TimeAdded, PermissionGrantDetails, IpAddress, UserAgent
   | extend timestamp = TimeAdded, AccountCustomEntity = ActorUPN, IPCustomEntity = IpAddress
+  | extend AccountName = tostring(split(ActorUPN, "@")[0]), AccountUPNSuffix = tostring(split(ActorUPN, "@")[1])
+  | extend AddingUserAccountName = tostring(split(AddingUser, "@")[0]), AddingUserAccountUPNSuffix = tostring(split(AddingUser, "@")[1])
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AccountCustomEntity
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AddingUser
+      - identifier: Name
+        columnName: AddingUserAccountName
+      - identifier: UPNSuffix
+        columnName: AddingUserAccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.2
+        columnName: IpAddress
+version: 1.0.3
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Primarily breaking up Account entity mappings into AccountName and 
     UPNSuffix
- Getting rid of extraneous variable names for entities columns such as IP

   Reason for Change(s):
   - Updating entity mapping for increased alert correlation

   Version Updated:
   - yes

   Testing Completed:
   - yes

   Checked that the validations are passing and have addressed any issues that are present:
   - no

