### PR TITLE
Use variables instead of parameters

### DIFF
--- a/Solutions/Commvault Security IQ/Data Connectors/azuredeploy_CommvaultSecurityIQ_FunctionApp.json
+++ b/Solutions/Commvault Security IQ/Data Connectors/azuredeploy_CommvaultSecurityIQ_FunctionApp.json
@@ -160,7 +160,7 @@
                         "AzureSentinelWorkspaceId": "[parameters('AzureSentinelWorkspaceId')]",
                         "AzureSentinelSharedKey": "[parameters('AzureSentinelSharedKey')]",
 						"ConnectionString": "[parameters('ConnectionString')]",
-                        "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', toLower(parameters('FunctionName')),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', toLower(parameters('FunctionName'))), '2019-06-01').keys[0].value, ';EndpointSuffix=',toLower(variables('StorageSuffix')))]",
+                        "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', toLower(variables('FunctionName')),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', toLower(variables('FunctionName'))), '2019-06-01').keys[0].value, ';EndpointSuffix=',toLower(variables('StorageSuffix')))]",
 						"KeyVaultName": "[parameters('KeyVaultName')]",
                         "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinel-CommvaultSecurityIQ-functionapp"
                     }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Use variables('FunctionName') instead of parameters('FunctionName')

   Reason for Change(s):
   - Use variables('FunctionName') instead of parameters('FunctionName'), because the function app name in the variable is function name and resource group id., which is the correct id.

   Version Updated:
   - Not needed

   Testing Completed:
   - Yes, I have tested it, if this works