### PR TITLE
Update Create-NewSolutionAndRulesFromList.ps1

### DIFF
--- a/Tools/Sentinel-All-In-One/v2/Scripts/Create-NewSolutionAndRulesFromList.ps1
+++ b/Tools/Sentinel-All-In-One/v2/Scripts/Create-NewSolutionAndRulesFromList.ps1
@@ -172,7 +172,7 @@ foreach ($result in $results ) {
                     "type"       = "Microsoft.OperationalInsights/workspaces/providers/metadata"
                     "id"         = $null
                     "properties" = @{
-                        "contentId" = $verdict.name
+                        "contentId" = $result.properties.mainTemplate.resources[0].name
                         "parentId"  = $verdict.id
                         "kind"      = "AnalyticsRule"
                         "version"   = $templateVersion


### PR DESCRIPTION
Modified line 175 to use the correct variable for the contentId field.  This will allow both the rule templates and the content hub to show that a rule has been used.

   Required items, please complete
   
   Change(s):
   Modified line 175 to use the correct variable for the contentId field.  This will allow both the rule templates and the content hub to show that a rule has been used.

   Reason for Change(s):
   The Content Hub was not showing that rules were in fact being used leading to some confusion.

  