### PR TITLE
changes for releasenotes and lastindex for data file check

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
@@ -34,7 +34,7 @@ else {
     $hasDataFolder = $path -like '*/data'
     if ($hasDataFolder) {
         # DATA FOLDER PRESENT
-        $dataFolderIndex = $path.IndexOf("/data", [StringComparison]"CurrentCultureIgnoreCase")
+        $dataFolderIndex = $path.LastIndexOf("/data", [StringComparison]"CurrentCultureIgnoreCase")
 
         if ($dataFolderIndex -le 0) {
             Write-Host "Given path is not from Solutions data folders. Please provide data file path from Solution"

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -2999,7 +2999,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
         if ($contentToImport.Description) {
             $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionDescription}}", $contentToImport.Description
             
-            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionName}}", [URI]::EscapeUriString($solutionName)
+            $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionName}}", [URI]::EscapeDataString($solutionName)
         }
         else {
             $global:baseCreateUiDefinition.parameters.config.basics.description = $global:baseCreateUiDefinition.parameters.config.basics.description -replace "{{SolutionDescription}}", ""


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - ReleaseNotes in createUi for solutions which contain "(" or ")" shows incorrect on UI page. Screenshots added below.
   - For dataminr pulse solution i noticed that during packaging we get below error. This has no impact on the final package of maintemplate and createUi. Here in our code we are checking for index of "/data" but for "Dataminr Pulse" solution it use to get here /Data and condition was satisfied. We have validated the existing solution and its content in live as well as in maintemplate so there is no impact of this. 

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes, test document in ado

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
