### PR TITLE
Detections test case fix

### DIFF
--- a/.script/tests/detectionTemplateSchemaValidation/DetectionTemplateSchemaValidationTests.cs
+++ b/.script/tests/detectionTemplateSchemaValidation/DetectionTemplateSchemaValidationTests.cs
@@ -201,19 +201,11 @@ namespace Kqlvalidations.Tests
         private List<string> GetYamlFilePathsByFileName(string detectionsYamlFileName)
         {
             var yamlFilePaths = new List<string>();
-            // Get file present in detection folder or else check in solution analytics rules folder
-            try
-            {
-                var filesList= (Directory.GetFiles(RootDetectionPaths, detectionsYamlFileName, SearchOption.AllDirectories).Where(s => s.Contains("\\Detections\\") || s.Contains("/Detections/") || s.Contains("Analytic Rules")).ToList());
+            var filesList = (Directory.GetFiles(RootDetectionPaths, detectionsYamlFileName, SearchOption.AllDirectories).Where(s => s.Contains("\\Detections\\") || s.Contains("/Detections/") || s.Contains("Analytic Rules")).ToList());
 
-                if (filesList.Any())
-                {
-                    yamlFilePaths.AddRange(filesList);
-                }
-            }
-            catch (Exception e) when (e.Message.Contains("Sequence contains more than one element"))
+            if (filesList.Any())
             {
-                throw new Exception($"Should not have 2 templates with the same name , problematic name is {detectionsYamlFileName}");
+                yamlFilePaths.AddRange(filesList);
             }
 
             return yamlFilePaths;


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - There were 2 files in our repo i.e. one in detections folder and one in solution analytic rules folder and test case use to pass if it identifies 1st file value so we have fixed by checking validation on all files with same name in detection and solution folder so that it fails.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

