### PR TITLE
Update Detection history fetching limit

### DIFF
--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendDetectionsHistory/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendDetectionsHistory/__init__.py
@@ -114,7 +114,7 @@ def fetch_and_send_detections(ctx: ApiContext, event_type: str, start_date: str)
         "include_dhcp": INCLUDE_DHCP,
         "include_events": INCLUDE_EVENTS,
         "filter_training_detections": True,
-        "limit": 50,
+        "limit": 100,
         "start_date": start_date,
     }
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Change limit to pull detection history

   Reason for Change(s):
   - Too big limit will cause timeout issues for the consumption plan and too small will make the history fetching to be slow

   Version Updated:
   -no

   Testing Completed:
   - yes

   Checked that the validations are passing and have addressed any issues that are present:
   - yes