### PR TITLE
create new GCP CCP template

### DIFF
--- a/DataConnectors/Templates/Connector_GCP_CCP_template.json
+++ b/DataConnectors/Templates/Connector_GCP_CCP_template.json
@@ -108,9 +108,9 @@
                                 "connectorUiConfig": {
                                     "id": "[variables('_uiConfigId1')]",
                                     "title": "[variables('connectorUiConfig_title')]",
-                                    "publisher": "Microsoft", // Modify to your user/company name
+                                    "publisher": "Microsoft // Modify to your user/company name",
                                     "descriptionMarkdown": "[variables('connectorUiConfig_descriptionMarkdown')]",
-                                    "graphQueriesTableName": "GCPTable_CL", // Modify to your table name, same as row 58
+                                    "graphQueriesTableName": "GCPTable_CL // Modify to your table name, same as row 58",
                                     "graphQueries": [
                                         {
                                             "metricName": "Total events received",
@@ -224,12 +224,12 @@
                                     "kind": "Solution"
                                 },
                                 "author": {
-                                    "name": "Microsoft" // Modify to your user/company name
+                                    "name": "Microsoft // Modify to your user/company name"
                                 },
                                 "support": {
-                                    "name": "Your Name/Company", // Modify to your user/company name
-                                    "email": "Email for support", // Modify to your email
-                                    "tier": "Partner",
+                                    "name": "Your Name/Company // Modify to your user/company name",
+                                    "email": "Email for support // Modify to your email",
+                                    "tier": "Partner // Partner or Community",
                                     "link": "link for help" // Modify to a support link
                                 },
                                 "dependencies": {

--- a/DataConnectors/Templates/Connector_GCP_CCP_template.json
+++ b/DataConnectors/Templates/Connector_GCP_CCP_template.json
@@ -230,7 +230,7 @@
                                     "name": "Your Name/Company // Modify to your user/company name",
                                     "email": "Email for support // Modify to your email",
                                     "tier": "Partner // Partner or Community",
-                                    "link": "link for help" // Modify to a support link
+                                    "link": "link for help // Modify to a support link"
                                 },
                                 "dependencies": {
                                     "criteria": [

--- a/DataConnectors/Templates/Connector_GCP_CCP_template.json
+++ b/DataConnectors/Templates/Connector_GCP_CCP_template.json
@@ -41,13 +41,13 @@
     },
     "variables": {
         "workspaceResourceId": "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]",
-        "_solutionName": "GCP Solution Name", // Modify to your solution name
+        "_solutionName": "GCP Solution Name // Modify to your solution name",
         "_solutionVersion": "3.0.0",
-        "_solutionAuthor": "User", // Modify to your user/company name
+        "_solutionAuthor": "User // Modify to your user/company name",
         "_packageIcon": "google_logo",
         "solutionId": "azuresentinel.azure-sentinel-solution-id-api",
         "_solutionId": "[variables('solutionId')]",
-        "uiConfigId1": "GCPDefinition", // Modify as you wish
+        "uiConfigId1": "GCPDefinition // Modify as you wish",
         "_uiConfigId1": "[variables('uiConfigId1')]",
         "dataConnectorVersionConnectorDefinition": "3.0.0",
         "dataConnectorVersionConnections": "3.0.0",
@@ -55,13 +55,13 @@
         "dataConnectorTemplateNameConnectorDefinition": "[concat(parameters('workspace'),'-dc-',uniquestring(variables('_dataConnectorContentIdConnectorDefinition')))]",
         "_dataConnectorContentIdConnections": "GCPTemplateConnections",
         "dataConnectorTemplateNameConnections": "[concat(parameters('workspace'),'-dc-',uniquestring(variables('_dataConnectorContentIdConnections')))]",
-        "dataType": "GCPTable_CL", // Modify to your table name
-        "streamName": "Custom-GCPTemplateStream", // Modify to your stream name
-        "dataCollectionRuleId": "GCPTemplate", // Modify to your DCR name
-        "connectorUiConfig_title": "GCP Generic Template", // Modify to your connector name
-        "streams": "Custom-GCPTemplateStream", // Modify to your stream name, same as row 59
-        "connectorUiConfig_descriptionMarkdown": "GCP Generic Template Description", // Modify to fit your description
-		"logAnalyticsTableId": "GCPTable_CL" // Modify to your table name, same as row 58
+        "dataType": "GCPTable_CL // Modify to your table name",
+        "streamName": "Custom-GCPTemplateStream // Modify to your stream name",
+        "dataCollectionRuleId": "GCPTemplate // Modify to your DCR name",
+        "connectorUiConfig_title": "GCP Generic Template // Modify to your connector name",
+        "streams": "Custom-GCPTemplateStream // Modify to your stream name, same as row 59",
+        "connectorUiConfig_descriptionMarkdown": "GCP Generic Template Description // Modify to fit your description",
+		"logAnalyticsTableId": "GCPTable_CL // Modify to your table name, same as row 58"
 
     },
     "resources": [
@@ -253,7 +253,11 @@
                                 "schema": {
                                     "name": "[variables('logAnalyticsTableId')]",
                                     "columns": [
-                                        // Columns
+                                        {
+						"name":" // Enter your Output table columns here",
+						"type":" // ",
+						"description":" // Skip this step if your data is only ingested to standard Log Analytics tables"
+					}
                                     ]
                                 }
                             }
@@ -267,9 +271,13 @@
                             "properties": {
                                 "dataCollectionEndpointId": "[concat('/subscriptions/',parameters('subscription'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Insights/dataCollectionEndpoints/',parameters('workspace'))]",
                                 "streamDeclarations": {
-                                    "Custom-GCPTemplateStream": { // Modify to your stream name, same as row 59
+                                    "Custom-GCPTemplateStream // Modify to your stream name, same as row 59": { 
                                         "columns": [
-                                            // Columns
+						{
+							"name":" // Enter your DCR columns here",
+							"type":" // ",
+							"description":" // "
+						}
                                         ]
                                     }
                                 },
@@ -284,13 +292,13 @@
                                     "dataFlows": [
                                         {
                                             "streams": [
-                                                "Custom-GCPTemplateStream" // Modify to your stream name, same as row 59
+                                                "Custom-GCPTemplateStream // Modify to your stream name, same as row 59"
                                             ],
                                             "destinations": [
                                                 "clv2ws1"
                                             ],
-                                            "transformKql": "source | extend TimeGenerated = now()", //KQL Transformation, must include TimeGenerated column
-                                            "outputStream": "Custom-GCPTable_CL" // Modify to your table name - Custom-YourTable_CL. table name is same as row 58 
+                                            "transformKql": "source | extend TimeGenerated = now() //KQL Transformation, must include TimeGenerated column",
+                                            "outputStream": "Custom-GCPTable_CL // Modify to your table name - Custom-YourTable_CL. table name is same as row 58 "
                                         }
                                     ]
                             }
@@ -315,9 +323,9 @@
                 "connectorUiConfig": {
                     "id": "[variables('_uiConfigId1')]",
                     "title": "[variables('connectorUiConfig_title')]",
-                    "publisher": "Your name/company", // Modify to your name/company
+                    "publisher": "Your name/company // Modify to your name/company",
                     "descriptionMarkdown": "[variables('connectorUiConfig_descriptionMarkdown')]",
-                    "graphQueriesTableName": "GCPTable_CL", // Your table name, same as row 58
+                    "graphQueriesTableName": "GCPTable_CL // Your table name, same as row 58",
                     "graphQueries": [
                         {
                             "metricName": "Total events received",
@@ -431,13 +439,13 @@
                     "kind": "Solution"
                 },
                 "author": {
-                    "name": "Your name/company" // Modify to your name/company
+                    "name": "Your name/company // Modify to your name/company"
                 },
                 "support": {
-                    "name": "Your name/company", // Modify to your name/company
-                    "email": "email for support", // Modify to your email
-                    "tier": "Partner", // "Partner" or "Community"
-                    "link": "link for support" // Modify to a support link
+                    "name": "Your name/company // Modify to your name/company",
+                    "email": "email for support // Modify to your email",
+                    "tier": " // Partner or Community",
+                    "link": "link for support // Modify to a support link"
                 },
                 "dependencies": {
                     "criteria": [
@@ -530,13 +538,13 @@
                                     "kind": "Solution"
                                 },
                                 "author": {
-                                    "name": "Your name/company" // Modify to your name/company
+                                    "name": "Your name/company // Modify to your name/company"
                                 },
                                 "support": {
-                                    "name": "Your name/company", // Modify to your name/company
-                                    "email": "email for support", // Modify to your email
-                                    "tier": "Partner", // "Partner" or "community"
-                                    "link": "link for support" // Modify to a support link
+                                    "name": "Your name/company // Modify to your name/company",
+                                    "email": "email for support // Modify to your email",
+                                    "tier": "Partner // Partner or community",
+                                    "link": "link for support // Modify to a support link"
                                 }
                             }
                         },
@@ -598,9 +606,9 @@
                 },
                 "support": {
                     "name": "[variables('_solutionAuthor')]",
-                    "email": "support email", // Modify to your email
-                    "tier": "Partner", //"Partner" or "community"
-                    "link": "link for support" // Modify to a support link
+                    "email": "support email // Modify to your email",
+                    "tier": "Partner // Partner or community",
+                    "link": "link for support // Modify to a support link"
                 },
                 "dependencies": {
                     "operator": "AND",

--- a/DataConnectors/Templates/Connector_GCP_CCP_template.json
+++ b/DataConnectors/Templates/Connector_GCP_CCP_template.json
@@ -1,0 +1,634 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "minLength": 1,
+            "type": "String",
+            "metadata": {
+                "description": "Not used, but needed to pass arm-ttk test `Location-Should-Not-Be-Hardcoded`.  We instead use the `workspace-location` which is derived from the LA workspace"
+            }
+        },
+        "workspace-location": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "[concat('Region to deploy solution resources -- separate from location selection',parameters('location'))]"
+            }
+        },
+        "subscription": {
+            "defaultValue": "[last(split(subscription().id, '/'))]",
+            "type": "String",
+            "metadata": {
+                "description": "subscription id where Microsoft Sentinel is setup"
+            }
+        },
+        "resourceGroupName": {
+            "defaultValue": "[resourceGroup().name]",
+            "type": "String",
+            "metadata": {
+                "description": "resource group name where Microsoft Sentinel is setup"
+            }
+        },
+        "workspace": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Workspace name for Log Analytics where Microsoft Sentinel is setup"
+            }
+        }
+    },
+    "variables": {
+        "workspaceResourceId": "[resourceId('microsoft.OperationalInsights/Workspaces', parameters('workspace'))]",
+        "_solutionName": "GCP Solution Name", // Modify to your solution name
+        "_solutionVersion": "3.0.0",
+        "_solutionAuthor": "User", // Modify to your user/company name
+        "_packageIcon": "google_logo",
+        "solutionId": "azuresentinel.azure-sentinel-solution-id-api",
+        "_solutionId": "[variables('solutionId')]",
+        "uiConfigId1": "GCPDefinition", // Modify as you wish
+        "_uiConfigId1": "[variables('uiConfigId1')]",
+        "dataConnectorVersionConnectorDefinition": "3.0.0",
+        "dataConnectorVersionConnections": "3.0.0",
+        "_dataConnectorContentIdConnectorDefinition": "[variables('uiConfigId1')]",
+        "dataConnectorTemplateNameConnectorDefinition": "[concat(parameters('workspace'),'-dc-',uniquestring(variables('_dataConnectorContentIdConnectorDefinition')))]",
+        "_dataConnectorContentIdConnections": "GCPTemplateConnections",
+        "dataConnectorTemplateNameConnections": "[concat(parameters('workspace'),'-dc-',uniquestring(variables('_dataConnectorContentIdConnections')))]",
+        "dataType": "GCPTable_CL", // Modify to your table name
+        "streamName": "Custom-GCPTemplateStream", // Modify to your stream name
+        "dataCollectionRuleId": "GCPTemplate", // Modify to your DCR name
+        "connectorUiConfig_title": "GCP Generic Template", // Modify to your connector name
+        "streams": "Custom-GCPTemplateStream", // Modify to your stream name, same as row 59
+        "connectorUiConfig_descriptionMarkdown": "GCP Generic Template Description", // Modify to fit your description
+		"logAnalyticsTableId": "GCPTable_CL" // Modify to your table name, same as row 58
+
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2020-10-01",
+            "name": "pid-c7d52c81-336e-4d9f-8654-3aa144a97c48-partnercenter",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": []
+                }
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/providers/contentTemplates",
+            "apiVersion": "2023-04-01-preview",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('dataConnectorTemplateNameConnectorDefinition'), variables('dataConnectorVersionConnectorDefinition'))]",
+            "location": "[parameters('workspace-location')]",
+            "dependsOn": [
+                "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/contentPackages', variables('_solutionId'))]"
+            ],
+            "properties": {
+                "contentId": "[variables('_dataConnectorContentIdConnectorDefinition')]",
+                "displayName": "[variables('_solutionName')]",
+                "contentKind": "DataConnector",
+                "contentProductId": "[concat(substring(variables('_solutionId'), 0, 50),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('_dataConnectorContentIdConnectorDefinition'),'-', variables('dataConnectorVersionConnectorDefinition'))))]",
+                "id": "[concat(substring(variables('_solutionId'), 0, 50),'-','dc','-', uniqueString(concat(variables('_solutionId'),'-','DataConnector','-',variables('dataConnectorTemplateNameConnectorDefinition'),'-', variables('dataConnectorVersionConnectorDefinition'))))]",
+                "mainTemplate": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "[variables('dataConnectorVersionConnectorDefinition')]",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentIdConnectorDefinition'))]",
+                            "apiVersion": "2022-09-01-preview",
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectorDefinitions",
+                            "location": "[parameters('workspace-location')]",
+                            "kind": "Customizable",
+                            "properties": {
+                                "connectorUiConfig": {
+                                    "id": "[variables('_uiConfigId1')]",
+                                    "title": "[variables('connectorUiConfig_title')]",
+                                    "publisher": "Microsoft", // Modify to your user/company name
+                                    "descriptionMarkdown": "[variables('connectorUiConfig_descriptionMarkdown')]",
+                                    "graphQueriesTableName": "GCPTable_CL", // Modify to your table name, same as row 58
+                                    "graphQueries": [
+                                        {
+                                            "metricName": "Total events received",
+                                            "legend": "[variables('connectorUiConfig_title')]",
+                                            "baseQuery": "{{graphQueriesTableName}}"
+                                        }
+                                    ],
+                                    "sampleQueries": [
+                                        {
+                                            "description": "Get Sample of logs",
+                                            "query": "{{graphQueriesTableName}}\n | take 10"
+                                        }
+                                    ],
+                                    "dataTypes": [
+                                        {
+                                            "name": "{{graphQueriesTableName}}",
+                                            "lastDataReceivedQuery": "{{graphQueriesTableName}}\n            | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+                                        }
+                                    ],
+                                    "connectivityCriteria": [
+                                        {
+                                            "type": "HasDataConnectors",
+                                            "value": null
+                                        }
+                                    ],
+                                    "availability": {
+                                        "status": 1,
+                                        "isPreview": false
+                                    },
+                                    "permissions": {
+                                        "resourceProvider": [
+                                            {
+                                                "provider": "Microsoft.OperationalInsights/workspaces",
+                                                "permissionsDisplayText": "Read and Write permissions are required.",
+                                                "providerDisplayName": "Workspace",
+                                                "scope": "Workspace",
+                                                "requiredPermissions": {
+                                                    "read": true,
+                                                    "write": true,
+                                                    "delete": true,
+                                                    "action": false
+                                                }
+                                            },
+                                            {
+                                                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                                                "permissionsDisplayText": "Read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                                                "providerDisplayName": "Keys",
+                                                "scope": "Workspace",
+                                                "requiredPermissions": {
+                                                    "read": false,
+                                                    "write": false,
+                                                    "delete": false,
+                                                    "action": true
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "instructionSteps": [
+                                        {
+                                            "instructions": [
+                                                {
+                                                    "type": "Markdown",
+                                                    "parameters": {
+                                                        "content": "#### 1. Set up your GCP environment \n You must have the following GCP resources defined and configured: topic, subscription for the topic, workload identity pool, workload identity provider and service account with permissions to get and consume from subscription. \n Terraform provides API for the IAM that creates the resources. [Link to Terraform scripts](https://github.com/Azure/Azure-Sentinel/tree/master/DataConnectors/GCP/Terraform/sentinel_resources_creation)."
+                                                    }
+                                                },
+                                                {
+                                                    "type": "CopyableLabel",
+                                                    "parameters": {
+                                                        "label": "Tenant ID: A unique identifier that is used as an input in the Terraform configuration within a GCP environment.",
+                                                        "fillWith": [
+                                                            "TenantId"
+                                                        ],
+                                                        "name": "PoolId",
+                                                        "disabled": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "Markdown",
+                                                    "parameters": {
+                                                        "content": "#### 2. Connect new collectors \n To enable GCP for Microsoft Sentinel, click the Add new collector button, fill the required information in the context pane and click on Connect."
+                                                    }
+                                                },
+                                                {
+                                                    "type": "GCPGrid",
+                                                    "parameters": {}
+                                                },
+                                                {
+                                                    "type": "GCPContextPane",
+                                                    "parameters": {}
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "isConnectivityCriteriasMatchSome": false
+                                }
+                            }
+                        },
+                        {
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('DataConnector-', variables('_dataConnectorContentIdConnectorDefinition')))]",
+                            "apiVersion": "2022-01-01-preview",
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                            "properties": {
+                                "parentId": "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/dataConnectorDefinitions', variables('_dataConnectorContentIdConnectorDefinition'))]",
+                                "contentId": "[variables('_dataConnectorContentIdConnectorDefinition')]",
+                                "kind": "DataConnector",
+                                "version": "[variables('dataConnectorVersionConnectorDefinition')]",
+                                "source": {
+                                    "sourceId": "[variables('_solutionId')]",
+                                    "name": "[variables('_solutionName')]",
+                                    "kind": "Solution"
+                                },
+                                "author": {
+                                    "name": "Microsoft" // Modify to your user/company name
+                                },
+                                "support": {
+                                    "name": "Your Name/Company", // Modify to your user/company name
+                                    "email": "Email for support", // Modify to your email
+                                    "tier": "Partner",
+                                    "link": "link for help" // Modify to a support link
+                                },
+                                "dependencies": {
+                                    "criteria": [
+                                        {
+                                            "version": "[variables('dataConnectorVersionConnections')]",
+                                            "contentId": "[variables('_dataConnectorContentIdConnections')]",
+                                            "kind": "ResourcesDataConnector"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "[variables('logAnalyticsTableId')]",
+                            "apiVersion": "2021-03-01-privatepreview",
+                            "type": "Microsoft.OperationalInsights/workspaces/tables",
+                            "location": "[parameters('workspace-location')]",
+                            "kind": null,
+                            "properties": {
+                                "schema": {
+                                    "name": "[variables('logAnalyticsTableId')]",
+                                    "columns": [
+                                        // Columns
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "[variables('dataCollectionRuleId')]",
+                            "apiVersion": "2021-09-01-preview",
+                            "type": "Microsoft.Insights/dataCollectionRules",
+                            "location": "[parameters('workspace-location')]",
+                            "kind": null,
+                            "properties": {
+                                "dataCollectionEndpointId": "[concat('/subscriptions/',parameters('subscription'),'/resourceGroups/',parameters('resourceGroupName'),'/providers/Microsoft.Insights/dataCollectionEndpoints/',parameters('workspace'))]",
+                                "streamDeclarations": {
+                                    "Custom-GCPTemplateStream": { // Modify to your stream name, same as row 59
+                                        "columns": [
+                                            // Columns
+                                        ]
+                                    }
+                                },
+								"destinations": {
+                                        "logAnalytics": [
+                                            {
+                                                "workspaceResourceId": "[variables('workspaceResourceId')]",
+                                                "name": "clv2ws1"
+                                            }
+                                        ]
+                                    },
+                                    "dataFlows": [
+                                        {
+                                            "streams": [
+                                                "Custom-GCPTemplateStream" // Modify to your stream name, same as row 59
+                                            ],
+                                            "destinations": [
+                                                "clv2ws1"
+                                            ],
+                                            "transformKql": "source | extend TimeGenerated = now()", //KQL Transformation, must include TimeGenerated column
+                                            "outputStream": "Custom-GCPTable_CL" // Modify to your table name - Custom-YourTable_CL. table name is same as row 58 
+                                        }
+                                    ]
+                            }
+                        }
+                    ]
+                },
+                "packageKind": "Solution",
+                "packageVersion": "[variables('_solutionVersion')]",
+                "packageName": "[variables('_solutionName')]",
+                "packageId": "[variables('_solutionId')]",
+                "contentSchemaVersion": "3.0.0",
+                "version": "[variables('_solutionVersion')]"
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectorDefinitions",
+            "apiVersion": "2022-09-01-preview",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentIdConnectorDefinition'))]",
+            "location": "[parameters('workspace-location')]",
+            "kind": "Customizable",
+            "properties": {
+                "connectorUiConfig": {
+                    "id": "[variables('_uiConfigId1')]",
+                    "title": "[variables('connectorUiConfig_title')]",
+                    "publisher": "Your name/company", // Modify to your name/company
+                    "descriptionMarkdown": "[variables('connectorUiConfig_descriptionMarkdown')]",
+                    "graphQueriesTableName": "GCPTable_CL", // Your table name, same as row 58
+                    "graphQueries": [
+                        {
+                            "metricName": "Total events received",
+                            "legend": "[variables('connectorUiConfig_title')]",
+                            "baseQuery": "{{graphQueriesTableName}}"
+                        }
+                    ],
+                    "sampleQueries": [
+                        {
+                            "description": "Get Sample of logs",
+                            "query": "{{graphQueriesTableName}}\n | take 10"
+                        }
+                    ],
+                    "dataTypes": [
+                        {
+                            "name": "{{graphQueriesTableName}}",
+                            "lastDataReceivedQuery": "{{graphQueriesTableName}}\n            | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+                        }
+                    ],
+                    "connectivityCriteria": [
+                        {
+                            "type": "HasDataConnectors",
+                            "value": null
+                        }
+                    ],
+                    "availability": {
+                        "status": 1,
+                        "isPreview": false
+                    },
+                    "permissions": {
+                        "resourceProvider": [
+                            {
+                                "provider": "Microsoft.OperationalInsights/workspaces",
+                                "permissionsDisplayText": "Read and Write permissions are required.",
+                                "providerDisplayName": "Workspace",
+                                "scope": "Workspace",
+                                "requiredPermissions": {
+                                    "read": true,
+                                    "write": true,
+                                    "delete": true,
+                                    "action": false
+                                }
+                            },
+                            {
+                                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
+                                "permissionsDisplayText": "Read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key)",
+                                "providerDisplayName": "Keys",
+                                "scope": "Workspace",
+                                "requiredPermissions": {
+                                    "read": false,
+                                    "write": false,
+                                    "delete": false,
+                                    "action": true
+                                }
+                            }
+                        ]
+                    },
+                    "instructionSteps": [
+                        {
+                            "instructions": [
+                                {
+                                    "type": "Markdown",
+                                    "parameters": {
+                                        "content": "#### 1. Set up your GCP environment \n You must have the following GCP resources defined and configured: topic, subscription for the topic, workload identity pool, workload identity provider and service account with permissions to get and consume from subscription. \n Terraform provides API for the IAM that creates the resources. [Link to Terraform scripts](https://github.com/Azure/Azure-Sentinel/tree/master/DataConnectors/GCP/Terraform/sentinel_resources_creation)."
+                                    }
+                                },
+                                {
+                                    "type": "CopyableLabel",
+                                    "parameters": {
+                                        "label": "Tenant ID: A unique identifier that is used as an input in the Terraform configuration within a GCP environment.",
+                                        "fillWith": [
+                                            "TenantId"
+                                        ],
+                                        "name": "PoolId",
+                                        "disabled": true
+                                    }
+                                },
+                                {
+                                    "type": "Markdown",
+                                    "parameters": {
+                                        "content": "#### 2. Connect new collectors \n To enable GCP for Microsoft Sentinel, click the Add new collector button, fill the required information in the context pane and click on Connect."
+                                    }
+                                },
+                                {
+                                    "type": "GCPGrid",
+                                    "parameters": {}
+                                },
+                                {
+                                    "type": "GCPContextPane",
+                                    "parameters": {}
+                                }
+                            ]
+                        }
+                    ],
+                    "isConnectivityCriteriasMatchSome": false
+                }
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+            "apiVersion": "2022-01-01-preview",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('DataConnector-', variables('_dataConnectorContentIdConnectorDefinition')))]",
+            "properties": {
+                "parentId": "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/dataConnectorDefinitions', variables('_dataConnectorContentIdConnectorDefinition'))]",
+                "contentId": "[variables('_dataConnectorContentIdConnectorDefinition')]",
+                "kind": "DataConnector",
+                "version": "[variables('dataConnectorVersionConnectorDefinition')]",
+                "source": {
+                    "sourceId": "[variables('_solutionId')]",
+                    "name": "[variables('_solutionName')]",
+                    "kind": "Solution"
+                },
+                "author": {
+                    "name": "Your name/company" // Modify to your name/company
+                },
+                "support": {
+                    "name": "Your name/company", // Modify to your name/company
+                    "email": "email for support", // Modify to your email
+                    "tier": "Partner", // "Partner" or "Community"
+                    "link": "link for support" // Modify to a support link
+                },
+                "dependencies": {
+                    "criteria": [
+                        {
+                            "version": "[variables('dataConnectorVersionConnections')]",
+                            "contentId": "[variables('_dataConnectorContentIdConnections')]",
+                            "kind": "ResourcesDataConnector"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/providers/contentTemplates",
+            "apiVersion": "2023-04-01-preview",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('dataConnectorTemplateNameConnections'), variables('dataConnectorVersionConnections'))]",
+            "location": "[parameters('workspace-location')]",
+            "dependsOn": [
+                "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/contentPackages', variables('_solutionId'))]"
+            ],
+            "properties": {
+                "contentId": "[variables('_dataConnectorContentIdConnections')]",
+                "displayName": "[variables('_solutionName')]",
+                "contentKind": "ResourcesDataConnector",
+                "id": "[concat(substring(variables('_solutionId'), 0, 50),'-','rdc','-', uniqueString(concat(variables('_solutionId'),'-','ResourcesDataConnector','-',variables('_dataConnectorContentIdConnections'),'-', variables('dataConnectorVersionConnections'))))]",
+                "mainTemplate": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "[variables('dataConnectorVersionConnections')]",
+                    "parameters": {
+                        "GCPProjectId": {
+                            "type": "String",
+                            "minLength": 4
+                        },
+                        "GCPProjectNumber": {
+                            "type": "String",
+                            "minLength": 1
+                        },
+                        "GCPWorkloadIdentityProviderId": {
+                            "type": "String"
+                        },
+                        "GCPServiceAccountEmail": {
+                            "type": "String",
+                            "minLength": 1
+                        },
+                        "GCPSubscriptionName": {
+                            "type": "String",
+                            "minLength": 3
+                        },
+                        "connectorDefinitionName": {
+                            "defaultValue": "connectorDefinitionName",
+                            "type": "string",
+                            "minLength": 1,
+                            "metadata": {
+                                "description": "connectorDefinitionName"
+                            }
+                        },
+                        "workspace2": {
+                            "defaultValue": "[parameters('workspace')]",
+                            "type": "string"
+                        },
+                        "dcrConfig": {
+                            "type": "object",
+                            "defaultValue": {
+                                "dataCollectionEndpoint": "data collection Endpoint",
+                                "dataCollectionRuleImmutableId": "data collection rule immutableId"
+                            }
+                        },
+                        "guidValue": {
+                            "type": "string",
+                            "defaultValue": "[[newGuid()]"
+                        }
+                    },
+                    "variables": {
+                        "_dataConnectorContentIdConnections": "[variables('_dataConnectorContentIdConnections')]",
+                        "connectorName": "[[concat('GCPTemplate', parameters('guidValue'))]"
+                    },
+                    "resources": [
+                        {
+                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',concat('DataConnector-', variables('_dataConnectorContentIdConnections')))]",
+                            "apiVersion": "2022-01-01-preview",
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+                            "properties": {
+                                "parentId": "[extensionResourceId(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspace')), 'Microsoft.SecurityInsights/dataConnectors', variables('_dataConnectorContentIdConnections'))]",
+                                "contentId": "[variables('_dataConnectorContentIdConnections')]",
+                                "kind": "ResourcesDataConnector",
+                                "version": "[variables('dataConnectorVersionConnections')]",
+                                "source": {
+                                    "sourceId": "[variables('_solutionId')]",
+                                    "name": "[variables('_solutionName')]",
+                                    "kind": "Solution"
+                                },
+                                "author": {
+                                    "name": "Your name/company" // Modify to your name/company
+                                },
+                                "support": {
+                                    "name": "Your name/company", // Modify to your name/company
+                                    "email": "email for support", // Modify to your email
+                                    "tier": "Partner", // "Partner" or "community"
+                                    "link": "link for support" // Modify to a support link
+                                }
+                            }
+                        },
+                        {
+                            "name": "[[concat(parameters('workspace2'),'/Microsoft.SecurityInsights/',variables('connectorName'))]",
+                            "apiVersion": "2022-12-01-preview",
+                            "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
+                            "location": "[parameters('workspace-location')]",
+                            "kind": "GCP",
+                            "properties": {
+                                "connectorDefinitionName": "[[parameters('connectorDefinitionName')]",
+                                "dcrConfig": {
+                                    "streamName": "[variables('streamName')]",
+                                    "dataCollectionEndpoint": "[[parameters('dcrConfig').dataCollectionEndpoint]",
+                                    "dataCollectionRuleImmutableId": "[[parameters('dcrConfig').dataCollectionRuleImmutableId]"
+                                },
+                                "dataType": "[variables('dataType')]",
+                                "auth": {
+                                    "serviceAccountEmail": "[[parameters('GCPServiceAccountEmail')]",
+                                    "projectNumber": "[[parameters('GCPProjectNumber')]",
+                                    "workloadIdentityProviderId": "[[parameters('GCPWorkloadIdentityProviderId')]"
+                                },
+                                "request": {
+                                    "projectId": "[[parameters('GCPProjectId')]",
+                                    "subscriptionNames": [
+                                        "[[parameters('GCPSubscriptionName')]"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "packageKind": "Solution",
+                "packageVersion": "[variables('_solutionVersion')]",
+                "packageName": "[variables('_solutionName')]",
+                "contentProductId": "[concat(substring(variables('_solutionId'), 0, 50),'-','rdc','-', uniqueString(concat(variables('_solutionId'),'-','ResourcesDataConnector','-',variables('_dataConnectorContentIdConnections'),'-', variables('dataConnectorVersionConnections'))))]",
+                "packageId": "[variables('_solutionId')]",
+                "contentSchemaVersion": "3.0.0",
+                "version": "[variables('_solutionVersion')]"
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/providers/contentPackages",
+            "apiVersion": "2023-04-01-preview",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('_solutionId'))]",
+            "location": "[parameters('workspace-location')]",
+            "properties": {
+                "version": "[variables('_solutionVersion')]",
+                "kind": "Solution",
+                "contentSchemaVersion": "3.0.0",
+                "contentId": "[variables('_solutionId')]",
+                "source": {
+                    "kind": "Solution",
+                    "name": "[variables('_solutionName')]",
+                    "sourceId": "[variables('_solutionId')]"
+                },
+                "author": {
+                    "name": "[variables('_solutionAuthor')]"
+                },
+                "support": {
+                    "name": "[variables('_solutionAuthor')]",
+                    "email": "support email", // Modify to your email
+                    "tier": "Partner", //"Partner" or "community"
+                    "link": "link for support" // Modify to a support link
+                },
+                "dependencies": {
+                    "operator": "AND",
+                    "criteria": [
+                        {
+                            "kind": "DataConnector",
+                            "contentId": "[variables('dataConnectorVersionConnectorDefinition')]",
+                            "version": "[variables('_dataConnectorContentIdConnectorDefinition')]"
+                        }
+                    ]
+                },
+                "firstPublishDate": "2022-06-24",
+                "providers": [
+                    "[variables('_solutionAuthor')]"
+                ],
+                "categories": {
+                    "domains": [
+                        "Security - Cloud Security"
+                    ]
+                },
+                "contentKind": "Solution",
+                "packageId": "[variables('_solutionId')]",
+                "contentProductId": "[concat(substring(variables('_solutionId'), 0, 50),'-','sl','-', uniqueString(concat(variables('_solutionId'),'-','Solution','-',variables('_solutionId'),'-', variables('_solutionVersion'))))]",
+                "displayName": "[variables('_solutionName')]",
+                "publisherDisplayName": "[variables('_solutionId')]",
+                "descriptionHtml": "test",
+                "icon": "[variables('_packageIcon')]"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
Publishing new template for GCP type CCP data connectors

   Reason for Change(s):
This template will be referenced from the [ReadMe.md](https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/ReadMe.md)

   Version Updated:
First version

   Testing Completed:
Yes by Daniel Zatakovy
