### PR TITLE
Added MS-PIM-Fairfax as a trusted identity for role modification, to support GCC-High / Azure Government

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/PrivlegedRoleAssignedOutsidePIM.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/PrivlegedRoleAssignedOutsidePIM.yaml
@@ -65,5 +65,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.5
+version: 1.0.6
 kind: Scheduled

--- a/Solutions/Microsoft Entra ID/Analytic Rules/PrivlegedRoleAssignedOutsidePIM.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/PrivlegedRoleAssignedOutsidePIM.yaml
@@ -23,7 +23,7 @@ query: |
   AuditLogs
   | where Category =~ "RoleManagement"
   | where OperationName has "Add member to role outside of PIM"
-          or (LoggedByService =~ "Core Directory" and OperationName =~ "Add member to role" and Identity != "MS-PIM")
+          or (LoggedByService =~ "Core Directory" and OperationName =~ "Add member to role" and Identity != "MS-PIM" and Identity != "MS-PIM-Fairfax")
   | mv-apply TargetResource = TargetResources on 
     (
         where TargetResource.type =~ "User"


### PR DESCRIPTION
Change(s):
   - Added MS-PIM-Fairfax as a trusted identity for role modification, to support GCC-High / Azure Government

   Reason for Change(s):
   - Added support for GCC-High / Azure Government. Without this change, the analytics rule generates an incident for all PIM activations.

   Version Updated:
   - Yes
   - 1.0.5 -> 1.0.6

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes