### PR TITLE
Update Network Session ASIM parser for Cisco Meraki

### DIFF
--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionCiscoMeraki.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionCiscoMeraki.yaml
@@ -143,6 +143,8 @@ ParserQuery: |
     let DvcActionLookup = datatable(pattern: string, DvcAction: string, EventResult: string)[
         "allow", "Allow", "Success",
         "deny", "Deny", "Failure",
+        "0", "Allow", "Success",
+        "1", "Deny", "Failure",
         "Blocked", "Deny", "Failure"
     ];
     let EventResultLookup = datatable(LogSubType: string, EventResult_type: string)[
@@ -180,6 +182,8 @@ ParserQuery: |
             | extend NetworkIcmpType = iff(isnotempty(NetworkIcmpCode), coalesce(NetworkIcmpType_lookup, NetworkIcmpType), "")
             | extend pattern = coalesce(pattern1, pattern2)
             | lookup DvcActionLookup on pattern
+            | extend direction = case(pattern has_any ('0','1'), 'ingress', pattern has_any ('allow','deny'), 'egress', 'unknown')
+            | lookup NetworkDirectionLookup on direction
             | lookup EventSeverityDvcActionLookup on DvcAction
             | extend
                 SrcMacAddr = trim('"', mac),

--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionCiscoMeraki.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionCiscoMeraki.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Network Session ASIM parser for Cisco Meraki
-  Version: '1.1.1'
-  LastUpdated: Mar 28 2024
+  Version: '1.1.2'
+  LastUpdated: Jun 26 2024
 Product:
   Name: Cisco Meraki
 Normalization:

--- a/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionCiscoMeraki.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionCiscoMeraki.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Network Session ASIM filtering parser for Cisco Meraki
-  Version: '1.1.1'
-  LastUpdated: Mar 28 2024
+  Version: '1.1.2'
+  LastUpdated: Jul 15 2024
 Product:
   Name: Cisco Meraki
 Normalization:
@@ -170,6 +170,8 @@ ParserQuery: |
   let DvcActionLookup = datatable(pattern: string, DvcAction: string, EventResult: string)[
       "allow", "Allow", "Success",
       "deny", "Deny", "Failure",
+      "0", "Allow", "Success",
+      "1", "Deny", "Failure",
       "Blocked", "Deny", "Failure"
   ];
   let EventResultLookup = datatable(LogSubType: string, EventResult_type: string)[
@@ -231,6 +233,8 @@ ParserQuery: |
           | extend NetworkIcmpType = iff(isnotempty(NetworkIcmpCode), coalesce(NetworkIcmpType_lookup, NetworkIcmpType), "")
           | extend pattern = coalesce(trim("'", pattern1), trim("'", pattern2))
           | extend pattern = trim('"', pattern)
+          | extend direction = case(pattern has_any ('0','1'), 'ingress', pattern has_any ('allow','deny'), 'egress', 'unknown')
+          | lookup NetworkDirectionLookup on direction
           | lookup DvcActionLookup on pattern
           | lookup EventSeverityDvcActionLookup on DvcAction
           | extend


### PR DESCRIPTION
Added direction field for flows/firewall logType and added extra parsing for deviceAction for the inbound traffic (this one uses 0 for allow and 1 for deny). Based on: https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/Syslog_Server_Overview_and_Configuration

   Required items, please complete
   
   Change(s):
   - Added direction field for flows/firewall logType
   - added extra parsing for deviceAction for the inbound traffic (this one uses 0 for allow and 1 for deny)

   Reason for Change(s):
   - Device action wasn't properly extracted for inbound traffic, since the pattern field shows 0 instead of allow and 1 instead of deny. Direction was missing for Flows/Firewall log type as there's no direct field for that.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

