### PR TITLE
Add guid to name for ccp poller file and handle sentinelEntitiesMappings field

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -2718,6 +2718,10 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                 {
                                     $alertRule.entityMappings = @($alertRule.entityMappings);
                                 }
+                                elseif($yamlField -eq "sentinelEntitiesMappings" -and $yaml.$yamlField.length -lt 2)
+                                {
+                                    $alertRule.sentinelEntitiesMappings = @($alertRule.sentinelEntitiesMappings);
+                                }
                             }
                         }
                         # Create Alert Rule Resource Object


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added guid parameter in inner resource and used this in "name" of ccp poller file. This changes was to show multiple rows in grid when a ccp connector connects.
   - For solution "IoTOTThreatMonitoringwithDefenderforIoT", property "sentinelEntitiesMappings" in Analytic rule is not coming in array so fixed this.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


