### PR TITLE
Minor change to exclude google links and array from data type validation

### DIFF
--- a/.script/package-automation/hyperlink-validation.ps1
+++ b/.script/package-automation/hyperlink-validation.ps1
@@ -111,7 +111,7 @@ foreach($item in $filteredFiles)
 $exclusionList = @(".py$",".png$",".jpg$",".jpeg$",".conf$", ".svg$", ".html$", ".ps1$", ".psd1$", "requirements.txt$", "host.json$", "proxies.json$", "/function.json$", ".xml$", ".zip$", ".md$")
 $filterOutExclusionList = $finalFilteredFiles | Where-Object { $_ -notmatch ($exclusionList -join '|')  }
 
-$exclusionDomainList = @("&&sudo","schema.management","schemas.microsoft","twitter.com", "s-platform.api.opendns.com", "github.com", "azure.microsoft.com", "sts.windows.net")
+$exclusionDomainList = @("&&sudo","schema.management","schemas.microsoft","twitter.com", "s-platform.api.opendns.com", "github.com", "azure.microsoft.com", "sts.windows.net", "oauth2.googleapis.com", "monitoring.googleapis.com")
 
 foreach ($currentFile in $filterOutExclusionList)
 {

--- a/.script/package-automation/validateFieldTypes.ps1
+++ b/.script/package-automation/validateFieldTypes.ps1
@@ -80,7 +80,7 @@ try {
         foreach ($param in $parameters) {
             $type = $param.Value.type.ToLower()
 
-            if ($type -ne 'securestring' -and $type -ne 'object') {
+            if ($type -ne 'securestring' -and $type -ne 'object' -and $type -ne 'array') {
                 $resourceLevelInvalidFields += $param.Name
             }
         }
@@ -88,7 +88,7 @@ try {
 
       if ($resourceLevelInvalidFields.Count -gt 0) {
         $hasInvalidResourceParameterType = $true
-        Write-Host "Invalid resource level parameters field(s) type. Please update the 'type' value for below given list to 'securestring' or 'object'"
+        Write-Host "Invalid resource level parameters field(s) type. Please update the 'type' value for below given list to 'securestring', 'object' or 'array'."
         foreach ($item in $resourceLevelInvalidFields) {
           Write-Host "--> $item"
         }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In hyperlink validation script, added "oauth2.googleapis.com" and "monitoring.googleapis.com" to the exclusion domain list. This is for pr PR number 12113.
   - In validate data type array is added to the list of valid data types for parameters. This is for Salesforce Cloud Service solution.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Not required

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

