### PR TITLE
Updating validation for entityMapping max from 5 to 10

### DIFF
--- a/.script/tests/detectionTemplateSchemaValidation/Models/QueryBasedTemplateInternalModel.cs
+++ b/.script/tests/detectionTemplateSchemaValidation/Models/QueryBasedTemplateInternalModel.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Sentinel.Analytics.Management.AnalyticsTemplatesServic
         public Dictionary<string, string> CustomDetails { get; set; }
 
         [JsonProperty("entityMappings", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
-        [ValidEntityMappings(entityMappingsMinLength: 1, entityMappingsMaxLength: 5, fieldMappingsMinLength: 1, fieldMappingsMaxLength: 3)]
+        [ValidEntityMappings(entityMappingsMinLength: 1, entityMappingsMaxLength: 10, fieldMappingsMinLength: 1, fieldMappingsMaxLength: 3)] // max for entityMappings is 10 - https://learn.microsoft.com/en-us/azure/sentinel/sentinel-service-limits, max for field mappings is 3, look for "three" in the docs - https://learn.microsoft.com/en-us/azure/sentinel/entities-reference
         public List<EntityMapping> EntityMappings { get; set; }
 
         [JsonProperty("alertDetailsOverride", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated entityMappingsMaxLength: 10 from 5

   Reason for Change(s):
   - 10 entity mappings is supported now, so the validation is failing when it should not - https://learn.microsoft.com/en-us/azure/sentinel/sentinel-service-limits
