### PR TITLE
Adding a query to hunt for impacket atexec module

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Execution/detect-impacket-atexec.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Execution/detect-impacket-atexec.yaml
@@ -1,0 +1,40 @@
+id: 75e3a1b2-bd6d-4e79-8c74-85a3bc0b0617
+name: detect-impacket-atexec
+description: |
+  This query looks for signs of impacket atexec module. Should work with others using similar technique.
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/impacket-part-3/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceEvents
+  - DeviceRegistryEvents
+  - DeviceProcessEvents
+tactics:
+- Execution
+relevantTechniques:
+  - T1053 
+query: |
+  let lookuptime = 30d;
+  DeviceEvents
+  | where Timestamp >ago(lookuptime)
+  | where ActionType == 'NamedPipeEvent' 
+  | where AdditionalFields contains "atsvc"
+  | project DeviceName, Timestamp, DeviceId, RemoteIP, PipeName = extractjson("$.PipeName", AdditionalFields, typeof(string)), RemoteClientsAccess = extractjson("$.RemoteClientsAccess", AdditionalFields, typeof(string)), ShareName = extractjson("$.ShareName", AdditionalFields, typeof(string))
+  | join (
+  DeviceRegistryEvents
+  | where Timestamp >ago(lookuptime)
+  | where ActionType == 'RegistryKeyCreated' 
+  | where RegistryKey contains @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\"
+  | project RegTimestamp = Timestamp, DeviceName, DeviceId, RegistryKey, RegistryValueData, RegistryValueName, RegistryValueType, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessId, InitiatingProcessCreationTime
+  ) on DeviceName, DeviceId
+  | where RegTimestamp between ((Timestamp - 2m) .. (Timestamp + 2m))
+  | join (
+  DeviceProcessEvents
+  | where Timestamp >ago(lookuptime)
+  | where InitiatingProcessFileName =~ "svchost.exe"
+  | where InitiatingProcessCommandLine contains "Schedule"
+  | project DeviceId, DeviceName, FileName, ProcessCommandLine, ProcessId, ProcessStartTimestamp = Timestamp, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessId, InitiatingProcessCreationTime
+  ) on DeviceName, DeviceId, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessId, InitiatingProcessCreationTime
+  | where ProcessStartTimestamp between ( Timestamp .. (Timestamp +2m))
+  | project DeviceName, Timestamp, StartedProcess = FileName, StartedProcessCommandLine = ProcessCommandLine, StartedProcessId = ProcessId, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessId, InitiatingProcessCreationTime, RegistryKey, RemoteIP, PipeName


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   -Added Hunting Queries/Microsoft 365 Defender/Execution/detect-impacket-atexec.yaml

   Reason for Change(s):
   - Added hunting query to hunt for Impacket AtExec module.

Here is a pic of it running in advanced hunt, just in case you need it:
![Screenshot 2024-06-01 at 17 14 46](https://github.com/Azure/Azure-Sentinel/assets/90253114/29d1bb69-7183-4ea7-bfb5-c7a7cbb31280)

