### PR TITLE
fix syslog ng conf file path

### DIFF
--- a/DataConnectors/Syslog/Forwarder_AMA_installer.py
+++ b/DataConnectors/Syslog/Forwarder_AMA_installer.py
@@ -5,6 +5,9 @@
 # This script is used to install the AMA on a linux machine and configure the
 # Syslog daemon on the linux machine for a data forwarding connector scenario.
 # For more information please check the Azure Monitoring Agent documentation.
+# If using Python 3 make sure it's set as the default command on the machine, or run the script with the 'python3'
+# command instead of 'python'.
+
 import subprocess
 import time
 
@@ -20,6 +23,7 @@ rsyslog_old_config_udp_content = "# provides UDP syslog reception\n$ModLoad imud
 rsyslog_old_config_tcp_content = "# provides TCP syslog reception\n$ModLoad imtcp\n$InputTCPServerRun " + daemon_default_incoming_port + "\n"
 syslog_ng_documantation_path = "https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.26/administration-guide/34#TOPIC-1431029"
 rsyslog_documantation_path = "https://www.rsyslog.com/doc/master/configuration/actions.html"
+temp_file_path = "/tmp/syslog_temp_config.txt"
 
 
 def print_error(input_str):
@@ -127,12 +131,12 @@ def set_rsyslog_new_configuration():
     Sets the Rsyslog configuration to listen on port 514 for incoming requests- For new config format
     """
     with open(rsyslog_conf_path, "rt") as fin:
-        with open("tmp.txt", "wt") as fout:
+        with open(temp_file_path, "wt") as fout:
             for line in fin:
                 if "imudp" in line or "imtcp" in line:
                     # Load configuration line requires 1 replacement
                     if "load" in line:
-                        fout.write(line.replace("#", "", 1))
+                        fout.write(line.lstrip("#"))
                     # Port configuration line requires 2 replacements
                     elif "port" in line:
                         fout.write(line.replace("#", "", 2))
@@ -140,7 +144,7 @@ def set_rsyslog_new_configuration():
                         fout.write(line)
                 else:
                     fout.write(line)
-    command_tokens = ["sudo", "mv", "tmp.txt", rsyslog_conf_path]
+    command_tokens = ["sudo", "cp", temp_file_path, rsyslog_conf_path]
     write_new_content = subprocess.Popen(command_tokens, stdout=subprocess.PIPE)
     time.sleep(3)
     o, e = write_new_content.communicate()
@@ -247,7 +251,7 @@ def set_syslog_ng_configuration():
     comment_line = False
     snet_found = False
     with open(syslog_ng_conf_path, "rt") as fin:
-        with open("tmp.txt", "wt") as fout:
+        with open(temp_file_path, "wt") as fout:
             for line in fin:
                 # fount snet
                 if "s_net" in line and not "#":
@@ -262,7 +266,7 @@ def set_syslog_ng_configuration():
                     comment_line = False
                 # write line correctly
                 fout.write(line if not comment_line else ("#" + line))
-    command_tokens = ["sudo", "mv", "tmp.txt", syslog_ng_conf_path]
+    command_tokens = ["sudo", "cp", temp_file_path, syslog_ng_conf_path]
     write_new_content = subprocess.Popen(command_tokens, stdout=subprocess.PIPE)
     time.sleep(3)
     o, e = write_new_content.communicate()


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Bugfix in CEF installation script to modify Syslog-ng configuration file instead of Rsyslog configuration file.

   Reason for Change(s):
   - Bug fix.

   Version Updated:
   - No need

   Testing Completed:
   - Manual testing

-----------------------------------------------------------------------------------------------------------
