### PR TITLE
Added permission: none for Slash command dispatch

### DIFF
--- a/.github/workflows/slash-command-dispatch.yaml
+++ b/.github/workflows/slash-command-dispatch.yaml
@@ -43,6 +43,7 @@ jobs:
           GeneratedToken: ${{ steps.generate_token.outputs.token }}
         with:
           token: ${{ env.GeneratedToken }}
+          permission: none
           commands: |
             package
             Package


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added permission: none for slash command dispatch.

   Reason for Change(s):
   - Added permission: none for slash command dispatch.
   
   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

As we are using github apps there will be no user pat token and due to this we are using permission none so that the slash command will get triggered. 
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/307007a6-534f-49df-b1d3-fdfdcf1c1a19)
