### PR TITLE
Pipeline validation for String to SecureString check in MainTemplate

### DIFF
--- a/.script/package-automation/validateFieldTypes.ps1
+++ b/.script/package-automation/validateFieldTypes.ps1
@@ -74,17 +74,23 @@ try {
     $resourceContent = $mainTemplateFileContent.resources | Where-Object { $_.type -eq 'Microsoft.OperationalInsights/workspaces/providers/contentTemplates' }
 
     if ($null -ne $resourceContent -and $resourceContent.Count -gt 0) {
-      foreach($rc in $resourceContent) {
-        $rcParam = $rc.properties.mainTemplate.parameters
-        $resourceInvalidFieldsList = @();
-        $resourceInvalidFieldsList = GetInvalidFields -resourceParameterProp $rcParam
+      $resourceLevelInvalidFields = @();
+      foreach ($rc in $resourceContent) {
+        $parameters = $rc.properties.mainTemplate.parameters.PSObject.Properties
+        foreach ($param in $parameters) {
+            $type = $param.Value.type.ToLower()
 
-        if ($resourceInvalidFieldsList.Count -gt 0) {
-          $hasInvalidResourceParameterType = $true
-          Write-Host "Invalid resource level parameters field(s) type. Please update the 'type' value for below given list to 'securestring'"
-          foreach ($item in $resourceInvalidFieldsList) {
-            Write-Host "--> $item"
-          }
+            if ($type -ne 'securestring' -and $type -ne 'object') {
+                $resourceLevelInvalidFields += $param.Name
+            }
+        }
+      }
+
+      if ($resourceLevelInvalidFields.Count -gt 0) {
+        $hasInvalidResourceParameterType = $true
+        Write-Host "Invalid resource level parameters field(s) type. Please update the 'type' value for below given list to 'securestring' or 'object'"
+        foreach ($item in $resourceLevelInvalidFields) {
+          Write-Host "--> $item"
         }
       }
     }
@@ -95,6 +101,6 @@ try {
   }
 }
 catch {
-  Write-Host "Error occured in validateFieldTypes file. Error Details : $_"
+  Write-Host "Error occurred in validateFieldTypes file. Error Details : $_"
   exit 1
 }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In Github Workflow, updated code to fail the pipeline if CCP parameters are not of type 'securestring' or 'object'.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


