### PR TITLE
TI upload indicators - update data connector to include doc fwlink

### DIFF
--- a/Solutions/Threat Intelligence/Data Connectors/template_ThreatIntelligenceUploadIndicators.json
+++ b/Solutions/Threat Intelligence/Data Connectors/template_ThreatIntelligenceUploadIndicators.json
@@ -2,7 +2,7 @@
     "id": "ThreatIntelligenceUploadIndicatorsAPI",
     "title": "Threat Intelligence Upload Indicators API (Preview)",
     "publisher": "Microsoft",
-    "descriptionMarkdown": "Microsoft Sentinel offers a data plane API to bring in threat intelligence from your Threat Intelligence Platform (TIP), such as Threat Connect, Palo Alto Networks MineMeld, MISP, or other integrated applications. Threat indicators can include IP addresses, domains, URLs, file hashes and email addresses.",
+    "descriptionMarkdown": "Microsoft Sentinel offers a data plane API to bring in threat intelligence from your Threat Intelligence Platform (TIP), such as Threat Connect, Palo Alto Networks MineMeld, MISP, or other integrated applications. Threat indicators can include IP addresses, domains, URLs, file hashes and email addresses. For more information, see the [Microsoft Sentinel documentation](https://go.microsoft.com/fwlink/p/?linkid=2269830&wt.mc_id=sentinel_dataconnectordocs_content_cnl_csasci).",
     "graphQueries": [
         {
             "metricName": "Total indicators received",


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
- Add fwlink to related doc on learn.microsoft.com in the data connector file for TI upload indicators

   Reason for Change(s):
   - To cross link data connector page Docs team autogenerates to appropriate install info. (related auto gen page: https://learn.microsoft.com/en-us/azure/sentinel/data-connectors/threat-intelligence-upload-indicators-api)

   Version Updated:
   - Not applicable

   Testing Completed:
   - No

   Checked that the validations are passing and have addressed any issues that are present:
   - Not applicable