### PR TITLE
Update nrt_FirstAppOrServicePrincipalCredential.yaml

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/nrt_FirstAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/nrt_FirstAppOrServicePrincipalCredential.yaml
@@ -53,7 +53,7 @@ query: |
   //| where targetType =~ "Application" // or targetType =~ "ServicePrincipal"
   | project-away new_value_set, old_value_set
   | project-reorder TimeGenerated, OperationName, InitiatingUserPrincipalName, InitiatingAadUserId, InitiatingAppName, InitiatingAppServicePrincipalId, InitiatingIpAddress, UserAgent, targetDisplayName, targetId, targetType, keyDisplayName, keyType, keyUsage, keyIdentifier, CorrelationId, TenantId
-  | extend Name = tostring(split(InitiatingUserPrincipalName,'@',0)[0]), UPNSuffix = tostring(split(InitiatingUserPrincipalName,'@',1)[0])
+  | extend InitiatedByName = tostring(split(InitiatingUserPrincipalName,'@',0)[0]), InitiatedByUPNSuffix = tostring(split(InitiatingUserPrincipalName,'@',1)[0])
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -75,7 +75,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.5
+version: 1.0.6
 kind: NRT
 metadata:
 source:


### PR DESCRIPTION
   Change(s):
   - Map InitiatedByUPNSuffix and InitiatedByName fields properly

   Reason for Change(s):
   - Entity names mapped incorrectly

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

