### PR TITLE
Sentinel all in one v2

### DIFF
--- a/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlerts.json
+++ b/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlerts.json
@@ -61,7 +61,9 @@
             "location": "[resourceGroup().location]"
         },
         {
-            "dependsOn": ["[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]"],
+            "dependsOn": [
+                "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]"
+            ],
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",
             "name": "sleep",
@@ -92,7 +94,9 @@
             ]
         },
         {
-            "dependsOn": ["[concat('Microsoft.Authorization/roleAssignments/', parameters('roleGuid'))]"],
+            "dependsOn": [
+                "[concat('Microsoft.Authorization/roleAssignments/', parameters('roleGuid'))]"
+            ],
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",
             "name": "deployRules",
@@ -107,8 +111,8 @@
             "properties": {
                 "forceUpdateTag": "1",
                 "azPowerShellVersion": "3.0",
-                 "arguments": "[concat('-Workspace ', parameters('workspaceName'), ' -ResourceGroup ', resourceGroup().name, ' -Solutions ', variables('solutions'), ' -SeveritiesToInclude ', string(variables('severities')), ' -Region ', parameters('location'), ' -IsGov $false')]",
-                "primaryScriptUri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/Scripts/Create-NewSolutionAndRulesFromList.ps1",
+                "arguments": "[concat('-Workspace ', parameters('workspaceName'), ' -ResourceGroup ', resourceGroup().name, ' -Solutions ', variables('solutions'), ' -SeveritiesToInclude ', string(variables('severities')), ' -Region ', parameters('location'), ' -IsGov $false')]",
+                "primaryScriptUri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/Scripts/Create-NewSolutionAndRulesFromList.ps1",
                 "supportingScriptUris": [],
                 "timeout": "PT30M",
                 "cleanupPreference": "OnExpiration",

--- a/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlerts.json
+++ b/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlerts.json
@@ -44,12 +44,13 @@
         },
         "roleGuid": {
             "type": "string",
-            "defaultValue": "[newGuid()]"
+            "defaultValue": "[guid(resourceGroup().id, 'b24988ac-6180-42a0-ab88-20f7382dd24c')]"
         }
     },
     "functions": [],
     "variables": {
         "identityName": "[concat('userIdentity',uniqueString(resourceGroup().id))]",
+        "roleGuidId": "[if(empty(parameters('roleGuid')), guid(resourceGroup().id, 'userIdentity', 'b24988ac-6180-42a0-ab88-20f7382dd24c'), parameters('roleGuid'))]",
         "solutions": "[replace(concat(parameters('enableSolutions1P'),if(and(not(empty(parameters('enableSolutions1P'))),not(empty(parameters('enableSolutionsEssentials')))),concat(',',parameters('enableSolutionsEssentials')),parameters('enableSolutionsEssentials')),if(or(not(empty(parameters('enableSolutionsEssentials'))),not(empty(parameters('enableSolutions1P')))),concat(',',parameters('enableSolutionsTraining')),parameters('enableSolutionsTraining'))),'\"','\\\"')]",
         "severities": "[if(empty(parameters('severityLevels')),'None',parameters('severityLevels'))]"
     },
@@ -83,7 +84,7 @@
         {
             "apiVersion": "2017-09-01",
             "type": "Microsoft.Authorization/roleAssignments",
-            "name": "[parameters('roleGuid')]",
+            "name": "[variables('roleGuidId')]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
                 "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')), '2018-11-30', 'Full').properties.principalId]",
@@ -95,7 +96,7 @@
         },
         {
             "dependsOn": [
-                "[concat('Microsoft.Authorization/roleAssignments/', parameters('roleGuid'))]"
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
             ],
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",

--- a/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlertsGov.json
+++ b/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlertsGov.json
@@ -44,12 +44,13 @@
         },
         "roleGuid": {
             "type": "string",
-            "defaultValue": "[newGuid()]"
+            "defaultValue": "[guid(resourceGroup().id, 'b24988ac-6180-42a0-ab88-20f7382dd24c')]"
         }
     },
     "functions": [],
     "variables": {
         "identityName": "[concat('userIdentity',uniqueString(resourceGroup().id))]",
+        "roleGuidId": "[if(empty(parameters('roleGuid')), guid(resourceGroup().id, 'userIdentity', 'b24988ac-6180-42a0-ab88-20f7382dd24c'), parameters('roleGuid'))]",
         "solutions": "[replace(concat(parameters('enableSolutions1P'),if(and(not(empty(parameters('enableSolutions1P'))),not(empty(parameters('enableSolutionsEssentials')))),concat(',',parameters('enableSolutionsEssentials')),parameters('enableSolutionsEssentials')),if(or(not(empty(parameters('enableSolutionsEssentials'))),not(empty(parameters('enableSolutions1P')))),concat(',',parameters('enableSolutionsTraining')),parameters('enableSolutionsTraining'))),'\"','\\\"')]",
         "severities": "[if(empty(parameters('severityLevels')),'None',parameters('severityLevels'))]"
     },
@@ -83,7 +84,7 @@
         {
             "apiVersion": "2017-09-01",
             "type": "Microsoft.Authorization/roleAssignments",
-            "name": "[parameters('roleGuid')]",
+            "name": "[variables('roleGuidId')]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
                 "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')), '2018-11-30', 'Full').properties.principalId]",
@@ -95,7 +96,7 @@
         },
         {
             "dependsOn": [
-                "[concat('Microsoft.Authorization/roleAssignments/', parameters('roleGuid'))]"
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
             ],
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",

--- a/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlertsGov.json
+++ b/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlertsGov.json
@@ -61,7 +61,9 @@
             "location": "[resourceGroup().location]"
         },
         {
-            "dependsOn": [ "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]" ],
+            "dependsOn": [
+                "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('identityName'))]"
+            ],
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",
             "name": "sleep",
@@ -92,7 +94,9 @@
             ]
         },
         {
-            "dependsOn": [ "[concat('Microsoft.Authorization/roleAssignments/', parameters('roleGuid'))]" ],
+            "dependsOn": [
+                "[concat('Microsoft.Authorization/roleAssignments/', parameters('roleGuid'))]"
+            ],
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",
             "name": "deployRules",
@@ -108,7 +112,7 @@
                 "forceUpdateTag": "1",
                 "azPowerShellVersion": "3.0",
                 "arguments": "[concat('-Workspace ', parameters('workspaceName'), ' -ResourceGroup ', resourceGroup().name, ' -Solutions ', variables('solutions'), ' -SeveritiesToInclude ', string(variables('severities')), ' -Region ', parameters('location'), ' -IsGov $true')]",
-                "primaryScriptUri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/Scripts/Create-NewSolutionAndRulesFromList.ps1",
+                "primaryScriptUri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/Scripts/Create-NewSolutionAndRulesFromList.ps1",
                 "supportingScriptUris": [],
                 "timeout": "PT30M",
                 "cleanupPreference": "OnExpiration",

--- a/Tools/Sentinel-All-In-One/v2/azuredeploy.json
+++ b/Tools/Sentinel-All-In-One/v2/azuredeploy.json
@@ -151,8 +151,7 @@
             "defaultValue": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main"
         }
     },
-    "variables": {
-    },
+    "variables": {},
     "resources": [
         {
             "type": "Microsoft.Resources/resourceGroups",
@@ -172,7 +171,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/workspace.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/workspace.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -211,7 +210,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/settings.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/settings.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -243,7 +242,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/dataConnectors.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/dataConnectors.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -281,7 +280,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/solutionsAndAlerts.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlerts.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {

--- a/Tools/Sentinel-All-In-One/v2/azuredeployGov.json
+++ b/Tools/Sentinel-All-In-One/v2/azuredeployGov.json
@@ -148,7 +148,7 @@
             "metadata": {
                 "description": "The location of resources"
             },
-            "defaultValue": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2"
         }
     },
     "variables": {
@@ -172,7 +172,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/workspace.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/workspace.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -211,7 +211,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/settings.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/settings.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -243,7 +243,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/dataConnectorsGov.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/dataConnectorsGov.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -281,7 +281,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/garybushey/AllInOneGov/main/LinkedTemplates/solutionsAndAlertsGov.json",
+                    "uri": "https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Tools/Sentinel-All-In-One/v2/LinkedTemplates/solutionsAndAlertsGov.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Ensure the ARM templates only reference Powershell scripts in **this** repo
   - Make the deploy script role assignment idempotent so the template can be run multiple times

   Reason for Change(s):
   - The current template references scripts from `garybushey/AllInOneGov` which already exist in this repo `Azure/Azure-Sentinel`
   - Running the playbook more than once would fail if deploying content hub content or rules because the newGUID would conflict with the existing IAM permission. This change makes the ID predictable, but can still be overwritten

   Version Updated: ✅

   Testing Completed: 
   - Have tested with my bicep version

Is there any chance this ARM template exists in a bicep form? I think bicep here would be preferable as it would allow more simple local file references which can be forked and built without requiring publicly available JSON blobs. And presumably avoiding issues where we're cross referencing files like happened here.
I've parsed and converted myself but it's not terribly pretty.