### PR TITLE
Python Version Updated to 3.11 in Oracle Cloud Infrastructure

### DIFF
--- a/Solutions/Oracle Cloud Infrastructure/Data Connectors/azuredeploy_OCI_logs_API_FunctionApp.json
+++ b/Solutions/Oracle Cloud Infrastructure/Data Connectors/azuredeploy_OCI_logs_API_FunctionApp.json
@@ -204,7 +204,7 @@
                 "alwaysOn": true,
                 "reserved": true,
                 "siteConfig": {
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
 


### PR DESCRIPTION
Required items, please complete

Change(s):
Change in Python Version to 3.11

Reason for Change(s):
-As per requirement (Deprecation of 3.8)

Version Updated:
Python version - 3.11

Testing Completed:
Yes