### PR TITLE
aws-s3-fun-pythonversionupdate3.8to3.9

### DIFF
--- a/DataConnectors/AWS-S3-AzureFunction/azuredeploy_awss3.json
+++ b/DataConnectors/AWS-S3-AzureFunction/azuredeploy_awss3.json
@@ -198,7 +198,7 @@
                 "alwaysOn": true,
                 "reserved": true,
                 "siteConfig": {
-                    "linuxFxVersion": "python|3.8"
+                    "linuxFxVersion": "python|3.9"
                 },
 				"serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('HostingPlanName'))]"				
 			},            


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated python version 3.8 to 3.9

   Reason for Change(s):
   - Deprecation on 3.8 version

   Version Updated:
   - 3.9