### PR TITLE
Revert Sentintel Entities to IP entitites

### DIFF
--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTDenialofService.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTDenialofService.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTExcessiveLoginAttempts.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTExcessiveLoginAttempts.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTFirmwareUpdates.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTFirmwareUpdates.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTHighBandwidth.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTHighBandwidth.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTINoSensorTrafficDetected.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTINoSensorTrafficDetected.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTIllegalFunctionCodes.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTIllegalFunctionCodes.yaml
@@ -48,8 +48,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -73,5 +79,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTInsecurePLC.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTInsecurePLC.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTInternetAccess.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTInternetAccess.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTMalware.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTMalware.yaml
@@ -48,8 +48,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -73,5 +79,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTNetworkScanning.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTNetworkScanning.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTPLCStopCommand.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTPLCStopCommand.yaml
@@ -48,8 +48,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -73,5 +79,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedDevice.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedDevice.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedNetworkConfiguration.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedNetworkConfiguration.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedPLCModifications.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedPLCModifications.yaml
@@ -49,8 +49,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -74,5 +80,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedRemoteAccess.yaml
+++ b/Solutions/IoTOTThreatMonitoringwithDefenderforIoT/Analytic Rules/IoTUnauthorizedRemoteAccess.yaml
@@ -47,8 +47,14 @@ query: |
     AlertManagementUri,
     Techniques
 entityMappings:
-sentinelEntitiesMappings:
-  - columnName: Entities
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceDeviceAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestDeviceAddress
 eventGroupingSettings:
   aggregationKind: AlertPerResult
 customDetails:
@@ -72,5 +78,5 @@ alertDetailsOverride:
       value: ProductComponentName
     - alertProperty: AlertLink
       value: AlertLink
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled


### PR DESCRIPTION
Required items, please complete

Change(s):

Revert MDIoT analytic rules entities mapping from Sentinel Entitites to IP entitites
Reason for Change(s):

Sentintel Entitites mapping didn't work
Version Updated:

Yes
Testing Completed:

Need help
Checked that the validations are passing and have addressed any issues that are present:

Need help