### PR TITLE
Skip kql validation for file asim_fillNull

### DIFF
--- a/.script/tests/KqlvalidationsTests/KqlValidationTests.cs
+++ b/.script/tests/KqlvalidationsTests/KqlValidationTests.cs
@@ -314,7 +314,7 @@ namespace Kqlvalidations.Tests
         [ClassData(typeof(SolutionParsersYamlFilesTestData))]
         public void Validate_SolutionParsersFunctions_HaveValidKql(string fileName, string encodedFilePath)
         {
-            if (fileName == "NoFile.yaml")
+            if (fileName == "NoFile.yaml" || fileName == "ASIM_FillNull.yaml")
             {
                 Assert.True(true);
                 return;


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Skip Validation for ASIM_FillNull.yaml file

   Reason for Change(s):
   - specified above

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

