### PR TITLE
Moving Orphan Hunting query to Solution Endpoint Threat Protection Essentials

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomFunctions/_ASim_ProcessEvent_Create.json
+++ b/.script/tests/KqlvalidationsTests/CustomFunctions/_ASim_ProcessEvent_Create.json
@@ -1,0 +1,440 @@
+{
+    "FunctionName": "_ASim_ProcessEvent_Create",
+    "FunctionParameters": [
+      {
+        "Name": "starttime",
+        "Type": "datetime",
+        "IsRequired": false
+      },
+      {
+        "Name": "endtime",
+        "Type": "datetime",
+        "IsRequired": false
+      },
+      {
+        "Name": "commandline_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "commandline_has_all",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "commandline_has_any_ip_prefix",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "actingprocess_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "targetprocess_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "parentprocess_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "targetusername",
+        "Type": "string",
+        "IsRequired": false
+      },
+      {
+        "Name": "dvcipaddr_has_any_prefix",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "dvcname_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "eventtype",
+        "Type": "string",
+        "IsRequired": false
+      },
+      {
+        "Name": "disabled",
+        "Type": "bool",
+        "IsRequired": false
+      }
+    ],
+    "FunctionResultColumns": [
+      {
+        "Name": "TimeGenerated",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "_ResourceId",
+        "Type": "String"
+      },
+      {
+        "Name": "Type",
+        "Type": "String"
+      },
+      {
+        "Name": "EventType",
+        "Type": "String"
+      },
+      {
+        "Name": "EventProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "EventProductVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "EventCount",
+        "Type": "Int32"
+      },
+      {
+        "Name": "EventMessage",
+        "Type": "String"
+      },
+      {
+        "Name": "EventVendor",
+        "Type": "String"
+      },
+      {
+        "Name": "EventSchemaVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "EventOriginalUid",
+        "Type": "String"
+      },
+      {
+        "Name": "EventOriginalType",
+        "Type": "String"
+      },
+      {
+        "Name": "EventStartTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "EventEndTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "EventReportUrl",
+        "Type": "String"
+      },
+      {
+        "Name": "EventResult",
+        "Type": "String"
+      },
+      {
+        "Name": "EventResultDetails",
+        "Type": "String"
+      },
+      {
+        "Name": "AdditionalFields",
+        "Type": "Object"
+      },
+      {
+        "Name": "DvcId",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcHostname",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcDomain",
+        "Type": "string"
+      },
+      {
+        "Name": "DvcIpAddr",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcOs",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcOsVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcMacAddr",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUsername",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUsernameType",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUserId",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUserIdType",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUserSessionId",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessName",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessCompany",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFileDescription",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFilename",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFileProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFileVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessIsHidden",
+        "Type": "SByte"
+      },
+      {
+        "Name": "TargetProcessInjectedAddress",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessMD5",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessSHA1",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessSHA256",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessSHA512",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessIMPHASH",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessCommandLine",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessCreationTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "TargetProcessId",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessGuid",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessIntegrityLevel",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessTokenElevation",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUsername",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUsernameType",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUserId",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUserIdType",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorSessionId",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessCommandLine",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessName",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessCompany",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessFileDescription",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessFileProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessFileVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessIsHidden",
+        "Type": "SByte"
+      },
+      {
+        "Name": "ActingProcessInjectedAddress",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessId",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessGuid",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessIntegrityLevel",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessMD5",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessSHA1",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessSHA256",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessSHA512",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessIMPHASH",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessCreationTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "ParentProcessName",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessCompany",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessFileDescription",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessFileProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessFileVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessIsHidden",
+        "Type": "SByte"
+      },
+      {
+        "Name": "ParentProcessInjectedAddress",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessId",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessGuid",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessIntegrityLevel",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessMD5",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessSHA1",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessSHA256",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessSHA512",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessIMPHASH",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessCreationTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "Dvc",
+        "Type": "String"
+      },
+      {
+        "Name": "User",
+        "Type": "String"
+      },
+      {
+        "Name": "Process",
+        "Type": "String"
+      },
+      {
+        "Name": "CommandLine",
+        "Type": "String"
+      },
+      {
+        "Name": "Hash",
+        "Type": "String"
+      }
+    ]
+  }

--- a/.script/tests/KqlvalidationsTests/CustomFunctions/_ASim_ProcessEvent_Terminate.json
+++ b/.script/tests/KqlvalidationsTests/CustomFunctions/_ASim_ProcessEvent_Terminate.json
@@ -1,0 +1,440 @@
+{
+    "FunctionName": "_ASim_ProcessEvent_Terminate",
+    "FunctionParameters": [
+      {
+        "Name": "starttime",
+        "Type": "datetime",
+        "IsRequired": false
+      },
+      {
+        "Name": "endtime",
+        "Type": "datetime",
+        "IsRequired": false
+      },
+      {
+        "Name": "commandline_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "commandline_has_all",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "commandline_has_any_ip_prefix",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "actingprocess_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "targetprocess_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "parentprocess_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "targetusername",
+        "Type": "string",
+        "IsRequired": false
+      },
+      {
+        "Name": "dvcipaddr_has_any_prefix",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "dvcname_has_any",
+        "Type": "dynamic",
+        "IsRequired": false
+      },
+      {
+        "Name": "eventtype",
+        "Type": "string",
+        "IsRequired": false
+      },
+      {
+        "Name": "disabled",
+        "Type": "bool",
+        "IsRequired": false
+      }
+    ],
+    "FunctionResultColumns": [
+      {
+        "Name": "TimeGenerated",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "_ResourceId",
+        "Type": "String"
+      },
+      {
+        "Name": "Type",
+        "Type": "String"
+      },
+      {
+        "Name": "EventType",
+        "Type": "String"
+      },
+      {
+        "Name": "EventProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "EventProductVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "EventCount",
+        "Type": "Int32"
+      },
+      {
+        "Name": "EventMessage",
+        "Type": "String"
+      },
+      {
+        "Name": "EventVendor",
+        "Type": "String"
+      },
+      {
+        "Name": "EventSchemaVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "EventOriginalUid",
+        "Type": "String"
+      },
+      {
+        "Name": "EventOriginalType",
+        "Type": "String"
+      },
+      {
+        "Name": "EventStartTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "EventEndTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "EventReportUrl",
+        "Type": "String"
+      },
+      {
+        "Name": "EventResult",
+        "Type": "String"
+      },
+      {
+        "Name": "EventResultDetails",
+        "Type": "String"
+      },
+      {
+        "Name": "AdditionalFields",
+        "Type": "Object"
+      },
+      {
+        "Name": "DvcId",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcHostname",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcDomain",
+        "Type": "string"
+      },
+      {
+        "Name": "DvcIpAddr",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcOs",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcOsVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "DvcMacAddr",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUsername",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUsernameType",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUserId",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUserIdType",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetUserSessionId",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessName",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessCompany",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFileDescription",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFilename",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFileProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessFileVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessIsHidden",
+        "Type": "SByte"
+      },
+      {
+        "Name": "TargetProcessInjectedAddress",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessMD5",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessSHA1",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessSHA256",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessSHA512",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessIMPHASH",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessCommandLine",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessCreationTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "TargetProcessId",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessGuid",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessIntegrityLevel",
+        "Type": "String"
+      },
+      {
+        "Name": "TargetProcessTokenElevation",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUsername",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUsernameType",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUserId",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorUserIdType",
+        "Type": "String"
+      },
+      {
+        "Name": "ActorSessionId",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessCommandLine",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessName",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessCompany",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessFileDescription",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessFileProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessFileVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessIsHidden",
+        "Type": "SByte"
+      },
+      {
+        "Name": "ActingProcessInjectedAddress",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessId",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessGuid",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessIntegrityLevel",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessMD5",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessSHA1",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessSHA256",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessSHA512",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessIMPHASH",
+        "Type": "String"
+      },
+      {
+        "Name": "ActingProcessCreationTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "ParentProcessName",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessCompany",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessFileDescription",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessFileProduct",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessFileVersion",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessIsHidden",
+        "Type": "SByte"
+      },
+      {
+        "Name": "ParentProcessInjectedAddress",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessId",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessGuid",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessIntegrityLevel",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessMD5",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessSHA1",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessSHA256",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessSHA512",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessIMPHASH",
+        "Type": "String"
+      },
+      {
+        "Name": "ParentProcessCreationTime",
+        "Type": "DateTime"
+      },
+      {
+        "Name": "Dvc",
+        "Type": "String"
+      },
+      {
+        "Name": "User",
+        "Type": "String"
+      },
+      {
+        "Name": "Process",
+        "Type": "String"
+      },
+      {
+        "Name": "CommandLine",
+        "Type": "String"
+      },
+      {
+        "Name": "Hash",
+        "Type": "String"
+      }
+    ]
+  }

--- a/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/ASimProcess_CertutilLoLBins.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/ASimProcess_CertutilLoLBins.yaml
@@ -1,0 +1,27 @@
+id: eb022863-9ae2-41d4-b633-29e4d024b76f
+name: Certutil (LOLBins and LOLScripts, Normalized Process Events)
+description: |
+  This detection uses Normalized Process Events to hunt Certutil activities.
+description-detailed: |
+  This detection uses Normalized Process Events to hunt Certutil activities.
+requiredDataConnectors: []
+tactics:
+  - CommandAndControl
+relevantTechniques:
+  - T1105
+query: |
+  _ASim_ProcessEvent_Create
+  | where Process has "certutil.exe"
+  // Uncomment the next line and add your commandLine Whitelisted/ignore terms. For example "urlcache"
+  // | where CommandLine !contains ("urlcache") 
+
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: User
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Dvc
+version: 1.0.0

--- a/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/ASimProcess_WindowsSystemShutdownReboot.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/ASimProcess_WindowsSystemShutdownReboot.yaml
@@ -1,0 +1,24 @@
+id: 5db1f6f9-9de9-43a9-b7cc-357486b42fc6
+name: Windows System Shutdown/Reboot (Normalized Process Events)
+description: |
+  This detection uses Normalized Process Events to detect System Shutdown/Reboot (MITRE Technique: T1529).
+description-detailed: |
+  This detection uses Normalized Process Events to detect System Shutdown/Reboot (MITRE Technique: T1529). 
+requiredDataConnectors: []
+tactics:
+  - Impact
+relevantTechniques:
+  - T1529
+query: |
+  _ASim_ProcessEvent_Create
+  | where Process has "shutdown.exe" 
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: User
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Dvc
+version: 1.0.0

--- a/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/DownloadOfNewFileUsingCurl.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/DownloadOfNewFileUsingCurl.yaml
@@ -1,0 +1,60 @@
+id: 7108c86b-a3ef-42d0-b50b-3e251fb1f84c
+name: Download of New File Using Curl
+description: |
+  Threat actors may use tools such as Curl to download additional files, communicate with C2 infrastructure, or exfiltrate data. This query looks for new files being downloaded using Curl.
+description-detailed: |
+  Threat actors may use tools such as Curl to download additional files, communicate with C2 infrastructure, or exfiltrate data. This query looks for new files being downloaded using Curl. Curl also has legitimate uses files and hosts should be reviewed to identify potentially malicious activity.
+  Ref: https://www.microsoft.com/security/blog/2022/07/27/untangling-knotweed-european-private-sector-offensive-actor-using-0-day-exploits/
+requiredDataConnectors:
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceNetworkEvents
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvents
+tactics:
+  - CommandAndControl
+relevantTechniques:
+  - T1071
+query: |
+  let known_files = DeviceNetworkEvents
+    | where TimeGenerated between (ago(7d)..ago(1d))
+    | where InitiatingProcessFileName has "curl"
+    | extend url = extract("http[s]?:\\/\\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", 0,InitiatingProcessCommandLine)
+    | extend ip = extract("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}[^ ]*", 0, InitiatingProcessCommandLine)
+    | extend remote_file = iif(isnotempty(url), url, ip)
+    | union (SecurityEvent
+    | where TimeGenerated between (ago(7d)..ago(1d))
+    | where EventID == 4688
+    | where CommandLine has "curl"
+    | extend url = extract("http[s]?:\\/\\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", 0,CommandLine)
+    | extend ip = extract("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}[^ ]*", 0, CommandLine)
+    | extend remote_file = iif(isnotempty(url), url, ip))
+    | summarize by remote_file;
+    DeviceNetworkEvents
+    | where TimeGenerated > ago(1d)
+    | where InitiatingProcessFileName has "curl"
+    | extend url = extract("http[s]?:\\/\\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", 0,InitiatingProcessCommandLine)
+    | extend ip = extract("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}[^ ]*", 0, InitiatingProcessCommandLine)
+    | extend remote_file = iif(isnotempty(url), url, ip)
+    | union (SecurityEvent
+    | where EventID == 4688
+    | where CommandLine has "curl"
+    | extend url = extract("http[s]?:\\/\\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", 0,CommandLine)
+    | extend ip = extract("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}[^ ]*", 0, CommandLine)
+    | extend remote_file = iif(isnotempty(url), url, ip))
+    | where remote_file !in (known_files)
+entityMappings:
+  - entityType: URL
+    fieldMappings:
+      - identifier: Url
+        columnName: url
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ip
+  - entityType: File
+    fieldMappings:
+      - identifier: Name
+        columnName: remote_file
+version: 1.0.0

--- a/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/WindowsFirewallUpdateUsingNetsh.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/WindowsFirewallUpdateUsingNetsh.yaml
@@ -1,4 +1,4 @@
-id: 3dc5dc8b-160b-407e-9925-24a91e3599df
+id: e3e8c913-e5e9-4517-b4f7-dd1ec071888f
 name: Rare Windows Firewall Rule updates using Netsh
 description: |
   This query searches for rare firewall rule changes using netsh utility by comparing rule names and program names from the previous day.

--- a/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/WindowsFirewallUpdateUsingNetsh.yaml
+++ b/Solutions/Endpoint Threat Protection Essentials/Hunting Queries/WindowsFirewallUpdateUsingNetsh.yaml
@@ -1,0 +1,147 @@
+id: 3dc5dc8b-160b-407e-9925-24a91e3599df
+name: Rare Windows Firewall Rule updates using Netsh
+description: |
+  This query searches for rare firewall rule changes using netsh utility by comparing rule names and program names from the previous day.
+description-detailed: |
+  This query will show rare firewall rule changes using netsh utility by comparing rule names and program names from the previous day.
+  with those from the historical chosen time frame.
+  - This technique was seen in relation to Solarigate attack but the results can indicate potential  malicious activity used in different attacks.
+  - The process name in each data source is commented out as an adversary could rename it. It is advisable to keep process name commented but
+    if the results show unrelated false positives, users may want to uncomment it.
+  - Note also that the queries use the KQL "has_all" operator, which hasn't yet been documented officially, but will be soon.
+    In short, "has_all" will only match when the referenced field has all strings in the list.
+  Refer to netsh syntax: https://docs.microsoft.com/windows-server/administration/windows-commands/netsh
+  Refer to our Microsoft Defender XDR blog for details on use during the Solorigate attack:
+  https://www.microsoft.com/security/blog/2021/01/20/deep-dive-into-the-solorigate-second-stage-activation-from-sunburst-to-teardrop-and-raindrop/
+severity: Low
+requiredDataConnectors:
+  - connectorId: SecurityEvents
+    dataTypes:
+      - SecurityEvent
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceProcessEvents
+tactics:
+  - Execution
+relevantTechniques:
+  - T1204
+tags:
+  - Solorigate
+  - NOBELIUM
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  // historical time frame
+  let lookback = totimespan((endtime-starttime)*7);
+  let AccountAllowList = dynamic(['SYSTEM']);
+  let tokens = dynamic(["add", "delete", "set"]);
+  (union isfuzzy=true
+  (
+  SecurityEvent
+  | where TimeGenerated >= ago(lookback)
+  // remove comment below to adjust for noise
+  // | where Process =~ "netsh.exe"
+  | where CommandLine has_all ("advfirewall", "firewall") and CommandLine has_any (tokens)
+  | where AccountType !~ "Machine" and Account !in~ (AccountAllowList)
+  | extend KeyValuePairs = extract_all(@'(?P<key>\w+)=(?P<value>[a-zA-Z0-9-\":\\\s$_@()."]+\"|[a-zA-Z0-9-\":$_\\@()."]+)', dynamic(["key","value"]), CommandLine)
+  | mv-apply KeyValuePairs on (
+    summarize CommandLineParsed = make_bag(bag_pack(tostring(KeyValuePairs[0]), KeyValuePairs[1]))
+   )
+  | extend RuleName = tostring(parse_json(CommandLineParsed).name), Program = tostring(parse_json(CommandLineParsed).program)
+  | join kind=leftanti (
+  SecurityEvent
+  | where TimeGenerated between (starttime..endtime)
+  // remove comment below to adjust for noise
+  // | where Process =~ "netsh.exe"
+  | where CommandLine has_all ("advfirewall", "firewall") and CommandLine has_any (tokens)
+  | where AccountType !~ "Machine" and Account !in~ (AccountAllowList)
+  | extend KeyValuePairs = extract_all(@'(?P<key>\w+)=(?P<value>[a-zA-Z0-9-\":\\\s$_@()."]+\"|[a-zA-Z0-9-\":$_\\@()."]+)', dynamic(["key","value"]), CommandLine)
+  | mv-apply KeyValuePairs on (
+    summarize CommandLineParsed = make_bag(bag_pack(tostring(KeyValuePairs[0]), KeyValuePairs[1]))
+   )
+  | extend RuleName = tostring(parse_json(CommandLineParsed).name), Program = tostring(parse_json(CommandLineParsed).program)
+  ) on RuleName, Program
+  | summarize count() , StartTime= min(TimeGenerated), EndTime=max(TimeGenerated) by Type, Computer, Account, SubjectDomainName, SubjectUserName, RuleName, Program, CommandLineParsed = tostring(CommandLineParsed), Process, ParentProcessName
+  | extend timestamp = StartTime, AccountCustomEntity = Account, HostCustomEntity = Computer
+  ),
+  (
+  DeviceProcessEvents
+  | where TimeGenerated >= ago(lookback)
+  // remove comment below to adjust for noise
+  // | where InitiatingProcessFileName =~ "netsh.exe"
+  | where InitiatingProcessCommandLine has_all ("advfirewall", "firewall") and InitiatingProcessCommandLine has_any (tokens)
+  | where AccountName !in~ (AccountAllowList)
+  | extend KeyValuePairs = extract_all(@'(?P<key>\w+)=(?P<value>[a-zA-Z0-9-\":\\\s$_@()."]+\"|[a-zA-Z0-9-\":$_\\@()."]+)', dynamic(["key","value"]), InitiatingProcessCommandLine)
+  | mv-apply KeyValuePairs on (
+    summarize CommandLineParsed = make_bag(bag_pack(tostring(KeyValuePairs[0]), KeyValuePairs[1]))
+  )
+  | extend RuleName = tostring(parse_json(CommandLineParsed).name), Program = tostring(parse_json(CommandLineParsed).program)
+  | join kind=leftanti (
+  DeviceProcessEvents
+  | where TimeGenerated between (starttime..endtime)
+  // remove comment below to adjust for noise
+  // | where InitiatingProcessFileName =~ "netsh.exe"
+  | where InitiatingProcessCommandLine has_all ("advfirewall", "firewall") and InitiatingProcessCommandLine has_any (tokens)
+  | where AccountName !in~ (AccountAllowList)
+  | extend KeyValuePairs = extract_all(@'(?P<key>\w+)=(?P<value>[a-zA-Z0-9-\":\\\s$_@()."]+\"|[a-zA-Z0-9-\":$_\\@()."]+)', dynamic(["key","value"]), InitiatingProcessCommandLine)
+  | mv-apply KeyValuePairs on (
+    summarize CommandLineParsed = make_bag(bag_pack(tostring(KeyValuePairs[0]), KeyValuePairs[1]))
+  )
+  | extend RuleName = tostring(parse_json(CommandLineParsed).name), Program = tostring(parse_json(CommandLineParsed).program)
+  ) on RuleName, Program
+  | summarize count() , StartTime= min(TimeGenerated), EndTime=max(TimeGenerated) by Type, DeviceName, AccountName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, RuleName, Program,  CommandLineParsed = tostring(CommandLineParsed), InitiatingProcessFileName, InitiatingProcessParentFileName
+  | extend timestamp = StartTime, AccountCustomEntity = InitiatingProcessAccountName, HostCustomEntity = DeviceName
+  ),
+  (
+  Event
+  | where TimeGenerated > ago(lookback)
+  | where Source == "Microsoft-Windows-Sysmon"
+  | where EventID == 1
+  | extend EventData = parse_xml(EventData).DataItem.EventData.Data
+  | mv-expand bagexpansion=array EventData
+  | evaluate bag_unpack(EventData)
+  | extend Key=tostring(['@Name']), Value=['#text']
+  | evaluate pivot(Key, any(Value), TimeGenerated, Source, EventLog, Computer, EventLevel, EventLevelName, EventID, UserName, RenderedDescription, MG, ManagementGroupName, Type, _ResourceId)
+  // remove comment below to adjust for noise
+  // | where OriginalFileName =~ "netsh.exe"
+  | where CommandLine has_all ("advfirewall", "firewall") and CommandLine has_any (tokens)
+  | where User !in~ (AccountAllowList)
+  | extend KeyValuePairs = extract_all(@'(?P<key>\w+)=(?P<value>[a-zA-Z0-9-\":\\\s$_@()."]+\"|[a-zA-Z0-9-\":$_\\@()."]+)', dynamic(["key","value"]), CommandLine)
+  | mv-apply KeyValuePairs on (
+    summarize CommandLineParsed = make_bag(bag_pack(tostring(KeyValuePairs[0]), KeyValuePairs[1]))
+  )
+  | extend RuleName = tostring(parse_json(CommandLineParsed).name), Program = tostring(parse_json(CommandLineParsed).program)
+  | join kind=leftanti (
+  Event
+  | where TimeGenerated > ago(lookback)
+  | where Source == "Microsoft-Windows-Sysmon"
+  | where EventID == 1
+  | extend EventData = parse_xml(EventData).DataItem.EventData.Data
+  | mv-expand bagexpansion=array EventData
+  | evaluate bag_unpack(EventData)
+  | extend Key=tostring(['@Name']), Value=['#text']
+  | evaluate pivot(Key, any(Value), TimeGenerated, Source, EventLog, Computer, EventLevel, EventLevelName, EventID, UserName, RenderedDescription, MG, ManagementGroupName, Type, _ResourceId)
+  // remove comment below to adjust for noise
+  // | where OriginalFileName =~ "netsh.exe"
+  | where CommandLine has_all ("advfirewall", "firewall") and CommandLine has_any (tokens)
+  | where User !in~ (AccountAllowList)
+  | extend KeyValuePairs = extract_all(@'(?P<key>\w+)=(?P<value>[a-zA-Z0-9-\":\\\s$_@()."]+\"|[a-zA-Z0-9-\":$_\\@()."]+)', dynamic(["key","value"]), CommandLine)
+  | mv-apply KeyValuePairs on (
+    summarize CommandLineParsed = make_bag(bag_pack(tostring(KeyValuePairs[0]), KeyValuePairs[1]))
+  )
+  | extend RuleName = tostring(parse_json(CommandLineParsed).name), Program = tostring(parse_json(CommandLineParsed).program)
+  ) on RuleName, Program
+  | extend Type = strcat(Type, ": ", Source)
+  | summarize count() , StartTime= min(TimeGenerated), EndTime=max(TimeGenerated) by Type, Computer, User, Process, RuleName, Program, CommandLineParsed = tostring(CommandLineParsed), ParentImage
+  )
+  )
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: User
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: Computer
+version: 1.0.0


### PR DESCRIPTION
   Change(s):
   - Moved hunting query WindowsFirewallUpdateUsingNetsh.yaml to Endpoint Threat Protection Essentials Solution
   
   Reason for Change(s):
   - Hunting query was not available in Content hub

   Version Updated:
   - Yes

   Testing Completed:
   - Yes, Functional testing