### PR TITLE
Add new Hunting folder for Spoof AH queries and add 1 AH query example

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Display Name - Spoof and Impersonation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Display Name - Spoof and Impersonation.yaml
@@ -1,0 +1,30 @@
+id: 6a570927-8638-4a6f-ac09-72a7d51ffa3c
+name: Display Name - Spoof and Impersonation
+description: |
+  This query helps reviewing incoming email messages where the Display Name of the sender contains own or other partner company/brand name
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+- Initial access
+query: |
+  let emailDelivered = EmailEvents
+  | where Timestamp < ago(24hrs)
+  and DeliveryAction == "Delivered"
+  and SenderDisplayName contains "Microsoft"
+  | summarize count() by SenderFromAddress
+  | where count_ > 3 // ensuring that some level of communications has occured.
+  | project SenderFromAddress;
+  EmailEvents
+  | where Timestamp > ago(24hrs)
+  | where DeliveryAction == "Delivered"
+  and EmailDirection == "Inbound"
+  and OrgLevelAction != "Block"
+  and UserLevelAction != "Block"
+  and SenderDisplayName contains "Microsoft"
+  | extend NewMsg = case(Subject contains "RE:", false, Subject contains "FW:", false, true )
+  | project SenderDisplayName, SenderFromAddress, NetworkMessageId, SenderMailFromAddress, RecipientEmailAddress, DeliveryAction, DeliveryLocation, ThreatTypes, DetectionMethods, NewMsg, Subject
+  | join kind=leftanti  ( emailDelivered ) on SenderFromAddress
+  | order by SenderMailFromAddress
+  | summarize count() by SenderDisplayName, SenderFromAddress, NetworkMessageId, SenderMailFromAddress, RecipientEmailAddress, DeliveryAction, DeliveryLocation, ThreatTypes, DetectionMethods, NewMsg, Subject


### PR DESCRIPTION
Adding a new folder as part of validating adding more Email related AH queries to the repro. I am working in the MDO PG as CxE PM and we will add many more queries in the upcoming weeks.
This is the firs example to test the check-in/pull request process works.

- Created new folder for Spoof and Impersonation related queries
- Add 1 new query as new .yaml file to hunt for Brand Impersonation attacks using Email Sender Display Name to add know brand names eg like "Microsoft" to increase legitimacy of the lure.

If you have questions reach me out directly.

Daniel M

