### PR TITLE
Update azuredeploy_QualysKB_API_FunctionApp.json

### DIFF
--- a/Solutions/Qualys VM Knowledgebase/Data Connectors/azuredeploy_QualysKB_API_FunctionApp.json
+++ b/Solutions/Qualys VM Knowledgebase/Data Connectors/azuredeploy_QualysKB_API_FunctionApp.json
@@ -180,7 +180,7 @@
                   "clientAffinityEnabled": true,
                    "alwaysOn": true,
                   "siteConfig": {
-                        "powerShellVersion": "~7"
+                        "powerShellVersion": "7.4"
                     }
               },
               "resources": [

--- a/Solutions/Qualys VM Knowledgebase/ReleaseNotes.md
+++ b/Solutions/Qualys VM Knowledgebase/ReleaseNotes.md
@@ -1,5 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                                                 |
 |-------------|--------------------------------|--------------------------------------------------------------------|
-| 3.0.1       | 03-05-2024                     | Added Deploy to Azure Goverment button for Government portal in **Dataconnector** <br/> Fixed Metadata issue for ParserName and ParentId mismatch |
+| 3.0.1       | 03-05-2024                     | Added Deploy to Azure Goverment button for Government portal in **Dataconnector** <br/> Fixed Metadata issue for ParserName and ParentId mismatch  |
 | 3.0.0       | 12-10-2023                     | Manual deployment instructions updated for **Data Connector**		|  
                                                                                                                  


### PR DESCRIPTION
Function App getting PS version 7, deprecated in 2022.

   Required items, please complete
   
   Change(s): PowerShell version
   - See guidance below

   Reason for Change(s): PS version 7 deprecated in 2022.
   - See guidance below

   Testing Completed: Changed PS version to 7.4, no module error anymore.
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below