### PR TITLE
Fix entity in BulkChangestoPrivilegedAccountPermissions.yaml

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/BulkChangestoPrivilegedAccountPermissions.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/BulkChangestoPrivilegedAccountPermissions.yaml
@@ -80,9 +80,9 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: InitiatingIPAddress
+        columnName: InitiatingIpAddress
 customDetails:
     InitiatedByUser: InitiatedByUser
     TargetUser: TargetUserPrincipalName
-version: 1.0.6
+version: 1.0.7
 kind: Scheduled


### PR DESCRIPTION
Fixed IP entity

   Required items, please complete
   
   Change(s):
   - Changed IP entity InitiatingIPAddress to InitiatingIpAddress

   Reason for Change(s):
   - IP entity was broken. There was a typo on the field name, should have been InitiatingIpAddress

   Version Updated:
   - yes

   Testing Completed:
   - yes

   Checked that the validations are passing and have addressed any issues that are present:
   - yes
