### PR TITLE
Remove space in kind parameter in deploy json file

### DIFF
--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/azuredeploy_FortinetFortiNdrCloud_API_FunctionApp.json
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/azuredeploy_FortinetFortiNdrCloud_API_FunctionApp.json
@@ -164,7 +164,7 @@
                   "[resourceId('Microsoft.Web/serverfarms', variables('FunctionName'))]",
                   "[resourceId('Microsoft.Insights/components', variables('FunctionName'))]"
               ],
-              "kind": "functionapp, linux",
+              "kind": "functionapp,linux",
               "identity": {
                   "type": "SystemAssigned"
               },


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Remove space for `kind` parameter in auzredeploy file

   Reason for Change(s):
   - "The provided resource kind 'functionapp, linux' has these invalid characters: ' '. The kind can only be a letter, digit, '-', '.' or '_'."

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


