### PR TITLE
Update Azure Firewall - Port Scan.yaml

### DIFF
--- a/Solutions/Azure Firewall/Analytic Rules/Azure Firewall - Port Scan.yaml
+++ b/Solutions/Azure Firewall/Analytic Rules/Azure Firewall - Port Scan.yaml
@@ -36,7 +36,7 @@ query: |
   | where AlertTimedCountPortsInBinTime > MinimumDifferentPortsThreshold),
   (AzureDiagnostics
   | where OperationName == "AzureFirewallApplicationRuleLog" or OperationName == "AzureFirewallNetworkRuleLog"
-  | parse msg_s with * "from " SourceIp ":" SourcePort:int " to " Fqdn ":" DestinationPort:int
+  | parse msg_s with * "from " SourceIp ":" SourcePort:int " to " Fqdn ":" DestinationPort:int *
   | where isnotempty(Fqdn) and isnotempty(SourceIp)
   | summarize AlertTimedCountPortsInBinTime = dcount(DestinationPort) by SourceIp, bin(TimeGenerated, BinTime), Fqdn
   | where AlertTimedCountPortsInBinTime > MinimumDifferentPortsThreshold)
@@ -49,5 +49,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: Fqdn
-version: 1.1.1
+version: 1.1.2
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Fixed the parse operator for the AzureDiagnostics query. 

   Reason for Change(s):
   - Since the operation is not closed with a * the parsing fails and the columns are not created.
   - When the columns aren't created, an Azure Firewall with a standard SKU using classic network rules will not detect an nmap scan.

   Version updated:
   - Yes (1.1.2)

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No, but cross-referenced Microsoft documentation to ensure that the syntax is correct and tested the query. It didn't work before but does now.

> References: 
> - https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/parseoperator