### PR TITLE
Update run.ps1 - fix LoginURL check

### DIFF
--- a/DataConnectors/O365 Data/O365APItoAS-Template/TimerTrigger/run.ps1
+++ b/DataConnectors/O365 Data/O365APItoAS-Template/TimerTrigger/run.ps1
@@ -252,7 +252,7 @@ if (-Not [string]::IsNullOrEmpty($LAURI)){
 }
 $LoginURL = $env:loginEndpoint
 if (-Not [string]::IsNullOrEmpty($LoginURL)){
-	if($LoginURL.Trim() -notin @("https://login.microsoftonline.us","https://login.partner.microsoftonline.cn","https://login.microsoftonline.com"))
+	if($LoginURL.Trim() -notin @("https://login.microsoftonline.us/","https://login.partner.microsoftonline.cn/","https://login.microsoftonline.com/"))
 	{
 		Write-Error -Message "MCASActivity-SecurityEvents: Invalid Login Endpoint Uri." -ErrorAction Stop
 		Exit


### PR DESCRIPTION
Will be necessary to re-create the zip as well, if this fix is accepted.

   Required items, please complete
   
   Change(s):
   - Fix for LoginURL check

   Reason for Change(s):
   - In azuredeploy.json the loginEndpoint dynamic parameter is set to `[environment().authentication.loginEndpoint]` which will return with a trailing `/` ([docs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-deployment)) and as such this test will always fail and halt the process.
   - Removing the `/` from the variable broke the auth. process. 
   - Suspect an issue was introduced in the PR from 8 months ago? #8933 


   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


