### PR TITLE
🐛 Fix broken Mango Sandstorm rule

### DIFF
--- a/Detections/MultipleDataSources/powershell_MangoSandstorm.yaml
+++ b/Detections/MultipleDataSources/powershell_MangoSandstorm.yaml
@@ -1,5 +1,5 @@
 id: ce74dc9a-cb3c-4081-8c2f-7d39f6b7bae1
-name: Identify Mango Sandstorm powershell commands  
+name: Identify Mango Sandstorm powershell commands
 description: |
   'The query below identifies powershell commands used by the threat actor Mango Sandstorm.
   Reference:  https://www.microsoft.com/security/blog/2022/08/25/mercury-leveraging-log4j-2-vulnerabilities-in-unpatched-systems-to-target-israeli-organizations/'
@@ -7,7 +7,7 @@ severity: High
 requiredDataConnectors:
   - connectorId: SecurityEvents
     dataTypes:
-      - SecurityEvent 
+      - SecurityEvent
   - connectorId: MicrosoftThreatProtection
     dataTypes:
       - DeviceProcessEvents
@@ -29,23 +29,22 @@ query: |
   | where EventID == 4688
   | where Process has_any ("powershell.exe","powershell_ise.exe","pwsh.exe") and CommandLine has_cs "-exec bypass -w 1 -enc"
   | where CommandLine  contains_cs "UwB0AGEAcgB0AC0ASgBvAGIAIAAtAFMAYwByAGkAcAB0AEIAbABvAGMAawAgAHsAKABzAGEAcABzACAAKAAiAHAA"
-  | extend DvcHostName = Computer, ProcessID = ProcessId
+  | extend DvcHostname = Computer, ProcessId = tostring(ProcessId), ActorUsername = Account
   ),
   (DeviceProcessEvents
-  | where FileName =~ "powershell.exe" and ProcessCommandLine has_cs "-exec bypass -w 1 -enc"  
-  | where ProcessCommandLine contains_cs "UwB0AGEAcgB0AC0ASgBvAGIAIAAtAFMAYwByAGkAcAB0AEIAbABvAGMAawAgAHsAKABzAGEAcABzACAAKAAiAHAA" 
-  | extend DvcHostName = DeviceName, ProcessID = InitiatingProcessId
+  | where FileName =~ "powershell.exe" and ProcessCommandLine has_cs "-exec bypass -w 1 -enc"
+  | where ProcessCommandLine contains_cs "UwB0AGEAcgB0AC0ASgBvAGIAIAAtAFMAYwByAGkAcAB0AEIAbABvAGMAawAgAHsAKABzAGEAcABzACAAKAAiAHAA"
+  | extend DvcHostname = DeviceName, ProcessId = tostring(InitiatingProcessId), ActorUsername = strcat(AccountDomain, @"\", AccountName)
   ),
   (imProcessCreate
   | where Process has_any ("powershell.exe","powershell_ise.exe","pwsh.exe") and CommandLine has_cs "-exec bypass -w 1 -enc"
   | where CommandLine  contains_cs "UwB0AGEAcgB0AC0ASgBvAGIAIAAtAFMAYwByAGkAcAB0AEIAbABvAGMAawAgAHsAKABzAGEAcABzACAAKAAiAHAA"
-  | extend ProcessID = TargetProcessId
+  | extend ProcessId = tostring(TargetProcessId)
   )
   )
-  | extend AccountName = tostring(split(ActorUsername, "\\")[0]), AccountNTDomain = tostring(split(ActorUsername, "\\")[1]), ProcessID = TargetProcessId
+  | extend AccountName = tostring(split(ActorUsername, "\\")[0]), AccountNTDomain = tostring(split(ActorUsername, "\\")[1])
   | extend HostName = tostring(split(DvcHostname, ".")[0]), DomainIndex = toint(indexof(DvcHostname, '.'))
   | extend HostNameDomain = iff(DomainIndex != -1, substring(DvcHostname, DomainIndex + 1), DvcHostname)
- 
 entityMappings:
   - entityType: Account
     fieldMappings:
@@ -53,8 +52,8 @@ entityMappings:
         columnName: ActorUsername
       - identifier: Name
         columnName: AccountName
-      - identifier: UPNSuffix
-        columnName: AccountUPNSuffix
+      - identifier: NTDomain
+        columnName: AccountNTDomain
   - entityType: Host
     fieldMappings:
       - identifier: FullName
@@ -66,8 +65,8 @@ entityMappings:
   - entityType: Process
     fieldMappings:
       - identifier: ProcessId
-        columnName: ProcessID
-version: 1.0.4
+        columnName: ProcessId
+version: 1.0.5
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
This rule was all kinds of broken
   
   Change(s):
   - Add `ActorUsername` for tables where it doesn't exist
   - Fixed the mixed case of `DvcHostname` and `ProcessId` breaking entities, preferring lowercase style as per https://learn.microsoft.com/azure/sentinel/normalization-schema-process-event
   - Fixed redundant and broken `ProcessID` assignment outside the union. Also cast all ProcessId fields to string so the entity doesn't break.
   - Fix the non-existent UPNSuffix entity, using NTDomain instead

   Reason for Change(s):
   - So the rule can deploy and work correctly

   Version Updated: ✅

   Testing Completed: ✅