### PR TITLE
Fix Azure CLI version comparison bug

### DIFF
--- a/Solutions/SAP/sapcon-sentinel-kickstart-sapcon-java.sh
+++ b/Solutions/SAP/sapcon-sentinel-kickstart-sapcon-java.sh
@@ -421,7 +421,7 @@ elif [ "$os" == '"sles"' ]; then
 		if which az >/dev/null 2>&1; then
 			#AZ is installed, check if it is out-of date version with compatibility issues
 			azver=$(az version | jq '."azure-cli"')
-			if verlte "2.33.1" "$azver"; then
+			if verlte "$azver" "2.33.1"; then
 				echo "Installed version $azver is out of date, removing older version"
 				sudo zypper rm -y --clean-deps azure-cli >/dev/null
 				echo "Installing Azure CLI"

--- a/Solutions/SAP/sapcon-sentinel-kickstart.sh
+++ b/Solutions/SAP/sapcon-sentinel-kickstart.sh
@@ -499,7 +499,7 @@ elif [ "$os" == '"sles"' ]; then
 		if which az >/dev/null 2>&1; then
 			#AZ is installed, check if it is out-of date version with compatibility issues
 			azver=$(az version | jq '."azure-cli"')
-			if verlte "2.33.1" "$azver"; then
+			if verlte "$azver" "2.33.1"; then
 				echo "Installed version $azver is out of date, removing older version"
 				sudo zypper rm -y --clean-deps azure-cli >/dev/null
 				echo "Installing Azure CLI"

--- a/Solutions/SAP/sapcon-sentinel-ui-agent-kickstart.sh
+++ b/Solutions/SAP/sapcon-sentinel-ui-agent-kickstart.sh
@@ -271,7 +271,7 @@ elif [ "$os" == '"sles"' ]; then
 		if which az >/dev/null 2>&1; then
 			#AZ is installed, check if it is out-of date version with compatibility issues
 			azver=$(az version | jq '."azure-cli"')
-			if verlte "2.33.1" "$azver"; then
+			if verlte "$azver" "2.33.1"; then
 				log "Installed version $azver is out of date, removing older version"
 				sudo zypper rm -y --clean-deps azure-cli >/dev/null
 				log "Installing Azure CLI"


### PR DESCRIPTION
   Change(s):
   - This commit swaps the arguments to `verlte "$azver" "2.33.1"` so that the function correctly returns true only when the installed version is less than or equal to 2.33.1

   Reason for Change(s):
   - The scripts currently check for an outdated Azure CLI version by calling `verlte "2.33.1" "$azver"`, which incorrectly evaluates newer versions (e.g., 2.38.2) as outdated due to reversed argument order.
   - This fix prevents unnecessary removal and reinstallation of the Azure CLI.