### PR TITLE
Fix functionApp code text which is adding (using Azure Function)

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -1903,6 +1903,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             $instructionArray = $templateSpecConnectorData.instructionSteps
                             ($instructionArray | ForEach {if($_.description -and $_.description.IndexOf('[Deploy To Azure]') -gt 0){$existingFunctionApp = $true;}})
 
+                            $hasFunctionAppManualDeploymentText = $instructionArray | Where-Object { $_.description.IndexOf('Manual Deployment of Azure Functions') -gt 0 }
+
                             if ($existingFunctionApp -eq $false)
                             {
                                 # check if only instructions object is present without any description
@@ -1925,6 +1927,8 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                                                         break
                                                     }
                                                 }
+
+                                                $hasFunctionAppManualDeploymentText = $instructionItem.parameters.instructionSteps | Where-Object { $_.description.IndexOf('Manual Deployment of Azure Functions') -gt 0 }
                                             }
                                         }
                                     }
@@ -1933,7 +1937,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
 
                             if($existingFunctionApp)
                             {
-                                $templateSpecConnectorData.title = ($templateSpecConnectorData.title.Contains("using Azure Functions")) ? $templateSpecConnectorData.title : $templateSpecConnectorData.title + " (using Azure Functions)"
+                                $templateSpecConnectorData.title = ($templateSpecConnectorData.title.Contains("using Azure Functions")) ? $templateSpecConnectorData.title : $hasFunctionAppManualDeploymentText ? $templateSpecConnectorData.title + " (using Azure Functions)" : $templateSpecConnectorData.title;
                             }
                         }
 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Fixed function app text so that (using Azure function) suffix will be added only to those which uses Manual deployment of Azure function.

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


