### PR TITLE
Python Version Updated to 3.11 in Palo Alto Prism Cloud

### DIFF
--- a/Solutions/PaloAltoPrismaCloud/Data Connectors/azuredeploy_PrismaCloud_API_FunctionApp.json
+++ b/Solutions/PaloAltoPrismaCloud/Data Connectors/azuredeploy_PrismaCloud_API_FunctionApp.json
@@ -143,7 +143,7 @@
                 "alwaysOn": true,
                 "reserved": true,
                 "siteConfig": {
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
 


### PR DESCRIPTION
Change(s):
Change in Python Version to 3.11

Reason for Change(s):
-As per requirement (Deprecation of 3.8)

Version Updated:
Python version - 3.11

Testing Completed:
Yes