### PR TITLE
Adding a query which is looking for LSASS credential dumping

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Credential Access/lsass-credential-dumping.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Credential Access/lsass-credential-dumping.yaml
@@ -1,0 +1,30 @@
+id: a50138af-4bad-4615-9e55-ced36a836806
+name: lsass-credential-dumping
+description: |
+  This query looks for signs of credential dumping based on process activity instead of targeting process names.
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/lsass-credential-dumping/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceEvents
+  - DeviceFileEvents
+tactics:
+- Credential Access
+relevantTechniques:
+  - T1003.001
+query: |
+  let lookuptime = 30d;
+  DeviceEvents
+  | where Timestamp >ago(lookuptime)
+  | where ActionType == "OpenProcessApiCall"
+  | where FileName =~ "lsass.exe"
+  | project ApiCallTimestamp = Timestamp, InitiatingProcessFileName=tolower(InitiatingProcessFileName), InitiatingProcessCommandLine=tolower(InitiatingProcessCommandLine), InitiatingProcessId, InitiatingProcessCreationTime=tolower(InitiatingProcessCreationTime), InitiatingProcessParentFileName=tolower(InitiatingProcessParentFileName)
+  | join (
+  DeviceFileEvents
+  | where ActionType == "FileCreated"
+  | where Timestamp >ago(lookuptime)
+  | project FileEventTimestamp = Timestamp, InitiatingProcessFileName=tolower(InitiatingProcessFileName), InitiatingProcessCommandLine=tolower(InitiatingProcessCommandLine), InitiatingProcessId, InitiatingProcessCreationTime=tolower(InitiatingProcessCreationTime), InitiatingProcessParentFileName=tolower(InitiatingProcessParentFileName), FileActionType = ActionType, FilePath = FolderPath, ModifiedFileName = FileName
+  ) on InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessId, InitiatingProcessCreationTime
+  | where FileEventTimestamp between (ApiCallTimestamp .. (ApiCallTimestamp + 1m))
+  | project ApiCallTimestamp, FileEventTimestamp, FilePath,FileActionType, ModifiedFileName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessId, InitiatingProcessParentFileName

--- a/Hunting Queries/Microsoft 365 Defender/Credential Access/lsass-credential-dumping.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Credential Access/lsass-credential-dumping.yaml
@@ -10,7 +10,7 @@ requiredDataConnectors:
   - DeviceEvents
   - DeviceFileEvents
 tactics:
-- Credential Access
+- CredentialAccess
 relevantTechniques:
   - T1003.001
 query: |


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added Hunting Queries/Microsoft 365 Defender/Credential Access/lsass-credential-dumping.yaml

   Reason for Change(s):
   - Added a Defender for Endpoint threat hunting query to look for signs of LSASS memory dumping.
