### PR TITLE
Check for an additional Custom String CEF field in Imperva Connector Function App

### DIFF
--- a/Solutions/ImpervaCloudWAF/Data Connectors/ImpervaWAFCloudSentinelConnector/__init__.py
+++ b/Solutions/ImpervaCloudWAF/Data Connectors/ImpervaWAFCloudSentinelConnector/__init__.py
@@ -165,7 +165,7 @@ class ImpervaFilesHandler:
             if val.startswith('"') and val.endswith('"'):
                 val = val[1:-1]
             parsed_cef[key]=val
-        cs_array = ['cs1','cs2','cs3','cs4','cs5','cs6','cs7','cs8']
+        cs_array = ['cs1','cs2','cs3','cs4','cs5','cs6','cs7','cs8','cs9']
         for elem in cs_array:
             try:
                 if parsed_cef[elem] is not None:


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Check for the 9th Custom String CEF field.

   Reason for Change(s):
   - Imperva has 3 types of CEF logs that can be retrieved through REST API, one of them is AttackAnalytics, this last one is expected to have cs9 and cs9label fields. I would prefer the Function App to check if these fields are present in the log and to parse them correctly.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
