### PR TITLE
AWS connector script to create a bucket fails on tags on PWSH on macOS

### DIFF
--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -58,3 +58,9 @@ The `ConfigAwsConnector.ps1` script has two parameters:
 - `-LogPath` specifies a custom path to create the script activity log file.
 - `-AwsLogType` specifies the AWS log type to configure. Valid options are: "VPC", "CloudTrail", "GuardDuty". If this parameter is specified, the user will not be prompted for this information.
 
+##Known issues
+###AWS connector script to create a bucket fails on tags on Power shell core on macOS and following is the error
+- Error parsing parameter '--tagging': Invalid JSON: Expecting property name enclosed in double quotes: line 1 column 2 (char 1) JSON received: {\"TagSet\":[{\"Key\": \"Operator\", \"Value\": \"Microsoft_Sentinel_Automation_Script\"}]}
+
+- Please use this script to over come the AWS bucket tagging issue in mac os and Navigate to [AWS Bucket Tagging MacOS]("https://github.com/Azure/Azure-Sentinel\DataConnectors\AWS-S3\Utils\AwsResourceCreatorV1.ps1") 
+

--- a/DataConnectors/AWS-S3/Utils/AwsResourceCreator.ps1
+++ b/DataConnectors/AWS-S3/Utils/AwsResourceCreator.ps1
@@ -166,7 +166,7 @@ function New-S3Bucket
                 {
                     Write-Log "S3 Bucket $bucketName created successfully" -LogFileName $LogFileName -Indent 2
                     Write-Log "Executing: aws s3api put-bucket-tagging --bucket $bucketName --tagging  ""{\""TagSet\"":[$(Get-SentinelTagInJsonFormat)]}""" -LogFileName $LogFileName -Severity Verbose
-                    aws s3api put-bucket-tagging --bucket $bucketName --tagging  "{\""TagSet\"":[$(Get-SentinelTagInJsonFormat)]}"
+                    aws s3api put-bucket-tagging --bucket BUCKET_NAME --tagging '{"TagSet":[{"Key": "Operator", "Value": "Microsoft_Sentinel_Automation_Script"}]}'
                 }
                 elseif($error[0] -Match "InvalidBucketName")
                 {

--- a/DataConnectors/AWS-S3/Utils/AwsResourceCreatorV1.ps1
+++ b/DataConnectors/AWS-S3/Utils/AwsResourceCreatorV1.ps1
@@ -166,7 +166,7 @@ function New-S3Bucket
                 {
                     Write-Log "S3 Bucket $bucketName created successfully" -LogFileName $LogFileName -Indent 2
                     Write-Log "Executing: aws s3api put-bucket-tagging --bucket $bucketName --tagging  ""{\""TagSet\"":[$(Get-SentinelTagInJsonFormat)]}""" -LogFileName $LogFileName -Severity Verbose
-                    aws s3api put-bucket-tagging --bucket $bucketName --tagging  "{\""TagSet\"":[$(Get-SentinelTagInJsonFormat)]}"
+                    aws s3api put-bucket-tagging --bucket BUCKET_NAME --tagging '{"TagSet":[{"Key": "Operator", "Value": "Microsoft_Sentinel_Automation_Script"}]}'
                 }
                 elseif($error[0] -Match "InvalidBucketName")
                 {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Tagging script change

   Reason for Change(s):
        https://github.com/Azure/Azure-Sentinel/issues/10210
   - AWS connector script to create a bucket fails on tags on PWSH on macOS

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - Yes at customer environment

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


# Guidance <- remove section before submitting
-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for XYZ.yaml

   Reason for Change(s):
   - New schema used for XYZ.yaml
   - Resolves ISSUE #1234

   Version updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

_Note: If updating a detection, you must update the version field._

> Before the submission has been made, please look at running the KQL and Yaml Validation Checks locally.
> https://github.com/Azure/Azure-Sentinel#run-kql-validation-locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
