### PR TITLE
Added validation for app insights to la in pipeline

### DIFF
--- a/.github/workflows/validateClassicAppInsights.yaml
+++ b/.github/workflows/validateClassicAppInsights.yaml
@@ -1,0 +1,51 @@
+# Identify Microsoft.Insights/components is present and using WorkspaceResourceId in PR. If type is present but WorkspaceResourceId is not used then fail the build as Classic App Insights is retiring on 24 Feb 2024.
+name: Validate Classic App Insights
+env:
+  APPINSIGHTS: "${{ vars.APPINSIGHTS }}"
+  BASE_FOLDER_PATH: "${{ vars.BASEFOLDERPATH }}"
+  BRANCH_NAME: "${{ github.event.client_payload.pull_request.head.ref || github.event.client_payload.pullRequestBranchName }}"
+  PULL_REQUEST_NUMBER: "${{ github.event.pull_request.number }}"
+  RUNID: "${{ github.run_id }}"
+  GITHUB_APPS_ID: "${{ secrets.APPLICATION_ID }}"
+  GITHUB_APPS_KEY: "${{ secrets.APPLICATION_PRIVATE_KEY }}"
+
+on:
+  pull_request: 
+    branches:
+      - master
+    paths:
+      - Solutions/**
+      - DataConnectors/**
+
+jobs:
+  validateClassicAppInsights:
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.merged && !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        with:
+          app-id: ${{ env.GITHUB_APPS_ID }}
+          private-key: ${{ env.GITHUB_APPS_KEY }}
+
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        env:
+          GeneratedToken: ${{ steps.generate_token.outputs.token }}
+        with:
+          ref: "${{ env.BRANCH_NAME }}"
+          fetch-depth: 2
+          token: ${{ env.GeneratedToken}}
+
+      - id: validateAppInsights
+        name: validateAppInsights
+        if: ${{ success() }}
+        shell: pwsh
+        run: |
+          $runId = "${{ env.RUNID }}"
+          $instrumentationKey = "${{ env.APPINSIGHTS }}"
+          $pullRequestNumber = "${{ env.PULL_REQUEST_NUMBER }}"
+          $baseFolderPath = "${{ env.BASE_FOLDER_PATH }}"
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module powershell-yaml
+          ./.script/package-automation/validateClassicAppInsights.ps1 $runId $pullRequestNumber $instrumentationKey $baseFolderPath

--- a/.script/package-automation/validateClassicAppInsights.ps1
+++ b/.script/package-automation/validateClassicAppInsights.ps1
@@ -1,0 +1,108 @@
+param($runId, $pullRequestNumber, $instrumentationKey, $baseFolderPath)
+
+Write-Host "Inside of Validate Classic App Insights!"
+
+try {
+  $baseFolderPath = $baseFolderPath + "/"
+  $baseFolderPath = $baseFolderPath.replace("//", "/")
+
+  function ReadFileContent($filePath) {
+    try {
+        if (!(Test-Path -Path "$filePath")) {
+            return $null;
+        }
+
+        $stream = New-Object System.IO.StreamReader -Arg "$filePath";
+        $content = $stream.ReadToEnd();
+        $stream.Close();
+
+        return ($null -eq $content -or $content -eq '') ? $null : $content;
+    }
+    catch {
+        Write-Host "Error occured in ReadFileContent. Error details : $_"
+        return $null;
+    }
+  }
+
+  function GetFilesWithoutWorkspaceResourceIds($filesList) {
+    $appInsightResourceWithoutWorkspaceResourceList = @()
+    foreach($file in $filesList) {
+      $filePath = $baseFolderPath + "/" + $file;
+      $filePath = $filePath.replace("//", "/")
+      Write-Host "File Path is $filePath"
+      $fileHasAppInsightsComponentType = Select-String -Path "$filePath" -Pattern '"type": "Microsoft.Insights/components"', '"type":"Microsoft.Insights/components"'
+
+      if ($null -ne $fileHasAppInsightsComponentType) {
+        $fileContent = ReadFileContent -filePath "$filePath"
+        $objFileContent = $fileContent | ConvertFrom-Json 
+        $appInsightComponentObject = $objFileContent.resources | Where-Object { $_.type -eq 'Microsoft.Insights/components'}
+
+        $hasWorkspaceResourceId = [bool]($appInsightComponentObject.PSobject.Properties.name -match "WorkspaceResourceId")
+        if (!$hasWorkspaceResourceId) {
+          # if not present then throw error by adding to list later
+          $appInsightResourceWithoutWorkspaceResourceList += $file;
+        }
+      }
+    }
+
+    return $appInsightResourceWithoutWorkspaceResourceList;
+  }
+
+  # identify if changes are in dataConnectors folder which is at root of the repo
+  $diff = git diff --diff-filter=d --name-only --first-parent HEAD^ HEAD
+  Write-Host "List of files in PR: $diff"
+  $standaloneDataConnectors = $diff | Where-Object { $_ -like 'DataConnectors/*' -and $_ -like '*azuredeploy*' }
+  $hasStandaloneDataConnectors = ($null -ne $standaloneDataConnectors -and $standaloneDataConnectors.Count -gt 0) ? $true : $false
+
+  if ($hasStandaloneDataConnectors) {
+    Write-Host "Standalone dataConnector files $standaloneDataConnectors"
+    $failedStandaloneDataConnectorsList = @()
+    # has change in standalone dataconnectors folder
+    $failedStandaloneDataConnectorsList = GetFilesWithoutWorkspaceResourceIds -filesList $standaloneDataConnectors
+
+    if ($failedStandaloneDataConnectorsList.Count -gt 0) {
+      Write-Host "::error:: Please add property 'WorkspaceResourceId' for 'Microsoft.Insights/components' type in below given file(s)!"
+      foreach ($filePath in $failedStandaloneDataConnectorsList) {
+        Write-Host "::error:: --> $filePath"
+      }
+    }
+  }
+
+  # when changes are in Solution folder
+  . $PSScriptRoot/getSolutionName.ps1 $runId $pullRequestNumber $instrumentationKey $false
+  $hasSolutionName = $solutionName -eq '' ? $false : $true
+  if ($hasSolutionName) {
+    Write-Host "SolutionName is $solutionName"
+    $solutionFolderPath = 'Solutions/' + $solutionName + "/"
+    $filesinSolutions = git ls-files | Where-Object { $_ -like "$solutionFolderPath*" }
+    Write-Host "Solution files $filesinSolutions"
+    if ($null -ne $filesinSolutions -and $filesinSolutions.Count -gt 0) {
+      $filterSolutionFiles = $filesinSolutions | Where-Object { $_ -like '*azureDeploy*' }
+
+      if ($null -ne $filterSolutionFiles -and $filterSolutionFiles.Count -gt 0) {
+        $filterSolutionFilesCount = $filterSolutionFiles.Count
+        Write-Host "Number of azuredeploy files found in Solution $filterSolutionFilesCount"
+        
+        $appInsightResourceWithoutWorkspaceResourceList = @()
+        $appInsightResourceWithoutWorkspaceResourceList = GetFilesWithoutWorkspaceResourceIds -filesList $filterSolutionFiles
+
+        if ($appInsightResourceWithoutWorkspaceResourceList.Count -gt 0) {
+          Write-Host "::error:: Please add property 'WorkspaceResourceId' for 'Microsoft.Insights/components' type in below given file(s)!"
+          foreach ($filePath in $appInsightResourceWithoutWorkspaceResourceList) {
+            Write-Host "::error:: --> $filePath"
+          }
+        }
+      }
+    }
+  }
+
+  if (($null -ne $failedStandaloneDataConnectorsList -and 
+  $failedStandaloneDataConnectorsList.Count -gt 0) -or 
+  ($null -ne $appInsightResourceWithoutWorkspaceResourceList -and $appInsightResourceWithoutWorkspaceResourceList.Count -gt 0)) {
+    exit 1
+  }
+}
+catch {
+  Write-Host "Error Occured in validateClassicAppInsights script. Error Details: $_"
+  exit 1
+}

--- a/.script/package-automation/validateClassicAppInsights.ps1
+++ b/.script/package-automation/validateClassicAppInsights.ps1
@@ -37,7 +37,7 @@ try {
         $objFileContent = $fileContent | ConvertFrom-Json 
         $appInsightComponentObject = $objFileContent.resources | Where-Object { $_.type -eq 'Microsoft.Insights/components'}
 
-        $hasWorkspaceResourceId = [bool]($appInsightComponentObject.PSobject.Properties.name -match "WorkspaceResourceId")
+        $hasWorkspaceResourceId = [bool]($appInsightComponentObject.properties.PSobject.Properties.name -match "WorkspaceResourceId")
         if (!$hasWorkspaceResourceId) {
           # if not present then throw error by adding to list later
           $appInsightResourceWithoutWorkspaceResourceList += $file;
@@ -72,7 +72,6 @@ try {
   . $PSScriptRoot/getSolutionName.ps1 $runId $pullRequestNumber $instrumentationKey $false
   $hasSolutionName = $solutionName -eq '' ? $false : $true
   if ($hasSolutionName) {
-    Write-Host "SolutionName is $solutionName"
     $solutionFolderPath = 'Solutions/' + $solutionName + "/"
     $filesinSolutions = git ls-files | Where-Object { $_ -like "$solutionFolderPath*" }
     Write-Host "Solution files $filesinSolutions"

--- a/.script/package-automation/validateClassicAppInsights.ps1
+++ b/.script/package-automation/validateClassicAppInsights.ps1
@@ -47,7 +47,7 @@ try {
 
   # identify if changes are in dataConnectors folder which is at root of the repo
   $diff = git diff --diff-filter=A --name-only --first-parent HEAD^ HEAD
-  Write-Host "List of files changes in PR for Standalone DataConnectors: $diff"
+  Write-Host "List of new files added in PR for Standalone DataConnectors: $diff"
   $standaloneDataConnectors = $diff | Where-Object { $_ -like 'DataConnectors/*' -and $_ -like '*azuredeploy*' }
   $hasStandaloneDataConnectors = ($null -ne $standaloneDataConnectors -and $standaloneDataConnectors.Count -gt 0) ? $true : $false
 
@@ -63,11 +63,13 @@ try {
         Write-Host "::error:: --> $filePath"
       }
     }
+  } else {
+    Write-Host "Skipping as there are no new azuredeploy files for validation in standalone data connectors!"
   }
 
   # when changes are in solutions folder in azuredeploy file
   $solutionFilesdiff = git diff --diff-filter=A --name-only --first-parent HEAD^ HEAD;
-  Write-Host "List of files changed in PR for Solution: $diff"
+  Write-Host "List of new files added in PR for Solution: $diff"
   $solutionsAzureDeployFilesPath = $solutionFilesdiff | Where-Object { $_ -like 'Solutions/*' -and $_ -like '*azuredeploy*' }
 
   if ($solutionsAzureDeployFilesPath.Count -gt 0) {
@@ -81,6 +83,8 @@ try {
         Write-Host "::error:: --> $filePath"
       }
     }
+  } else {
+    Write-Host "Skipping as there are no new azuredeploy files for validation in Solutions!"
   }
 
   if (($null -ne $failedStandaloneDataConnectorsList -and 


### PR DESCRIPTION
   Required items, please complete
 ### WE WILL MERGE THIS PR ONCE OTHER PRS ON APP INSIGHTS TO LA ARE MERGED

- [PR1 ](https://github.com/Azure/Azure-Sentinel/pull/9857)

- [PR2](https://github.com/Azure/Azure-Sentinel/pull/9814)

   Change(s):
   - When a PR is raised or pushed any changes in PR then it will check if there are any azuredeploy file in standalone data connectors or solutions which contains "Microsoft.Insights/components" and has WorkspaceResourceId property in it. If the specified type doesnt have this property then it will fail the pipeline build.

   Reason for Change(s):
   - Added new files for validation

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


**Testing Result:**

When there are no new files added for azuredeploy file then it will pass like below:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/574024e8-05e0-47de-84cb-fcc6487f8a83)


When new file is added but it doesnt have WorkspaceResourceId property then it will fail like below:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/59253915-be11-4979-95aa-7afdd6b49f54)
