### PR TITLE
Update azuredeploy_MimecastSEG_AzureFunctionApp.json

### DIFF
--- a/Solutions/MimecastSEG/Data Connectors/azuredeploy_MimecastSEG_AzureFunctionApp.json
+++ b/Solutions/MimecastSEG/Data Connectors/azuredeploy_MimecastSEG_AzureFunctionApp.json
@@ -8,6 +8,12 @@
         "description": "The name of the function app that you wish to create."
       }
     },
+    "hostingPlan": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure App Services Plan where this function app will run."
+      }
+    },
     "objectId": {
       "type": "string",
       "metadata": {
@@ -114,7 +120,7 @@
   },
   "variables": {
     "functionAppName": "[parameters('appName')]",
-    "hostingPlanName": "[parameters('appName')]",
+    "hostingPlanName": "[parameters('hostingPlan')]",
     "applicationInsightsName": "[parameters('appName')]",
     "storageAccountName": "[parameters('appName')]"
   },


### PR DESCRIPTION
   Change(s):
   - Create a parameter for hostingPlan, instead of using the appName for it.

   Reason for Change(s):
   - It helps resolve errors when the app service plan doesn't exist, and you get quota errors which are misleading.
   - Rather than making an erroneous assumption, we just ask the user for the plan name.

   Testing completed:
   - Implemented the same template in Sentinel and it works.