### PR TITLE
Add reader role

### DIFF
--- a/Solutions/SAP/Sample Authorizations Role File/MSFTSEN_SENTINEL_READER.SAP
+++ b/Solutions/SAP/Sample Authorizations Role File/MSFTSEN_SENTINEL_READER.SAP
@@ -1,0 +1,119 @@
+DATE                                              20240925                                          112745
+RELEASE                                           758
+LOADED_AGRS                                       /MSFTSEN/SENTINEL_READER
+AGR_DEFINE                                        400/MSFTSEN/SENTINEL_READER                                    DEVELOPER   20240327082114000000000000000DEVELOPER   20240925104259000000000000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000001S_ADMI_FCD__________00    U  O000010
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000002S_APPL_LOG__________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000003S_RFC     __________00    U  O000004
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000004S_SAL     __________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000005S_SCD0_OBJ__________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000006S_TABU_NAM__________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000007S_TCODE   __________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000008S_TRANSPRT__________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000009S_USER_GRP__________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000010S_WF_WI   __________00    U  O000000
+AGR_1250                                          400/MSFTSEN/SENTINEL_READER      000011S_XMI_PROD__________00    U  O000017
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000001S_ADMI_FCD__________00    S_ADMI_FCDAUDD                                                                            U  O000011
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000002S_ADMI_FCD__________00    S_ADMI_FCDSPOS                                                                            U  O000011
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000003S_APPL_LOG__________00    ACTVT     03                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000004S_APPL_LOG__________00    ALG_OBJECT*                                                                               U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000005S_APPL_LOG__________00    ALG_SUBOBJ*                                                                               U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000006S_RFC     __________00    ACTVT     16                                                                              U  O000005
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000007S_RFC     __________00    RFC_NAME  /MSFTSEN/*                                                                      U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000008S_RFC     __________00    RFC_NAME  /OSP/SYSTEM_TIMEZONE                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000009S_RFC     __________00    RFC_NAME  ARFC                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000010S_RFC     __________00    RFC_NAME  BAPI_USER_GET_DETAIL                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000011S_RFC     __________00    RFC_NAME  BAPI_XBP_APPL_LOG_CONTENT_GET                                                   U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000012S_RFC     __________00    RFC_NAME  BAPI_XBP_JOB_JOBLOG_READ                                                        U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000013S_RFC     __________00    RFC_NAME  BAPI_XMI_LOGOFF                                                                 U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000014S_RFC     __________00    RFC_NAME  BAPI_XMI_LOGON                                                                  U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000015S_RFC     __________00    RFC_NAME  BAPI_XMI_SET_AUDITLEVEL                                                         U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000016S_RFC     __________00    RFC_NAME  CTS_API                                                                         U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000017S_RFC     __________00    RFC_NAME  CTS_API_READ_CHANGE_REQUEST                                                     U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000018S_RFC     __________00    RFC_NAME  DDIF_FIELDINFO_GET                                                              U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000019S_RFC     __________00    RFC_NAME  RFC1                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000020S_RFC     __________00    RFC_NAME  RFCPING                                                                         U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000021S_RFC     __________00    RFC_NAME  RFC_GET_FUNCTION_INTERFACE                                                      U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000022S_RFC     __________00    RFC_NAME  RFC_READ_TABLE                                                                  U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000023S_RFC     __________00    RFC_NAME  RFC_SYSTEM_INFO                                                                 U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000093S_XMI_PROD__________00    INTERFACE XBP                                                                             U  O000020
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000024S_RFC     __________00    RFC_NAME  RSAU_API_GET_LOG_DATA                                                           U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000025S_RFC     __________00    RFC_NAME  SALX                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000026S_RFC     __________00    RFC_NAME  SAP_WAPI_READ_CONTAINER                                                         U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000027S_RFC     __________00    RFC_NAME  SDIFRUNTIME                                                                     U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000028S_RFC     __________00    RFC_NAME  SLIC_LOCAL_HWKEY                                                                U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000029S_RFC     __________00    RFC_NAME  SMOI                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000030S_RFC     __________00    RFC_NAME  STFC                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000031S_RFC     __________00    RFC_NAME  SUSR_USER_AUTH_FOR_OBJ_GET                                                      U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000032S_RFC     __________00    RFC_NAME  SU_USER                                                                         U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000033S_RFC     __________00    RFC_NAME  SWRR                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000034S_RFC     __________00    RFC_NAME  SXBP                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000035S_RFC     __________00    RFC_NAME  SXBP_EXT                                                                        U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000036S_RFC     __________00    RFC_NAME  SXMI                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000037S_RFC     __________00    RFC_NAME  SYST                                                                            U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000038S_RFC     __________00    RFC_NAME  TH_SERVER_LIST                                                                  U  O000006
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000039S_RFC     __________00    RFC_TYPE  FUGR                                                                            U  O000007
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000040S_RFC     __________00    RFC_TYPE  FUNC                                                                            U  O000007
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000041S_SAL     __________00    SAL_ACTVT SHOW_LOG                                                                        U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000042S_SCD0_OBJ__________00    ACTVT     08                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000043S_SCD0_OBJ__________00    OBJECTCLAS*                                                                               U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000044S_TABU_NAM__________00    ACTVT     03                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000045S_TABU_NAM__________00    TABLE     ADCP                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000046S_TABU_NAM__________00    TABLE     ADR6                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000047S_TABU_NAM__________00    TABLE     AGR_1251                                                                        U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000048S_TABU_NAM__________00    TABLE     AGR_AGRS                                                                        U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000049S_TABU_NAM__________00    TABLE     AGR_DEFINE                                                                      U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000050S_TABU_NAM__________00    TABLE     AGR_FLAGS                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000051S_TABU_NAM__________00    TABLE     AGR_PROF                                                                        U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000052S_TABU_NAM__________00    TABLE     AGR_TCODES                                                                      U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000053S_TABU_NAM__________00    TABLE     AGR_USERS                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000054S_TABU_NAM__________00    TABLE     BALHDR                                                                          U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000055S_TABU_NAM__________00    TABLE     CDHDR                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000056S_TABU_NAM__________00    TABLE     CDPOS                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000057S_TABU_NAM__________00    TABLE     DBTABLOG                                                                        U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000058S_TABU_NAM__________00    TABLE     DEVACCESS                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000059S_TABU_NAM__________00    TABLE     E070                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000060S_TABU_NAM__________00    TABLE     PAHI                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000061S_TABU_NAM__________00    TABLE     RSAUFILES                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000062S_TABU_NAM__________00    TABLE     SACF_ALERT                                                                      U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000063S_TABU_NAM__________00    TABLE     SNCSYSACL                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000064S_TABU_NAM__________00    TABLE     SOUD                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000065S_TABU_NAM__________00    TABLE     SWWLOGHIST                                                                      U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000066S_TABU_NAM__________00    TABLE     SWWWIHEAD                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000067S_TABU_NAM__________00    TABLE     T000                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000068S_TABU_NAM__________00    TABLE     TBTCO                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000069S_TABU_NAM__________00    TABLE     TMSQAFILTER                                                                     U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000070S_TABU_NAM__________00    TABLE     TSP01                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000071S_TABU_NAM__________00    TABLE     USER_ADDR                                                                       U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000072S_TABU_NAM__________00    TABLE     USGRP_USER                                                                      U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000073S_TABU_NAM__________00    TABLE     USR01                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000074S_TABU_NAM__________00    TABLE     USR02                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000075S_TABU_NAM__________00    TABLE     USR05                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000076S_TABU_NAM__________00    TABLE     USR21                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000077S_TABU_NAM__________00    TABLE     USR41                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000078S_TABU_NAM__________00    TABLE     USRACL                                                                          U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000079S_TABU_NAM__________00    TABLE     USRSTAMP                                                                        U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000080S_TABU_NAM__________00    TABLE     UST04                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000081S_TCODE   __________00    TCD       SM51                                                                            U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000082S_TRANSPRT__________00    ACTVT     03                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000083S_TRANSPRT__________00    TTYPE     *                                                                               U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000084S_USER_GRP__________00    ACTVT     03                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000085S_USER_GRP__________00    ACTVT     05                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000086S_USER_GRP__________00    CLASS     SUPER                                                                           U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000087S_WF_WI   __________00    TASK_CLASS*                                                                               U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000088S_WF_WI   __________00    WFACTVT   44                                                                              U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000089S_WF_WI   __________00    WI_TYPE   *                                                                               U  O000000
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000090S_XMI_PROD__________00    EXTCOMPANYMicrosoft                                                                       U  O000018
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000091S_XMI_PROD__________00    EXTPRODUCTAzure Sentinel                                                                  U  O000019
+AGR_1251                                          400/MSFTSEN/SENTINEL_READER      000092S_XMI_PROD__________00    INTERFACE XAL                                                                             U  O000020
+AGR_TEXTS                                         400/MSFTSEN/SENTINEL_READER      E00000Microsoft Sentinel for SAP agent- read only
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      COLL_AGR  DEVELOPER   20240327082114DEVELOPER   20240327082114
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      DEVCLASS  DEVELOPER   20240327082114DEVELOPER   20240327082114
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      MASTER_LANDEVELOPER   20240327082114DEVELOPER   20240327082114E
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      RESP_USER DEVELOPER   20240327082114DEVELOPER   20240327082114
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      SYS_FLAG  DEVELOPER   20240327082114DEVELOPER   20240327082114
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      FORCE_MIX DEVELOPER   20240327082114DEVELOPER   20240925104259
+AGR_FLAGS                                         400/MSFTSEN/SENTINEL_READER      FORCE_YEL DEVELOPER   20240327082114DEVELOPER   20240925104259
+AGR_TIME                                          400/MSFTSEN/SENTINEL_READER      SYSTTARTMPDEVELOPER   20240327082114000000000000000DEVELOPER   20240327082114000000000000000
+AGR_TIME                                          400/MSFTSEN/SENTINEL_READER      PROFILE   DEVELOPER   20240327082114000000000000000DEVELOPER   20240925104259000000000000000
+AGR_LSD                                           400/MSFTSEN/SENTINEL_READER                                    E


### PR DESCRIPTION
Adding the reader role to, eventually replace the connector role, and adhere to the azure concept of reader and responder.
Up until disrupt, we had two SAP ABAP roles we used to as templates to be assigned to the users our agents used to retrieve data from SAP:
/MSFTSEN/SENTINEL_AGENT_BASIC- for systems up to SAP version 7.4
/MSFTSEN/SENTINEL_CONNECTOR- for systems versions 7.4 and higher
 
We are now switching the roles to be these (still testing):
/MSFTSEN/SENTINEL_READER- “Sentinel for SAP agent- read only”.
/MSFTSEN/SENTINEL_RESPONDER- “Sentinel for SAP agent- read and respond to threats”.
 
The logic behind this is to simplify the user experience, and match the sentinel permissions concept of contributor, reader, responder etc.
The new Reader role merges all authorizations from the two legacy roles. 