### PR TITLE
Fixed TLS default version related thing by udating it to TLS1.2

### DIFF
--- a/Solutions/Vectra XDR/Data Connectors/VectraDataConnector/azuredeploy_Connector_VectraXDR_AzureFunction.json
+++ b/Solutions/Vectra XDR/Data Connectors/VectraDataConnector/azuredeploy_Connector_VectraXDR_AzureFunction.json
@@ -276,7 +276,8 @@
                         }
                     },
                     "keySource": "Microsoft.Storage"
-                }
+                },
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated azure deploy file by adding TLS1.2 as default value

   Reason for Change(s):
   - As the current TLS default version of 1.0 will be deprecated soon in starting of November and also client is facing issue while configuring it with the default value of TLS1.0

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
