### PR TITLE
Update McAfeeEPOEvent.yaml

### DIFF
--- a/Solutions/McAfee ePolicy Orchestrator/Parsers/McAfeeEPOEvent.yaml
+++ b/Solutions/McAfee ePolicy Orchestrator/Parsers/McAfeeEPOEvent.yaml
@@ -51,6 +51,7 @@ FunctionQuery: |
     | extend DstDvcHostname = extract(@'\<TargetHostName\>(.*?)\<\/TargetHostName\>', 1, SyslogMessage)
     | extend DstUserName = extract(@'\<TargetUserName\>(.*?)\<\/TargetUserName\>', 1, SyslogMessage)
     | extend TargetProcessName = extract(@'\<TargetProcessName\>(.*?)\<\/TargetProcessName\>', 1, SyslogMessage)
+    | extend TargetHash = extract(@'\<TargetHash\>(.*?)\<\/TargetHash\>', 1, SyslogMessage)
     | extend DstFileName = extract(@'\<TargetFileName\>(.*?)\<\/TargetFileName\>', 1, SyslogMessage)
     | extend Target = extract(@'\<CustomFields target=\"(.*?)\"\>', 1, SyslogMessage)
     | extend BladeName = extract(@'\<BladeName\>(.*?)\<\/BladeName\>', 1, SyslogMessage)
@@ -155,6 +156,7 @@ FunctionQuery: |
             , DstDvcHostname
             , DstUserName
             , TargetProcessName
+            , TargetHash
             , DstFileName
             , Target
             , BladeName


### PR DESCRIPTION
   Change(s):
   - Added TargetHash column to parser results

   Reason for Change(s):
   - The parser was missing the hash (TargetHash) column from McAffee ePO Syslogs. Tested locally, worked ok.

   Version Updated:
   - Not updated

   Testing Completed:
   - Yes (worked ok)

   Checked that the validations are passing and have addressed any issues that are present: