### PR TITLE
Skip domain links specified in playbook

### DIFF
--- a/.script/package-automation/hyperlink-validation.ps1
+++ b/.script/package-automation/hyperlink-validation.ps1
@@ -111,7 +111,7 @@ foreach($item in $filteredFiles)
 $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$", ".md$")
 $filterOutExclusionList = $finalFilteredFiles | Where-Object { $_ -notmatch ($exclusionList -join '|')  }
 
-$exclusionDomainList = @("&&sudo","schema.management","schemas.microsoft","twitter.com")
+$exclusionDomainList = @("&&sudo","schema.management","schemas.microsoft","twitter.com", "s-platform.api.opendns.com", "github.com")
 
 foreach ($currentFile in $filterOutExclusionList)
 {

--- a/.script/package-automation/hyperlink-validation.ps1
+++ b/.script/package-automation/hyperlink-validation.ps1
@@ -111,7 +111,7 @@ foreach($item in $filteredFiles)
 $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$", ".md$")
 $filterOutExclusionList = $finalFilteredFiles | Where-Object { $_ -notmatch ($exclusionList -join '|')  }
 
-$exclusionDomainList = @("&&sudo","schema.management","schemas.microsoft","twitter.com", "s-platform.api.opendns.com", "github.com")
+$exclusionDomainList = @("&&sudo","schema.management","schemas.microsoft","twitter.com", "s-platform.api.opendns.com", "github.com", "azure.microsoft.com")
 
 foreach ($currentFile in $filterOutExclusionList)
 {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added domain to skip from hyperlink validation for Cisco Umbrella solution playbooks.
   - Below are the links that need to be skipped:
     a. azure.microsoft.com --> this is used in function app file in data connector which timeout with warning error.
     b. s-platform.api.opendns.com --> This is in playbook of cisco umbrella in enforcement custom connector.
     c. github.com --> We have added a link in playbook to redirect to readme file from playbook.

   Reason for Change(s):
   This domain will fail, so we have to skip validation for those domains.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

