### PR TITLE
CheckPoint-3.11-version-update

### DIFF
--- a/Solutions/Check Point/CheckPointConnector/deployCP_proxy_gov.json
+++ b/Solutions/Check Point/CheckPointConnector/deployCP_proxy_gov.json
@@ -77,7 +77,7 @@
                             "value": "python"
                         }
                     ],
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
             "resources": [

--- a/Solutions/Check Point/CheckPointConnector/deployCP_proxy_gov.json
+++ b/Solutions/Check Point/CheckPointConnector/deployCP_proxy_gov.json
@@ -70,7 +70,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~2"
+                            "value": "~4"
                         },
                         {
                             "name": "FUNCTIONS_WORKER_RUNTIME",

--- a/Solutions/Check Point/CheckpointFunctionapp/deployCP_proxy.json
+++ b/Solutions/Check Point/CheckpointFunctionapp/deployCP_proxy.json
@@ -77,7 +77,7 @@
                             "value": "python"
                         }
                     ],
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
             "resources": [

--- a/Solutions/Check Point/CheckpointFunctionapp/deployCP_proxy.json
+++ b/Solutions/Check Point/CheckpointFunctionapp/deployCP_proxy.json
@@ -70,7 +70,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~2"
+                            "value": "~4"
                         },
                         {
                             "name": "FUNCTIONS_WORKER_RUNTIME",


### PR DESCRIPTION
Required items, please complete

Change(s):
Change in Python Version to 3.11

Reason for Change(s):
-As per requirement (Deprecation of 3.8)

Version Updated:
Python version - 3.11

Testing Completed:
Unable to test due to connector having issue. 