### PR TITLE
Updated analytic rules for missing TTPs - Cisco SDWAN

### DIFF
--- a/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelIPSEventThreshold.yaml
+++ b/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelIPSEventThreshold.yaml
@@ -13,7 +13,10 @@ queryPeriod: 3h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - Discovery
+  - InitialAccess
+relevantTechniques:
+  - T1190
+  - T1189
 query: |
   CiscoSyslogUTD 
   | where Classification == "Enter classification" 
@@ -31,5 +34,5 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: Classification
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelIntrusionEvents.yaml
+++ b/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelIntrusionEvents.yaml
@@ -13,7 +13,10 @@ queryPeriod: 3h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - DefenseEvasion
+  - InitialAccess
+relevantTechniques:
+  - T1190
+  - T1189
 query: |
   CiscoSyslogUTD
   | where SignatureId == "Enter SignatureId"
@@ -29,5 +32,5 @@ entityMappings:
     fieldMappings:
       - identifier: Key
         columnName: SignatureId
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelMalwareEvents.yaml
+++ b/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelMalwareEvents.yaml
@@ -16,7 +16,9 @@ queryPeriod: 3h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - Discovery
+  - ResourceDevelopment
+relevantTechniques:
+  - T1587.001
 query: |
   CiscoSyslogUTD
   | where isnotempty(Malware) and Malware != "None"
@@ -49,5 +51,5 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: Username
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled

--- a/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelMonitorCriticalIP.yaml
+++ b/Solutions/Cisco SD-WAN/Analytic Rules/CiscoSDWANSentinelMonitorCriticalIP.yaml
@@ -16,7 +16,9 @@ queryPeriod: 3h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
-  - Discovery
+  - CommandAndControl
+relevantTechniques:
+  - T1071
 query: |
   CiscoSyslogUTD
   | union (CiscoSDWANNetflow)
@@ -35,5 +37,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: SourceIP
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Updated analytic rules for missing TTPs 

   Reason for Change(s):
   - Missing Tactics and Techniques

   Version Updated:
   - Yes

   Testing Completed:
   - Yes