### PR TITLE
🐛 Analytic rules fixes 2024-06-11

### DIFF
--- a/Detections/MultipleDataSources/StarBlizzardDomainsAugust2022.yaml
+++ b/Detections/MultipleDataSources/StarBlizzardDomainsAugust2022.yaml
@@ -7,20 +7,20 @@ requiredDataConnectors:
   - connectorId: AzureMonitor(VMInsights)
     dataTypes:
       - VMConnection
-  - connectorId: CiscoASA 
-    dataTypes: 
-      - CommonSecurityLog 
-  - connectorId: PaloAltoNetworks 
-    dataTypes: 
-      - CommonSecurityLog 
+  - connectorId: CiscoASA
+    dataTypes:
+      - CommonSecurityLog
+  - connectorId: PaloAltoNetworks
+    dataTypes:
+      - CommonSecurityLog
   - connectorId: MicrosoftThreatProtection
     dataTypes:
       - DeviceNetworkEvents
       - EmailUrlInfo
       - EmailEvents
   - connectorId: AzureFirewall
-    dataTypes: 
-      - AzureDiagnostics  
+    dataTypes:
+      - AzureDiagnostics
 queryFrequency: 1d
 queryPeriod: 1d
 triggerOperator: gt
@@ -36,47 +36,47 @@ tags:
 query: |
   let iocs = externaldata(DateAdded:string,IoC:string,Type:string) [@"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Sample%20Data/Feeds/SEABORGIUMIOC.csv"] with (format="csv", ignoreFirstRecord=True);
   let DomainNames = (iocs | where Type =~ "domainname"| project IoC);
-  (union isfuzzy=true 
-  (CommonSecurityLog  
-  | parse Message with * '(' DNSName ')' *  
-  | where DNSName in~ (DomainNames) 
-  | extend Account = SourceUserID, Computer = DeviceName, IPAddress =  DestinationIP 
-  ), 
+  (union isfuzzy=true
+  (CommonSecurityLog
+  | parse Message with * '(' DNSName ')' *
+  | where DNSName in~ (DomainNames)
+  | extend Account = SourceUserID, Computer = DeviceName, IPAddress =  DestinationIP
+  ),
   (_Im_Dns (domain_has_any=DomainNames)
-  | extend DNSName = DnsQuery 
+  | extend DNSName = DnsQuery
   | extend IPAddress =  SrcIpAddr, Computer = Dvc
-  ), 
+  ),
   (_Im_WebSession (url_has_any=DomainNames)
   | extend DNSName = tostring(parse_url(Url)["Host"])
   | extend IPAddress =  SrcIpAddr, Computer = Dvc
-  ), 
-  (VMConnection  
-  | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' * 
-  | where DNSName  in~ (DomainNames) 
-  | extend IPAddress = RemoteIp 
-  ), 
-  (DeviceNetworkEvents 
-  | where RemoteUrl  has_any (DomainNames)  
-  | extend IPAddress = RemoteIP 
-  | extend Computer = DeviceName 
+  ),
+  (VMConnection
+  | parse RemoteDnsCanonicalNames with * '["' DNSName '"]' *
+  | where DNSName  in~ (DomainNames)
+  | extend IPAddress = RemoteIp
+  ),
+  (DeviceNetworkEvents
+  | where RemoteUrl  has_any (DomainNames)
+  | extend IPAddress = RemoteIP
+  | extend Computer = DeviceName
   ),
   (EmailUrlInfo
-  | where Url has_any (DomainNames) 
-  | join (EmailEvents 
-  | where EmailDirection == "Inbound" ) on NetworkMessageId 
-  | extend IPAddress = SenderIPv4 
-  | extend Account = RecipientEmailAddress 
+  | where Url has_any (DomainNames)
+  | join (EmailEvents
+  | where EmailDirection == "Inbound" ) on NetworkMessageId
+  | extend IPAddress = SenderIPv4
+  | extend Account = RecipientEmailAddress
   ),
-  (AzureDiagnostics 
+  (AzureDiagnostics
   | where ResourceType == "AZUREFIREWALLS"
   | where Category == "AzureFirewallApplicationRule"
   | parse msg_s with Protocol 'request from ' SourceHost ':' SourcePort 'to ' DestinationHost ':' DestinationPort '. Action:' Action
   | where isnotempty(DestinationHost)
-  | where DestinationHost has_any (DomainNames)  
-  | extend DNSName = DestinationHost 
+  | where DestinationHost has_any (DomainNames)
+  | extend DNSName = DestinationHost
   | extend IPAddress = SourceHost
-  ) 
-  ) 
+  )
+  )
   | extend AccountName = tostring(split(Account, "@")[0]), AccountUPNSuffix = tostring(split(Account, "@")[1])
   | extend HostName = tostring(split(Computer, ".")[0]), DomainIndex = toint(indexof(Computer, '.'))
   | extend HostNameDomain = iff(DomainIndex != -1, substring(Computer, DomainIndex + 1), Computer)
@@ -88,7 +88,7 @@ entityMappings:
       - identifier: Name
         columnName: AccountName
       - identifier: UPNSuffix
-        columnName: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: Host
     fieldMappings:
       - identifier: FullName
@@ -101,7 +101,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IPAddress
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled
 metadata:
     source:

--- a/Solutions/Microsoft Entra ID/Analytic Rules/ADFSDomainTrustMods.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/ADFSDomainTrustMods.yaml
@@ -37,7 +37,7 @@ query: |
   | mv-expand TargetResources
   | extend modifiedProperties = parse_json(TargetResources).modifiedProperties
   | mv-expand modifiedProperties
-  | mv-apply Property = modifiedProperties on 
+  | mv-apply Property = modifiedProperties on
     (
         where Property.displayName =~ "LiveType"
         | extend targetDisplayName = tostring(Property.displayName),
@@ -46,7 +46,7 @@ query: |
   | where NewDomainValue has "Federated"
   )
   )
-  | mv-apply AdditionalDetail = AdditionalDetails on 
+  | mv-apply AdditionalDetail = AdditionalDetails on
     (
         where AdditionalDetail.key =~ "User-Agent"
         | extend UserAgent = tostring(AdditionalDetail.value)
@@ -81,6 +81,6 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: InitiatingIPAddress
-version: 1.1.0
+        columnName: InitiatingIpAddress
+version: 1.1.1
 kind: Scheduled

--- a/Solutions/Microsoft Entra ID/Analytic Rules/AccountCreatedDeletedByNonApprovedUser.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/AccountCreatedDeletedByNonApprovedUser.yaml
@@ -56,6 +56,6 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: InitiatingIPAddress
-version: 1.1.0
+        columnName: InitiatingIpAddress
+version: 1.1.1
 kind: Scheduled

--- a/Solutions/Microsoft Entra ID/Analytic Rules/AzureADRoleManagementPermissionGrant.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/AzureADRoleManagementPermissionGrant.yaml
@@ -27,23 +27,23 @@ tags:
 query: |
   AuditLogs
   | where Category =~ "ApplicationManagement" and LoggedByService =~ "Core Directory" and OperationName in~ ("Add delegated permission grant", "Add app role assignment to service principal")
-  | mv-apply TargetResource = TargetResources on 
+  | mv-apply TargetResource = TargetResources on
     (
         where TargetResource.type =~ "ServicePrincipal" and array_length(TargetResource.modifiedProperties) > 0 and isnotnull(TargetResource.displayName)
         | extend props = TargetResource.modifiedProperties
     )
-  | mv-apply Property = props on 
+  | mv-apply Property = props on
     (
         where Property.displayName in~ ("AppRole.Value","DelegatedPermissionGrant.Scope")
         | extend DisplayName = tostring(Property.displayName), PermissionGrant = trim('"',tostring(Property.newValue))
     )
   | where PermissionGrant has "RoleManagement.ReadWrite.Directory"
-  | mv-apply Property = props on 
+  | mv-apply Property = props on
     (
         where Property.displayName =~ "ServicePrincipal.DisplayName"
         | extend TargetAppDisplayName = trim('"',tostring(Property.newValue))
     )
-  | mv-apply Property = props on 
+  | mv-apply Property = props on
     (
         where Property.displayName =~ "ServicePrincipal.ObjectID"
         | extend TargetAppServicePrincipalId = trim('"',tostring(Property.newValue))
@@ -53,7 +53,7 @@ query: |
   | extend InitiatingUserPrincipalName = tostring(InitiatedBy.user.userPrincipalName)
   | extend InitiatingAadUserId = tostring(InitiatedBy.user.id)
   | extend InitiatingIpAddress = tostring(iff(isnotempty(InitiatedBy.user.ipAddress), InitiatedBy.user.ipAddress, InitiatedBy.app.ipAddress))
-  | project TimeGenerated, OperationName, Result, PermissionGrant, TargetAppDisplayName, TargetAppServicePrincipalId, InitiatingAppName, InitiatingAppServicePrincipalId, 
+  | project TimeGenerated, OperationName, Result, PermissionGrant, TargetAppDisplayName, TargetAppServicePrincipalId, InitiatingAppName, InitiatingAppServicePrincipalId,
   InitiatingUserPrincipalName, InitiatingAadUserId, InitiatingIpAddress, TargetResources, AdditionalDetails, CorrelationId
   | extend InitiatingAccountName = tostring(split(InitiatingUserPrincipalName, "@")[0]), InitiatingAccountUPNSuffix = tostring(split(InitiatingUserPrincipalName, "@")[1])
 entityMappings:
@@ -84,6 +84,6 @@ entityMappings:
   - entityType: IP
     fieldMappings:
       - identifier: Address
-        columnName: InitiatingIPAddress
-version: 1.1.0
+        columnName: InitiatingIpAddress
+version: 1.1.1
 kind: Scheduled

--- a/Solutions/Windows Security Events/Analytic Rules/NRT_execute_base64_decodedpayload.yaml
+++ b/Solutions/Windows Security Events/Analytic Rules/NRT_execute_base64_decodedpayload.yaml
@@ -35,7 +35,7 @@ entityMappings:
   - entityType: Account
     fieldMappings:
       - identifier: FullName
-        columnName: TargetAccount
+        columnName: SubjectAccount
       - identifier: Name
         columnName: AccountName
       - identifier: NTDomain
@@ -48,5 +48,5 @@ entityMappings:
         columnName: HostName
       - identifier: DnsDomain
         columnName: HostNameDomain
-version: 1.0.1
+version: 1.0.2
 kind: NRT


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Fix buggy analytics causing deployment failures

   Reason for Change(s):
   - **NRT_execute_base64_decodedpayload.yaml**: `TargetAccount` doesn't exist as a column or in the schema, `SubjectAccount` does
   - **StarBlizzardDomainsAugust2022.yaml**: UPNSuffix entity was referencing `UPNSuffix` instead of `AccountUPNSuffix` 
   - **ADFSDomainTrustMods.yaml**: mismatched entity case `InitiatingIPAddress` -> `InitiatingIpAddress`
   - **AccountCreatedDeletedByNonApprovedUser.yaml**: mismatched entity case `InitiatingIPAddress` -> `InitiatingIpAddress`
   - **AzureADRoleManagementPermissionGrant.yaml**: mismatched entity case `InitiatingIPAddress` -> `InitiatingIpAddress`

   Version Updated: ✅

   Testing Completed: ✅