### PR TITLE
Update analytic rule for missing TTPs - Network Session Essentials 

### DIFF
--- a/Solutions/Network Session Essentials/Analytic Rules/NetworkPortSweepFromExternalNetwork.yaml
+++ b/Solutions/Network Session Essentials/Analytic Rules/NetworkPortSweepFromExternalNetwork.yaml
@@ -69,8 +69,11 @@ queryPeriod: 1h
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
+  - Reconnaissance
   - Discovery
 relevantTechniques:
+  - T1590
+  - T1046
 query: |
   let lookback = 1h;
   let threshold = 20;
@@ -86,5 +89,5 @@ customDetails:
 alertDetailsOverride:
   alertDisplayNameFormat: Network Port Sweep detected on {{DstPortNumber}}
   alertDescriptionFormat: 'Network Port Sweep was detection by multiple IPs'
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - Update analytic rule for missing TTPs

   Reason for Change(s):
   - Missing tactics and techniques

   Version Updated:
   - Yes

   Testing Completed:
   - Yes