### PR TITLE
Update alert rule version in tool

### DIFF
--- a/Tools/ConvertYamlToJson/ConvertSentinelRuleFrom-Yaml.ps1
+++ b/Tools/ConvertYamlToJson/ConvertSentinelRuleFrom-Yaml.ps1
@@ -99,7 +99,7 @@ function ConvertSentinelRuleFrom-Yaml {
             $template = [PSCustomObject]@{
                 '$schema'      = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"
                 contentVersion = "1.0.0.0"
-                Parameters     = @{
+                parameters     = @{
                     Workspace = @{
                         type = "string"
                     }
@@ -110,7 +110,7 @@ function ConvertSentinelRuleFrom-Yaml {
                         name       = ""
                         type       = "Microsoft.OperationalInsights/workspaces/providers/alertRules"
                         kind       = "Scheduled"
-                        apiVersion = "2021-03-01-preview"
+                        apiVersion = "2023-02-01-preview"
                         properties = [PSCustomObject]@{}
                     }
                 )

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -3172,7 +3172,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                 $dict.Add('huntingOperationalInsightsWorkspacesApiVersion', '2021-06-01')
                 $dict.Add('parserOperationalInsightsWorkspacesApiVersion', '2020-08-01')
                 $dict.Add('savedSearchesApiVersion', '2022-10-01')
-                $dict.Add('alertRuleApiVersion', '2022-04-01-preview')
+                $dict.Add('alertRuleApiVersion', '2023-02-01-preview')
                 $dict.Add('commonResourceMetadataApiVersion', '2022-01-01-preview')
                 $dict.Add('insightsWorkbookApiVersion', '2021-08-01')
             }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated alert rule version to latest at 2 places. one in convert yaml to json tool and another in v3 tool

   Reason for Change(s):
   - Updated alert rule version to latest

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

In maintemplate packaging file we see:
![image](https://github.com/Azure/Azure-Sentinel/assets/107389644/08557018-2020-46ab-a423-710cc6653c48)
