### PR TITLE
Reverts PR 9947

### DIFF
--- a/Solutions/Recorded Future/Playbooks/IndicatorImport/RecordedFuture-ThreatIntelligenceImport/azuredeploy.json
+++ b/Solutions/Recorded Future/Playbooks/IndicatorImport/RecordedFuture-ThreatIntelligenceImport/azuredeploy.json
@@ -100,7 +100,7 @@
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": {
-                                    "value": "@body('Select')",
+                                    "indicators": "@body('Select')",
                                     "sourcesystem": "Recorded Future"
                                 },
                                 "host": {


### PR DESCRIPTION
See comments in PR 9947 for context - #9947 

   Required items, please complete
   
   Change(s):
Revert changes in PR 9947 - see comments in PR for context, there was an error with Microsoft regional deployments causing this issue in Australia regions. TL;DR

   Reason for Change(s):
Revert changes in PR 9947 - see comments in PR for context, there was an error with Microsoft regional deployments causing this issue in Australia regions. TL;DR

   Version Updated:

   Testing Completed:
Revert changes in PR 9947 - see comments in PR for context, there was an error with Microsoft regional deployments causing this issue in Australia regions. TL;DR

   Checked that the validations are passing and have addressed any issues that are present:
  Revert changes in PR 9947 - see comments in PR for context, there was an error with Microsoft regional deployments causing this issue in Australia regions. TL;DR
