### PR TITLE
Force TLS1.2 in azuredeploy_Connector_ImpervaWAFCloud_AzureFunction.json

### DIFF
--- a/Solutions/ImpervaCloudWAF/Data Connectors/azuredeploy_Connector_ImpervaWAFCloud_AzureFunction.json
+++ b/Solutions/ImpervaCloudWAF/Data Connectors/azuredeploy_Connector_ImpervaWAFCloud_AzureFunction.json
@@ -83,7 +83,8 @@
                         }
                     },
                     "keySource": "Microsoft.Storage"
-                }
+                },
+                "minimumTlsVersion": "TLS1_2"
             }
         },
         {


### PR DESCRIPTION
   Change(s):
   - Force the use of TLS1.2 on the Storage Account

   Reason for Change(s):
   - TLS1.0 and TLS1.1 will soon be deprecated by Microsoft : https://techcommunity.microsoft.com/blog/azurestorageblog/tls-1-0-and-1-1-support-will-be-removed-for-new--existing-azure-storage-accounts/4026181

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A