### PR TITLE
Fix bug for parser rename

### DIFF
--- a/.script/tests/asimParsersTest/runAsimTesters.ps1
+++ b/.script/tests/asimParsersTest/runAsimTesters.ps1
@@ -50,16 +50,20 @@ function run {
     # Iterate over the lines
     foreach ($line in $modifiedFilesStatusLines) {
         # Split the line into status and file name
-        $status, $file = $line -split "\t", 2
+        $parts = $line -split "\t"
+        # Assigning the first part to $status and the last part to $file
+        $status = $parts[0]
+        $file = $parts[-1]  # -1 index refers to the last element
         # Check if the file is a YAML file
         if ($file -like "*.yaml") {
             # Add the file name and status to the array
             $global:modifiedFiles += New-Object PSObject -Property @{
                 Name = $file
-                Status = switch ($status) {
+                Status = switch -Regex ($status) {
                     "A" { "Added" }
                     "M" { "Modified" }
                     "D" { "Deleted" }
+                    "R" { "Renamed" }
                     default { "Unknown" }
                 }
             }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Add support for Parser rename change

   Reason for Change(s):
   - Script was unable to detect parser rename change and was failing due to this.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes