### PR TITLE
Suspicious registry additions

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-base64-encoded-registry-keys.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-base64-encoded-registry-keys.yaml
@@ -23,4 +23,4 @@ query: |
   | extend DecodedCommand = replace(@'\x00','', base64_decode_tostring(RegistryValueData))
   | extend ExtractedDecodedCommand = base64_decode_tostring(ExtractedB64)
   | where isnotempty(DecodedCommand) or isnotempty(ExtractedDecodedCommand)
-  | project Timestamp, DeviceName, DecodedCommand, ExtractedDecodedCommand, RegistryValueData, RegistryKey, RegistryValueName, RegistryValueType, PreviousRegistryValueData, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentFileName, InitiatingProcessRemoteSessionDeviceName, InitiatingProcessRemoteSessionIP
+  | project Timestamp, DeviceName, DecodedCommand, ExtractedDecodedCommand, RegistryValueData, RegistryKey, RegistryValueName, RegistryValueType, PreviousRegistryValueData, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentFileName

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-base64-encoded-registry-keys.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-base64-encoded-registry-keys.yaml
@@ -1,0 +1,26 @@
+id: 4751319e-6d20-4c26-893d-baaad90f0747
+name: suspicious-base64-encoded-registry-keys
+description: |
+  Looks for suspicious base64 encoded registry keys being created.
+  Author: Jouni Mikkola
+  References:
+  https://threathunt.blog/registry-hunts/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceRegistryEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1112
+query: |
+  DeviceRegistryEvents
+  | where Timestamp > ago(30d)
+  | where ActionType has_any ('RegistryValueSet','RegistryKeyCreated')
+  | where isnotempty(RegistryValueData)
+  | where RegistryValueData matches regex @'\s+([A-Za-z0-9+/]{4,}(?:[A-Za-z0-9+/]{2}[=]{2}|[A-Za-z0-9+/]{3}=)?)\s+' or RegistryValueData matches regex @'^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$'
+  | extend ExtractedB64 = trim(" ",extract(@'(?:\s+)[A-Za-z0-9+\/=]+(?:\s+)',0,RegistryValueData))
+  | extend DecodedCommand = replace(@'\x00','', base64_decode_tostring(RegistryValueData))
+  | extend ExtractedDecodedCommand = base64_decode_tostring(ExtractedB64)
+  | where isnotempty(DecodedCommand) or isnotempty(ExtractedDecodedCommand)
+  | project Timestamp, DeviceName, DecodedCommand, ExtractedDecodedCommand, RegistryValueData, RegistryKey, RegistryValueName, RegistryValueType, PreviousRegistryValueData, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentFileName, InitiatingProcessRemoteSessionDeviceName, InitiatingProcessRemoteSessionIP

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-command-interpreters-added-to-registry.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-command-interpreters-added-to-registry.yaml
@@ -24,4 +24,4 @@ query: |
   // Search for registry values containing 'powershell' or 'cmd'
   | where RegistryValueData has_any('powershell','cmd')
   // Project relevant fields for analysis
-  | project Timestamp, DeviceName, RegistryKey, RegistryValueName, RegistryValueData, InitiatingProcessAccountName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessRemoteSessionDeviceName, InitiatingProcessRemoteSessionIP, InitiatingProcessParentFileName
+  | project Timestamp, DeviceName, RegistryKey, RegistryValueName, RegistryValueData, InitiatingProcessAccountName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentFileName

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-command-interpreters-added-to-registry.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-command-interpreters-added-to-registry.yaml
@@ -1,0 +1,27 @@
+id: 74dd8aa9-996b-44b1-bf36-9ac9ef6d2c02
+name: suspicious-command-interpreters-added-to-registry
+description: |
+  Looks for suspicious addition of command interpreters to windows registry.
+  Author: Jouni Mikkola
+  References:
+  https://threathunt.blog/registry-hunts/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceRegistryEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1112
+query: |
+  DeviceRegistryEvents
+  // Filter out events initiated by OneDriveSetup.exe to reduce noise
+  | where InitiatingProcessVersionInfoInternalFileName != @"OneDriveSetup.exe"
+  // Look at events from the last 30 days
+  | where Timestamp > ago(30d)
+  // Consider only key set and key created actions
+  | where ActionType has_any ('RegistryValueSet','RegistryKeyCreated')
+  // Search for registry values containing 'powershell' or 'cmd'
+  | where RegistryValueData has_any('powershell','cmd')
+  // Project relevant fields for analysis
+  | project Timestamp, DeviceName, RegistryKey, RegistryValueName, RegistryValueData, InitiatingProcessAccountName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessRemoteSessionDeviceName, InitiatingProcessRemoteSessionIP, InitiatingProcessParentFileName

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-keywords-in-registry.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-keywords-in-registry.yaml
@@ -1,0 +1,21 @@
+id: 749f313e-08b4-48f6-9f9d-ba57c1abbf55
+name: suspicious-keywords-in-registry
+description: |
+  Looks for suspicious keyword additions to windows registry.
+  Author: Jouni Mikkola
+  References:
+  https://threathunt.blog/registry-hunts/
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceRegistryEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1112
+query: |
+  DeviceRegistryEvents
+  | where Timestamp > ago(30d)
+  | where ActionType has_any ('RegistryValueSet','RegistryKeyCreated')
+  | where RegistryValueData has_any('xor','new-item','invoke-expression','iex','sleep','invoke-','System.Net.HttpWebRequest','webclient','iwr','curl')  // Look for common obfuscation techniques or commands used in malicious scripts
+  | project Timestamp, DeviceName, RegistryKey, RegistryValueName, RegistryValueData, InitiatingProcessAccountName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessRemoteSessionDeviceName, InitiatingProcessRemoteSessionIP, InitiatingProcessParentFileName  // Project relevant fields for analysis

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-keywords-in-registry.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-keywords-in-registry.yaml
@@ -18,4 +18,4 @@ query: |
   | where Timestamp > ago(30d)
   | where ActionType has_any ('RegistryValueSet','RegistryKeyCreated')
   | where RegistryValueData has_any('xor','new-item','invoke-expression','iex','sleep','invoke-','System.Net.HttpWebRequest','webclient','iwr','curl')  // Look for common obfuscation techniques or commands used in malicious scripts
-  | project Timestamp, DeviceName, RegistryKey, RegistryValueName, RegistryValueData, InitiatingProcessAccountName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessRemoteSessionDeviceName, InitiatingProcessRemoteSessionIP, InitiatingProcessParentFileName  // Project relevant fields for analysis
+  | project Timestamp, DeviceName, RegistryKey, RegistryValueName, RegistryValueData, InitiatingProcessAccountName, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessParentFileName  // Project relevant fields for analysis


### PR DESCRIPTION
Added queries to find for suspicious registry additions.

Change(s):

- Adding Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-base64-encoded-registry-keys.yaml 
- Adding Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-command-interpreters-added-to-registry.yaml
- Adding Hunting Queries/Microsoft 365 Defender/Defense evasion/suspicious-keywords-in-registry.yaml Reason for 

Pics of queries running:
<img width="1036" alt="Screenshot 2025-02-09 at 14 33 30" src="https://github.com/user-attachments/assets/bdf677e6-1f73-4d28-bc19-86c6b2d0630f" />
<img width="1075" alt="Screenshot 2025-02-09 at 14 34 36" src="https://github.com/user-attachments/assets/1f0e0d26-a630-466c-9f17-cec506beabea" />
<img width="1084" alt="Screenshot 2025-02-09 at 14 34 00" src="https://github.com/user-attachments/assets/ea84d1f7-5323-41fd-9535-4ec3a39b9c07" />
