### PR TITLE
Create ActiveDirectory_Account_lockout_and_unlocks.yaml

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Initial access/ActiveDirectory_Account_lockout_and_unlocks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Initial access/ActiveDirectory_Account_lockout_and_unlocks.yaml
@@ -10,6 +10,6 @@ tactics:
 - Initial Access
 relevantTechniques: []
 query: |
-IdentityDirectoryEvents
-| where ActionType == 'Account Unlock changed'
-| extend AccountLockStatus = iif(tobool(parse_json(AdditionalFields)['TO Account Unlock']), 'Locked', 'Unlocked')
+    IdentityDirectoryEvents
+    | where ActionType == 'Account Unlock changed'
+    | extend AccountLockStatus = iif(tobool(parse_json(AdditionalFields)['TO Account Unlock']), 'Locked', 'Unlocked')

--- a/Hunting Queries/Microsoft 365 Defender/Initial access/ActiveDirectory_Account_lockout_and_unlocks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Initial access/ActiveDirectory_Account_lockout_and_unlocks.yaml
@@ -10,6 +10,6 @@ tactics:
 - Initial Access
 relevantTechniques: []
 query: |
-  IdentityDirectoryEvents
+IdentityDirectoryEvents
 | where ActionType == 'Account Unlock changed'
 | extend AccountLockStatus = iif(tobool(parse_json(AdditionalFields)['TO Account Unlock']), 'Locked', 'Unlocked')

--- a/Hunting Queries/Microsoft 365 Defender/Initial access/ActiveDirectory_Account_lockout_and_unlocks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Initial access/ActiveDirectory_Account_lockout_and_unlocks.yaml
@@ -1,0 +1,15 @@
+id: 9f384f37-ff17-446d-b49a-40c6fb98b1ba
+name: Active Directory Account lockout and unlocks
+description: |
+  This query lists Active Directory accounts lockout and unlock events
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - IdentityDirectoryEvents
+tactics:
+- Initial Access
+relevantTechniques: []
+query: |
+  IdentityDirectoryEvents
+| where ActionType == 'Account Unlock changed'
+| extend AccountLockStatus = iif(tobool(parse_json(AdditionalFields)['TO Account Unlock']), 'Locked', 'Unlocked')


### PR DESCRIPTION

   Required items, please complete
   
   Change(s):
   - added Active Directory Account lockout and unlocks AH query for MDI

   Reason for Change(s):
   - Adding an easy-to-use query to view account lockouts and unlocks in the environment


