### PR TITLE
Update MailBoxTampering.yaml

### DIFF
--- a/Detections/MultipleDataSources/MailBoxTampering.yaml
+++ b/Detections/MultipleDataSources/MailBoxTampering.yaml
@@ -69,8 +69,6 @@ query: |
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: Initiatedby
       - identifier: Name
         columnName: AccountName
       - identifier: UPNSuffix
@@ -79,7 +77,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: IpAddress
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION

   Required items, please complete
   
   Change(s):
   - Deletion of the EntityMapping for "Initiatedby"

   Reason for Change(s):
   - The column "Initiatedby" in the EntityMappings is not present because of the project in line 67. The ANR is not deployable in Sentinel. Since the column "AccountName" is also in the EntityMappings, "Initiatedby" is in my opinion not necessary.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


