### PR TITLE
Mimecast solutions 3.0.2 - Bugfix dataconnector to not set workspace default log retention to 30 days

### DIFF
--- a/Solutions/MimecastAudit/Data Connectors/azuredeploy_MimecastAudit_AzureFunctionApp.json
+++ b/Solutions/MimecastAudit/Data Connectors/azuredeploy_MimecastAudit_AzureFunctionApp.json
@@ -224,10 +224,6 @@
       "location": "[parameters('location')]",
       "type": "Microsoft.OperationalInsights/workspaces",
       "properties": {
-        "sku": {
-          "name": "pergb2018"
-        },
-        "retentionInDays": 30,
         "features": {
           "legacy": 0,
           "searchVersion": 1,

--- a/Solutions/MimecastAudit/Data/Solution_MimecastAudit.json
+++ b/Solutions/MimecastAudit/Data/Solution_MimecastAudit.json
@@ -13,7 +13,7 @@
         "Data Connectors/MimecastAudit_API_AzureFunctionApp.json"
     ],
     "BasePath": "C:\\Azure-Sentinel\\Solutions\\MimecastAudit",
-    "Version": "3.0.0",
+    "Version": "3.0.2",
     "Metadata": "SolutionMetadata.json",
     "TemplateSpec": true,
     "Is1PConnector": false

--- a/Solutions/MimecastAudit/Package/mainTemplate.json
+++ b/Solutions/MimecastAudit/Package/mainTemplate.json
@@ -41,7 +41,7 @@
     "email": "dlapi@mimecast.com",
     "_email": "[variables('email')]",
     "_solutionName": "MimecastAudit",
-    "_solutionVersion": "3.0.1",
+    "_solutionVersion": "3.0.2",
     "solutionId": "mimecastnorthamerica1584469118674.azure-sentinel-solution-mimecastaudit",
     "_solutionId": "[variables('solutionId')]",
     "analyticRuleVersion1": "1.0.0",

--- a/Solutions/MimecastAudit/ReleaseNotes.md
+++ b/Solutions/MimecastAudit/ReleaseNotes.md
@@ -1,4 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.2       | 18-01-2024                     | Bugfix **Dataconnector** do not set workspace default log retention to 30 days |
 | 3.0.1       | 05-12-2023                     | Enhanced **Dataconnector** to use existing workspace and updated checkpoint mechanism |
 | 3.0.0       | 23-08-2023                     | Initial Solution Release                    |

--- a/Solutions/MimecastSEG/Data Connectors/azuredeploy_MimecastSEG_AzureFunctionApp.json
+++ b/Solutions/MimecastSEG/Data Connectors/azuredeploy_MimecastSEG_AzureFunctionApp.json
@@ -227,7 +227,6 @@
         "sku": {
           "name": "pergb2018"
         },
-        "retentionInDays": 30,
         "features": {
           "legacy": 0,
           "searchVersion": 1,

--- a/Solutions/MimecastSEG/Data Connectors/azuredeploy_MimecastSEG_AzureFunctionApp.json
+++ b/Solutions/MimecastSEG/Data Connectors/azuredeploy_MimecastSEG_AzureFunctionApp.json
@@ -224,9 +224,6 @@
       "location": "[parameters('location')]",
       "type": "Microsoft.OperationalInsights/workspaces",
       "properties": {
-        "sku": {
-          "name": "pergb2018"
-        },
         "features": {
           "legacy": 0,
           "searchVersion": 1,

--- a/Solutions/MimecastSEG/Data/Solution_MimecastSEG.json
+++ b/Solutions/MimecastSEG/Data/Solution_MimecastSEG.json
@@ -21,7 +21,7 @@
         "Data Connectors/MimecastSEG_API_AzureFunctionApp.json"
     ],
     "BasePath": "C:\\Azure-Sentinel\\Solutions\\MimecastSEG",
-    "Version": "3.0.0",
+    "Version": "3.0.2",
     "Metadata": "SolutionMetadata.json",
     "TemplateSpec": true,
     "Is1PConnector": false

--- a/Solutions/MimecastSEG/Package/mainTemplate.json
+++ b/Solutions/MimecastSEG/Package/mainTemplate.json
@@ -41,7 +41,7 @@
     "email": "dlapi@mimecast.com",
     "_email": "[variables('email')]",
     "_solutionName": "MimecastSEG",
-    "_solutionVersion": "3.0.1",
+    "_solutionVersion": "3.0.2",
     "solutionId": "mimecastnorthamerica1584469118674.azure-sentinel-solution-mimecastseg",
     "_solutionId": "[variables('solutionId')]",
     "analyticRuleVersion1": "1.0.0",

--- a/Solutions/MimecastSEG/ReleaseNotes.md
+++ b/Solutions/MimecastSEG/ReleaseNotes.md
@@ -1,4 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.2       | 18-01-2024                     | Bugfix **Dataconnector** do not set workspace default log retention to 30 days |
 | 3.0.1       | 05-12-2023                     | Enhanced **Dataconnector** to use existing workspace and updated checkpoint mechanism |
 | 3.0.0       | 23-08-2023                     | Initial Solution Release                    |

--- a/Solutions/MimecastTIRegional/Data Connectors/azuredeploy_MimecastTIRegional_AzureFunctionApp.json
+++ b/Solutions/MimecastTIRegional/Data Connectors/azuredeploy_MimecastTIRegional_AzureFunctionApp.json
@@ -227,7 +227,6 @@
         "sku": {
           "name": "pergb2018"
         },
-        "retentionInDays": 30,
         "features": {
           "legacy": 0,
           "searchVersion": 1,

--- a/Solutions/MimecastTIRegional/Data Connectors/azuredeploy_MimecastTIRegional_AzureFunctionApp.json
+++ b/Solutions/MimecastTIRegional/Data Connectors/azuredeploy_MimecastTIRegional_AzureFunctionApp.json
@@ -224,9 +224,6 @@
       "location": "[parameters('location')]",
       "type": "Microsoft.OperationalInsights/workspaces",
       "properties": {
-        "sku": {
-          "name": "pergb2018"
-        },
         "features": {
           "legacy": 0,
           "searchVersion": 1,

--- a/Solutions/MimecastTIRegional/Data/Solution_MimecastTIRegional.json
+++ b/Solutions/MimecastTIRegional/Data/Solution_MimecastTIRegional.json
@@ -10,7 +10,7 @@
         "Data Connectors/MimecastTIRegional_API_AzureFunctionApp.json"
     ],
     "BasePath": "C:\\Azure-Sentinel\\Solutions\\MimecastTIRegional",
-    "Version": "3.0.0",
+    "Version": "3.0.2",
     "Metadata": "SolutionMetadata.json",
     "TemplateSpec": true,
     "Is1PConnector": false

--- a/Solutions/MimecastTIRegional/Package/mainTemplate.json
+++ b/Solutions/MimecastTIRegional/Package/mainTemplate.json
@@ -41,7 +41,7 @@
     "email": "dlapi@mimecast.com",
     "_email": "[variables('email')]",
     "_solutionName": "MimecastTIRegional",
-    "_solutionVersion": "3.0.1",
+    "_solutionVersion": "3.0.2",
     "solutionId": "mimecastnorthamerica1584469118674.azure-sentinel-solution-mimecasttiregional",
     "_solutionId": "[variables('solutionId')]",
     "workbookVersion1": "1.0.0",

--- a/Solutions/MimecastTIRegional/ReleaseNotes.md
+++ b/Solutions/MimecastTIRegional/ReleaseNotes.md
@@ -1,4 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.2       | 18-01-2024                     | Bugfix **Dataconnector** do not set workspace default log retention to 30 days |
 | 3.0.1       | 05-12-2023                     | Enhanced **Dataconnector** to use existing workspace and updated checkpoint mechanism |
 | 3.0.0       | 23-08-2023                     | Initial Solution Release                    |

--- a/Solutions/MimecastTTP/Data Connectors/azuredeploy_MimecastTTP_AzureFunctionApp.json
+++ b/Solutions/MimecastTTP/Data Connectors/azuredeploy_MimecastTTP_AzureFunctionApp.json
@@ -222,9 +222,6 @@
             "location": "[parameters('location')]",
             "type": "Microsoft.OperationalInsights/workspaces",
             "properties": {
-                "sku": {
-                    "name": "pergb2018"
-                },
                 "features": {
                     "legacy": 0,
                     "searchVersion": 1,

--- a/Solutions/MimecastTTP/Data Connectors/azuredeploy_MimecastTTP_AzureFunctionApp.json
+++ b/Solutions/MimecastTTP/Data Connectors/azuredeploy_MimecastTTP_AzureFunctionApp.json
@@ -225,7 +225,6 @@
                 "sku": {
                     "name": "pergb2018"
                 },
-                "retentionInDays": 30,
                 "features": {
                     "legacy": 0,
                     "searchVersion": 1,

--- a/Solutions/MimecastTTP/Data/Solution_MimecastTTP.json
+++ b/Solutions/MimecastTTP/Data/Solution_MimecastTTP.json
@@ -15,7 +15,7 @@
         "Data Connectors/MimecastTTP/MimecastTTP_API_FunctionApp.json"
     ],
     "BasePath": "C:\\Azure-Sentinel\\Solutions\\MimecastTTP",
-    "Version": "3.0.0",
+    "Version": "3.0.2",
     "Metadata": "SolutionMetadata.json",
     "TemplateSpec": true,
     "Is1PConnector": false

--- a/Solutions/MimecastTTP/Package/mainTemplate.json
+++ b/Solutions/MimecastTTP/Package/mainTemplate.json
@@ -41,7 +41,7 @@
     "email": "dlapi@mimecast.com",
     "_email": "[variables('email')]",
     "_solutionName": "MimecastTTP",
-    "_solutionVersion": "3.0.1",
+    "_solutionVersion": "3.0.2",
     "solutionId": "mimecastnorthamerica1584469118674.azure-sentinel-solution-mimecastttp",
     "_solutionId": "[variables('solutionId')]",
     "analyticRuleVersion1": "1.0.0",

--- a/Solutions/MimecastTTP/ReleaseNotes.md
+++ b/Solutions/MimecastTTP/ReleaseNotes.md
@@ -1,5 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
-| 3.0.2       | 18-1-2024                     | Bugfix **Dataconnector** do not set workspace default log retention to 30 days |
+| 3.0.2       | 18-01-2024                     | Bugfix **Dataconnector** do not set workspace default log retention to 30 days |
 | 3.0.1       | 05-12-2023                     | Enhanced **Dataconnector** to use existing workspace and updated checkpoint mechanism |
 | 3.0.0       | 23-08-2023                     | Initial Solution Release                    |

--- a/Solutions/MimecastTTP/ReleaseNotes.md
+++ b/Solutions/MimecastTTP/ReleaseNotes.md
@@ -1,4 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.2       | 18-1-2024                     | Bugfix **Dataconnector** do not set workspace default log retention to 30 days |
 | 3.0.1       | 05-12-2023                     | Enhanced **Dataconnector** to use existing workspace and updated checkpoint mechanism |
 | 3.0.0       | 23-08-2023                     | Initial Solution Release                    |


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Change Mimecast dataconnector function apps so they do not set workspace default log retention to 30 days

   Reason for Change(s):
   - Fix data retention being changed when deploying function apps - [Issue 9780](https://github.com/Azure/Azure-Sentinel/issues/9780)

   Version Updated:
   -  Yes, increment version to 3.0.2 from 3.0.0 & 3.0.1 for solution

   Testing Completed:
   - Need Help - Full solution package deployment needs to be tested
   - Tested function app ARM templates only

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below