### PR TITLE
AliCloud function - run in time-based iteration & add graceful shutdown

### DIFF
--- a/Solutions/Alibaba Cloud/DataConnectors/AliCloudSentinelConnector/__init__.py
+++ b/Solutions/Alibaba Cloud/DataConnectors/AliCloudSentinelConnector/__init__.py
@@ -42,9 +42,9 @@ if (not match):
 
 def generate_date(state):
     current_time = datetime.utcnow().replace(second=0, microsecond=0) - timedelta(minutes=10)
-    i = state.get()
-    if i is not None:
-        past_time = datetime.strptime(state.get(), "%d.%m.%Y %H:%M:%S")
+    last_processed_saved_time = state.get()
+    if last_processed_saved_time is not None:
+        past_time = datetime.strptime(last_processed_saved_time, "%d.%m.%Y %H:%M:%S")
         if past_time is not None:
             logging.info("The last time point is: {}".format(past_time))
         else:


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - AliCloud azure function connector will now run in 60-seconds (configurable) chunks. In every iteration, it will retrieve the data for that time range only, send it to LA, and then update the state manager with that chunk end-time. Then, it will move to the next 60-second chunk. 
   - Added graceful cancellation mechanism. Since max time for function is 20 minutes, we will stop it once we get to 18 minutes (configurable), before we get a timeout error. That way, the next function execution can continue from the last successful timestamp, so less chance of duplicate data and data loss.
   - Fixed bug in which the state is updated at the start of the run (in the generate_date method). We should only update the state after we successfully published data to LA (in our case, when we finished a time range chunk).

   Reason for Change(s):
   - Multiple timeouts for customer with high volume. Function tries to retrieve data from last 30 minutes, and as a result, fails on timeout just before finishing to process it.

   Testing Completed:
   - No - this isn't a KQL/table change, so existing testing & validation do not exist.

   Checked that the validations are passing and have addressed any issues that are present:
   - No - this isn't a KQL/table change, so existing testing & validation do not exist.
