### PR TITLE
Update record count limit post to Sentinel using Sentinel API

### DIFF
--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/azuredeploy_FortinetFortiNdrCloud_API_FunctionApp.json
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/azuredeploy_FortinetFortiNdrCloud_API_FunctionApp.json
@@ -49,7 +49,7 @@
             "defaultValue": ""
         },
         "FncApiToken": {
-            "type": "string",
+            "type": "securestring",
             "defaultValue": ""
         },
         "FncAccountUuid": {

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/azuredeploy_FortinetFortiNdrCloud_API_FunctionApp.json
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/azuredeploy_FortinetFortiNdrCloud_API_FunctionApp.json
@@ -99,6 +99,10 @@
         "LogLevel": {
             "type": "string",
             "defaultValue": "INFO"
+        },
+        "PostingLimit": {
+            "type": "int",
+            "defaultValue": 3000
         }
       },
       "variables": {
@@ -275,6 +279,7 @@
                           "FncDaysToCollectDetections": "[parameters('FncDaysToCollectDetections')]",
                           "PollingDelay": "[parameters('PollingDelay')]",
                           "LogLevel": "[parameters('LogLevel')]",
+                          "PostingLimit": "[parameters('PostingLimit')]",
                           "logAnalyticsUri": "[variables('LogAnalyticsUri')]",
                           "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinel-FortinetFortiNDR-functionapp"
                       } 

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEvents/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEvents/__init__.py
@@ -15,6 +15,7 @@ ACCOUNT_CODE = os.environ.get("FncAccountCode")
 API_TOKEN = os.environ.get("ApiToken")
 BUCKET_NAME = os.environ.get("FncBucketName") or DEFAULT_BUCKET_NAME
 LOGGER_LEVEL = os.environ.get("LogLevel") or "INFO"
+POSTING_LIMIT = os.environ.get("PostingLimit") or 3000
 
 
 def main(args: dict) -> str:
@@ -74,7 +75,7 @@ def validate_args(args: dict):
 
 
 def post_events_inc(events, event_type):
-    limit = 3000
+    limit = POSTING_LIMIT
     count = len(events)
     start = 0
     while start < count:

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEvents/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEvents/__init__.py
@@ -15,7 +15,7 @@ ACCOUNT_CODE = os.environ.get("FncAccountCode")
 API_TOKEN = os.environ.get("ApiToken")
 BUCKET_NAME = os.environ.get("FncBucketName") or DEFAULT_BUCKET_NAME
 LOGGER_LEVEL = os.environ.get("LogLevel") or "INFO"
-POSTING_LIMIT = os.environ.get("PostingLimit") or 3000
+POSTING_LIMIT = int(os.environ.get("PostingLimit", "3000"))
 
 
 def main(args: dict) -> str:

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEvents/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEvents/__init__.py
@@ -74,7 +74,7 @@ def validate_args(args: dict):
 
 
 def post_events_inc(events, event_type):
-    limit = 5000
+    limit = 3000
     count = len(events)
     start = 0
     while start < count:

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEventsHistory/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEventsHistory/__init__.py
@@ -13,7 +13,7 @@ AWS_SECRET_KEY = os.environ.get("AwsSecretAccessKey")
 ACCOUNT_CODE = os.environ.get("FncAccountCode")
 BUCKET_NAME = os.environ.get("FncBucketName") or DEFAULT_BUCKET_NAME
 LOGGER_LEVEL = os.environ.get("LogLevel") or "INFO"
-POSTING_LIMIT = os.environ.get("PostingLimit") or 3000
+POSTING_LIMIT = int(os.environ.get("PostingLimit", "3000"))
 
 
 def main(args: dict) -> str:

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEventsHistory/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEventsHistory/__init__.py
@@ -68,7 +68,7 @@ def validate_args(args: dict):
 
 
 def post_events_inc(events, event_type):
-    limit = 5000
+    limit = 3000
     count = len(events)
     start = 0
     while start < count:

--- a/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEventsHistory/__init__.py
+++ b/Solutions/Fortinet FortiNDR Cloud/Data Connectors/fortinetFortiNdrCloudDataConn/FetchAndSendEventsHistory/__init__.py
@@ -13,6 +13,7 @@ AWS_SECRET_KEY = os.environ.get("AwsSecretAccessKey")
 ACCOUNT_CODE = os.environ.get("FncAccountCode")
 BUCKET_NAME = os.environ.get("FncBucketName") or DEFAULT_BUCKET_NAME
 LOGGER_LEVEL = os.environ.get("LogLevel") or "INFO"
+POSTING_LIMIT = os.environ.get("PostingLimit") or 3000
 
 
 def main(args: dict) -> str:
@@ -68,7 +69,7 @@ def validate_args(args: dict):
 
 
 def post_events_inc(events, event_type):
-    limit = 3000
+    limit = POSTING_LIMIT
     count = len(events)
     start = 0
     while start < count:


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Update record count limit when posting to Sentinel with API and make it configurable
   - Make the API Token field to be a secret string rather than a plain string

   Reason for Change(s):
   - Current limit may cause the API post call to exceed Sentinel API 30Mb limit

   Version Updated:
   - no

   Testing Completed:
   - Yes