### PR TITLE
Adding query to hunt for impacke dcomexec

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Execution/detect-impacket-dcomexec.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Execution/detect-impacket-dcomexec.yaml
@@ -1,0 +1,42 @@
+id: 3069ee4c-68a2-4512-9048-4751bc0fbac2
+name: detect-impacket-dcomexec
+description: |
+  This query looks for signs of impacket dcomexec module.
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/impacket-part-2/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceNetworkEvents
+  - DeviceProcessEvents
+tactics:
+- Execution
+relevantTechniques:
+  - T1559.001
+query: |
+  let LookupTime = 30d;
+  DeviceNetworkEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessFileName =~ "explorer.exe"
+  | where ActionType == 'InboundConnectionAccepted' 
+  | project InboundConnTimestamp = Timestamp, DeviceName, InboundConnectionToExplorer = RemoteIP, InitiatingProcessFileName, InitiatingProcessCreationTime, InitiatingProcessId
+  | join kind=leftouter (
+  DeviceProcessEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessFileName =~ "explorer.exe"
+  | project ProcessStartTimestamp = Timestamp, DeviceName, StartedProcessCmdline = tolower(ProcessCommandLine), StartedProcessCreationTime = ProcessCreationTime, StartedProcessId = ProcessId, StartedProcessFileName = tolower(FileName), StartedProcessFolderPath = tolower(FolderPath), InitiatingProcessFileName, InitiatingProcessCreationTime, InitiatingProcessId
+  ) on DeviceName, InitiatingProcessFileName, InitiatingProcessCreationTime, InitiatingProcessId
+  | where ProcessStartTimestamp between (InboundConnTimestamp .. (InboundConnTimestamp + 1m))
+  | join kind=leftouter ( 
+  DeviceProcessEvents 
+  | where Timestamp > ago(LookupTime) 
+  | where InitiatingProcessParentFileName =~ "explorer.exe"
+  |project DeviceName, ChildProcessTimestamp = Timestamp, StartedProcessCmdline = tolower(InitiatingProcessCommandLine), StartedProcessCreationTime = InitiatingProcessCreationTime, StartedProcessId = InitiatingProcessId, StartedProcessFileName = tolower(InitiatingProcessFileName), StartedProcessFolderPath = tolower(InitiatingProcessFolderPath), ChildProcessId= ProcessId, ChildProcessName = FileName, ChildProcessCommandLine = ProcessCommandLine 
+  ) on DeviceName, StartedProcessCmdline, StartedProcessCreationTime, StartedProcessId, StartedProcessFileName, StartedProcessFolderPath
+  | join kind=leftouter ( 
+  DeviceNetworkEvents 
+  | where Timestamp > ago(LookupTime) 
+  | where InitiatingProcessParentFileName =~ "explorer.exe"
+  |project DeviceName, ChildProcessTimestamp = Timestamp, StartedProcessCmdline = tolower(InitiatingProcessCommandLine), StartedProcessCreationTime = InitiatingProcessCreationTime, StartedProcessId = InitiatingProcessId, StartedProcessFileName = tolower(InitiatingProcessFileName), StartedProcessFolderPath = tolower(InitiatingProcessFolderPath), RemoteIP, RemoteUrl
+  ) on DeviceName, StartedProcessCmdline, StartedProcessCreationTime, StartedProcessId, StartedProcessFileName, StartedProcessFolderPath
+  | summarize ConnectedAddresses = make_set(RemoteIP), ConnectedUrl = make_set(RemoteUrl), ChildProcesses = make_set(ChildProcessName), ChildProcessCmdlines = make_set(ChildProcessCommandLine) by DeviceName, InitiatingSourceIP = InboundConnectionToExplorer, StartedProcessCmdline, StartedProcessCreationTime, StartedProcessId, StartedProcessFileName, StartedProcessFolderPath, Timestamp = InboundConnTimestamp


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Add Hunting Queries/Microsoft 365 Defender/Execution/detect-impacket-dcomexec.yaml

   Reason for Change(s):
   - Add a hunting query to look for impacket dcomexec module usage.