### PR TITLE
Update ScanSecrets.yaml to output only verified results

### DIFF
--- a/.github/workflows/ScanSecrets.yaml
+++ b/.github/workflows/ScanSecrets.yaml
@@ -15,4 +15,4 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       continue-on-error: true
       with:
-        extra_args: --exclude-paths=.script/SecretScanning/Excludepathlist --no-verification
+        extra_args: --exclude-paths=.script/SecretScanning/Excludepathlist --only-verified


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - added a new flag to output only verified results

   Reason for Change(s):
   - earlier flag is flagging the plain text as unverified secret key 
   - 
![image](https://github.com/user-attachments/assets/051572ee-82c8-442c-9012-b65abc0d4da0)

![image](https://github.com/user-attachments/assets/a3979df9-6aa8-4af6-8c6f-a909840a97cf)


   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes