### PR TITLE
Update ConvertSentinelRuleFrom-Yaml.ps1

### DIFF
--- a/Tools/ConvertYamlToJson/ConvertSentinelRuleFrom-Yaml.ps1
+++ b/Tools/ConvertYamlToJson/ConvertSentinelRuleFrom-Yaml.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 <#
 .SYNOPSIS
     Convert Microsoft Sentinel YAML rules to JSON ARM format
@@ -18,7 +19,7 @@
     Output is the JSON file
 .NOTES
     AUTHOR: P.Khabazi
-    LASTEDIT: 16-03-2022
+    LASTEDIT: 05-06-2024
 #>
 
 function ConvertSentinelRuleFrom-Yaml {
@@ -149,7 +150,7 @@ function ConvertSentinelRuleFrom-Yaml {
 
             #Export to JSON
             try {
-                $template | ConvertTo-Json -Depth 20 | Out-File $outputFile -ErrorAction Stop
+                $template | ConvertTo-Json -Depth 20 -EscapeHandling EscapeNonAscii | Out-File $outputFile -ErrorAction Stop
             }
             catch {
                 Write-Error $_.Exception.Message


### PR DESCRIPTION
  Change(s):
   - Add -EscapeHandling EscapeNonAscii to ConvertTo-Json call to prevent errors when non-ASCII characters are included.  This requires Powershell 7.2 or higher.

   Reason for Change(s):
   - Some existing YAML files contain non-ASCII characters and fail to convert.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Need help.  Is there a validation for PowerShell scripts?
