### PR TITLE
FIxing Url Typo

### DIFF
--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_GuardDuty_template.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_GuardDuty_template.yaml
@@ -148,4 +148,4 @@ alertDetailsOverride:
   alertTacticsColumnName: ThreatPurpose
   alertSeverityColumnName: Severity
 kind: Scheduled
-version: 1.0.4
+version: 1.0.5


### PR DESCRIPTION
   Change(s):
   - Fixed typo on Url identifier

   Reason for Change(s):
   - To fix a typo

   Version Updated:
   - No
   
Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - No