### PR TITLE
Fixed wrong account parsing in AuditLog block for MultiplePasswordresetsbyUser

### DIFF
--- a/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
+++ b/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
@@ -124,7 +124,7 @@ entityMappings:
         columnName: TargetName
       - identifier: UPNSuffix
         columnName: TargetUPNSuffix
-version: 2.1.5
+version: 2.1.6
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
+++ b/Detections/MultipleDataSources/MultiplePasswordresetsbyUser.yaml
@@ -56,7 +56,7 @@ query: |
   | where EventID in ("4723","4724")
   | extend SubjectUserSid = tostring(EventData.SubjectUserSid)
   | extend TargetUserName = tostring(EventData.TargetUserName)
-  | extend Account =  strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
+  | extend Account = strcat(tostring(EventData.SubjectDomainName),"\\", tostring(EventData.SubjectUserName))
   | extend AccountType=case(Account endswith "$" or SubjectUserSid in ("S-1-5-18", "S-1-5-19", "S-1-5-20"), "Machine", isempty(SubjectUserSid), "", "User")
   | project TimeGenerated, Computer, AccountType, Account, Type, TargetUserName),
   (//Azure Active Directory Password reset events
@@ -67,10 +67,10 @@ query: |
     (
         where TargetResource.type =~ "User"
         | extend AccountType = tostring(TargetResource.type),
-                 Account = tostring(TargetResource.userPrincipalName),
-                 TargetUserName = tolower(tostring(TargetResource.displayName))
+                 Account = tostring(InitiatedBy.user.userPrincipalName),
+                 TargetUserName = tolower(tostring(TargetResource.userPrincipalName))
     )
-  | project TimeGenerated, AccountType, Account, Computer = "", Type),
+  | project TimeGenerated, AccountType, Account, TargetUserName, Computer = "", Type),
   (//OfficeActive ActiveDirectory Password reset events
   OfficeActivity
   | where OfficeWorkload == "AzureActiveDirectory"


### PR DESCRIPTION
Fixed wrong account parsing in AuditLog block

   Required items, please complete
   
   Change(s):
   - Changed Account from tostring(TargetResource.userPrincipalName) to tostring(InitiatedBy.user.userPrincipalName)
   - Changed TargetUserName from tolower(tostring(TargetResource.displayName) to tolower(tostring(TargetResource.userPrincipalName)
   - Added TargetUserName to project under the AuditLog block

   Reason for Change(s):
   - Account was wrongly parsed and TargetUserName wasn't being used on project, thus was missing.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
