### PR TITLE
fix spelling in data connector templates

### DIFF
--- a/Solutions/CTM360/Data Connectors/CBS/CTM360_CBS_API_functionApp.json
+++ b/Solutions/CTM360/Data Connectors/CBS/CTM360_CBS_API_functionApp.json
@@ -1,6 +1,6 @@
 {
     "id": "CBSPollingIDAzureFunctions",
-    "title": "Cyber Blind Spot Intergration",
+    "title": "Cyber Blind Spot Integration",
     "publisher": "CTM360",
     "descriptionMarkdown": "Through the API integration, you have the capability to retrieve all the issues related to your CBS organizations via a RESTful interface.",
     "graphQueries": [


### PR DESCRIPTION
This affects the autogenerated data connector pages in Learn docs.

   Required items, please complete
   
   Change(s):
   fixed spelling errors in Data Connector names

   Reason for Change(s):
   The spelling errors show up in the autogenerated docs on Learn