### PR TITLE
Update KQLValidation Test cases version 

### DIFF
--- a/.script/tests/KqlvalidationsTests/Kqlvalidations.Tests.csproj
+++ b/.script/tests/KqlvalidationsTests/Kqlvalidations.Tests.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
+	  <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Sentinel.KustoServices" Version="6.6.0" />
+    <PackageReference Include="Microsoft.Azure.Sentinel.KustoServices" Version="6.7.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />

--- a/.script/tests/KqlvalidationsTests/Kqlvalidations.Tests.sln
+++ b/.script/tests/KqlvalidationsTests/Kqlvalidations.Tests.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30621.155
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kqlvalidations.Tests", "Kqlvalidations.Tests.csproj", "{5B7A7358-FA15-45A7-B780-50180855845C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5B7A7358-FA15-45A7-B780-50180855845C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5B7A7358-FA15-45A7-B780-50180855845C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B7A7358-FA15-45A7-B780-50180855845C}.Debug|x64.ActiveCfg = Debug|x64
+		{5B7A7358-FA15-45A7-B780-50180855845C}.Debug|x64.Build.0 = Debug|x64
 		{5B7A7358-FA15-45A7-B780-50180855845C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B7A7358-FA15-45A7-B780-50180855845C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B7A7358-FA15-45A7-B780-50180855845C}.Release|x64.ActiveCfg = Release|x64
+		{5B7A7358-FA15-45A7-B780-50180855845C}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated KustoService to 6.7.0 and changes any cpu to x64 for the error

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


