### PR TITLE
Use arrivalTime to avoid missing events

### DIFF
--- a/Solutions/CyberArkEPM/DataConnectors/CyberArkEPMSentinelConnector/__init__.py
+++ b/Solutions/CyberArkEPM/DataConnectors/CyberArkEPMSentinelConnector/__init__.py
@@ -149,7 +149,7 @@ def main(mytimer: func.TimerRequest) -> None:
     except Exception as err:
         logging.error("CyberArkEPMServerURL is invalid")
         return
-    filter_date = '{"filter": "eventDate GE ' + str(start_time) + ' AND eventDate LE ' + end_time + '"}'
+    filter_date = '{"filter": "arrivalTime GE ' + str(start_time) + ' AND arrivalTime LE ' + end_time + '"}'
     aggregated_events = []
     raw_events = []
     aggregated_policy_audits = []

--- a/Solutions/CyberArkEPM/ReleaseNotes.md
+++ b/Solutions/CyberArkEPM/ReleaseNotes.md
@@ -1,4 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                             |
 |-------------|--------------------------------|------------------------------------------------|
-| 3.0.0       | 27-07-2023                     | Updated solution to fix deployment validations | 
 | 3.0.1       | 13-01-2025                     | Fix late arriving events scenario              |
+| 3.0.0       | 27-07-2023                     | Updated solution to fix deployment validations | 
+

--- a/Solutions/CyberArkEPM/ReleaseNotes.md
+++ b/Solutions/CyberArkEPM/ReleaseNotes.md
@@ -1,3 +1,4 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                             |
 |-------------|--------------------------------|------------------------------------------------|
 | 3.0.0       | 27-07-2023                     | Updated solution to fix deployment validations | 
+| 3.0.1       | 13-01-2025                     | Fix late arriving events scenario              |

--- a/Solutions/CyberArkEPM/ReleaseNotes.md
+++ b/Solutions/CyberArkEPM/ReleaseNotes.md
@@ -1,5 +1,4 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                             |
 |-------------|--------------------------------|------------------------------------------------|
-| 3.0.1       | 13-01-2025                     | Fix late arriving events scenario              |
 | 3.0.0       | 27-07-2023                     | Updated solution to fix deployment validations | 
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - __init__.py

   Reason for Change(s):
   - Use arrivalTime instead of eventDate to avoid missing events

