### PR TITLE
Re: DomainTools Microsoft Sentinel Solutions - CodeQL alerts - CRM:01390016354

### DIFF
--- a/Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/DomainRiskScore/__init__.py
+++ b/Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/DomainRiskScore/__init__.py
@@ -1,7 +1,7 @@
 import json
 import logging
+import hashlib
 from datetime import datetime
-from hashlib import sha256
 from hmac import new
 from os import environ
 from urllib.parse import urlencode, urlunparse
@@ -56,7 +56,7 @@ class DTSigner:
         """
         params = "".join([self.api_username, timestamp, uri])
         return new(
-            self.api_key.encode("utf-8"), params.encode("utf-8"), digestmod=sha256
+            self.api_key.encode("utf-8"), params.encode("utf-8"), digestmod=hashlib.sha256
         ).hexdigest()
 
 


### PR DESCRIPTION
   Change(s):
   - Use hashlib.sha256 to avoid any ambiguity

   Reason for Change(s):
   - Attempting to resolve CodeQL alerts - CRM:01390016354

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Need Help

**Additional Details:**
We received CodeQL alerts asking us to switch hashing algorithms to sha256. For example: 

```
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/DomainRiskScore/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
```

However, I'm unable to find any reference to md5 hash algorithm in the file referenced in the above example, or any of the files referenced in the full CodeQL alert. The only hash algorithm I see in the above referenced file is already sha256. I'm unfamiliar with how these alerts are generated, is it possible this alert was generated on an old package?

This PR changes import/syntax of `sha256` to `hashlib.sha256` in case that's what the "Use hashlib.sha256 to avoid any ambiguity" part of the CodeQL alert is referring to? Please review the changes in this PR. If this resolves the issue, I will apply the same update to the remaining files mentioned in the CodeQL alert and re-submit the PR. If no changes are needed, I'll close this PR. Please let me know if a different fix is required, thank you!

Full Code QL alert:
```

Due Date | Issue | SolutionName | FilePath | Fix |   |   |  
-- | -- | -- | -- | -- | -- | -- | --
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseIPHost-Domains/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ClassicReverseIP/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/EnrichDomain/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotByRegistrantName/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/DomainProfile/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/DomainSearch/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseIPWhois/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseIP/__init__.py | Change sha1 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotMXHost/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReturnTaggedWithAll/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseEmailDomain/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/Evidence/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotBySSLHash/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/InvestigateDomain/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseNameServer/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotByRegistrantOrg/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReturnDomainsFromSearchHash/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseEmail/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/HostingHistory/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/WhoisHistory/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotNameServerHost/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReverseWhois/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/WhoisLookup/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ParsedWhois/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/ReturnTaggedWithAny/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotByNameserverIPAddress/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotByMXIP/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/DomainRiskScore/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity
11/10/2024 | Use of unrecognized hash algorithm | DomainTools | Solutions/DomainTools/Playbooks/CustomConnector/DomainTools_FunctionAppConnector/PivotSSLEmail/__init__.py | Change md5 to sha256. Use hashlib.sha256 to avoid any ambiguity

```

