### PR TITLE
Changed AAD to Entra ID where it was missing for consistency

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/SuspiciousAADJoinedDeviceUpdate.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/SuspiciousAADJoinedDeviceUpdate.yaml
@@ -92,11 +92,11 @@ entityMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
 alertDetailsOverride:
-  alertDisplayNameFormat: Suspicious AAD Joined Device Update {{OldDeviceName}} renamed to {{NewDeviceName}} and {{UpdatedPropertiesCount}} properties changed
+  alertDisplayNameFormat: Suspicious Entra ID Joined Device Update {{OldDeviceName}} renamed to {{NewDeviceName}} and {{UpdatedPropertiesCount}} properties changed
   alertDescriptionFormat: |
     This query looks for suspicious updates to an Microsoft Entra ID joined device where the device name is changed and the device falls out of compliance.
     In this case {{OldDeviceName}} was renamed to {{NewDeviceName}} and {{UpdatedPropertiesCount}} properties were changed.
-    This could occur when a threat actor steals a Device ticket from an Autopilot provisioned device and uses it to AAD Join a new  device.
+    This could occur when a threat actor updates the details of an Autopilot provisioned device using a stolen device ticket, in order to access certificates and keys.
     Ref: https://dirkjanm.io/assets/raw/Insomnihack%20Breaking%20and%20fixing%20Azure%20AD%20device%20identity%20security.pdf
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
Changed AAD to Entra ID where it was missing for consistency. After someone changed to Entra ID, they did not change in all places, so fixed it. There is no change to the code.

   Required items, please complete
   
   Change(s):
   - Changed AAD to Entra ID where it was missing for consistency

   Reason for Change(s):
   - After someone changed to Entra ID, they did not change in all places, so it was inconsistent.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes