### PR TITLE
Fixed MITRE tactics typo

### DIFF
--- a/Solutions/Corelight/Hunting Queries/CorelightRepetitiveDnsFailures.yaml
+++ b/Solutions/Corelight/Hunting Queries/CorelightRepetitiveDnsFailures.yaml
@@ -9,7 +9,7 @@ requiredDataConnectors:
       - Corelight_v2_dns
       - corelight_dns
 tactics:
-  - CommanAndControl
+  - CommandAndControl
 relevantTechniques:
   - T1094
   - T1043


### PR DESCRIPTION
Change(s):
   - Changed MITRE tactic in /Solutions/Corelight/Hunting Queries/CorelightRepetitiveDnsFailures.yaml file from 'CommanAndControl' to 'CommandAndControl'.

Reason for Change(s):
- Fix typo
   
Version updated
- Not applicable
   
Testing Completed:
- No

Checked that the validations are passing and have addressed any issues that are present:
- No