### PR TITLE
Fixed IP entity for "Time series anomaly for data size transferred to public internet"

### DIFF
--- a/Detections/MultipleDataSources/TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
+++ b/Detections/MultipleDataSources/TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
@@ -111,7 +111,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: SourceIPMax
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
+++ b/Detections/MultipleDataSources/TimeSeriesAnomaly-MultiVendor_DataExfiltration.yaml
@@ -110,7 +110,7 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: SouceIPMax
+        columnName: SourceIPMax
 version: 1.0.5
 kind: Scheduled
 metadata:


### PR DESCRIPTION
There was a typo SouceIPMax instead of SourceIPMax

   Required items, please complete
   
   Change(s):
   - Fixed IP Entity.

   Reason for Change(s):
   - There was a typo SouceIPMax instead of SourceIPMax

   Version Updated:
   - No changes to the detection, just the entity, so version wasn't changed.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
