### PR TITLE
Adding a query looking for rare processes as a service

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Persistence/Rare-process-as-a-service.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Persistence/Rare-process-as-a-service.yaml
@@ -1,0 +1,60 @@
+id: a60ac80f-dce6-43ec-b102-9ae8c094d5dc
+name: Rare-process-as-a-service
+description: |
+  This query is looking for rarely seen processes which are launched as a service. 
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/rare-process-launch-as-a-service/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+  - DeviceNetworkEvents
+  - DeviceFileEvents
+  - DeviceImageLoadEvents
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1543
+  - T1543.003
+query: |
+  let LookupTime = 30d;
+  let WhiteList = pack_array(
+  "svchost.exe",
+  "mssense.exe",
+  "msmpeng.exe",
+  "searchindexer.exe",
+  "microsoftedgeupdate.exe"
+  );
+  let GetServices = materialize (
+  DeviceProcessEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessParentFileName contains "services.exe"
+  | where InitiatingProcessFileName !in~(WhiteList)
+  | project Timestamp, DeviceName, StartedChildProcess = FileName, StartedChildProcessSHA1 = SHA1, StartedChildProcessCmdline = ProcessCommandLine, ServiceProcessSHA1 = InitiatingProcessSHA1, ServiceProcess = InitiatingProcessFileName, ServiceProcessCmdline = InitiatingProcessCommandLine, ServiceProcessID = InitiatingProcessId, ServiceProcessCreationTime = InitiatingProcessCreationTime, ServiceProcessUser = InitiatingProcessAccountName
+  );
+  GetServices
+  | summarize count() by ServiceProcess, DeviceName
+  | where count_ < 6 
+  | join kind = inner GetServices on ServiceProcess, DeviceName 
+  | join kind = leftouter ( 
+  DeviceNetworkEvents 
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessParentFileName contains "services.exe"
+  | where InitiatingProcessFileName !in~(WhiteList)
+  | project Timestamp, DeviceName, ServiceProcessSHA1 = InitiatingProcessSHA1, ServiceProcess = InitiatingProcessFileName, ServiceProcessCmdline = InitiatingProcessCommandLine, ServiceProcessID = InitiatingProcessId, ServiceProcessCreationTime = InitiatingProcessCreationTime, ServiceProcessUser = InitiatingProcessAccountName, NetworkAction = ActionType, RemoteIP, RemoteUrl
+  ) on DeviceName, ServiceProcess, ServiceProcessCmdline, ServiceProcessCreationTime, ServiceProcessID, ServiceProcessUser, ServiceProcessSHA1
+  | join kind = leftouter (
+  DeviceFileEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessParentFileName contains "services.exe"
+  | where InitiatingProcessFileName !in~(WhiteList)
+  | project Timestamp, DeviceName, ServiceProcessSHA1 = InitiatingProcessSHA1, ServiceProcess = InitiatingProcessFileName, ServiceProcessCmdline = InitiatingProcessCommandLine, ServiceProcessID = InitiatingProcessId, ServiceProcessCreationTime = InitiatingProcessCreationTime, ServiceProcessUser = InitiatingProcessAccountName, FileAction = ActionType, ModifiedFile = FileName, ModifiedFileSHA1 = SHA1, ModifiedFilePath = FolderPath
+  ) on DeviceName, ServiceProcess, ServiceProcessCmdline, ServiceProcessCreationTime, ServiceProcessID, ServiceProcessUser, ServiceProcessSHA1
+  | join kind = leftouter (
+  DeviceImageLoadEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessParentFileName contains "services.exe"
+  | where InitiatingProcessFileName !in~(WhiteList)
+  | project Timestamp, DeviceName, ServiceProcessSHA1 = InitiatingProcessSHA1, ServiceProcess = InitiatingProcessFileName, ServiceProcessCmdline = InitiatingProcessCommandLine, ServiceProcessID = InitiatingProcessId, ServiceProcessCreationTime = InitiatingProcessCreationTime, ServiceProcessUser = InitiatingProcessAccountName, LoadedDLL = FileName, LoadedDLLSHA1 = SHA1, LoadedDLLPath = FolderPath
+  ) on DeviceName, ServiceProcess, ServiceProcessCmdline, ServiceProcessCreationTime, ServiceProcessID, ServiceProcessUser, ServiceProcessSHA1
+  | summarize ConnectedAddresses = make_set(RemoteIP), ConnectedUrls = make_set(RemoteUrl), FilesModified = make_set(ModifiedFile),FileModFolderPath = make_set(ModifiedFilePath),FileModHA1s = make_set(ModifiedFileSHA1), ChildProcesses = make_set(StartedChildProcess), ChildCommandlines = make_set(StartedChildProcessCmdline), DLLsLoaded = make_set(LoadedDLL), DLLSHA1 = make_set(LoadedDLLSHA1) by DeviceName, ServiceProcess, ServiceProcessCmdline, ServiceProcessCreationTime, ServiceProcessID, ServiceProcessUser, ServiceProcessSHA1


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added Hunting Queries/Microsoft 365 Defender/Persistence/Rare-process-as-a-service.yaml

   Reason for Change(s):
   - Added a Defender for Endpoint threat hunting query to look for rare processes launched as windows service.

  
