### PR TITLE
Ccp version change, auto release notes and update condition

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -1861,7 +1861,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                             {
                                                 foreach ($desc in $instructionItem.parameters.instructionSteps)
                                                 {
-                                                    if ($desc.description && $desc.description.IndexOf('Deploy To Azure') -gt 0)
+                                                    if ($desc.description -and $desc.description.IndexOf('Deploy To Azure') -gt 0)
                                                     {
                                                         $existingFunctionApp = $true
                                                         break

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -2976,6 +2976,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
     {
         if ($contentToImport.Description) {
             $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionDescription}}", $contentToImport.Description
+
+            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionName}}", $solutionName
         }
         else {
             $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionDescription}}", ""

--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -205,7 +205,7 @@ function Get-ContentTemplateResource($contentResourceDetails, $TemplateCounter, 
             contentProductId = "[concat(take(variables('_solutionId'), 50),'-','$resoureKindTag','-', uniqueString(concat(variables('_solutionId'),'-','$resoureKind','-',$contentId,'-', $contentVersion)))]";
             packageId = "[variables('_solutionId')]";
             contentSchemaVersion = $contentResourceDetails.contentSchemaVersion;
-            version = "[variables('_solutionVersion')]";
+            version = "[variables('dataConnectorCCPVersion')]";
         }
     }
 }

--- a/Tools/Create-Azure-Sentinel-Solution/common/templating/baseCreateUiDefinition.json
+++ b/Tools/Create-Azure-Sentinel-Solution/common/templating/baseCreateUiDefinition.json
@@ -6,7 +6,7 @@
     "config": {
       "isWizard": false,
       "basics": {
-        "description": "{{Logo}}\n\n**Note:** _There may be [known issues](https://aka.ms/sentinelsolutionsknownissues) pertaining to this Solution, please refer to them before installing._\n\n{{SolutionDescription}}\n\n{{DataConnectorCount}}{{ParserCount}}{{WorkbookCount}}{{AnalyticRuleCount}}{{HuntingQueryCount}}{{WatchlistCount}}{{LogicAppCustomConnectorCount}}{{FunctionAppsCount}}{{PlaybookCount}}\n\n[Learn more about Microsoft Sentinel](https://aka.ms/azuresentinel) | [Learn more about Solutions](https://aka.ms/azuresentinelsolutionsdoc)",
+        "description": "{{Logo}}\n\n**Note:** Please refer to the following before installing the solution: \n\n• Review the solution [Release Notes](https://github.com/Azure/Azure-Sentinel/tree/master/Solutions/{{SolutionName}}/ReleaseNotes.md)\n\n • There may be [known issues](https://aka.ms/sentinelsolutionsknownissues) pertaining to this Solution, please refer to them before installing.\n\n{{SolutionDescription}}\n\n{{DataConnectorCount}}{{ParserCount}}{{WorkbookCount}}{{AnalyticRuleCount}}{{HuntingQueryCount}}{{WatchlistCount}}{{LogicAppCustomConnectorCount}}{{FunctionAppsCount}}{{PlaybookCount}}\n\n[Learn more about Microsoft Sentinel](https://aka.ms/azuresentinel) | [Learn more about Solutions](https://aka.ms/azuresentinelsolutionsdoc)",
         "subscription": {
           "resourceProviders": [
             "Microsoft.OperationsManagement/solutions",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated CCP data connector version instead of solutionversion.
   - Added automatic release notes on package creation
   - updated condition && with -and as the it is not valid condition in powershell. This change is for cef based where it is coming as using azure function in display name.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


After package for CEF based connector it will shown like below:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/b50811d9-8dd8-42f6-b9ad-77c2147d94be)

Release notes are added like below automatically:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/097e0bbf-fb6d-4bd0-ba2b-48c6b60d964d)
