### PR TITLE
fix: naming changes to reflect current naming conventions

### DIFF
--- a/Playbooks/RecordedFuture-Block-IPs-and-Domains-on-Microsoft-Defender-for-Endpoint/readme.md
+++ b/Playbooks/RecordedFuture-Block-IPs-and-Domains-on-Microsoft-Defender-for-Endpoint/readme.md
@@ -19,7 +19,7 @@ The following Azure roles and permissions will be needed at various stages of in
 
 - Recorded Future Token
 
-The **RecordedFuture_IP_SCF_ImportToDefenderATP** logic app uses Graph API and permissions **ThreatIndicators.ReadWrite.OwnedBy** are described in [Microsoft Graph Security Permissions](https://learn.microsoft.com/en-us/graph/api/tiindicator-submittiindicators?view=graph-rest-beta&tabs=http#permissions).
+The **RecordedFuture_IP_SCF_ImportToDefenderEndpoint** logic app uses Graph API and permissions **ThreatIndicators.ReadWrite.OwnedBy** are described in [Microsoft Graph Security Permissions](https://learn.microsoft.com/en-us/graph/api/tiindicator-submittiindicators?view=graph-rest-beta&tabs=http#permissions).
 
 - [Microsoft Graph Security](https://learn.microsoft.com/en-us/graph/api/resources/tiindicator?view=graph-rest-beta)
 - [Microsoft Graph Security & Azure Logic Apps](https://learn.microsoft.com/en-us/azure/connectors/connectors-integrate-security-operations-create-api-microsoft-graph-security)

--- a/Playbooks/RecordedFuture_IP_SCF/RecordedFuture_IP_SCF_ImportToDefenderEndpoint.json
+++ b/Playbooks/RecordedFuture_IP_SCF/RecordedFuture_IP_SCF_ImportToDefenderEndpoint.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "metadata": {
-        "title": "RecordedFuture_IP_SCF_ImportToDefenderATP",
+        "title": "RecordedFuture_IP_SCF_ImportToDefenderEndpoint",
         "description": "This playbook leverages the Recorded Future API and automatically imports the Command and Control IP Security Control Feed, as Threat Intelligence Indicators, for prevention purposes in Defender ATP",
         "prerequisites": "",
         "postDeployment": [
@@ -22,7 +22,7 @@
         "releaseNotes": [
             {
                 "version": "1.0",
-                "title": "RecordedFuture_IP_SCF_ImportToDefenderATP",
+                "title": "RecordedFuture_IP_SCF_ImportToDefenderEndpoint",
                 "notes": [ "Initial version" ]
             },
              {
@@ -34,7 +34,7 @@
     },
     "parameters": {
         "PlaybookName": {
-            "defaultValue": "RecordedFuture_IP_SCF_ImportToDefenderATP",
+            "defaultValue": "RecordedFuture_IP_SCF_ImportToDefenderEndpoint",
             "type": "string"
         }
     },
@@ -122,7 +122,7 @@
             "type": "Microsoft.Logic/workflows",
             "location": "[resourceGroup().location]",
             "tags": {
-                "hidden-SentinelTemplateName": "RecordedFuture_IP_SCF_ImportToDefenderATP",
+                "hidden-SentinelTemplateName": "RecordedFuture_IP_SCF_ImportToDefenderEndpoint",
                 "hidden-SentinelTemplateVersion": "1.0"
             },
             "identity": {

--- a/Playbooks/RecordedFuture_IP_SCF/RecordedFuture_IP_SCF_IndicatorProcessor.json
+++ b/Playbooks/RecordedFuture_IP_SCF/RecordedFuture_IP_SCF_IndicatorProcessor.json
@@ -5,13 +5,13 @@
         "title": "RecordedFuture_IP_SCF_IndicatorProcessor",
         "description": "This playbook leverages the Recorded Future API and automatically imports the Command and Control IP Security Control Feed, as Threat Intelligence Indicators, for prevention purposes in Defender ATP",
         "prerequisites": [
-            "First install the RecordedFuture_IP_SCF_ImportToDefenderATP playbook.",
+            "First install the RecordedFuture_IP_SCF_ImportToDefenderEndpoint playbook.",
             "To use the Recorded Future for Azure connector, you will need a valid API token from Recorded Future as described in the documentation https://learn.microsoft.com/en-us/connectors/recordedfuturev2/#how-to-get-credentials"
         ],
         "postDeployment": [
             "After deployment you have to open the playbook to configure all connections and press save."
         ],
-        "prerequisitesDeployTemplateFile": "./RecordedFuture_IP_SCF_ImportToDefenderATP.json",
+        "prerequisitesDeployTemplateFile": "./RecordedFuture_IP_SCF_ImportToDefenderEndpoint.json",
         "lastUpdateTime": "2024-03-18T13:37:00.000Z",
         "entities": [],
         "tags": [ "Threat Intelligence" ],
@@ -41,7 +41,7 @@
             "type": "string"
         },
         "PlaybookNameBatching": {
-            "defaultValue": "RecordedFuture_IP_SCF_ImportToDefenderATP",
+            "defaultValue": "RecordedFuture_IP_SCF_ImportToDefenderEndpoint",
             "type": "String"
         }
     },
@@ -79,7 +79,7 @@
                         "For_each": {
                             "foreach": "@body('Recorded_Future_RiskLists_and_SCF_Download')",
                             "actions": {
-                                "RecordedFuture_IP_SCF_ImportToDefenderATP": {
+                                "RecordedFuture_IP_SCF_ImportToDefenderEndpoint": {
                                     "runAfter": {},
                                     "type": "SendToBatch",
                                     "inputs": {

--- a/Playbooks/RecordedFuture_IP_SCF/readme.md
+++ b/Playbooks/RecordedFuture_IP_SCF/readme.md
@@ -16,7 +16,7 @@ The following Azure roles and permissions will be needed at various stages of in
 - Logic app contributor
 
 - Recorded Future Token
-The **RecordedFuture_IP_SCF_ImportToDefenderATP** logic app uses Graph API and permissions **ThreatIndicators.ReadWrite.OwnedBy** are described in [Microsoft Graph Security Permissions](https://learn.microsoft.com/en-us/graph/api/tiindicator-submittiindicators?view=graph-rest-beta&tabs=http#permissions).
+The **RecordedFuture_IP_SCF_ImportToDefenderEndpoint** logic app uses Graph API and permissions **ThreatIndicators.ReadWrite.OwnedBy** are described in [Microsoft Graph Security Permissions](https://learn.microsoft.com/en-us/graph/api/tiindicator-submittiindicators?view=graph-rest-beta&tabs=http#permissions).
 
 - [Microsoft Graph Security](https://learn.microsoft.com/en-us/graph/api/resources/tiindicator?view=graph-rest-beta)
 - [Microsoft Graph Security & Azure Logic Apps](https://learn.microsoft.com/en-us/azure/connectors/connectors-integrate-security-operations-create-api-microsoft-graph-security)
@@ -31,7 +31,7 @@ Playbooks takes a dependency on functionality like Azure Logic Apps, Azure Monit
 How to use cost analysis to monitor your costs:
 
 - https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/cost-analysis-common-uses
-  
+
 ## Adjust Cadence of pulling Risk Lists
 
 You can adjust the cadence in the Recurrence block of the IndicatorProcessor logic apps.
@@ -42,14 +42,14 @@ However, if you do so it is critical that you also adjust the expirationDateTime
 
 ## Installation order
 
-Due to internal Microsoft Logic Apps dependencies, please deploy first the **RecordedFuture_IP_SCF_ImportToDefenderATP** playbook before the **RecordedFuture_IP_SCF_IndicatorProcessor** one.
+Due to internal Microsoft Logic Apps dependencies, please deploy first the **RecordedFuture_IP_SCF_ImportToDefenderEndpoint** playbook before the **RecordedFuture_IP_SCF_IndicatorProcessor** one.
 
 ## Installation links
 
-Links to deploy the RecordedFuture_IP_SCF_ImportToDefenderATP playbook template:
+Links to deploy the RecordedFuture_IP_SCF_ImportToDefenderEndpoint playbook template:
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FRecordedFuture_IP_SCF%2FRecordedFuture_IP_SCF_ImportToDefenderATP.json)
-[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FRecordedFuture_IP_SCF%2FRecordedFuture_IP_SCF_ImportToDefenderATP.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FRecordedFuture_IP_SCF%2FRRecordedFuture_IP_SCF_ImportToDefenderEndpoint.json)
+[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FPlaybooks%2FRecordedFuture_IP_SCF%2FRecordedFuture_IP_SCF_ImportToDefenderEndpoint.json)
 
 Links to deploy the RecordedFuture_IP_SCF_IndicatorProcessor playbook template:
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - renaming of playbook and logic apps
   - documentations changes to reflect renaming

   Reason for Change(s):
   - naming to reflect current naming conventions