### PR TITLE
Update NRT_NewAppOrServicePrincipalCredential.yaml

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
@@ -56,25 +56,29 @@ query: |
   //| where targetType =~ "Application" // or targetType =~ "ServicePrincipal"
   | project-away diff, new_value_set, old_value_set
   | project-reorder TimeGenerated, OperationName, InitiatingUserPrincipalName, InitiatingAadUserId, InitiatingAppName, InitiatingAppServicePrincipalId, InitiatingIpAddress, UserAgent, targetDisplayName, targetId, targetType, keyDisplayName, keyType, keyUsage, keyIdentifier, CorrelationId, TenantId
-  | extend Name = tostring(split(InitiatingUserPrincipalName,'@',0)[0]), UPNSuffix = tostring(split(InitiatingUserPrincipalName,'@',1)[0])
+  | extend InitiatedByName = tostring(split(InitiatingUserPrincipalName,'@',0)[0]), InitiatedByUPNSuffix = tostring(split(InitiatingUserPrincipalName,'@',1)[0])
 entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
         columnName: InitiatingUserPrincipalName
       - identifier: Name
-        columnName: InitiatingAppName
+        columnName: InitiatedByName
+      - identifier: UPNSuffix
+        columnName: InitiatedByUPNSuffix
   - entityType: Account
     fieldMappings:
       - identifier: AadUserId
         columnName: InitiatingAadUserId
   - entityType: Account
     fieldMappings:
+      - identifier: Name
+        columnName: InitiatingAppName
       - identifier: AadUserId
         columnName: InitiatingAppServicePrincipalId
   - entityType: IP
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.4
+version: 1.0.5
 kind: NRT


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Moved InitiatingAppName to the proper Account filed mapping which means it goes with the InitiatingAppServicePrincipalId mapping
   - Fixed the original mapping that was meant to be for InitiatedByName and InitiatedByUPNSuffix

   Reason for Change(s):
   - Entity mappings were incorrect for the UPN account type and the subsequent PR below didn't make the correct fix.
   - The PR #9936 that was approved for changing the UPN account "Name" mapping to InitiatingAppName was incorrectly applied to the wrong Account mapping.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
