### PR TITLE
Adding new workflow for scanning secrets in commits

### DIFF
--- a/.github/workflows/ScanSecrets.yaml
+++ b/.github/workflows/ScanSecrets.yaml
@@ -13,6 +13,6 @@ jobs:
         fetch-depth: 0
     - name: Secret Scanning
       uses: trufflesecurity/trufflehog@main
-	  continue-on-error: true
+      continue-on-error: true
       with:
         extra_args: --exclude-paths=.script/SecretScannning/Excludepathlist --no-verification

--- a/.github/workflows/ScanSecrets.yaml
+++ b/.github/workflows/ScanSecrets.yaml
@@ -15,4 +15,4 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       continue-on-error: true
       with:
-        extra_args: --exclude-paths=.script/SecretScannning/Excludepathlist --no-verification
+        extra_args: --exclude-paths=.script/SecretScanning/Excludepathlist --no-verification

--- a/.github/workflows/ScanSecrets.yaml
+++ b/.github/workflows/ScanSecrets.yaml
@@ -1,0 +1,18 @@
+name: Scanning for secrets in commits
+on:
+ pull_request:
+    branches:
+      - master
+jobs:
+  Scan_Secrets_in_commit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Secret Scanning
+      uses: trufflesecurity/trufflehog@main
+	  continue-on-error: true
+      with:
+        extra_args: --exclude-paths=.script/SecretScannning/Excludepathlist --no-verification

--- a/.script/SecretScanning/Excludepathlist
+++ b/.script/SecretScanning/Excludepathlist
@@ -1,0 +1,2 @@
+path_ofthe_file_toskip_from_scanning
+


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Addition of new workflow for scanning secrets in commits

   Reason for Change(s):
   - Prevent accidental credential leakage while committing code

   Version Updated:
   - v1 yes

   Testing Completed:
   - Yes 

   Checked that the validations are passing and have addressed any issues that are present:
   - yes


Secret scanning When< continue-on-error: true> is used 

Truffle hog able to identify the secrets but workflow ran successfully 

![image](https://github.com/Azure/Azure-Sentinel/assets/97503740/5399c894-f5d5-43f1-a172-7b88428ff897)

![image](https://github.com/Azure/Azure-Sentinel/assets/97503740/07931fdb-fbe9-4777-8dd5-1c8b62e58683)

Secret scanning when < continue-on-error: true> is not used 

Truffle hog able to identify and workflow also failed

![image](https://github.com/Azure/Azure-Sentinel/assets/97503740/e2d325d7-9b16-4180-8200-371620e7403d)

![image](https://github.com/Azure/Azure-Sentinel/assets/97503740/b9325410-5adc-49d5-9740-ce43d77f7413)






