### PR TITLE
Adding hunt queries, regsvr32, rundll32 and image based payload delivery

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-abnormal-extension.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-abnormal-extension.yaml
@@ -1,0 +1,29 @@
+id: f24f6403-cba0-4f3c-9f88-28782b9ea39a
+name: regsvr32-rundll32-image-loads-abnormal-extension
+description: |
+  This query is looking for regsvr32.exe or rundll32.exe loading DLL images with other extensions than .dll.
+  Joins the data to public network events.
+  References:
+  https://threathunt.blog/running-live-malware-for-threat-hunting-purposes/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+  - DeviceNetworkEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1218.010
+  - T1218.011
+query: |
+  DeviceImageLoadEvents 
+  | where Timestamp > ago(30d)
+  | where InitiatingProcessFileName has_any ("rundll32.exe","regsvr32.exe")
+  | where FileName !endswith ".dll"
+  | join (
+  DeviceNetworkEvents
+  | where Timestamp > ago(30d)
+  | where InitiatingProcessFileName has_any ("rundll32.exe","regsvr32.exe")
+  | where RemoteIPType == "Public"
+  ) on InitiatingProcessFileName, InitiatingProcessId, InitiatingProcessCreationTime, InitiatingProcessCommandLine
+  | project Timestamp, DeviceName, FileName, FolderPath, SHA1, InitiatingProcessFileName, InitiatingProcessCommandLine, RemoteIP, RemoteUrl, RemotePort, InitiatingProcessParentFileName

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
@@ -1,0 +1,41 @@
+id: 69eb9fb7-fe0d-4c34-8c81-3a828fc12abd
+name: regsvr32-rundll32-abnormal-image-loads
+description: |
+  The query is using the locations where malicious DLL images are often loaded from by regsvr32.dll and rundll32.exe.
+  After that the query looks for rare DLL images being loaded by SHA1 value. The data is finally joined to file creations, to look for creation of the DLL file.
+  It is quite CPU heavy though. More info of the query on my blog.
+  References:
+  https://threathunt.blog/dll-image-loads-from-suspicious-locations-by-regsvr32-exe-rundll32-exe/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceImageLoadEvents
+  - DeviceFileEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1218.010
+  - T1218.011
+query: |
+  let GenerateDLLloads = materialize (
+  DeviceImageLoadEvents
+  | where Timestamp > ago(7d)
+  | where InitiatingProcessFileName =~ "regsvr32.exe" or InitiatingProcessFileName =~ "rundll32.exe"
+  | where FolderPath startswith @"C:\users" or
+   FolderPath matches regex @".:\\ProgramData.[^\\\s]+.dll" or
+   FolderPath matches regex @".:\\Windows.[^\\\s]+.dll"
+  | extend folder = extract(@".*\\", 0, FolderPath)
+  | project LoadedDllSHA1 = SHA1, LoadedDllName = FileName, DllLoadTimestamp = Timestamp, DeviceId, DeviceName, folder, DllLoadProcessCommandLine = InitiatingProcessCommandLine, DllLoadProcessCreationTime = InitiatingProcessCreationTime, DllLoadProcessFileName = InitiatingProcessFileName, DllLoadProcessProcessId = InitiatingProcessId, DllLoadProcessSHA1 = InitiatingProcessSHA1, DllLoadProcessParentCreationTime = InitiatingProcessParentCreationTime, DllLoadProcessParentFileName = InitiatingProcessParentFileName, DllLoadProcessParentId=InitiatingProcessParentId
+  );
+  GenerateDLLloads
+  | summarize count() by LoadedDllSHA1 
+  | where count_ < 5 
+  | join kind=inner GenerateDLLloads on LoadedDllSHA1 
+  | join ( 
+  DeviceFileEvents 
+  | where Timestamp > ago(7d)
+  | where ActionType == 'FileCreated' or ActionType == 'FileRenamed'
+  | extend folder = extract(@".*\\", 0, FolderPath)
+  | project LoadedDllSHA1 = SHA1, LoadedDllName = FileName, folder, DllCreationTimestamp = Timestamp, DeviceId, DeviceName, DllCreationProcessCommandLine = InitiatingProcessCommandLine, DllCreationProcessCreationTime = InitiatingProcessCreationTime, DllCreationProcessFileName = InitiatingProcessFileName, DllCreationProcessId = InitiatingProcessId, DllCreationProcessSHA1 = InitiatingProcessSHA1, DllCreationProcessParentCreationTime = InitiatingProcessParentCreationTime, DllCreationProcessParentFileName = InitiatingProcessParentFileName, DllCreationProcessParentId = InitiatingProcessParentId
+  ) on LoadedDllName, LoadedDllSHA1, folder, DeviceName
+  | project LoadedDllSHA1, LoadedDllName, DllLoadTimestamp, DllCreationTimestamp, DllLoadProcessCommandLine, DllLoadProcessFileName, DllLoadProcessParentFileName, DllCreationProcessCommandLine, DllCreationProcessFileName, DllCreationProcessParentFileName, DeviceName, DllLoadProcessSHA1, DllCreationProcessSHA1, folder, DllLoadProcessCreationTime, DllLoadProcessProcessId, DllLoadProcessParentCreationTime, DllLoadProcessParentId, DllCreationProcessCreationTime, DllCreationProcessId, DllCreationProcessParentCreationTime, DllCreationProcessParentId, DeviceId

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
@@ -2,9 +2,7 @@ id: 69eb9fb7-fe0d-4c34-8c81-3a828fc12abd
 name: regsvr32-rundll32-abnormal-image-loads
 description: |
   This query is using the locations where malicious DLL images are often loaded from by regsvr32.dll and rundll32.exe.
-  After that the query looks for rare DLL images being loaded by SHA1 value. The data is finally joined to file creations, to look for creation of the DLL file.
-  It is quite CPU heavy. More info of the query on my blog.
-  References:
+  Blog:
   https://threathunt.blog/dll-image-loads-from-suspicious-locations-by-regsvr32-exe-rundll32-exe/
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
@@ -1,9 +1,9 @@
 id: 69eb9fb7-fe0d-4c34-8c81-3a828fc12abd
 name: regsvr32-rundll32-abnormal-image-loads
 description: |
-  The query is using the locations where malicious DLL images are often loaded from by regsvr32.dll and rundll32.exe.
+  This query is using the locations where malicious DLL images are often loaded from by regsvr32.dll and rundll32.exe.
   After that the query looks for rare DLL images being loaded by SHA1 value. The data is finally joined to file creations, to look for creation of the DLL file.
-  It is quite CPU heavy though. More info of the query on my blog.
+  It is quite CPU heavy. More info of the query on my blog.
   References:
   https://threathunt.blog/dll-image-loads-from-suspicious-locations-by-regsvr32-exe-rundll32-exe/
 requiredDataConnectors:

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-with-anomalous-parent-process.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-with-anomalous-parent-process.yaml
@@ -1,10 +1,8 @@
 id: bef2bd1b-885a-40f4-b48f-6f5564cd81f3
 name: regsvr32-rundll32-with-anomalous-parent-process
 description: |
-  This query looks for rundll32.exe or regsvr32.exe being spawned by abnormal processes: wscript.exe, powershell.exe, cmd.exe, pwsh.exe, cscript.exe. The data is joined to public network connections.
-  Can be done using only the DeviceNetworkEvents table but it will miss some of the Parent process informatiot (like cmdline).
-  In large environments, it maybe wiser to look only at the DeviceNetworkEvents, filtering to InitiatingProcessParentFileName.
-  References:
+  This query looks for rundll32.exe or regsvr32.exe being spawned by abnormal processes: wscript.exe, powershell.exe, cmd.exe, pwsh.exe, cscript.exe.
+  Blog:
   https://threathunt.blog/running-live-malware-for-threat-hunting-purposes/
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-with-anomalous-parent-process.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-with-anomalous-parent-process.yaml
@@ -1,0 +1,32 @@
+id: bef2bd1b-885a-40f4-b48f-6f5564cd81f3
+name: regsvr32-rundll32-with-anomalous-parent-process
+description: |
+  Looks for rundll32.exe or regsvr32.exe being spawned by abnormal processes: wscript.exe, powershell.exe, cmd.exe, pwsh.exe, cscript.exe. The data is joined to public network connections.
+  This can be done using only the DeviceNetworkEvents table but it will miss some of the Parent process informatiot (like cmdline). It is more efficient with using only a single table.
+  In large environments, it maybe wiser to look only at the DeviceNetworkEvents, filtering to InitiatingProcessParentFileName.
+  References:
+  https://threathunt.blog/running-live-malware-for-threat-hunting-purposes/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+  - DeviceNetworkEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1218.010
+  - T1218.011
+query: |
+  DeviceProcessEvents
+  | where Timestamp > ago(30d)
+  | where FileName has_any ("rundll32.exe","regsvr32.exe")
+  | where InitiatingProcessFileName has_any ("wscript.exe","powershell.exe","cmd.exe","pwsh.exe","cscript.exe")
+  | project Timestamp,DeviceName, InvestigatedProcessName=FileName, InvestigatedProcessCommandLine = ProcessCommandLine,InvestigatedProcessStartTime = ProcessCreationTime, InvestigatedProcessId = ProcessId, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentFileName
+  | join (
+  DeviceNetworkEvents
+  | where Timestamp > ago(30d)
+  | where InitiatingProcessFileName has_any ("rundll32.exe","regsvr32.exe")
+  | where RemoteIPType == "Public"
+  | project DeviceName, InvestigatedProcessName=InitiatingProcessFileName, InvestigatedProcessCommandLine = InitiatingProcessCommandLine,InvestigatedProcessStartTime = InitiatingProcessCreationTime, InvestigatedProcessId = InitiatingProcessId, RemoteIP, RemoteUrl
+  ) on DeviceName, InvestigatedProcessCommandLine, InvestigatedProcessId, InvestigatedProcessName, InvestigatedProcessStartTime
+  | project-away DeviceName1, InvestigatedProcessCommandLine1, InvestigatedProcessId1, InvestigatedProcessName1, InvestigatedProcessStartTime1

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-with-anomalous-parent-process.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/regsvr32-rundll32-with-anomalous-parent-process.yaml
@@ -1,8 +1,8 @@
 id: bef2bd1b-885a-40f4-b48f-6f5564cd81f3
 name: regsvr32-rundll32-with-anomalous-parent-process
 description: |
-  Looks for rundll32.exe or regsvr32.exe being spawned by abnormal processes: wscript.exe, powershell.exe, cmd.exe, pwsh.exe, cscript.exe. The data is joined to public network connections.
-  This can be done using only the DeviceNetworkEvents table but it will miss some of the Parent process informatiot (like cmdline). It is more efficient with using only a single table.
+  This query looks for rundll32.exe or regsvr32.exe being spawned by abnormal processes: wscript.exe, powershell.exe, cmd.exe, pwsh.exe, cscript.exe. The data is joined to public network connections.
+  Can be done using only the DeviceNetworkEvents table but it will miss some of the Parent process informatiot (like cmdline).
   In large environments, it maybe wiser to look only at the DeviceNetworkEvents, filtering to InitiatingProcessParentFileName.
   References:
   https://threathunt.blog/running-live-malware-for-threat-hunting-purposes/

--- a/Hunting Queries/Microsoft 365 Defender/Execution/anomalous-payload-delivered-from-iso-file.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Execution/anomalous-payload-delivered-from-iso-file.yaml
@@ -1,0 +1,35 @@
+id: 3539f855-611c-4787-b8a9-e3437f138805
+name: anomalous-payload-delivered-from-iso-file
+description: |
+  This query looks for lnk file executions from other locations than C: -drive. This can relate to ISO file being delivered to the user which then double clicks the file, which is mounted automatically.
+  Then the query joins to the DeviceProcessEvents where a process is started from the same drive a minute after the lnk file is executed.
+  Reference - https://threathunt.blog/detecting-a-payload-delivered-with-iso-files-using-mde/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+  - DeviceEvents
+tactics:
+  - Execution
+relevantTechniques:
+  -  T1204.003
+query: |
+  DeviceEvents
+  | where Timestamp > ago(30d) 
+  | where ActionType == 'BrowserLaunchedToOpenUrl' 
+  | where RemoteUrl endswith ".lnk"
+  | where RemoteUrl !startswith "C:"
+  | project LNKLaunchTimestamp = Timestamp, DeviceName, RemoteUrl
+  | parse RemoteUrl with Drive '\\' *
+  | extend Drive= tostring(Drive)
+  | where isnotempty(Drive)
+  | join (
+  DeviceProcessEvents
+  | where Timestamp > ago(30d)
+  | where FolderPath !startswith "C:"
+  | parse FolderPath with Drive '\\' *
+  | project Drive= tostring(Drive), StartedProcessTimestamp = Timestamp, StartedProcessName = FileName, StartedProcessSHA1 = SHA1, StartedProcessCommandline = ProcessCommandLine, StartedProcessPath = FolderPath, DeviceName, StartedProcessParentName = InitiatingProcessFileName, StartedProcessParentCmdline = InitiatingProcessCommandLine, StartedParentProcessFolderPath = InitiatingProcessFolderPath, StartedProcessGrandParent = InitiatingProcessParentFileName, Timestamp
+  ) on DeviceName, Drive
+  | where StartedProcessTimestamp between (LNKLaunchTimestamp ..(LNKLaunchTimestamp+1m))
+  | project-away Drive1, DeviceName1
+  | project-reorder LNKLaunchTimestamp, StartedProcessTimestamp, DeviceName, RemoteUrl, Drive, StartedProcessName, StartedProcessSHA1, StartedProcessPath,StartedProcessCommandline, StartedProcessParentName, StartedProcessParentCmdline, StartedParentProcessFolderPath, StartedProcessGrandParent, Timestamp

--- a/Hunting Queries/Microsoft 365 Defender/Execution/anomalous-payload-delivered-from-iso-file.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Execution/anomalous-payload-delivered-from-iso-file.yaml
@@ -1,8 +1,7 @@
 id: 3539f855-611c-4787-b8a9-e3437f138805
 name: anomalous-payload-delivered-from-iso-file
 description: |
-  This query looks for lnk file executions from other locations than C: -drive. This can relate to ISO file being delivered to the user which then double clicks the file, which is mounted automatically.
-  Then the query joins to the DeviceProcessEvents where a process is started from the same drive a minute after the lnk file is executed.
+  This query looks for lnk file executions from other locations than C: -drive, which can relate to mounted ISO-files.
   Reference - https://threathunt.blog/detecting-a-payload-delivered-with-iso-files-using-mde/
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection


### PR DESCRIPTION
   Required items, please complete
   
 Change(s):
   - Added anomalous-payload-delivered-from-iso-file.yaml
   - Added regsvr32-rundll32-with-anomalous-parent-process.yaml
   - Added regsvr32-rundll32-image-loads-from-abnormal-locations.yaml
   - Added regsvr32-rundll32-image-loads-abnormal-extension.yaml

   Reason for Change(s):
   - Added threat hunting queries for Defender for Endpoint.
