### PR TITLE
SentinelOne | Updated the requirements file for py_310 import errors

### DIFF
--- a/Solutions/SentinelOne/Data Connectors/requirements.txt
+++ b/Solutions/SentinelOne/Data Connectors/requirements.txt
@@ -5,3 +5,5 @@
 azure-storage-file-share==12.3.0
 azure-functions
 requests
+cffi
+cryptography


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated requirements file to include the libraries: `cffi` and `cryptography` 

   Reason for Change(s):
   - When the function runs on Python 3.10 version it fails to import. After some research on the web and Microsoft portal, got to know that adding these libraries will resolve the issue and it does, hence want to publish it for all Customers. 
![image](https://github.com/user-attachments/assets/dc4443e6-1dbb-40dd-bbae-91f48080f13c)

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No