### PR TITLE
Adding queries to look for abnormal sch task creation and launch

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Persistence/rare_sch_task_launch.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Persistence/rare_sch_task_launch.yaml
@@ -1,0 +1,45 @@
+id: e5c65f1f-2bf8-4b42-af8b-1f6adfeda0cc
+name: detect-impacket-wmiexec
+description: |
+  This query looks for signs of impacket wmiexec module usage. May hit other wmi execution-like techniques too.
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/impacket-part-2/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceEvents
+  - DeviceNetworkEvents
+  - DeviceProcessEvents
+tactics:
+- Execution
+relevantTechniques:
+  - T1047
+query: |
+ let LookupTime = 30d;
+  let GetRareWMIProcessLaunches = materialize (
+  DeviceEvents
+  | where Timestamp > ago(LookupTime)
+  | where ActionType == @"ProcessCreatedUsingWmiQuery"
+  | where isnotempty(FileName)
+  | summarize count() by SHA1, InitiatingProcessCommandLine
+  | where count_ < 5 | distinct SHA1); 
+  DeviceEvents 
+  | where Timestamp > ago(LookupTime)
+  | where ActionType == @"ProcessCreatedUsingWmiQuery"
+  | where SHA1 in~ (GetRareWMIProcessLaunches)
+  | where isnotempty(FileName)
+  | project DeviceName, WMIProcessLaunchTimestmap = Timestamp, ProcessLaunchedByWMI = tolower(FileName), ProcessLaunchedByWMICommandLine = tolower(ProcessCommandLine), ProcessLaunchedByWMICreationTime = ProcessCreationTime, ProcessLaunchedByWMISHA1 = tolower(SHA1), ProcessLaunchedByWMIID = ProcessId, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentCreationTime, InitiatingProcessParentFileName
+  | join kind=leftouter (
+  DeviceProcessEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessSHA1 in~ (GetRareWMIProcessLaunches)
+  |project DeviceName, ChildProcessTimestamp = Timestamp, ProcessLaunchedByWMI = tolower(InitiatingProcessFileName), ProcessLaunchedByWMICommandLine = tolower(InitiatingProcessCommandLine), ProcessLaunchedByWMICreationTime = InitiatingProcessCreationTime, ProcessLaunchedByWMISHA1 = tolower(InitiatingProcessSHA1), ProcessLaunchedByWMIID = InitiatingProcessId, WMIchild = FileName, WMIChildCommandline = ProcessCommandLine
+  ) on DeviceName, ProcessLaunchedByWMI, ProcessLaunchedByWMICommandLine, ProcessLaunchedByWMISHA1, ProcessLaunchedByWMIID
+  | join kind=leftouter (
+  DeviceNetworkEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessSHA1 in~ (GetRareWMIProcessLaunches)
+  |project DeviceName, ChildProcessTimestamp = Timestamp, ProcessLaunchedByWMI = tolower(InitiatingProcessFileName), ProcessLaunchedByWMICommandLine = tolower(InitiatingProcessCommandLine), ProcessLaunchedByWMICreationTime = InitiatingProcessCreationTime, ProcessLaunchedByWMISHA1 = tolower(InitiatingProcessSHA1), ProcessLaunchedByWMIID = InitiatingProcessId, WMIProcessRemoteIP = RemoteIP, WMIProcessRemoteURL = RemoteUrl
+  ) on DeviceName, ProcessLaunchedByWMI, ProcessLaunchedByWMICommandLine, ProcessLaunchedByWMISHA1, ProcessLaunchedByWMIID
+  | where isnotempty(WMIProcessRemoteIP) or isnotempty(WMIchild)
+  | summarize ConnectedAddresses = make_set(WMIProcessRemoteIP), ConnectedURLs = make_set(WMIProcessRemoteURL), LaunchedProcessNames = make_set(WMIchild), LaunchedProcessCmdlines = make_set(WMIChildCommandline) by DeviceName, ProcessLaunchedByWMI, ProcessLaunchedByWMICommandLine, ProcessLaunchedByWMICreationTime, ProcessLaunchedByWMISHA1, ProcessLaunchedByWMIID

--- a/Hunting Queries/Microsoft 365 Defender/Persistence/rare_sch_task_with_activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Persistence/rare_sch_task_with_activity.yaml
@@ -1,0 +1,56 @@
+id: ce76992a-8cd6-4605-9f45-cde9aae87244
+name: rare_sch_task_with_activity
+description: |
+  Looks for rare process launch as a scheduled task and activity done by the processes.
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/hunting-for-malicious-scheduled-tasks/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+  - DeviceNetworkEvents
+  - DeviceFileEvents
+  - DeviceRegistryEvents
+  - DeviceLogonEvents
+  - DeviceImageLoadEvents
+  - DeviceEvents
+tactics:
+- Persistence
+relevantTechniques:
+  - T1053
+query: |
+  let RunningScheduledTasks = materialize(
+  DeviceProcessEvents
+  | where InitiatingProcessFileName == @"svchost.exe"
+  | where InitiatingProcessCommandLine == @"svchost.exe -k netsvcs -p -s Schedule"
+  | project Timestamp, DeviceName, AccountName, FileName, ProcessCommandLine, ProcessId, FolderPath
+  | where FileName != @"MpCmdRun.exe"
+  | where FolderPath !startswith @"C:\Windows\System32\" or FileName =~ "cmd.exe" or FileName =~ "powershell.exe" or FileName =~ "rundll32.exe" or FileName =~ "regsvr32.exe"
+  | summarize count() by FileName, ProcessCommandLine, FolderPath
+  | where count_ < 3
+  | summarize
+      Names = make_set(FileName),
+      CommandLines = make_set(ProcessCommandLine),
+      FolderPaths = make_set(FolderPath)
+  );
+  let Names = RunningScheduledTasks
+  | project Names
+  | mv-expand extended = Names
+  | project asstring = tostring(extended)
+  | distinct tolower(asstring);
+  let CommandLines = RunningScheduledTasks
+  | project CommandLines
+  | mv-expand extended = CommandLines
+  | project asstring = tostring(extended)
+  | distinct tolower(asstring);
+  let FolderPaths = RunningScheduledTasks
+  | project FolderPaths
+  | mv-expand extended = FolderPaths
+  | project asstring = tostring(extended)
+  | distinct tolower(asstring);
+  union DeviceProcessEvents,DeviceNetworkEvents,DeviceFileEvents,DeviceRegistryEvents,DeviceLogonEvents,DeviceImageLoadEvents,DeviceEvents
+  | where tolower(InitiatingProcessFileName) in (Names)
+  and tolower(InitiatingProcessCommandLine) in (CommandLines)
+  and tolower(InitiatingProcessFolderPath) in (FolderPaths)
+  | sort by Timestamp desc
+  | summarize Actions = make_set(ActionType), FileNames = make_set(FileName), RemoteIPs = make_set(RemoteIP) by InitiatingProcessFileName, InitiatingProcessId, InitiatingProcessCommandLine, InitiatingProcessCreationTime, DeviceName

--- a/Hunting Queries/Microsoft 365 Defender/Persistence/sch_task_creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Persistence/sch_task_creation.yaml
@@ -1,0 +1,45 @@
+id: e5c65f1f-2bf8-4b42-af8b-1f6adfeda0cc
+name: detect-impacket-wmiexec
+description: |
+  This query looks for signs of impacket wmiexec module usage. May hit other wmi execution-like techniques too.
+  Author: Jouni Mikkola
+  More info: https://threathunt.blog/impacket-part-2/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceEvents
+  - DeviceNetworkEvents
+  - DeviceProcessEvents
+tactics:
+- Execution
+relevantTechniques:
+  - T1047
+query: |
+ let LookupTime = 30d;
+  let GetRareWMIProcessLaunches = materialize (
+  DeviceEvents
+  | where Timestamp > ago(LookupTime)
+  | where ActionType == @"ProcessCreatedUsingWmiQuery"
+  | where isnotempty(FileName)
+  | summarize count() by SHA1, InitiatingProcessCommandLine
+  | where count_ < 5 | distinct SHA1); 
+  DeviceEvents 
+  | where Timestamp > ago(LookupTime)
+  | where ActionType == @"ProcessCreatedUsingWmiQuery"
+  | where SHA1 in~ (GetRareWMIProcessLaunches)
+  | where isnotempty(FileName)
+  | project DeviceName, WMIProcessLaunchTimestmap = Timestamp, ProcessLaunchedByWMI = tolower(FileName), ProcessLaunchedByWMICommandLine = tolower(ProcessCommandLine), ProcessLaunchedByWMICreationTime = ProcessCreationTime, ProcessLaunchedByWMISHA1 = tolower(SHA1), ProcessLaunchedByWMIID = ProcessId, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentCreationTime, InitiatingProcessParentFileName
+  | join kind=leftouter (
+  DeviceProcessEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessSHA1 in~ (GetRareWMIProcessLaunches)
+  |project DeviceName, ChildProcessTimestamp = Timestamp, ProcessLaunchedByWMI = tolower(InitiatingProcessFileName), ProcessLaunchedByWMICommandLine = tolower(InitiatingProcessCommandLine), ProcessLaunchedByWMICreationTime = InitiatingProcessCreationTime, ProcessLaunchedByWMISHA1 = tolower(InitiatingProcessSHA1), ProcessLaunchedByWMIID = InitiatingProcessId, WMIchild = FileName, WMIChildCommandline = ProcessCommandLine
+  ) on DeviceName, ProcessLaunchedByWMI, ProcessLaunchedByWMICommandLine, ProcessLaunchedByWMISHA1, ProcessLaunchedByWMIID
+  | join kind=leftouter (
+  DeviceNetworkEvents
+  | where Timestamp > ago(LookupTime)
+  | where InitiatingProcessSHA1 in~ (GetRareWMIProcessLaunches)
+  |project DeviceName, ChildProcessTimestamp = Timestamp, ProcessLaunchedByWMI = tolower(InitiatingProcessFileName), ProcessLaunchedByWMICommandLine = tolower(InitiatingProcessCommandLine), ProcessLaunchedByWMICreationTime = InitiatingProcessCreationTime, ProcessLaunchedByWMISHA1 = tolower(InitiatingProcessSHA1), ProcessLaunchedByWMIID = InitiatingProcessId, WMIProcessRemoteIP = RemoteIP, WMIProcessRemoteURL = RemoteUrl
+  ) on DeviceName, ProcessLaunchedByWMI, ProcessLaunchedByWMICommandLine, ProcessLaunchedByWMISHA1, ProcessLaunchedByWMIID
+  | where isnotempty(WMIProcessRemoteIP) or isnotempty(WMIchild)
+  | summarize ConnectedAddresses = make_set(WMIProcessRemoteIP), ConnectedURLs = make_set(WMIProcessRemoteURL), LaunchedProcessNames = make_set(WMIchild), LaunchedProcessCmdlines = make_set(WMIChildCommandline) by DeviceName, ProcessLaunchedByWMI, ProcessLaunchedByWMICommandLine, ProcessLaunchedByWMICreationTime, ProcessLaunchedByWMISHA1, ProcessLaunchedByWMIID


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added three different queries for scheduled task hunting purposes.
   - Hunting Queries/Microsoft 365 Defender/Persistence/rare_sch_task_launch.yaml
   - Hunting Queries/Microsoft 365 Defender/Persistence/rare_sch_task_with_activity.yaml
   - Hunting Queries/Microsoft 365 Defender/Persistence/sch_task_creation.yaml

   Reason for Change(s):
   - Additional threat hunting queries to look for rare scheduled task creation and execution.

 
