### PR TITLE
[ThreatIntelligence] Move PMDTI and MDTI connectors to government solution

### DIFF
--- a/Solutions/Threat Intelligence Solution for Azure Government/Data/Solution_ThreatIntelligenceFairfax.json
+++ b/Solutions/Threat Intelligence Solution for Azure Government/Data/Solution_ThreatIntelligenceFairfax.json
@@ -5,7 +5,9 @@
 	"Description": "The Threat Intelligence solution contains data connectors for import of threat indicators into Microsoft Sentinel, analytic rules for matching TI data with event data, workbook, and hunting queries. Threat indicators can be malicious IP's, URL's, filehashes, domains, email addresses etc.",
 	"Data Connectors": [
 		"Solutions/Threat Intelligence Solution for Azure Government/Data Connectors/template_ThreatIntelligenceTaxii.json",
-		"Solutions/Threat Intelligence Solution for Azure Government/Data Connectors/template_ThreatIntelligenceUploadIndicators_ForGov.json"
+		"Solutions/Threat Intelligence Solution for Azure Government/Data Connectors/template_ThreatIntelligenceUploadIndicators_ForGov.json",
+		"Solutions/Threat Intelligence Solution for Azure Government/Data Connectors/template_PremiumMicrosoftDefenderForThreatIntelligence.json",
+		"Solutions/Threat Intelligence Solution for Azure Government/Data Connectors/template_MicrosoftDefenderThreatIntelligence.json"
 	],
 	"Workbooks": [
 		"Solutions/Threat Intelligence Solution for Azure Government/Workbooks/ThreatIntelligence.json"

--- a/Solutions/Threat Intelligence Solution for Azure Government/Data/Solution_ThreatIntelligenceFairfax.json
+++ b/Solutions/Threat Intelligence Solution for Azure Government/Data/Solution_ThreatIntelligenceFairfax.json
@@ -60,6 +60,8 @@
 	"Metadata": "SolutionMetadata.json",
 	"TemplateSpec": true,
 	"StaticDataConnectorIds": [
-		"ThreatIntelligenceTaxii"
+		"ThreatIntelligenceTaxii",
+		"MicrosoftDefenderThreatIntelligence",
+		"PremiumMicrosoftDefenderForThreatIntelligence"
 	]
 }

--- a/Solutions/Threat Intelligence Solution for Azure Government/ReleaseNotes.md
+++ b/Solutions/Threat Intelligence Solution for Azure Government/ReleaseNotes.md
@@ -1,5 +1,6 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.8		  | 06-11-2024					   | Removed (Preview) from name for **Data Connectors** Microsoft Defender Threat Intelligence and Premium Microsoft Defender Threat Intelligence |
 | 3.0.5       | 19-08-2024                     | Updated isConnectedQuery for **Data Connector** of "Threat Intelligence Upload Indicators API". |
 | 3.0.1       | 06-08-2024                     | Updated the URL in **data connector**       |
 | 3.0.0       | 02-08-2024                     | Added a new **data connector** of "Threat Intelligence Upload Indicators API" for Fairfax| 

--- a/Solutions/Threat Intelligence/Data Connectors/template_MicrosoftDefenderThreatIntelligence.json
+++ b/Solutions/Threat Intelligence/Data Connectors/template_MicrosoftDefenderThreatIntelligence.json
@@ -1,6 +1,6 @@
 {
     "id": "MicrosoftDefenderThreatIntelligence",
-    "title": "Microsoft Defender Threat Intelligence (Preview)",
+    "title": "Microsoft Defender Threat Intelligence",
     "publisher": "Microsoft",
     "logo": {
         "type": 258,

--- a/Solutions/Threat Intelligence/Data Connectors/template_PremiumMicrosoftDefenderThreatIntelligence.json
+++ b/Solutions/Threat Intelligence/Data Connectors/template_PremiumMicrosoftDefenderThreatIntelligence.json
@@ -1,6 +1,6 @@
 {
     "id": "PremiumMicrosoftDefenderForThreatIntelligence",
-    "title": "Premium Microsoft Defender Threat Intelligence (Preview)",
+    "title": "Premium Microsoft Defender Threat Intelligence",
     "publisher": "Microsoft",
     "logo": {
         "type": 258,

--- a/Solutions/Threat Intelligence/ReleaseNotes.md
+++ b/Solutions/Threat Intelligence/ReleaseNotes.md
@@ -1,5 +1,6 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.8		  | 06-11-2024					   | Removed (Preview) from name for **Data Connectors** Microsoft Defender Threat Intelligence and Premium Microsoft Defender Threat Intelligence |
 | 3.0.6		  | 24-09-2024					   | Updated Entity Mappings of **Analytical Rules** 				 			  |
 | 3.0.5       | 19-08-2024                     | Updated isConnectedQuery for **Data Connector** of "Threat Intelligence Upload Indicators API". |
 | 3.0.4       | 22-05-2024                     | Updated connectivity criteria for **Data Connector** and added New **Data Connector** for Premium Microsoft Defender Threat Intelligence (Preview)   					  |


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Removed "(Preview)" from names for the Premium Microsoft Defender for Threat Intelligence and Microsoft Defender for Threat Intelligence connectors. 
   - Added these two connector templates to the government solution package.
   
   Reason for Change(s):
   - Connectors moving to GA from Public Preview

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Need Help
   - Getting errors while running the detection scripts and package creation tool
![Screenshot 2024-11-06 194111](https://github.com/user-attachments/assets/b7249988-d3a6-4a96-b9f3-4aae9b85e728)
