### PR TITLE
Handle multiple placeholders, stepcollectorConfig and handle ccp multiple folders

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1
@@ -331,5 +331,5 @@ try {
     }
 }
 catch {
-    Write-Host "Error occurred in catch of createSolutionV3 file Error details are $_"
+    Write-Host "Error occurred in catch of createSolutionV3 file Error details are $_" -ForegroundColor Red
 }

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -65,7 +65,7 @@ function ReadFileContent($filePath) {
         }
     }
     catch {
-        Write-Host "Error occured in ReadFileContent. Error details : $_"
+        Write-Host "Error occured in ReadFileContent. Error details : $_" -ForegroundColor Red
         return $null;
     }
 }
@@ -2581,7 +2581,7 @@ function PrepareSolutionMetadata($solutionMetadataRawContent, $contentResourceDe
                             $yaml = ConvertFrom-YAML $content # Convert YAML to PSObject
                         }
                         catch {
-                            Write-Host "Failed to deserialize $file" -ForegroundColor Red
+                            Write-Host "Failed to deserialize $file, Error Details: $_" -ForegroundColor Red
                             break;
                         }
 

--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -54,6 +54,24 @@ function New-ParametersForConnectorInstuctions($instructions) {
                 type         = "securestring";
                 minLength    = 1;
             }
+
+            $setDefaultValueAndRemoveMinLength = $false
+            $hasRequiredValidationProperty = [bool]($instruction.parameters.PSobject.Properties.name -match "validations")
+            if ($hasRequiredValidationProperty) {
+                $hasRequiredProperty = [bool]($instruction.parameters.validations.PSobject.Properties.name -match "required")
+                if ($hasRequiredProperty) {
+                    $isRequiredTrue = [bool]($instruction.parameters.validations.required) 
+                    if (!$isRequiredTrue) {
+                        $setDefaultValueAndRemoveMinLength = $true
+                    }
+                }
+            }
+
+            if ($setDefaultValueAndRemoveMinLength) {
+                $newParameter.defaultValue = ""
+                $newParameter.PSObject.Properties.Remove('minLength')
+            }
+
             $templateParameter | Add-Member -MemberType NoteProperty -Name $instruction.parameters.name -Value $newParameter
         }
         elseif ($instruction.type -eq "OAuthForm") {
@@ -275,6 +293,57 @@ function Add-NewObjectParameter {
     }
 
     return $TemplateResourceObj
+}
+
+function Convert-ToParameterFormat($propValue) {
+
+    $regex = [regex]'\{{([a-zA-Z0-9_]+)\}}'
+    $matchesPattern = $regex.Matches($propValue)
+ 
+    if ($matchesPattern.Count -eq 0) {
+        # No placeholders, return as-is
+        return $propValue
+    }
+ 
+    # If the value is exactly one match and no literal text
+    if ($matchesPattern.Count -eq 1 -and $propValue -eq $matchesPattern[0].Value) {
+        $paramName = $matchesPattern[0].Groups[1].Value
+
+        $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName "$paramName" -isSecret $true
+
+        return "[[parameters('$paramName')]"
+    }
+
+    $result = "[[concat("
+    $lastIndex = 0
+ 
+    foreach ($matchValue in $matchesPattern) {
+        # Add the part before the match as a string (if not empty)
+        if ($matchValue.Index -gt $lastIndex) {
+            $literalPart = $propValue.Substring($lastIndex, $matchValue.Index - $lastIndex)
+            $escapedLiteral = $literalPart -replace "'", "''"  # Escape single quotes
+            $result += "'$escapedLiteral',"
+        }
+ 
+        # Add the parameter reference
+        $paramName = $matchValue.Groups[1].Value
+ 
+        $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName "$paramName" -isSecret $true
+ 
+        $result += "parameters('$paramName'),"
+        $lastIndex = $matchValue.Index + $matchValue.Length
+    }
+ 
+    # Add the remaining part after the last match
+    if ($lastIndex -lt $propValue.Length) {
+        $remaining = $propValue.Substring($lastIndex)
+        $escapedRemaining = $remaining -replace "'", "''"
+        $result += "'$escapedRemaining',"
+    }
+ 
+    # Remove trailing comma and close concat
+    $result = $result.TrimEnd(',') + ")]"
+    return $result
 }
 
 # THIS IS THE STARTUP FUNCTION FOR CCP RESOURCE CREATOR
@@ -689,21 +758,29 @@ function createCCPConnectorResources($contentResourceDetails, $dataFileMetadata,
                     }
 
                     if ($fileContent.type -eq "Microsoft.OperationalInsights/workspaces/tables") {
-                        $resourceName = $fileContent.name
-                        $armResource = Get-ArmResource $resourceName $fileContent.type $fileContent.kind $fileContent.properties
+                        foreach($fileContentData in $fileContent) {
+                            $resourceName = $fileContentData.name
 
-                        $hasLocationProperty = [bool]($armResource.PSobject.Properties.name -match "location")
-                        if ($hasLocationProperty) {
-                            $locationProperty = $armResource.location
-                            $placeHoldersMatched = $locationProperty | Select-String $placeHolderPatternMatches -AllMatches
-
-                            if ($placeHoldersMatched.Matches.Value.Count -gt 0) {
-                                $placeHolderName = $placeHoldersMatched.Matches.Value.replace("{{", "").replace("}}", "")
-                                $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName $placeHolderName -isSecret $true
+                            $hasTable = $templateContentConnectorDefinition.properties.mainTemplate.resources | Where-Object { $_.type -eq "Microsoft.OperationalInsights/workspaces/tables" -and $_.name -eq $resourceName }
+                            if ($hasTable) {
+                                continue
                             }
-                        }
+
+                            $armResource = Get-ArmResource $resourceName $fileContentData.type $fileContentData.kind $fileContentData.properties
+
+                            $hasLocationProperty = [bool]($armResource.PSobject.Properties.name -match "location")
+                            if ($hasLocationProperty) {
+                                $locationProperty = $armResource.location
+                                $placeHoldersMatched = $locationProperty | Select-String $placeHolderPatternMatches -AllMatches
+
+                                if ($placeHoldersMatched.Matches.Value.Count -gt 0) {
+                                    $placeHolderName = $placeHoldersMatched.Matches.Value.replace("{{", "").replace("}}", "")
+                                    $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName $placeHolderName -isSecret $true
+                                }
+                            }
 
                         $templateContentConnectorDefinition.properties.mainTemplate.resources += $armResource
+                        }
                     }
                 }
 
@@ -714,17 +791,33 @@ function createCCPConnectorResources($contentResourceDetails, $dataFileMetadata,
             ## Build the full package resources
             $paramItems = Get-ConnectionsTemplateParameters $activeResource $ccpItem;
             $finalParameters = $templateContentConnections.properties.mainTemplate.parameters;
-            foreach ($prop1 in $paramItems.psobject.Properties) {
-                $hasProperty = $false;
-                foreach ($prop2 in $finalParameters.psobject.Properties) {
-                    if ($prop1.Name -eq $prop2.Name) {
-                        $hasProperty = $true
-                        break;
+            foreach ($paramItem in $paramItems.PSObject.Properties) {
+                $existingParam = $finalParameters.PSObject.Properties[$paramItem.Name]
+            
+                if (-not $existingParam) {
+                    # Parameter doesn't exist, add it
+                    $finalParameters | Add-Member -MemberType NoteProperty -Name $paramItem.Name -Value $paramItem.Value
+                } else {
+                    # Parameter exists, compare and update if necessary
+                    $paramValue = $paramItem.Value
+                    $existingValue = $existingParam.Value
+            
+                    # Simple comparison, can be made deeper if properties are nested
+                    $isDifferent = $false
+            
+                    foreach ($subProp in $paramValue.PSObject.Properties) {
+                        if (-not $existingValue.PSObject.Properties[$subProp.Name] -or 
+                            $existingValue.$($subProp.Name) -ne $subProp.Value) {
+                            $isDifferent = $true
+                            break
+                        }
                     }
-                }
-
-                if (!$hasProperty) {
-                    $finalParameters | Add-Member -MemberType NoteProperty -Name $prop1.Name -Value $prop1.Value
+            
+                    if ($isDifferent) {
+                        # Update the whole parameter if it's different
+                        $finalParameters.PSObject.Properties.Remove($paramItem.Name)
+                        $finalParameters | Add-Member -MemberType NoteProperty -Name $paramItem.Name -Value $paramItem.Value
+                    }
                 }
             }
 
@@ -772,7 +865,7 @@ function createCCPConnectorResources($contentResourceDetails, $dataFileMetadata,
         }
     }
     catch {
-        Write-Host "Error occurred in createCCPConnector file. Error Details $_"
+        Write-Host "Error occurred in createCCPConnector file. Error Details $_" -ForegroundColor Red
     }
 }
 
@@ -809,13 +902,21 @@ function ProcessPropertyPlaceholders($armResource, $templateContentConnections,
                     # normal string field
                     $hasMoreText = $placeHoldersMatched.Line.Replace("{{$($placeHolderName)}}", '')
                     if ($hasMoreText.Length -gt 0) {
-                        $propertyObject.$($propertyName) = "[[concat(parameters('$($placeHolderName)'), '$($hasMoreText)')]"
+                        $formattedValue = Convert-ToParameterFormat -propValue $propertyObject.$($propertyName)
+                        $propertyObject.$($propertyName) = $formattedValue
                     } else {
                         $propertyObject.$($propertyName) = "[[parameters('$($placeHolderName)')]"
                     }
                 }
 
-                $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName $placeHolderName -isSecret $isSecret -minLength $minLength
+                # when multiple placeholders are present in the same field
+                if ($placeHolderName.Count -gt 1) {
+                    foreach ($placeHolder in $placeHolderName) {
+                        $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName $placeHolder -isSecret $isSecret -minLength $minLength
+                    }
+                } else {
+                    $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName $placeHolderName -isSecret $isSecret -minLength $minLength
+                }
             }
         }
     }
@@ -881,39 +982,8 @@ function CreateRestApiPollerResourceProperties($armResource, $templateContentCon
     if ($armResource.properties.request.PSObject.Properties["apiEndPoint"] -and 
         $armResource.properties.request.apiEndPoint.contains("{{"))
     {
-        # identify any placeholders in apiEndpoint
-        $endPointUrl = $armResource.properties.request.apiEndPoint
-        $placeHoldersMatched = $endPointUrl | Select-String $placeHolderPatternMatches -AllMatches
-
-        if ($placeHoldersMatched.Matches.Value.Count -gt 0) 
-        {
-            # has some placeholders 
-            $finalizedEndpointUrl = "[[concat("
-            $closureBrackets = ")]"
-
-            foreach ($currentPlaceHolder in $placeHoldersMatched.Matches.Value) {
-                $placeHolderName = $currentPlaceHolder.replace("{{", "").replace("}}", "")
-                $splitEndpoint = $endPointUrl -split "($currentPlaceHolder)"
-
-                foreach($splitItem in $splitEndpoint) 
-                {
-                    if ($splitItem -eq '') {
-                        continue
-                    }
-                    if ($splitItem -eq $currentPlaceHolder) 
-                    {
-                        $finalizedEndpointUrl += "parameters('" + $placeHolderName + "'),"
-                        $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName "$placeHolderName" -isSecret $true
-                    } 
-                    else 
-                    {
-                        $finalizedEndpointUrl += "'" + $splitItem + "',"
-                    }
-                }
-            }
-
-            $armResource.properties.request.apiEndPoint = $finalizedEndpointUrl.Substring(0, $finalizedEndpointUrl.Length - 1) + $closureBrackets
-        }
+        $apiPointUrl = $armResource.properties.request.apiEndPoint
+        $armResource.properties.request.apiEndPoint = Convert-ToParameterFormat -propValue $apiPointUrl
     }
 
     # headers placeholder
@@ -924,17 +994,7 @@ function CreateRestApiPollerResourceProperties($armResource, $templateContentCon
         {
             $headerPropName = $headerProps.Name
             $headerPropValue = $headerProps.Value
-
-            if ($headerPropValue.ToString().contains("{{")) 
-            {
-                $placeHoldersMatched = $headerPropValue | Select-String $placeHolderPatternMatches -AllMatches
-                if ($placeHoldersMatched.Matches.Value.Count -gt 0) 
-                {
-                    $placeHolderName = $placeHoldersMatched.Matches.Value.replace("{{", "").replace("}}", "")
-                    $armResource.properties.request.headers."$headerPropName" = "[[parameters('$($placeHolderName)')]"
-                    $templateContentConnections.properties.mainTemplate = addNewParameter -templateResourceObj $templateContentConnections.properties.mainTemplate -parameterName "$placeHolderName" -isSecret $true
-                }
-            }
+            $armResource.properties.request.headers."$headerPropName" = Convert-ToParameterFormat -propValue $headerPropValue
         }
     }
 
@@ -966,7 +1026,19 @@ function CreateRestApiPollerResourceProperties($armResource, $templateContentCon
         foreach ($stepId in $stepIds) {
             # Check if the stepId exists in the stepCollectorConfigs
             if ($armResource.properties.stepCollectorConfigs.PSObject.Properties.Match($stepId)) {
-                ProcessPropertyPlaceholders -armResource $armResource -templateContentConnections $templateContentConnections -isOnlyObjectCheck $false -propertyObject $armResource.properties.stepCollectorConfigs.$stepId.request -propertyName 'apiEndpoint' -isInnerObject $true -innerObjectName 'request' -kindType $kindType -isSecret $true -isRequired $false -fileType $fileType -minLength 4 -isCreateArray $false
+                $propObect = $armResource.properties.stepCollectorConfigs.$stepId.request
+                ProcessPropertyPlaceholders -armResource $armResource -templateContentConnections $templateContentConnections -isOnlyObjectCheck $false -propertyObject $propObect -propertyName 'apiEndpoint' -isInnerObject $true -innerObjectName 'request' -kindType $kindType -isSecret $true -isRequired $false -fileType $fileType -minLength 4 -isCreateArray $false
+
+                $hasStepCollectorConfigsHeaders = [bool]($propObect.PSobject.Properties.name -match "headers")
+                if ($hasStepCollectorConfigsHeaders) 
+                {
+                    foreach ($headerProps in $propObect.headers.PsObject.Properties) 
+                    {
+                        $headerPropName = $headerProps.Name
+                        $headerPropValue = $headerProps.Value
+                        $propObect.headers."$headerPropName" = Convert-ToParameterFormat -propValue $headerPropValue
+                    }
+                }
             } else {
                 Write-Host "Warning: Step ID $stepId not found in stepCollectorConfigs."
             }
@@ -974,6 +1046,12 @@ function CreateRestApiPollerResourceProperties($armResource, $templateContentCon
     }
 
     QueryParameters($armResource)
+
+    $hasQueryParametersTemplate = [bool]($armResource.properties.request.PSobject.Properties.name -match "queryParametersTemplate")
+    if ($hasQueryParametersTemplate) {
+        $queryParametersTemplateValue = $armResource.properties.request.queryParametersTemplate
+        $armResource.properties.request.queryParametersTemplate = Convert-ToParameterFormat -propValue $queryParametersTemplateValue
+    }
 }
 
 function Paging($armResource) {
@@ -1081,4 +1159,24 @@ function CreateAwsResourceProperties($armResource, $templateContentConnections, 
     ProcessPropertyPlaceholders -armResource $armResource -templateContentConnections $templateContentConnections -isOnlyObjectCheck $false -propertyObject $armResource.properties -propertyName 'roleArn' -isInnerObject $false -innerObjectName $null -kindType $kindType -isSecret $true -isRequired $true -fileType $fileType -minLength 3 -isCreateArray $false
 
     ProcessPropertyPlaceholders -armResource $armResource -templateContentConnections $templateContentConnections -isOnlyObjectCheck $false -propertyObject $armResource.properties -propertyName 'sqsUrls' -isInnerObject $false -innerObjectName $null -kindType $kindType -isSecret $true -isRequired $true -fileType $fileType -minLength 3 -isCreateArray $true
+
+    $hasDataFormat = [bool]($armResource.properties.PSobject.Properties.name -match "dataFormat")
+    if ($hasDataFormat) {
+        $hasFormatProperty = [bool]($armResource.properties.dataFormat.PSobject.Properties.name.tolower() -match "format")
+        if ($hasFormatProperty) {
+            # check for csv format
+            $hasCsvFormat = [bool]($armResource.properties.dataFormat.format -match "csv")
+            if ($hasCsvFormat) {
+                $hasCsvDelimiterProperty = [bool]($armResource.properties.dataFormat.PSobject.Properties.name.tolower() -match "csvdelimiter")
+                if ($hasCsvDelimiterProperty) {
+                    if ($armResource.properties.dataFormat.CsvDelimiter -eq " ") {
+                        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptySpaceString" -NotePropertyValue " "
+                        $armResource.properties.dataFormat.CsvDelimiter = "[variables('TemplateEmptySpaceString')]"
+                    }
+                }
+            } else {
+                $armResource.properties.dataFormat.format = "json"
+            }
+        }
+    }
 }

--- a/Tools/Create-Azure-Sentinel-Solution/common/get-ccp-details.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/get-ccp-details.ps1
@@ -15,9 +15,10 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
             $file = $file.Replace("$baseFolderPath/", "").Replace("Solutions/", "").Replace("$solutionName/", "")
 
             $currentFileDCPath = ($baseFolderPath + $solutionName + "/" + $file).Replace("//", "/")
-            Write-Host "currentFileDCPath $currentFileDCPath"
+            $ccpBaseFolderPath = (Split-Path -Path $currentFileDCPath -Parent) -replace '\\', '/'
+            Write-Host "currentFileDCPath $currentFileDCPath, ccpBaseFolderPath $ccpBaseFolderPath"
             #$fileContent = Get-Content -Raw $currentFileDCPath | Out-String | ConvertFrom-Json
-
+            
             $fileContent = ReadFileContent -filePath $currentFileDCPath
             if ($null -eq $fileContent) {
                 exit 1;
@@ -52,6 +53,7 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
                             PollerConnectorDefinitionName = $pollerName
                             IsProcessed = $false;
                             DCPollerName = "";
+                            CCPBaseFolder = $ccpBaseFolderPath;
                         }
                     } else {
                         [array]$ccpDict += [PSCustomObject]@{
@@ -71,6 +73,7 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
                             PollerConnectorDefinitionName = $pollerName
                             IsProcessed = $false;
                             DCPollerName = "";
+                            CCPBaseFolder = $ccpBaseFolderPath;
                         }
                     }
                 } else {
@@ -91,6 +94,7 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
                         PollerConnectorDefinitionName = ""
                         IsProcessed = $false;
                         DCPollerName = "";
+                        CCPBaseFolder = $ccpBaseFolderPath;
                     }
                 }
             }
@@ -105,8 +109,10 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
         foreach ($ccpDefinitionFile in $ccpDict) {
             #identify given file is present in dc folder or not
             foreach ($inputFile in $(Get-ChildItem -Path $identifiedDCPath -Include *.json -Recurse)) {
-                if ($inputFile.Extension -eq ".md" -or $inputFile.Extension -eq ".txt" -or $inputFile.Extension -eq ".py" -or $inputFile.Extension -eq ".zip" -or 
-                $inputFile.Name -eq "Images" -or $inputFile.Name -eq "function.json" -or $inputFile.Name -eq "host.json" -or $inputFile.Name -eq "proxies.json")
+                $currentFolderPath = $inputFile.DirectoryName -replace '\\', '/'
+                if ($currentFolderPath -ne $ccpDefinitionFile.CCPBaseFolder -or
+                ($inputFile.Extension -eq ".md" -or $inputFile.Extension -eq ".txt" -or $inputFile.Extension -eq ".py" -or $inputFile.Extension -eq ".zip" -or 
+                $inputFile.Name -eq "Images" -or $inputFile.Name -eq "function.json" -or $inputFile.Name -eq "host.json" -or $inputFile.Name -eq "proxies.json"))
                 {
                     continue;
                 }
@@ -207,7 +213,9 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
         # identify relation between poller and DCR
         foreach ($ccpPollerFile in $ccpDict) {
             foreach ($inputFile in $(Get-ChildItem -Path $identifiedDCPath -Include *.json -Recurse)) {
-                if ($inputFile.Extension -eq ".md" -or $inputFile.Extension -eq ".txt" -or $inputFile.Extension -eq ".py" -or $inputFile.Extension -eq ".zip" -or 
+                $currentFolderPath = $inputFile.DirectoryName -replace '\\', '/'
+                if ($currentFolderPath -ne $ccpPollerFile.CCPBaseFolder -or
+                $inputFile.Extension -eq ".md" -or $inputFile.Extension -eq ".txt" -or $inputFile.Extension -eq ".py" -or $inputFile.Extension -eq ".zip" -or 
                 $inputFile.Name -eq "Images" -or $inputFile.Name -eq "function.json" -or $inputFile.Name -eq "host.json" -or $inputFile.Name -eq "proxies.json")
                 {
                     continue;
@@ -233,7 +241,7 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
                                         # not found in mapping
                                         Write-Host "Error For given CCP Data Connector poller, mapping not found in StandardLogStreams. Please make sure that StreamName in Data Connector poller file and that in DCR Stream name are correct. Refer StandardLogStreams.ps1 file for Standard mapping. Refer Tools/Create-Azure-Sentinel-Solution/common/StandardLogStreams.ps1 file for Standard mapping." -BackgroundColor Red
                                         exit 1; 
-                                    } elseif ($dcrDataFlowStream.streams[0] -ne $dcPollerStreamNameValue) {
+                                    } elseif ($dcrDataFlowStream.streams[0].ToString() -ne $dcPollerStreamNameValue) {
                                         # when dc poller streamname expected mapping value is not equal to dcr file stream name
                                         Write-Host "Error For given CCP, DCR file 'stream' value is not correct. Please make sure that StreamName in Data Connector poller file and that in DCR Stream name are correct. Refer Tools/Create-Azure-Sentinel-Solution/common/StandardLogStreams.ps1 file for Standard mapping." -BackgroundColor Red
                                         exit 1; 
@@ -291,7 +299,9 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
         # identify relation between DCR and table
         foreach ($ccpTable in $ccpDict) {
             foreach ($inputFile in $(Get-ChildItem -Path $identifiedDCPath -Include *.json -Recurse)) {
-                if ($inputFile.Extension -eq ".md" -or $inputFile.Extension -eq ".txt" -or $inputFile.Extension -eq ".py" -or $inputFile.Extension -eq ".zip" -or 
+                $currentFolderPath = $inputFile.DirectoryName -replace '\\', '/'
+                if ($currentFolderPath -ne $ccpTable.CCPBaseFolder -or
+                $inputFile.Extension -eq ".md" -or $inputFile.Extension -eq ".txt" -or $inputFile.Extension -eq ".py" -or $inputFile.Extension -eq ".zip" -or 
                 $inputFile.Name -eq "Images" -or $inputFile.Name -eq "function.json" -or $inputFile.Name -eq "host.json" -or $inputFile.Name -eq "proxies.json")
                 {
                     continue;
@@ -344,7 +354,7 @@ function Get-CCP-Dict($dataFileMetadata, $baseFolderPath, $solutionName, $DCFold
     return $ccpDict;
   }
   catch {
-    Write-Host "Error in get-ccpdetails. Error Details: $_"
+    Write-Host "Error in get-ccpdetails. Error Details: $_" -ForegroundColor Red
     return $null;
   }
 }
@@ -374,9 +384,12 @@ function GetCCPTableFilePaths($existingCCPDict, $baseFolderPath, $solutionName, 
                     # check if current file path already present in variable $existingCCPDict if not present then add it in new variable list
                     $isTablePresent = $false;
                     foreach ($ccpRecord in $existingCCPDict) {
-                        if ($ccpRecord.TableFilePath -ne '' -and $ccpRecord.TableFilePath -eq $currentTableFilePath) {
-                            $isTablePresent = $true;
-                            break;
+                        $currentFolderPath = $inputFile.DirectoryName -replace '\\', '/'
+                        if ($currentFolderPath -eq $ccpDefinitionFile.CCPBaseFolder) {
+                            if ($ccpRecord.TableFilePath -ne '' -and $ccpRecord.TableFilePath -eq $currentTableFilePath) {
+                                $isTablePresent = $true;
+                                break;
+                            }
                         }
                     }
                     if (!$isTablePresent) {

--- a/Tools/Create-Azure-Sentinel-Solution/common/standardLogStreams.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/standardLogStreams.ps1
@@ -92,7 +92,7 @@ $standardStreamMapping += @{ Key = 'USAGE_METERING'; Value = 'Microsoft-Usage'}
 $standardStreamMapping += @{ Key = 'SENTINEL_WATCHLIST'; Value = 'Microsoft-Watchlist'}
 $standardStreamMapping += @{ Key = 'SECURITY_WEF_EVENT_BLOB'; Value = 'Microsoft-WindowsEvent'}
 $standardStreamMapping += @{ Key = 'SECURITY_WEF_EVENT_BLOB_OBO'; Value = 'Microsoft-WindowsEvent'}
-
+$standardStreamMapping += @{ Key = 'SENTINEL_AWSROUTE53RESOLVER'; Value = 'Microsoft-AWSRoute53Resolver'}
 
 # Function to check if a key exists in the array of hashtables
 function GetKeyValue {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Handle multiple placeholders for apiendpoint, tokenendpoint.
   - Handle replacement of placeholder for queryParametersTemplate,headers, apiendpoint in stepcollectorconfig
   - When field in ccp data connectordefinition is marked as required with below, then minLength and Default value is there but if we want to make defaultValue ="" and remove minLength then using below for Textbox field type can now be possible:
     
`{
                                                "type": "Textbox",
                                                "parameters": {
                                                    "label": "Queue URL",
                                                    "type": "text",
                                                    "name": "queueUrl",
                                                    "validations": {
                                                        "required": false
                                                    }
                                                }
                                            },`
 
   - Handle multiple tables in a single file. For sophos endpoint protection solution we can have multiple tables in a single file.
  
   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA
   
   Testing Completed:
   - Tested by creating maintemplate for Okta, CyberArkAudit, Ermes browser security, Sophos endpoint protection, GCP audit logs, Aws_AccessLogs solutions.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

