### PR TITLE
check if comment already exist for detection in pr

### DIFF
--- a/.github/workflows/addCommentToRemindUpdatingTemplateVersion.yml
+++ b/.github/workflows/addCommentToRemindUpdatingTemplateVersion.yml
@@ -7,9 +7,34 @@ on:
        - 'Solutions/**/Analytic Rules/**'
       
 jobs:
-  add-comment:
-    uses: ./.github/workflows/addComment.yaml
+  checkCommentAlreadyExist:
+    runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.head.repo.fork }}
+    outputs:
+      hasAutoDetectionComment: ${{ steps.job1.outputs.hasAutoDetectionComment }}
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: Hello how are you I am GitHub bot
+      - id: job1
+        shell: pwsh
+        run: |
+          $commentId = ${{ steps.fc.outputs.comment-id }}
+          if ($commentId) {
+            Write-Output "hasAutoDetectionComment=$true" >> $env:GITHUB_OUTPUT
+            Write-Host "Comment Already Present!"
+          } else {
+            Write-Output "hasAutoDetectionComment=$false" >> $env:GITHUB_OUTPUT
+            Write-Host "Comment Not Present!"
+          }
+
+  add-comment:
+    needs: checkCommentAlreadyExist
+    if: ${{ success() && needs.checkCommentAlreadyExist.outputs.hasAutoDetectionComment == 'False' }} 
+    uses: ./.github/workflows/addComment.yaml
     with:
       message: |
         **Hello how are you I am GitHub bot**


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In a PR when there is a change in detection or analytic rule a comment is added automatically. This comment is always added when a new commit is pushed to the pr so we are now going the check if pr already has the comment if it is not present then only add else dont add the comment on pr.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

