### PR TITLE
Removing custom entity mapping

### DIFF
--- a/Detections/CiscoUmbrella/CiscoUmbrellaConnectionNon-CorporatePrivateNetwork.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaConnectionNon-CorporatePrivateNetwork.yaml
@@ -22,17 +22,15 @@ query: |
   | where DvcAction =~ 'Allowed'
   | where UrlCategory has_any ('Dynamic and Residential', 'Personal VPN')
   | project TimeGenerated, SrcIpAddr, Identities
-  | extend IPCustomEntity = SrcIpAddr
-  | extend AccountCustomEntity = Identities
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: Identities
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.0
+        columnName: SrcIpAddr
+version: 1.1.1
 kind: Scheduled
 

--- a/Detections/CiscoUmbrella/CiscoUmbrellaConnectionToUnpopularWebsiteDetected.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaConnectionToUnpopularWebsiteDetected.yaml
@@ -30,15 +30,14 @@ query: |
   | where Hostname !in (top_million_list)
   | extend Message = "Connect to unpopular website (possible malicious payload delivery)"
   | project Message, SrcIpAddr, DstIpAddr,UrlOriginal, TimeGenerated
-  | extend IPCustomEntity = SrcIpAddr, UrlCustomEntity = UrlOriginal
 entityMappings:
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: UrlCustomEntity
+        columnName: UrlOriginal
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.1
+        columnName: SrcIpAddr
+version: 1.1.2
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaCryptoMinerUserAgentDetected.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaCryptoMinerUserAgentDetected.yaml
@@ -21,15 +21,14 @@ query: |
   | where HttpUserAgentOriginal contains "XMRig" or HttpUserAgentOriginal contains "ccminer"
   | extend Message = "Crypto Miner User Agent"
   | project Message, SrcIpAddr, DstIpAddr, UrlOriginal, TimeGenerated,HttpUserAgentOriginal
-  | extend IPCustomEntity = SrcIpAddr, UrlCustomEntity = UrlOriginal
 entityMappings:
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: UrlCustomEntity
+        columnName: UrlOriginal
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.1
+        columnName: SrcIpAddr
+version: 1.1.2
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaEmptyUserAgentDetected.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaEmptyUserAgentDetected.yaml
@@ -21,15 +21,14 @@ query: |
   | where HttpUserAgentOriginal == ''
   | extend Message = "Empty User Agent"
   | project Message, SrcIpAddr, DstIpAddr, UrlOriginal, TimeGenerated
-  | extend IPCustomEntity = SrcIpAddr, UrlCustomEntity = UrlOriginal
 entityMappings:
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: UrlCustomEntity
+        columnName: UrlOriginal
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.1
+        columnName: SrcIpAddr
+version: 1.1.2
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaHackToolUserAgentDetected.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaHackToolUserAgentDetected.yaml
@@ -69,15 +69,14 @@ query: |
   | where HttpUserAgentOriginal has_any (user_agents)
   | extend Message = "Hack Tool User Agent"
   | project Message, SrcIpAddr, DstIpAddr, UrlOriginal, TimeGenerated, HttpUserAgentOriginal
-  | extend IPCustomEntity = SrcIpAddr, UrlCustomEntity = UrlOriginal
 entityMappings:
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: UrlCustomEntity
+        columnName: UrlOriginal
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.1
+        columnName: SrcIpAddr
+version: 1.1.2
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaPowershellUserAgentDetected.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaPowershellUserAgentDetected.yaml
@@ -22,15 +22,14 @@ query: |
   | where HttpUserAgentOriginal contains "WindowsPowerShell"
   | extend Message = "Windows PowerShell User Agent"
   | project Message, SrcIpAddr, DstIpAddr, UrlOriginal, TimeGenerated,HttpUserAgentOriginal
-  | extend IPCustomEntity = SrcIpAddr, UrlCustomEntity = UrlOriginal
 entityMappings:
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: UrlCustomEntity
+        columnName: UrlOriginal
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.1
+        columnName: SrcIpAddr
+version: 1.1.2
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaRareUserAgentDetected.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaRareUserAgentDetected.yaml
@@ -27,15 +27,14 @@ query: |
   | where HttpUserAgentOriginal !in (user_agents_list)
   | extend Message = "Rare User Agent"
   | project Message, SrcIpAddr, DstIpAddr, UrlOriginal, TimeGenerated, HttpUserAgentOriginal
-  | extend IPCustomEntity = SrcIpAddr, UrlCustomEntity = UrlOriginal
 entityMappings:
   - entityType: URL
     fieldMappings:
       - identifier: Url
-        columnName: UrlCustomEntity
+        columnName: UrlOriginal
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.1
+        columnName: SrcIpAddr
+version: 1.1.2
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaRequestAllowedHarmfulMaliciousURICategory.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaRequestAllowedHarmfulMaliciousURICategory.yaml
@@ -39,16 +39,14 @@ query: |
         UrlCategory contains 'Lingerie/Bikini' or
         UrlCategory contains 'Weapons'
   | project TimeGenerated, SrcIpAddr, Identities
-  | extend IPCustomEntity = SrcIpAddr
-  | extend AccountCustomEntity = Identities
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: Identities
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.0
+        columnName: SrcIpAddr
+version: 1.1.1
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaRequestBlocklistedFileType.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaRequestBlocklistedFileType.yaml
@@ -24,16 +24,14 @@ query: |
   | extend Filename = extract(@'.*\/*\/(.*\.\w+)$', 1, UrlOriginal)
   | where file_ext in (file_ext_blocklist)
   | project TimeGenerated, SrcIpAddr, Identities, Filename
-  | extend IPCustomEntity = SrcIpAddr
-  | extend AccountCustomEntity = Identities
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: Identities
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.0.0
+        columnName: SrcIpAddr
+version: 1.0.1
 kind: Scheduled

--- a/Detections/CiscoUmbrella/CiscoUmbrellaURIContainsIPAddress.yaml
+++ b/Detections/CiscoUmbrella/CiscoUmbrellaURIContainsIPAddress.yaml
@@ -21,16 +21,14 @@ query: |
   | where DvcAction =~ 'Allowed'
   | where UrlOriginal matches regex @'\Ahttp:\/\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*'
   | project TimeGenerated, SrcIpAddr, Identities
-  | extend IPCustomEntity = SrcIpAddr
-  | extend AccountCustomEntity = Identities
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: AccountCustomEntity
+        columnName: Identities
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: IPCustomEntity
-version: 1.1.0
+        columnName: SrcIpAddr
+version: 1.1.1
 kind: Scheduled


### PR DESCRIPTION
  Change(s):
   - Remove Custom entity mapping

   Reason for Change(s):
   - Legacy mapping method needs to be removed

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
