### PR TITLE
Update NRT_NewAppOrServicePrincipalCredential.yaml

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
@@ -14,7 +14,7 @@ requiredDataConnectors:
 tactics:
   - DefenseEvasion
 relevantTechniques:
-  - T1550.001
+  - T1550
 tags:
   - Solorigate
   - NOBELIUM
@@ -63,9 +63,7 @@ entityMappings:
       - identifier: FullName
         columnName: InitiatingUserPrincipalName
       - identifier: Name
-        columnName: InitiatedByName
-      - identifier: UPNSuffix
-        columnName: InitiatedByUPNSuffix
+        columnName: InitiatingAppName
   - entityType: Account
     fieldMappings:
       - identifier: AadUserId
@@ -78,5 +76,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.3
+version: 1.0.4
 kind: NRT


### PR DESCRIPTION
There are no columns InitiatedByName + InitiatedByUPNSuffix

   Required items, please complete
   
   Change(s):
   - Fixed entity mapping (columns were not existant) and Technique (sub-techniques are not allowed)

   Reason for Change(s):
   - Rule is not deployable since last changes

   Version Updated:
   - 1.0.3
  
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
