### PR TITLE
Set `minimumTlsVersion` to `TLS1_2`

### DIFF
--- a/Solutions/Auth0/Data Connectors/azuredeploy_Auth0_FunctionApp.json
+++ b/Solutions/Auth0/Data Connectors/azuredeploy_Auth0_FunctionApp.json
@@ -64,6 +64,7 @@
             },
             "kind": "StorageV2",
             "properties": {
+                "minimumTlsVersion": "TLS1_2",
                 "networkAcls": {
                     "bypass": "AzureServices",
                     "virtualNetworkRules": [],


### PR DESCRIPTION
**Use `TLS 1.2` for Azure Storage**

   Required items, please complete
   
   Change(s):
   - Updated `Solutions/Auth0/Data Connectors/azuredeploy_Auth0_FunctionApp.json`

   Reason for Change(s):
   - Azure Storage is retiring support for `TLS1_0` and `TLS1_1` starting November 1, 2025. Updating the minimum TLS version to `TLS1_2` ensures continued compatibility with Azure services.

   Version Updated:
   - Changed `TLS1_0` to `TLS1_2`

   Testing Completed:
   - Yes
   - The minimum TLS version was `TLS1_0`.
![image](https://github.com/user-attachments/assets/7d4d5386-53aa-4617-ba44-c8c0ded8e95c)
   - The minimum TLS version is now `TLS1_2`.
![image](https://github.com/user-attachments/assets/bb445285-ff0a-4615-a052-ad4a2de08f9b)

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes