### PR TITLE
Create DataCollectionRulePowerShellEvents

### DIFF
--- a/DataConnectors/WindowsEvents/DataCollectionRulePowerShellEvents
+++ b/DataConnectors/WindowsEvents/DataCollectionRulePowerShellEvents
@@ -1,0 +1,86 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "String",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "westus2",
+            "allowedValues": [
+                "westus2",
+                "eastus2",
+                "eastus2euap",
+                "westeurope",
+                "northeurope"
+            ],
+            "type": "String",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "String",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Insights/dataCollectionRules",
+            "apiVersion": "2023-03-11",
+            "name": "[parameters('dataCollectionRuleName')]",
+            "location": "[parameters('location')]",
+            "tags": {
+                "createdBy": "Sentinel",
+                "createddate": "06/13/2022",
+                "owner": "madesous"
+            },
+            "properties": {
+                "dataSources": {
+                    "windowsEventLogs": [
+                        {
+                            "streams": [
+                                "Microsoft-WindowsEvent"
+                            ],
+                            "xPathQueries": [
+                                "Microsoft-Windows-PowerShell/Operational!*[System[(EventID=4104)]]",
+                                "PowerShellCore/Operational!*[System[(EventID=4104)]]"
+                            ],
+                            "name": "eventLogsDataSource"
+                        }
+                    ]
+                },
+                "destinations": {
+                    "logAnalytics": [
+                        {
+                            "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                            "name": "DataCollectionEvent"
+                        }
+                    ]
+                },
+                "dataFlows": [
+                    {
+                        "streams": [
+                            "Microsoft-WindowsEvent"
+                        ],
+                        "destinations": [
+                            "DataCollectionEvent"
+                        ],
+                        "transformKql": "source | where SystemUserId !in ('S-1-5-18', 'S-1-5-19') | extend ScriptBlockText =  parse_json(EventData).ScriptBlockText, ScriptBlockId = tostring(EventData.ScriptBlockId), MessageNumber = tostring(EventData.MessageNumber), MessageTotal = tostring(EventData.MessageTotal), Path = tostring(EventData.Path) | where tostring(ScriptBlockText) != 'prompt' | where Path != '.vscode\\\\extensions\\\\' and Path != 'C:\\\\Windows\\\\TEMP\\\\SDIAG_([A-Za-z0-9]+(-[A-Za-z0-9]+)+)\\\\CL_Utility.ps1' and Path != 'C:\\\\ProgramData\\\\Microsoft\\\\Windows Defender Advanced Threat Protection\\\\DataCollection\\\\'"
+                    }
+                ]
+            }
+        }
+    ],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "String",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}


### PR DESCRIPTION
This data collection rule filters event 4104 from PowerShell or PowerShell Core and streams it to the WindowEvent table. It also filters out events that are not so valuable (e.g. generated by system accounts, etc.)

   Required items, please complete
   
   Change(s):
   - I have created a new data collection rule. This data collection rule filters event 4104 from PowerShell or PowerShell Core and streams it to the WindowEvent table. It also filters out events that are not so valuable (e.g. generated by system accounts, etc.)

   Reason for Change(s):
   - It's a new file.

  

-----------------------------------------------------------------------------------------------------------
