### PR TITLE
Change timerange to 1d instead of 3d

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/SigninPasswordSpray.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/SigninPasswordSpray.yaml
@@ -5,7 +5,7 @@ description: |
   IP address within a time window. If the number of accounts breaches the threshold just once, all failures from the IP address within the time range
   are bought into the result. Details on whether there were successful authentications by the IP address within the time window are also included.
   This can be an indicator that an attack was successful.
-  The default failure acccount threshold is 5, Default time window for failures is 20m and default look back window is 3 days
+  The default failure acccount threshold is 5, Default time window for failures is 20m and default look back window is 1 day
   Note: Due to the number of possible accounts involved in a password spray it is not possible to map identities to a custom entity.
   References: https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-sign-ins-error-codes.'
 severity: Medium
@@ -26,7 +26,7 @@ tactics:
 relevantTechniques:
   - T1110
 query: |
-    let timeRange = 3d;
+    let timeRange = 1d;
     let lookBack = 7d;
     let authenticationWindow = 20m;
     let authenticationThreshold = 5;
@@ -84,5 +84,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled


### PR DESCRIPTION
Using 3d causes duplicate triggers 2 days in a row for the same event, which doesn't make sense.

   Required items, please complete
   
   Change(s):
   - Change timerange to 1d instead of 3d

   Reason for Change(s):
   - Using 3d causes duplicate triggers 2 days in a row for the same event

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
