### PR TITLE
Fix for analytic pipeline comment

### DIFF
--- a/.github/workflows/addCommentToRemindUpdatingTemplateVersion.yml
+++ b/.github/workflows/addCommentToRemindUpdatingTemplateVersion.yml
@@ -17,3 +17,4 @@ jobs:
         I see that you changed templates under the detections/analytic rules folder. Did you remember to update the version of the templates you changed?
         If not, and if you want customers to be aware that a new version of this template is available, please update the ``version`` property of the template you changed.
       prNumber: "${{ github.event.pull_request.number }}"
+    secrets: inherit

--- a/.github/workflows/checkPRContentChange.yaml
+++ b/.github/workflows/checkPRContentChange.yaml
@@ -48,3 +48,4 @@ jobs:
     uses: ./.github/workflows/addLabelOnPr.yaml
     with:
       labelName: "Content-Package"
+    secrets: inherit


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - For analytic rule comment is not adding because worflow secrets should be inherited. secrets inherit allows inner workflows to use those values.

   Reason for Change(s):
   - There are minor change

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

**Testing:**
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/f718b77b-569a-4545-ab0a-cbc661fdcb96)
