### PR TITLE
Analytic Rule "requiredDataConnectors" property should be [] in maintemplate and handle ARM-TTK Error

### DIFF
--- a/.github/actions/entrypoint.ps1
+++ b/.github/actions/entrypoint.ps1
@@ -38,13 +38,14 @@ if ($mainTemplateChanged -eq $true)
         }
         elseif($testInfo.Name -eq 'Template Should Not Contain Blanks')
         {
-            for ($i = 0; $i -lt $testInfo.AllOutput.Count; $i++) {
-                $lineNumber = $testInfo.AllOutput[$i].Location.Line;
+            $uniqueAllOutputs = $testInfo.AllOutput | Get-Unique
+            for ($i = 0; $i -lt $uniqueAllOutputs.Count; $i++) {
+                $lineNumber = $uniqueAllOutputs[$i].Location.Line;
                 $selectedLineContent = $mainTemplateContent | Select-Object -First $lineNumber | Select-Object -Last 1;
                 if ($selectedLineContent -like '*"requiredDataConnectors"*') {
                     $hasRequiredDataConnectorsError = $true
                 } else {
-                    $filteredTestInfoAllOutput.Add($testInfo.AllOutput[$i]);
+                    $filteredTestInfoAllOutput.Add($uniqueAllOutputs[$i]);
                 }
             }
         }
@@ -62,6 +63,9 @@ if ($mainTemplateChanged -eq $true)
                     $testInfo.Summary.Fail = $testInfo.Summary.Fail - 1
                     $testInfo.Summary.Pass = $testInfo.Summary.Pass + 1
                 }
+            } elseif ($null -ne $testInfo.Summary -and $filteredTestInfoAllOutput.Count -gt 0)
+            {
+                $testInfo.AllOutput = $filteredTestInfoAllOutput
             }
 
             $filterTestResults.Add($testInfo)

--- a/.github/actions/entrypoint.ps1
+++ b/.github/actions/entrypoint.ps1
@@ -13,12 +13,6 @@ if ($mainTemplateChanged -eq $true)
     # SKIP ANY ERRORS ON contentProductId AND id 
     $filterTestResults = New-Object System.Collections.ArrayList
     $hasContentProductIdError = $false
-    $hasRequiredDataConnectorsError = $false
-
-    $mainTemplateFilePath = ($PackageFolderPath + "/mainTemplate.json").Replace("//", "/")
-    $mainTemplateContent = Get-Content "$mainTemplateFilePath"
-
-    $filteredTestInfoAllOutput = New-Object System.Collections.ArrayList
     foreach($testInfo in $MainTemplateTestResults)
     {
         if ($testInfo.Name -eq 'IDs Should Be Derived From ResourceIDs' -and $testInfo.Errors.Count -gt 0)
@@ -36,36 +30,11 @@ if ($mainTemplateChanged -eq $true)
                 }
             }
         }
-        elseif($testInfo.Name -eq 'Template Should Not Contain Blanks')
-        {
-            $uniqueAllOutputs = $testInfo.AllOutput | Get-Unique
-            for ($i = 0; $i -lt $uniqueAllOutputs.Count; $i++) {
-                $lineNumber = $uniqueAllOutputs[$i].Location.Line;
-                $selectedLineContent = $mainTemplateContent | Select-Object -First $lineNumber | Select-Object -Last 1;
-                if ($selectedLineContent -like '*"requiredDataConnectors"*') {
-                    $hasRequiredDataConnectorsError = $true
-                } else {
-                    $filteredTestInfoAllOutput.Add($uniqueAllOutputs[$i]);
-                }
-            }
-        }
         else {
             if ($null -ne $testInfo.Summary -and $hasContentProductIdError -eq $true)
             {
                 $testInfo.Summary.Fail = $testInfo.Summary.Fail - 1
                 $testInfo.Summary.Pass = $testInfo.Summary.Pass + 1
-            }
-
-            if ($null -ne $testInfo.Summary -and $hasRequiredDataConnectorsError -eq $true)
-            {
-                $testInfo.AllOutput = $filteredTestInfoAllOutput
-                if ($filteredTestInfoAllOutput.Count -eq 0) {
-                    $testInfo.Summary.Fail = $testInfo.Summary.Fail - 1
-                    $testInfo.Summary.Pass = $testInfo.Summary.Pass + 1
-                }
-            } elseif ($null -ne $testInfo.Summary -and $filteredTestInfoAllOutput.Count -gt 0)
-            {
-                $testInfo.AllOutput = $filteredTestInfoAllOutput
             }
 
             $filterTestResults.Add($testInfo)

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -2500,11 +2500,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                         }
                         else
                         {
-                            $alertRule | Add-Member -NotePropertyName requiredDataConnectors -NotePropertyValue "[variables('TemplateEmptyArray')]";
-                            if (!$global:baseMainTemplate.variables.TemplateEmptyArray) 
-                            {
-                                $global:baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyArray" -NotePropertyValue "[json('[]')]"
-                            }
+                            $alertRule | Add-Member -NotePropertyName requiredDataConnectors -NotePropertyValue @();
                         }
 
                         if (!$yaml.severity) {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - For analytic rules we are changing "requiredDataConnectors" value if [] in source then in maintemplate also it should come as [] without making use of json[].
   - Also, added skip validation for armttk in Github pipeline to skip if we get "Template should not contain blanks" error for "requiredDataConnectors" property. -- reverted code for this as pr for arm-ttk is approved and is merged so we dont need this.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

Maintemplate for Apache Log4j Vulnerability Detection solution has source file "requiredDataConnectors" value as [] which is the expected output as shown below:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/5fac7501-0e5f-4298-9f6f-67fb4d7d84a6)

