### PR TITLE
Sophose-3.11-version-update

### DIFF
--- a/Solutions/Sophos Endpoint Protection/Data Connectors/azuredeploy_SophosEP_API_FunctionApp.json
+++ b/Solutions/Sophos Endpoint Protection/Data Connectors/azuredeploy_SophosEP_API_FunctionApp.json
@@ -135,7 +135,7 @@
                 "alwaysOn": true,
                 "reserved": true,
                 "siteConfig": {
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
 


### PR DESCRIPTION
Required items, please complete

Change(s):
Change in Python Version to 3.11
Repackaged the solution for Data Connector Instructions.

Reason for Change(s):
As per requirement (Deprecation of 3.8)

Version Updated:
Python version - 3.11

Testing Completed:
Yes