### PR TITLE
Added missing TargetUserName and TargetDomainName

### DIFF
--- a/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
+++ b/Detections/SecurityEvent/UserAccountEnabledDisabled_10m.yaml
@@ -94,7 +94,7 @@ query: |
   | where DisableTime - EnableTime < spanoftime
   | extend TimeDelta = DisableTime - EnableTime
   | where tolong(TimeDelta) >= threshold
-  | project TimeDelta, EnableTime, EnableEventID, EnableActivity, Computer, TargetAccount, TargetSid, UserPrincipalName, 
+  | project TimeDelta, EnableTime, EnableEventID, EnableActivity, Computer, TargetAccount, TargetSid, TargetUserName, TargetDomainName, UserPrincipalName, 
   AccountUsedToEnable, SIDofAccountUsedToEnable, DisableTime, DisableEventID, DisableActivity, AccountUsedToDisable, SIDofAccountUsedToDisable, 
   EnabledBySubjectUserName, EnabledBySubjectDomainName, DisabledBySubjectUserName, DisabledBySubjectDomainName
   | extend HostName = tostring(split(Computer, ".")[0]), DomainIndex = toint(indexof(Computer, '.'))
@@ -137,7 +137,7 @@ entityMappings:
         columnName: HostName
       - identifier: NTDomain
         columnName: HostNameDomain
-version: 1.2.1
+version: 1.2.2
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
TargetUserName and TargetDomainName fields were missing as they were being used as entities, so rule was failing

   Required items, please complete
   
   Change(s):
   - Added missing TargetUserName and TargetDomainName

   Reason for Change(s):
   - Rule was failing after someone did the last update

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes