### PR TITLE
TheHive-3.11-version-update

### DIFF
--- a/Solutions/TheHive/Data Connectors/azuredeploy_Connector_TheHiveWebhooks_AzureFunction.json
+++ b/Solutions/TheHive/Data Connectors/azuredeploy_Connector_TheHiveWebhooks_AzureFunction.json
@@ -135,7 +135,7 @@
                 "alwaysOn": true,
                 "reserved": true,
                 "siteConfig": {
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
             "resources": [


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Change in Python Version to 3.11
   - Repackaged the solution for Data Connector Instructions.

   Reason for Change(s):
   - As per requirement (Deprecation of 3.8) 

   Version Updated:
   - Python version - 3.11
   

   Testing Completed:
   - yes
  