### PR TITLE
Updated content to retire Analytic Rule

### DIFF
--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -3278,5 +3278,10 @@
     "templateName": "NewHighSeverityVulnDetectedAcrossMulitpleHosts.yaml",
     "validationFailReason": "Since the content moved to new location, created dummy file with guidence for redirecting the customers to new location"
   }
+  {
+    "id": "04384937-e927-4595-8f3c-89ff58ed231f",
+    "templateName": "ForestBlizzardCredHarvesting.yaml",
+    "validationFailReason": "Anlytic Rule is obsolete and retired"
+  }
   // Temporarily adding Solution Parsers id's for  Solution Parsers KQL Validations - End
 ]

--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -3277,7 +3277,7 @@
     "id": "84cf1d59-f620-4fee-b569-68daf7008b7b",
     "templateName": "NewHighSeverityVulnDetectedAcrossMulitpleHosts.yaml",
     "validationFailReason": "Since the content moved to new location, created dummy file with guidence for redirecting the customers to new location"
-  }
+  },
   {
     "id": "04384937-e927-4595-8f3c-89ff58ed231f",
     "templateName": "ForestBlizzardCredHarvesting.yaml",

--- a/.script/tests/detectionTemplateSchemaValidation/SkipStrcutreValidationsTemplates.json
+++ b/.script/tests/detectionTemplateSchemaValidation/SkipStrcutreValidationsTemplates.json
@@ -529,5 +529,6 @@
 	"b04f6270-115a-47f1-8e4f-0817fab31bec",
 	"df292d06-f348-41ad-b780-0abb5acfe9ab",
     "b1f6aed2-ebb9-4fe4-bd7c-6657d02a0cc8",
-    "13424be6-aed7-448b-afe5-c03d8b29b4fe"
+    "13424be6-aed7-448b-afe5-c03d8b29b4fe",
+	"04384937-e927-4595-8f3c-89ff58ed231f"
 ]

--- a/Solutions/Microsoft 365/Analytic Rules/ForestBlizzardCredHarvesting.yaml
+++ b/Solutions/Microsoft 365/Analytic Rules/ForestBlizzardCredHarvesting.yaml
@@ -1,35 +1,5 @@
 id: 04384937-e927-4595-8f3c-89ff58ed231f
 name: Possible Forest Blizzard attempted credential harvesting - Sept 2020
 description: |
-  'Surfaces potential Forest Blizzard group Office365 credential harvesting attempts within OfficeActivity Logon events.
-  References: https://www.microsoft.com/security/blog/2020/09/10/strontium-detecting-new-patters-credential-harvesting/.'
-severity: Low
-status: Available 
-requiredDataConnectors:
-  - connectorId: Office365
-    dataTypes:
-      - OfficeActivity
-queryFrequency: 7d
-queryPeriod: 14d
-triggerOperator: gt
-triggerThreshold: 0
-tactics:
-  - CredentialAccess
-relevantTechniques:
-  - T1110
-query: |
-  let IPs = dynamic (["199.249.230.","185.220.101.","23.129.64.","109.70.100.","185.220.102."]);
-  OfficeActivity
-  | where RecordType in ("AzureActiveDirectoryAccountLogon", "AzureActiveDirectoryStsLogon") 
-  | where Operation != 'UserLoggedIn'
-  | extend UserAgent = iff(parse_json(ExtendedProperties)[0].Name =~ "UserAgent", extractjson("$[0].Value", ExtendedProperties, typeof(string)),"")
-  | mv-expand parse_json(ExtendedProperties)
-  | where ExtendedProperties.Name =~ "RequestType"
-  | extend RequestType = ExtendedProperties.Value
-  | where ClientIP has_any (IPs)
-  | summarize authAttempts=dcount(TimeGenerated), firstAttempt=min(TimeGenerated), lastAttempt=max(TimeGenerated), uniqueIPs=dcount(ClientIP), uniqueAccounts=dcount(UserId), attemptedAccounts=make_set(UserId) by UserAgent
-  | where authAttempts > 2500
-  | extend timestamp = firstAttempt
-  | sort by uniqueAccounts
-version: 2.0.1
-kind: Scheduled
+  This analytic rule is retired because IoCs are outdated. It is recommended to use Microsoft Entra ID Solution's Analytic rules instead to detect credential harvesting attempts.
+version: 3.0.0


### PR DESCRIPTION
   Change(s):
   - Update Analytic rule to retire content
   - Added id to skip validations

   Reason for Change(s):
   - Obsolete rule
   - https://github.com/Azure/Azure-Sentinel/issues/8709

   Version Updated:
   - Yes
   
   Testing Completed:
   - No, since rule is retiring 

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
