### PR TITLE
Update azuredeploy_Connector_TenableVM_AzureFunction.json

### DIFF
--- a/Solutions/Tenable App/Data Connectors/TenableVM/azuredeploy_Connector_TenableVM_AzureFunction.json
+++ b/Solutions/Tenable App/Data Connectors/TenableVM/azuredeploy_Connector_TenableVM_AzureFunction.json
@@ -8,6 +8,13 @@
             "maxLength": 11,
             "type": "string"
         },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "String",
+            "metadata": {
+                "description": "Location for all resources. Default value will inherit the location of the resource group, replace with the Azure Region name to use a specific region e.g. 'eastus'."
+            }
+        },
         "WorkspaceID": {
             "type": "string",
             "metadata": {
@@ -78,7 +85,7 @@
             "type": "Microsoft.Insights/components",
             "apiVersion": "2020-02-02",
             "name": "[variables('FunctionName')]",
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('location')]",
             "kind": "web",
             "properties": {
                 "Application_Type": "web",
@@ -90,7 +97,7 @@
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[tolower(variables('FunctionName'))]",
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('location')]",
             "sku": {
                 "name": "Standard_LRS",
                 "tier": "Standard"
@@ -161,7 +168,7 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2018-11-01",
             "name": "[variables('FunctionName')]",
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', tolower(variables('FunctionName')))]",
                 "[resourceId('Microsoft.Insights/components', variables('FunctionName'))]"


### PR DESCRIPTION
Add parameter to allow the Azure region for the resources to be deployed into to be a parameter instead of the previous which would always inherit the region of the resource group. Required where the Azure region for resources must be different to the Resource Group region, for example when hitting this error "Linux dynamic workers are not available in resource group".

   Required items, please complete
   
   Change(s):
   - Add parameter to allow the Azure region for the resources to be deployed into to be a parameter instead of the previous which would always inherit the region of the resource group.

   Reason for Change(s):
   - Required where the Azure region for resources must be different to the Resource Group region, for example when hitting this error "Linux dynamic workers are not available in resource group".

   Version Updated:
   - No but should be

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Need Help
