### PR TITLE
Fixed ssh_potentialBruteForce.yaml Account field

### DIFF
--- a/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
+++ b/Solutions/Syslog/Analytic Rules/ssh_potentialBruteForce.yaml
@@ -35,7 +35,7 @@ query: |
   | summarize StartTime = min(EventTimes), EndTime = max(EventTimes), UserList = make_set(user), ComputerList = make_set(Computer), ResourceIdList = make_set(_ResourceId), sum(PerHourCount) by IPAddress = ip
   // bringing through single computer and user if array only has 1, otherwise, referencing the column and hashing the ComputerList or UserList so we don't get accidental entity matches when reviewing alerts
   | extend HostName = iff(array_length(ComputerList) == 1, tostring(ComputerList[0]), strcat("SeeComputerListField","_", tostring(hash(tostring(ComputerList)))))
-  | extend Account = iff(array_length(ComputerList) == 1, tostring(UserList[0]), strcat("SeeUserListField","_", tostring(hash(tostring(UserList)))))
+  | extend Account = iff(array_length(UserList) == 1, tostring(UserList[0]), strcat("SeeUserListField","_", tostring(hash(tostring(UserList)))))
   | extend ResourceId = iff(array_length(ResourceIdList) == 1, tostring(ResourceIdList[0]), strcat("SeeResourceIdListField","_", tostring(hash(tostring(ResourceIdList)))))
 entityMappings:
   - entityType: Account
@@ -54,5 +54,5 @@ entityMappings:
     fieldMappings:
       - identifier: ResourceId
         columnName: ResourceId
-version: 1.1.5
+version: 1.1.6
 kind: Scheduled


### PR DESCRIPTION
Account was checking ComputerList instead of UserList. This has been fixed.

   Required items, please complete
   
   Change(s):
   - Changed ComputerList with UserList on setting the Account field.

   Reason for Change(s):
   - Account was checking ComputerList instead of UserList.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
