### PR TITLE
Data Connector Definition string to securestring

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -49,19 +49,10 @@ function Get-ConnectionsTemplateParameters($activeResource, $ccpItem) {
 function New-ParametersForConnectorInstuctions($instructions) {
     foreach ($instruction in $instructions) {
         if ($instruction.type -eq "Textbox") {
-            if ($instruction.parameters.name.ToLower().contains("secure") -or $instruction.parameters.name.ToLower().contains("password")) {
-                $newParameter = [PSCustomObject]@{
-                    defaultValue = $instruction.parameters.name;
-                    type         = "securestring";
-                    minLength    = 1;
-                }
-            }
-            else {
-                $newParameter = [PSCustomObject]@{
-                    defaultValue = $instruction.parameters.name;
-                    type         = "string";
-                    minLength    = 1;
-                }
+            $newParameter = [PSCustomObject]@{
+                defaultValue = $instruction.parameters.name;
+                type         = "securestring";
+                minLength    = 1;
             }
             $templateParameter | Add-Member -MemberType NoteProperty -Name $instruction.parameters.name -Value $newParameter
         }
@@ -234,7 +225,7 @@ function addNewParameter($templateResourceObj, $parameterName, $isSecret = $fals
     if (!$hasParameter) {
         $templateResourceObj.parameters | Add-Member -NotePropertyName "$parameterName" -NotePropertyValue ([PSCustomObject] @{
                 defaultValue = $isSecret ? "-NA-" : "Enter $parameterName value";
-                type         = $isSecret ? "securestring" : "string";
+                type         = "securestring";
                 minLength    = $minLength;
             })
     }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - For data connector definition parameters are coming as string instead of securestring.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Test

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


