### PR TITLE
Fix field name inconsistency in Fortigate parsers for ASim tables

### DIFF
--- a/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionFortinetFortiGate.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/ASimNetworkSessionFortinetFortiGate.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Network Session ASIM parser for Fortinet FortiGate
-  Version: '0.5'
-  LastUpdated: Dec 11, 2022
+  Version: '0.6'
+  LastUpdated: Mar 21, 2025
 Product:
   Name: Fortinet FortiGate
 Normalization:
@@ -70,30 +70,30 @@ ParserQuery: |
     | invoke _ASIM_ResolveNetworkProtocol ('Protocol')
     | project-rename DvcOriginalAction = DeviceAction
     | parse-kv AdditionalExtensions as (
-            FortinetFortiGatestart:datetime,
-            FortinetFortiGatesrcintfrole:string,
-            FortinetFortiGatedstintfrole:string,
-            FortinetFortiGateexternalID:string,
-            FortinetFortiGatepolicyid:int,
-            FortinetFortiGatedstcountry:string,
-            FortinetFortiGatesrccountry:string,
-            FortinetFortiGatecrscore:string,
-            FortinetFortiGateduration:int,
-            FortinetFortiGatesentpkt:long,
-            FortinetFortiGatercvdpkt:long
+            FTNTFGTstart:datetime,
+            FTNTFGTsrcintfrole:string,
+            FTNTFGTdstintfrole:string,
+            FTNTFGTexternalID:string,
+            FTNTFGTpolicyid:int,
+            FTNTFGTdstcountry:string,
+            FTNTFGTsrccountry:string,
+            FTNTFGTcrscore:string,
+            FTNTFGTduration:int,
+            FTNTFGTsentpkt:long,
+            FTNTFGTrcvdpkt:long
         ) with (pair_delimiter=';', kv_delimiter='=')
     | project-rename
-        EventStartTime          = FortinetFortiGatestart,
-        SrcZone                 = FortinetFortiGatesrcintfrole,
-        DstZone                 = FortinetFortiGatedstintfrole,
-        NetworkSessionId        = FortinetFortiGateexternalID,
-        NetworkRuleNumber       = FortinetFortiGatepolicyid,
-        NetworkDuration         = FortinetFortiGateduration,
-        DstGeoCountry           = FortinetFortiGatedstcountry,
-        SrcGeoCountry           = FortinetFortiGatesrccountry,
-        ThreatOriginalRiskLevel = FortinetFortiGatecrscore,
-        SrcPackets              = FortinetFortiGatesentpkt,
-        DstPackets              = FortinetFortiGatercvdpkt
+        EventStartTime          = FTNTFGTstart,
+        SrcZone                 = FTNTFGTsrcintfrole,
+        DstZone                 = FTNTFGTdstintfrole,
+        NetworkSessionId        = FTNTFGTexternalID,
+        NetworkRuleNumber       = FTNTFGTpolicyid,
+        NetworkDuration         = FTNTFGTduration,
+        DstGeoCountry           = FTNTFGTdstcountry,
+        SrcGeoCountry           = FTNTFGTsrccountry,
+        ThreatOriginalRiskLevel = FTNTFGTcrscore,
+        SrcPackets              = FTNTFGTsentpkt,
+        DstPackets              = FTNTFGTrcvdpkt
     | extend EventCount = int(1)
       , EventSchema = "NetworkSession"
       , EventSchemaVersion = "0.2.3"

--- a/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionFortinetFortiGate.yaml
+++ b/Parsers/ASimNetworkSession/Parsers/vimNetworkSessionFortinetFortiGate.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Network Session ASIM filtering parser for Fortinet FortiGate
-  Version: '0.4'
-  LastUpdated: Dec 11, 2022
+  Version: '0.5'
+  LastUpdated: Mar 21, 2025
 Product:
   Name: Fortinet FortiGate
 Normalization:
@@ -126,30 +126,30 @@ ParserQuery: |
       | invoke _ASIM_ResolveNetworkProtocol ('Protocol')
       | project-rename DvcOriginalAction = DeviceAction
       | parse-kv AdditionalExtensions as (
-              FortinetFortiGatestart:datetime,
-              FortinetFortiGatesrcintfrole:string,
-              FortinetFortiGatedstintfrole:string,
-              FortinetFortiGateexternalID:string,
-              FortinetFortiGatepolicyid:int,
-              FortinetFortiGatedstcountry:string,
-              FortinetFortiGatesrccountry:string,
-              FortinetFortiGatecrscore:string,
-              FortinetFortiGateduration:int,
-              FortinetFortiGatesentpkt:long,
-              FortinetFortiGatercvdpkt:long
+              FTNTFGTstart:datetime,
+              FTNTFGTsrcintfrole:string,
+              FTNTFGTdstintfrole:string,
+              FTNTFGTexternalID:string,
+              FTNTFGTpolicyid:int,
+              FTNTFGTdstcountry:string,
+              FTNTFGTsrccountry:string,
+              FTNTFGTcrscore:string,
+              FTNTFGTduration:int,
+              FTNTFGTsentpkt:long,
+              FTNTFGTrcvdpkt:long
           ) with (pair_delimiter=';', kv_delimiter='=')
       | project-rename
-          EventStartTime          = FortinetFortiGatestart,
-          SrcZone                 = FortinetFortiGatesrcintfrole,
-          DstZone                 = FortinetFortiGatedstintfrole,
-          NetworkSessionId        = FortinetFortiGateexternalID,
-          NetworkRuleNumber       = FortinetFortiGatepolicyid,
-          NetworkDuration         = FortinetFortiGateduration,
-          DstGeoCountry           = FortinetFortiGatedstcountry,
-          SrcGeoCountry           = FortinetFortiGatesrccountry,
-          ThreatOriginalRiskLevel = FortinetFortiGatecrscore,
-          SrcPackets              = FortinetFortiGatesentpkt,
-          DstPackets              = FortinetFortiGatercvdpkt
+          EventStartTime          = FTNTFGTstart,
+          SrcZone                 = FTNTFGTsrcintfrole,
+          DstZone                 = FTNTFGTdstintfrole,
+          NetworkSessionId        = FTNTFGTexternalID,
+          NetworkRuleNumber       = FTNTFGTpolicyid,
+          NetworkDuration         = FTNTFGTduration,
+          DstGeoCountry           = FTNTFGTdstcountry,
+          SrcGeoCountry           = FTNTFGTsrccountry,
+          ThreatOriginalRiskLevel = FTNTFGTcrscore,
+          SrcPackets              = FTNTFGTsentpkt,
+          DstPackets              = FTNTFGTrcvdpkt
       | extend EventCount = int(1)
         , EventSchema = "NetworkSession"
         , EventSchemaVersion = "0.2.3"

--- a/Parsers/ASimWebSession/Parsers/ASimWebSessionFortinetFortiGate.yaml
+++ b/Parsers/ASimWebSession/Parsers/ASimWebSessionFortinetFortiGate.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Web Session ASIM parser for Fortinet FortiGate
-  Version: '0.1'
-  LastUpdated: Nov 11th, 2023
+  Version: '0.2'
+  LastUpdated: Mar 21, 2025
 Product:
   Name: Fortinet FortiGate
 Normalization:
@@ -84,17 +84,17 @@ ParserQuery: |
         , SrcUsernameType = _ASIM_GetUsernameType(SrcUsername)
     | project-rename DvcOriginalAction = DeviceAction
     | parse-kv AdditionalExtensions as (
-            FortinetFortiGatestart:datetime,
-            FortinetFortiGatesrcintfrole:string,
-            FortinetFortiGatedstintfrole:string,
-            FortinetFortiGateexternalID:string,
-            FortinetFortiGatepolicyid:int,
-            FortinetFortiGatedstcountry:string,
-            FortinetFortiGatesrccountry:string,
-            FortinetFortiGatecrscore:string,
-            FortinetFortiGateduration:int,
-            FortinetFortiGatesentpkt:long,
-            FortinetFortiGatercvdpkt:long,
+            FTNTFGTstart:datetime,
+            FTNTFGTsrcintfrole:string,
+            FTNTFGTdstintfrole:string,
+            FTNTFGTexternalID:string,
+            FTNTFGTpolicyid:int,
+            FTNTFGTdstcountry:string,
+            FTNTFGTsrccountry:string,
+            FTNTFGTcrscore:string,
+            FTNTFGTduration:int,
+            FTNTFGTsentpkt:long,
+            FTNTFGTrcvdpkt:long,
             ['ad.referralurl']:string,
             ['ad.httpmethod']:string,
             ['ad.agent']:string
@@ -104,17 +104,17 @@ ParserQuery: |
         HttpReferrer            = ['ad.referralurl'],
         HttpRequestMethod       = ['ad.httpmethod'],
         HttpUserAgent           = ['ad.agent'],
-        EventStartTime          = FortinetFortiGatestart,
-        SrcZone                 = FortinetFortiGatesrcintfrole,
-        DstZone                 = FortinetFortiGatedstintfrole,
-        NetworkSessionId        = FortinetFortiGateexternalID,
-        RuleNumber              = FortinetFortiGatepolicyid,
-        NetworkDuration         = FortinetFortiGateduration,
-        DstGeoCountry           = FortinetFortiGatedstcountry,
-        SrcGeoCountry           = FortinetFortiGatesrccountry,
-        ThreatOriginalRiskLevel = FortinetFortiGatecrscore,
-        SrcPackets              = FortinetFortiGatesentpkt,
-        DstPackets              = FortinetFortiGatercvdpkt
+        EventStartTime          = FTNTFGTstart,
+        SrcZone                 = FTNTFGTsrcintfrole,
+        DstZone                 = FTNTFGTdstintfrole,
+        NetworkSessionId        = FTNTFGTexternalID,
+        RuleNumber              = FTNTFGTpolicyid,
+        NetworkDuration         = FTNTFGTduration,
+        DstGeoCountry           = FTNTFGTdstcountry,
+        SrcGeoCountry           = FTNTFGTsrccountry,
+        ThreatOriginalRiskLevel = FTNTFGTcrscore,
+        SrcPackets              = FTNTFGTsentpkt,
+        DstPackets              = FTNTFGTrcvdpkt
     | parse AdditionalExtensions with * "Method=" temp_HttpRequestMethod "|User-Agent=" temp_HttpUserAgent ";" *
     | extend 
         HttpRequestMethod = coalesce(temp_HttpRequestMethod,HttpRequestMethod),

--- a/Parsers/ASimWebSession/Parsers/vimWebSessionFortinetFortiGate.yaml
+++ b/Parsers/ASimWebSession/Parsers/vimWebSessionFortinetFortiGate.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Web Session ASIM filtering parser for Fortinet FortiGate
-  Version: '0.1'
-  LastUpdated: Nov 11th, 2023
+  Version: '0.2'
+  LastUpdated: Mar 21, 2025
 Product:
   Name: Fortinet FortiGate
 Normalization:
@@ -144,17 +144,17 @@ ParserQuery: |
         SrcUsernameType = _ASIM_GetUsernameType(SrcUsername)
     | project-rename DvcOriginalAction = DeviceAction
     | parse-kv AdditionalExtensions as (
-            FortinetFortiGatestart:datetime,
-            FortinetFortiGatesrcintfrole:string,
-            FortinetFortiGatedstintfrole:string,
-            FortinetFortiGateexternalID:string,
-            FortinetFortiGatepolicyid:int,
-            FortinetFortiGatedstcountry:string,
-            FortinetFortiGatesrccountry:string,
-            FortinetFortiGatecrscore:string,
-            FortinetFortiGateduration:int,
-            FortinetFortiGatesentpkt:long,
-            FortinetFortiGatercvdpkt:long,
+            FTNTFGTstart:datetime,
+            FTNTFGTsrcintfrole:string,
+            FTNTFGTdstintfrole:string,
+            FTNTFGTexternalID:string,
+            FTNTFGTpolicyid:int,
+            FTNTFGTdstcountry:string,
+            FTNTFGTsrccountry:string,
+            FTNTFGTcrscore:string,
+            FTNTFGTduration:int,
+            FTNTFGTsentpkt:long,
+            FTNTFGTrcvdpkt:long,
             ['ad.referralurl']:string,
             ['ad.httpmethod']:string,
             ['ad.agent']:string
@@ -164,17 +164,17 @@ ParserQuery: |
         HttpReferrer            = ['ad.referralurl'],
         HttpRequestMethod       = ['ad.httpmethod'],
         HttpUserAgent           = ['ad.agent'],
-        EventStartTime          = FortinetFortiGatestart,
-        SrcZone                 = FortinetFortiGatesrcintfrole,
-        DstZone                 = FortinetFortiGatedstintfrole,
-        NetworkSessionId        = FortinetFortiGateexternalID,
-        RuleNumber              = FortinetFortiGatepolicyid,
-        NetworkDuration         = FortinetFortiGateduration,
-        DstGeoCountry           = FortinetFortiGatedstcountry,
-        SrcGeoCountry           = FortinetFortiGatesrccountry,
-        ThreatOriginalRiskLevel = FortinetFortiGatecrscore,
-        SrcPackets              = FortinetFortiGatesentpkt,
-        DstPackets              = FortinetFortiGatercvdpkt
+        EventStartTime          = FTNTFGTstart,
+        SrcZone                 = FTNTFGTsrcintfrole,
+        DstZone                 = FTNTFGTdstintfrole,
+        NetworkSessionId        = FTNTFGTexternalID,
+        RuleNumber              = FTNTFGTpolicyid,
+        NetworkDuration         = FTNTFGTduration,
+        DstGeoCountry           = FTNTFGTdstcountry,
+        SrcGeoCountry           = FTNTFGTsrccountry,
+        ThreatOriginalRiskLevel = FTNTFGTcrscore,
+        SrcPackets              = FTNTFGTsentpkt,
+        DstPackets              = FTNTFGTrcvdpkt
     | parse AdditionalExtensions with * "Method=" temp_HttpRequestMethod "|User-Agent=" temp_HttpUserAgent ";" *
     | extend 
         HttpRequestMethod = coalesce(temp_HttpRequestMethod,HttpRequestMethod),


### PR DESCRIPTION
Required items, please complete
   
   Change(s):
   - Fixed incorrect field names in parse-kv statement for ASimNetworkSessionFortinetFortiGate and ASimWebSessionFortinetFortiGate parsers
   - Updated field names from FortinetFortiGate prefix to FTNTFGT prefix to match the correct format in ASimDnsFortinetFortigate
   
   Reason for Change(s):
   - Field naming inconsistency between the three Fortigate parsers in Microsoft Sentinel
   - VirtualMetric DataStream relies on these parsers for optimizing Fortigate logs sent to ASim tables
   - The incorrect field names prevent proper optimizations, especially for country information used by the sample processor
   - Resolves issue #11843
   
   Version Updated:
   - Yes
   
   Testing Completed:
   - Yes
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes