### PR TITLE
Added Compliance to payload in AWS-SecurityHubFindings

### DIFF
--- a/DataConnectors/AWS-SecurityHubFindings/AzFunAWSSecurityHubIngestion/__init__.py
+++ b/DataConnectors/AWS-SecurityHubFindings/AzFunAWSSecurityHubIngestion/__init__.py
@@ -101,6 +101,7 @@ def main(mytimer: func.TimerRequest) -> None:
                 payload.update({'Resources':finding['Resources']})            
                 payload.update({'WorkflowState':finding['WorkflowState']})                
                 payload.update({'RecordState':finding['RecordState']})
+		payload.update({'Compliance':finding['Compliance']})
                 
                 with sentinel:
                     sentinel.send(payload)


### PR DESCRIPTION
 Change(s):
   - Updated Payload to incorporate the Compliance field in DataConnectors/AWS-SecurityHubFindings/AzFunAWSSecurityHubIngestion/__init__.py

   Reason for Change(s):
   - Compliance field is necessary to categorize AWS Security Hub Findings

   Testing Completed:
   - No, need help

   Checked that the validations are passing and have addressed any issues that are present:
   - No, need help