### PR TITLE
minor fix conversion issue in tool

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -942,7 +942,7 @@ function CreateRestApiPollerResourceProperties($armResource, $templateContentCon
             $headerPropName = $headerProps.Name
             $headerPropValue = $headerProps.Value
 
-            if ($headerPropValue.contains("{{")) 
+            if ($headerPropValue.ToString().contains("{{")) 
             {
                 $placeHoldersMatched = $headerPropValue | Select-String $placeHolderPatternMatches -AllMatches
                 if ($placeHoldersMatched.Matches.Value.Count -gt 0) 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In headers of poller file if we have "x-xdr-auth-id": 1 then packaging tool fails with error in conversion as this is a int64 and contains is not supported so added ToString().

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

