### PR TITLE
Create IPEntity_Workday.yaml

### DIFF
--- a/Solutions/Threat Intelligence/Analytic Rules/IPEntity_Workday.yaml
+++ b/Solutions/Threat Intelligence/Analytic Rules/IPEntity_Workday.yaml
@@ -1,0 +1,59 @@
+id: a924d317-03d2-4420-a71f-4d347bda4bd8
+name: TI map IP entity to Workday
+description: |
+  Identifies a match in Workday Activity from any IP IOC from TI
+severity: Medium
+requiredDataConnectors:
+  - connectorId: ThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: ThreatIntelligenceTaxii
+    dataTypes:
+      - ThreatIntelligenceIndicator
+  - connectorId: Workday
+    dataTypes:
+      - Workday
+  - connectorId: MicrosoftDefenderThreatIntelligence
+    dataTypes:
+      - ThreatIntelligenceIndicator
+queryFrequency: 1h
+queryPeriod: 14d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+relevantTechniques:
+query: |
+let dtLookBack = 1h; // Define the lookback period for audit events
+let iocLookBack = 14d; // Define the lookback period for threat intelligence indicators
+ThreatIntelligenceIndicator
+| where isnotempty(NetworkIP) or isnotempty(EmailSourceIpAddress) or isnotempty(NetworkDestinationIP) or isnotempty(NetworkSourceIP) // Filter for indicators with relevant IP fields
+| where TimeGenerated >= ago(iocLookBack) // Filter indicators within the lookback period
+| extend TI_ipEntity = coalesce(NetworkIP, NetworkDestinationIP, NetworkSourceIP, EmailSourceIpAddress) // Combine IP fields into a single entity
+| summarize LatestIndicatorTime = arg_max(TimeGenerated, *) by IndicatorId, TI_ipEntity // Get the latest indicator time for each entity
+| where Active == true and ExpirationDateTime > now() // Filter for active indicators that have not expired
+| join kind=inner (
+    ASimAuditEventLogs
+    | where EventVendor == "Workday" // Filter for Workday events
+    | where TimeGenerated >= ago(dtLookBack) // Filter events within the lookback period
+    | where isnotempty(DvcIpAddr) // Filter for events with a device IP address
+    | extend WD_TimeGenerated = EventStartTime // Rename the event start time column
+    | project WD_TimeGenerated, ActorUsername, DvcIpAddr, Operation, Object // Select relevant columns
+) on $left.TI_ipEntity == $right.DvcIpAddr // Join on the IP entity
+| project LatestIndicatorTime, Description, ActivityGroupNames, IndicatorId, ThreatType, Url, ExpirationDateTime, ConfidenceScore, WD_TimeGenerated, ActorUsername, DvcIpAddr, Operation, Object // Select relevant columns after the join
+| extend timestamp = WD_TimeGenerated, Name = tostring(split(ActorUsername, '@', 0)[0]), UPNSuffix = tostring(split(ActorUsername, '@', 1)[0]) // Add additional fields for timestamp, name, and UPN suffix
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ActorUsername
+      - identifier: Name
+        columnName: Name
+      - identifier: UPNSuffix
+        columnName: UPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DvcIpAddr
+
+version: 1.0.0
+kind: Scheduled


### PR DESCRIPTION
IOC Match for Workday Activity

   Required items, please complete
   
   Change(s):
   -Created a TI detection for Workday activity that is written to ASimAuditEventLogs as part of the Workday CCP

   Reason for Change(s):
   - Gap in detection options

   Version Updated:
   - 1.0.0
 

   Testing Completed:
   - Need Help

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


