### PR TITLE
Update CiscoMeraki parser to contemplate firewall LogType

### DIFF
--- a/Solutions/CiscoMeraki/Parsers/CiscoMeraki.yaml
+++ b/Solutions/CiscoMeraki/Parsers/CiscoMeraki.yaml
@@ -2,7 +2,7 @@ id: f3811ff1-231c-453f-bd2c-cda06e7c3e1f
 Function:
   Title: Parser for CiscoMeraki
   Version: '1.0.1'
-  LastUpdated: '2023-08-23'
+  LastUpdated: '2024-06-27'
 Category: Microsoft Sentinel Parser
 FunctionName: CiscoMeraki
 FunctionAlias: CiscoMeraki

--- a/Solutions/CiscoMeraki/Parsers/CiscoMeraki.yaml
+++ b/Solutions/CiscoMeraki/Parsers/CiscoMeraki.yaml
@@ -1,7 +1,7 @@
 id: f3811ff1-231c-453f-bd2c-cda06e7c3e1f
 Function:
   Title: Parser for CiscoMeraki
-  Version: '1.0.0'
+  Version: '1.0.1'
   LastUpdated: '2023-08-23'
 Category: Microsoft Sentinel Parser
 FunctionName: CiscoMeraki
@@ -31,16 +31,17 @@ FunctionQuery: |
             )
     | extend Parser = extract_all(@"(\d+.\d+)\s([\w\-\_]+)\s([\w\-\_]+)\s([\S\s]+)$", dynamic([1, 2, 3, 4]), LogMessage)[0]
     | extend Epoch = tostring(Parser[0]),
-            DeviceName = coalesce(tostring(Parser[1]),column_ifexists("SrcHostname","")),
-            LogType = coalesce(column_ifexists("LogType",""),tostring(Parser[2])),
-            Substring = tostring(Parser[3])
+             DeviceName = coalesce(tostring(Parser[1]),column_ifexists("SrcHostname","")),
+             LogType = coalesce(column_ifexists("LogType",""),tostring(Parser[2])),
+             Substring = tostring(Parser[3])
     | extend EpochTimestamp = split(Epoch,".")
     | extend EventTimestamp = unixtime_seconds_todatetime(tolong(EpochTimestamp[0]))
     | extend EventStartTime = coalesce(EventTimestamp,column_ifexists("EventStartTime",datetime(null)))
     | extend SrcIpAddr = case(
                             isnotempty(column_ifexists("SrcIpAddr","")), column_ifexists("SrcIpAddr",""),
+                            LogType has "events", extract(@"last_known_client_ip=([0-9\.]+)\:",1,Substring),
                             LogType has "urls", extract(@"src=([0-9\.]+)\:",1,Substring),
-                            LogType has "flows", extract(@"src=([0-9\.]+)\s",1,Substring),
+                            LogType has_any ("flows","firewall"), extract(@"src=([0-9\.]+)\s",1,Substring),
                             LogType has "security_event", extract(@"src=([0-9\.]+)\:",1,Substring),
                             LogType has "ids-alerts", extract(@"src=([0-9\.]+)\:",1,Substring),
                             LogType has "events", extract(@"(peer_contact|ip_src)=\'([0-9\.]+)\:",2,Substring),
@@ -50,7 +51,7 @@ FunctionQuery: |
                                 isnotnull(column_ifexists("SrcPortNumber",int(null))),
                                 column_ifexists("SrcPortNumber",int(null)),
                                 LogType has "urls", toint(extract(@"src=([0-9\.]+)\:(\d+)\s",2,Substring)),
-                                LogType has "flows", toint(extract(@"sport=(\S+)",1,Substring)),
+                                LogType has_any ("flows","firewall"), toint(extract(@"sport=(\S+)",1,Substring)),
                                 LogType has "security_event", toint(extract(@"src=([0-9\.]+)\:(\d+)",2,Substring)),
                                 LogType has "ids-alerts", toint(extract(@"src=([0-9\.]+)\:(\d+)",2,Substring)),
                                 LogType has "events", toint(extract(@"(peer_contact|ip_src)=\'([0-9\.]+)\:(\d+)\'",3,Substring)),
@@ -59,7 +60,7 @@ FunctionQuery: |
     		 DstIpAddr = case(
                             isnotempty(column_ifexists("DstIpAddr","")), column_ifexists("DstIpAddr",""),
                             LogType has "urls",extract(@"dst=([0-9\.]+)\:",1,Substring),
-                            LogType has "flows", extract(@"dst=([0-9\.]+)\s",1,Substring),
+                            LogType has_any ("flows","firewall"), extract(@"dst=([0-9\.]+)\s",1,Substring),
                             LogType has "security_event", extract(@"dst=([0-9\.]+)\:",1,Substring),
                             ""
                         ),
@@ -67,7 +68,7 @@ FunctionQuery: |
                                 isnotnull(column_ifexists("DstPortNumber",int(null))),
                                 column_ifexists("DstPortNumber",int(null)),
                                 LogType has "urls", toint(extract(@"dst=([0-9\.]+)\:(\d+)\s",2,Substring)),
-                                LogType has "flows", toint(extract(@"dport=(\S+)",1,Substring)),
+                                LogType has_any ("flows","firewall"), toint(extract(@"dport=(\S+)",1,Substring)),
                                 LogType has "security_event", toint(extract(@"dst=([0-9\.]+)\:(\d+)",2,Substring)),
                                 int(null)
                             ),
@@ -80,18 +81,18 @@ FunctionQuery: |
     		 SrcMacAddr = case(
                             isnotempty(column_ifexists("SrcMacAddr","")), column_ifexists("SrcMacAddr",""),
                             LogType has "airmarshal_events", tostring(extract(@"src=\'(\S+)\'",1,Substring)),
-                            LogType has "flows", tostring(extract(@"mac=(\S+)\s",1,Substring)),
+                            LogType has_any ("flows","firewall"), tostring(extract(@"mac=(\S+)\s",1,Substring)),
                             LogType has "security_event", tostring(extract(@"shost=(\S+)\s",1,Substring)),
                             ""
                         ),
     		 NetworkProtocol = case(
                                 isnotempty(column_ifexists("NetworkProtocol","")), column_ifexists("NetworkProtocol",""),
                                 LogType has "ids-alerts", tostring(extract(@"protocol=(\w+)\s",1,Substring)),
-                                LogType has "flows", extract(@"protocol=(\w+)\s",1,Substring),
+                                LogType has_any ("flows","firewall"), extract(@"protocol=(\w+)\s",1,Substring),
                                 LogType has "security_event", tostring(extract(@"protocol=(\w+)\s",1,Substring)),
                                 ""
                             ),
-    		 Pattern = iff(LogType has "flows", extract(@"pattern\: ([\S\s]+)",1,Substring), dynamic("")),
+    		 Pattern = iff(LogType has_any ("flows","firewall"), extract(@"pattern\: ([\S\s]+)",1,Substring), dynamic("")),
     		 EventType = case(
                             isnotempty(column_ifexists("EventOriginalType","")), column_ifexists("EventOriginalType",""),
                             LogType has "airmarshal_events", tostring(extract(@"type= (\S+)",1,Substring)),
@@ -148,42 +149,42 @@ FunctionQuery: |
                                 ""
                         ),
     		 Message = iff(LogType has "security_event", tostring(extract(@"message: ([\w\.\-\+\,\s]+)(\s\w+\=)?",1,Substring)), column_ifexists("Message","")),
-    		 VpnType = iff(LogType has "events",  tostring(extract(@"vpn_type=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 PeerIdentity = iff(LogType has "events",  tostring(extract(@"peer_ident=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 Radio = iff(LogType has "events",  toint(extract(@"radio=\'(\d+)\'",1,Substring)), dynamic("")),
-    		 Group = iff(LogType has "events",  toint(extract(@"group=\'(\S+)?\'",1,Substring)), dynamic("")),
-    		 Attribute = iff(LogType has "events",  toint(extract(@"attr=\'(\S+)?\'",1,Substring)), dynamic("")),
+    		 VpnType = iff(LogType has "events", tostring(extract(@"vpn_type=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 PeerIdentity = iff(LogType has "events", tostring(extract(@"peer_ident=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 Radio = iff(LogType has "events", toint(extract(@"radio=\'(\d+)\'",1,Substring)), dynamic("")),
+    		 Group = iff(LogType has "events", toint(extract(@"group=\'(\S+)?\'",1,Substring)), dynamic("")),
+    		 Attribute = iff(LogType has "events", toint(extract(@"attr=\'(\S+)?\'",1,Substring)), dynamic("")),
     		 ClientMacAddr = case(
                             isnotempty(column_ifexists("SrcMacAddr","")), column_ifexists("SrcMacAddr",""),
-                            LogType has "events",  tostring(extract(@"client_mac=\'(\S+)\'",1,Substring)),
+                            LogType has "events", tostring(extract(@"client_mac=\'(\S+)\'",1,Substring)),
                             ""
                     ),
-    		 Reason = iff(LogType has "events",  toint(extract(@"reason=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 AppleDaReason = iff(LogType has "events",  toint(extract(@"apple_da_reason=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 Duration = iff(LogType has "events",  tostring(extract(@"duration=\'(\S+)\'",1,Substring)), ""),
-    		 FullConn = iff(LogType has "events",  tostring(extract(@"full_conn=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 IpResp = iff(LogType has "events",  tostring(extract(@"ip_resp=\'(\S+)\'\s",1,Substring)), dynamic("")),
-    		 HttpResp = iff(LogType has "events",  tostring(extract(@"http_resp=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 ArpResp = iff(LogType has "events",  tostring(extract(@"arp_resp=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 Reason = iff(LogType has "events", toint(extract(@"reason=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 AppleDaReason = iff(LogType has "events", toint(extract(@"apple_da_reason=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 Duration = iff(LogType has "events", tostring(extract(@"duration=\'(\S+)\'",1,Substring)), ""),
+    		 FullConn = iff(LogType has "events", tostring(extract(@"full_conn=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 IpResp = iff(LogType has "events", tostring(extract(@"ip_resp=\'(\S+)\'\s",1,Substring)), dynamic("")),
+    		 HttpResp = iff(LogType has "events", tostring(extract(@"http_resp=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 ArpResp = iff(LogType has "events", tostring(extract(@"arp_resp=\'(\S+)\'",1,Substring)), dynamic("")),
     		 ArpSrcIpAddr = case(
                             isnotempty(column_ifexists("SrcIpAddr","")), column_ifexists("SrcIpAddr",""),
-                            LogType has "events",  tostring(extract(@"arp_src=\'(\S+)\'",1,Substring)),
+                            LogType has "events", tostring(extract(@"arp_src=\'(\S+)\'",1,Substring)),
                             ""
                     ),
-    		 Connectivity = iff(LogType has "events",  tostring(extract(@"connectivity=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 Rtt = iff(LogType has "events",  tostring(extract(@"rtt=\'([\w+\.\s]+)\'",1,Substring)), dynamic("")),
-    		 UserName = iff(LogType has "events",  tostring(extract(@"identity=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 Aid = iff(LogType has "events",  tostring(extract(@"aid=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 Spi = iff(LogType has "events",  tostring(extract(@"spi=(\S+)$",1,Substring)), dynamic("")),
+    		 Connectivity = iff(LogType has "events", tostring(extract(@"connectivity=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 Rtt = iff(LogType has "events", tostring(extract(@"rtt=\'([\w+\.\s]+)\'",1,Substring)), dynamic("")),
+    		 UserName = iff(LogType has "events", tostring(extract(@"identity=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 Aid = iff(LogType has "events", tostring(extract(@"aid=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 Spi = iff(LogType has "events", tostring(extract(@"spi=(\S+)$",1,Substring)), dynamic("")),
     		 DvcMacAddr = case(
                             isnotempty(column_ifexists("DvcMacAddr","")), column_ifexists("DvcMacAddr",""),
-                            LogType has "events",  tostring(extract(@"device=\'(\S+)\'",1,Substring)),
+                            LogType has "events", tostring(extract(@"device=\'(\S+)\'",1,Substring)),
                             ""
                     ),
-    		 State = iff(LogType has "events",  tostring(extract(@"state=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 AlarmId = iff(LogType has "events",  toint(extract(@"alarm_id=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 DosCount = iff(LogType has "events",  tostring(extract(@"dos_count=\'(\S+)\'",1,Substring)), dynamic("")),
-    		 InterArrival = iff(LogType has "events",  tostring(extract(@"inter_arrival=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 State = iff(LogType has "events", tostring(extract(@"state=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 AlarmId = iff(LogType has "events", toint(extract(@"alarm_id=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 DosCount = iff(LogType has "events", tostring(extract(@"dos_count=\'(\S+)\'",1,Substring)), dynamic("")),
+    		 InterArrival = iff(LogType has "events", tostring(extract(@"inter_arrival=\'(\S+)\'",1,Substring)), dynamic("")),
     		 LogTimestamp = case(
                                 isnotnull(column_ifexists("EventStartTime",datetime(null))), column_ifexists("EventStartTime",datetime(null)),
                                 LogType has "security_event", unixtime_seconds_todatetime(tolong(split(tostring(extract(@"timestamp=(\S+)\s",1,Substring)),".")[0])),
@@ -193,15 +194,15 @@ FunctionQuery: |
     		 IpAddr = iff(LogType has "events", tostring(extract(@"dhcp lease of ip ([\d\.]+)", 1, Substring)), dynamic("")),
     		 ServerMacAddr = iff(LogType has "events", tostring(extract(@"server mac ([\w\:]+)", 1, Substring)), dynamic("")),
     		 RouterIpAddr = iff(LogType has "events", tostring(extract(@"router ([\d\.]+)", 1, Substring)), dynamic("")),
-    		 Subnet = iff(LogType has "events",  tostring(extract(@"subnet ([\d\.]+)", 1, Substring)), dynamic("")),
-    		 Dns = iff(LogType has "events",  split(extract(@"dns ([\d\.\,\:\s]+)", 1, Substring), ", "), dynamic(""))
+    		 Subnet = iff(LogType has "events", tostring(extract(@"subnet ([\d\.]+)", 1, Substring)), dynamic("")),
+    		 Dns = iff(LogType has "events", split(extract(@"dns ([\d\.\,\:\s]+)", 1, Substring), ", "), dynamic(""))
     | extend
-                ClientMacAddr = iif(isempty(ClientMacAddr), tostring(extract(@"client mac ([\w\:]+)", 1, Substring)), ClientMacAddr),
-    		    SrcPortNumber = iif(isempty(SrcPortNumber), toint(extract(@"port=\'(\S+)\'",1,Substring)), SrcPortNumber),
-                Dns = iif(Dns[0] == "", "", Dns)
+         ClientMacAddr = iif(isempty(ClientMacAddr), tostring(extract(@"client mac ([\w\:]+)", 1, Substring)), ClientMacAddr),
+    		 SrcPortNumber = iif(isempty(SrcPortNumber), toint(extract(@"port=\'(\S+)\'",1,Substring)), SrcPortNumber),
+         Dns = iif(Dns[0] == "", "", Dns)
     | extend LogType = case(
                         isnotempty(LogType), LogType,
-                        LogType !in ("urls", "airmarshal_events","security_event","ids-alerts", "events") and LogType !contains "flows", iif(isempty(LogType), "", LogType),
+                        LogType !in ("urls", "airmarshal_events","security_event","ids-alerts", "events") and LogType !contains "flows" and LogType !contains "firewall", iif(isempty(LogType), "", LogType),
                         ""
                     ),
              NetworkProtocol = case(NetworkProtocol has "tcp", "TCP",
@@ -214,22 +215,32 @@ FunctionQuery: |
                                   Priority == 3, "Low",
                                   Priority == 4, "Infomational",
                                   ""),
-            Disposition = case(
+             Disposition = case(
                                 EventType contains "File Scanned", tolower(column_ifexists("EventOriginalSeverity","")),
                                 LogType has "security_event", tostring(extract(@"disposition=(\w+)",1,Substring)),
                                 ""
                             ),
-            ThreatName = case(
+             ThreatName = case(
                                 LogType has "security_event", tostring(extract(@"name=(\S+)",1,Substring)),
                                 ""
                             ),
-            Sha256 = case (
+             Sha256 = case (
                                 EventType == "File Scanned", column_ifexists("Sha256",""),
                                 LogType has "security_event",  tostring(extract(@"sha256=(\S+)?",1,Substring)),
                                 ""
                             ),
-            Action = case(
-                                Action == "block", "deny",
-                                tolower(Action)
-                )
+             NetworkDirection = case (
+                               LogType has_any ("flows", "firewall") and Pattern has_any ('1','0'), "inbound", //added by Logicalis
+                               LogType has_any ("flows", "firewall") and Pattern has_any ('allow','deny'), "outbound", //added by Logicalis
+                               LogType has "flows" and ipv4_is_private(DstIpAddr) and not(ipv4_is_private(SrcIpAddr)), "inbound",
+                               LogType has "flows" and ipv4_is_private(SrcIpAddr) and not(ipv4_is_private(DstIpAddr)), "outbound",
+                               NetworkDirection
+                            ),
+             Action = case(
+                               //https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/Syslog_Server_Overview_and_Configuration
+                               LogType has_any ("flows","firewall") and (Pattern startswith "1" or Pattern startswith "deny"), "deny",
+                               LogType has_any ("flows","firewall") and (Pattern startswith "0" or Pattern startswith "allow"), "allow",
+                               Action == "block", "deny",
+                               tolower(Action)
+                          )
     | project-away Substring, Parser

--- a/Solutions/CiscoMeraki/Parsers/CiscoMeraki.yaml
+++ b/Solutions/CiscoMeraki/Parsers/CiscoMeraki.yaml
@@ -198,7 +198,7 @@ FunctionQuery: |
     		 Dns = iff(LogType has "events", split(extract(@"dns ([\d\.\,\:\s]+)", 1, Substring), ", "), dynamic(""))
     | extend
          ClientMacAddr = iif(isempty(ClientMacAddr), tostring(extract(@"client mac ([\w\:]+)", 1, Substring)), ClientMacAddr),
-    		 SrcPortNumber = iif(isempty(SrcPortNumber), toint(extract(@"port=\'(\S+)\'",1,Substring)), SrcPortNumber),
+         SrcPortNumber = iif(isempty(SrcPortNumber), toint(extract(@"port=\'(\S+)\'",1,Substring)), SrcPortNumber),
          Dns = iif(Dns[0] == "", "", Dns)
     | extend LogType = case(
                         isnotempty(LogType), LogType,


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added LogType firewall as it replaced flows on a Meraki firmware update
   - Inferred networkDirection from the log format as detailed in Meraki documentation "https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/Syslog_Server_Overview_and_Configuration"

   Reason for Change(s):
   - In Firmware MX18.101 and newer, the syslog messages for "flows" have been changed to "firewall", "vpn_firewall", "cellular_firewall" or "bridge_anyconnect_client_vpn_firewall"

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
