### PR TITLE
Tenant-based - Defender for Cloud: update data connector to include doc fwlink

### DIFF
--- a/Solutions/Microsoft Defender for Cloud/Data Connectors/MicrosoftDefenderForCloudTenantBased.json
+++ b/Solutions/Microsoft Defender for Cloud/Data Connectors/MicrosoftDefenderForCloudTenantBased.json
@@ -2,7 +2,7 @@
 	"id": "MicrosoftDefenderForCloudTenantBased",
 	"title": "Tenant-based Microsoft Defender for Cloud (Preview)",
 	"publisher": "Microsoft",
-	"descriptionMarkdown": "Microsoft Defender for Cloud is a security management tool that allows you to detect and quickly respond to threats across Azure, hybrid, and multi-cloud workloads. This connector allows you to stream your MDC security alerts from Microsoft 365 Defender into Microsoft Sentinel, so you can can leverage the advantages of XDR correlations connecting the dots across your cloud resources, devices and identities and view the data in workbooks, queries and investigate and respond to incidents.",
+	"descriptionMarkdown": "Microsoft Defender for Cloud is a security management tool that allows you to detect and quickly respond to threats across Azure, hybrid, and multi-cloud workloads. This connector allows you to stream your MDC security alerts from Microsoft 365 Defender into Microsoft Sentinel, so you can can leverage the advantages of XDR correlations connecting the dots across your cloud resources, devices and identities and view the data in workbooks, queries and investigate and respond to incidents. For more information, see the [Microsoft Sentinel documentation](https://go.microsoft.com/fwlink/p/?linkid=2269832&wt.mc_id=sentinel_dataconnectordocs_content_cnl_csasci).",
 	"logo": "Microsoft.svg",
 	"graphQueriesTableName": "SecurityAlerts",
 	"graphQueries": [


### PR DESCRIPTION
   Required items, please complete
Change(s):

Add fwlink to related doc on learn.microsoft.com in the data connector file for Tenant-based connector for Microsoft Defender for Cloud. 

Reason for Change(s):

To cross link data connector page Docs team autogenerates to appropriate install info. 

Version Updated:

Not applicable
Testing Completed:

No
Checked that the validations are passing and have addressed any issues that are present:

Not applicable




-----------------------------------------------------------------------------------------------------------
