### PR TITLE
Increment the simple-git package version to 3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jsonschema": "^1.2.6",
     "mocha": "^10.8.2",
     "prettier": "^1.19.1",
-    "simple-git": "3.5.0",
+    "simple-git": "3.15.0",
     "ts-node": "^10.9.2",
     "typescript": "^4.1.6",
     "xmlhttprequest": "^1.8.0",


### PR DESCRIPTION

   Change(s):
   - Increment the simple-git package version to 3.15.0

   Reason for Change(s):
   - simple-git 3.5.0 has critical severity vulnerabilities.

   Version Updated:
   - NA

   Testing Completed:
   - Yes