### PR TITLE
Update __init__.py to fix TypeError: 'int' object is not subscriptable

### DIFF
--- a/Solutions/GoogleWorkspaceReports/Data Connectors/GWorkspaceReportsAPISentinelConn/GWorkspaceReports-TimeTrigger/__init__.py
+++ b/Solutions/GoogleWorkspaceReports/Data Connectors/GWorkspaceReportsAPISentinelConn/GWorkspaceReports-TimeTrigger/__init__.py
@@ -120,39 +120,81 @@ def convertToDatetime(date_time,format):
     return datetime_str
 
 def GetDates(logType):
-    end_time = GetEndTime(logType)
+    end_time_dt_obj = GetEndTime(logType) # Renamed for clarity, this is a datetime object
     state = StateManager(connection_string=connection_string)
-    past_time = state.get()
-    activity_list = {}
-    if past_time is not None and len(past_time) > 0:
-        if is_json(past_time):
-            activity_list = past_time
-        # Check if state file has non-date format. If yes, then set start_time to past_time
-        else:
-            try:
-                newtime = datetime.strptime(past_time[:-1] + '.000Z', "%Y-%m-%dT%H:%M:%S.%fZ")
-                newtime = newtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                newtime = newtime[:-4] + 'Z'
-                for activity in activities:
-                    activity_list[activity] = newtime
-                activity_list = json.dumps(activity_list)
-            except Exception as err:
-                logging.info("Error while converting state. Its neither a json nor a valid date format {}".format(err))
-                logging.info("Setting start time to get events for last 5 minutes.")
-                past_time = (end_time - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                for activity in activities:
-                    activity_list[activity] = past_time[:-4] + 'Z'
-                activity_list = json.dumps(activity_list)
-    else:
-        logging.info("There is no last time point, trying to get events for last 5 minutes.")
-        past_time = (end_time - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        for activity in activities:
-            activity_list[activity] = past_time[:-4] + 'Z'
-        activity_list = json.dumps(activity_list)
-    end_time = end_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    end_time = end_time[:-4] + 'Z'
+    past_time_str_from_state = state.get() # This is a string from the state file, or None
     
-    return json.loads(activity_list) if (isBlank(logType)) else (json.loads(activity_list)[logType],end_time)
+    # activity_json_str will hold the JSON string representing the dictionary of activity timestamps
+    activity_json_str = "" 
+
+    # Default start time if no valid state or specific activity timestamp is found
+    # Use end_time_dt_obj for this calculation, as it's the relevant end time for the current GetDates call
+    default_initial_timestamp_str = (end_time_dt_obj - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + 'Z'
+
+    if past_time_str_from_state and len(past_time_str_from_state) > 0:
+        if is_json(past_time_str_from_state):
+            try:
+                decoded_past_time = json.loads(past_time_str_from_state)
+                if isinstance(decoded_past_time, dict):
+                    # The state is a valid JSON dictionary, use it.
+                    # Ensure all known activities have an entry, initialize if not.
+                    for activity_key in activities:
+                        if activity_key not in decoded_past_time:
+                            decoded_past_time[activity_key] = default_initial_timestamp_str
+                    activity_json_str = json.dumps(decoded_past_time)
+                else:
+                    # The state was valid JSON, but not a dictionary (e.g., "123" or "\"a string\"").
+                    # This is an invalid state format; reinitialize all activities.
+                    temp_dict = {}
+                    for activity_key_init in activities:
+                        temp_dict[activity_key_init] = default_initial_timestamp_str
+                    activity_json_str = json.dumps(temp_dict)
+            except json.JSONDecodeError as e:
+                # is_json passed, but json.loads failed. This should be rare.
+                logging.error(f"Failed to decode JSON from state (is_json was true): {past_time_str_from_state}. Error: {e}. Re-initializing.")
+                temp_dict = {}
+                for activity_key_init in activities:
+                    temp_dict[activity_key_init] = default_initial_timestamp_str
+                activity_json_str = json.dumps(temp_dict)
+        else:
+            # past_time_str_from_state is not JSON, try legacy format conversion (single timestamp for all activities)
+            temp_dict = {}
+            try:
+                newtime = datetime.strptime(past_time_str_from_state[:-1] + '.000Z', "%Y-%m-%dT%H:%M:%S.%fZ")
+                newtime_str = newtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + 'Z'
+                for activity_key_init in activities:
+                    temp_dict[activity_key_init] = newtime_str
+                activity_json_str = json.dumps(temp_dict)
+            except Exception as err:
+                logging.error("Error while converting legacy state. Its neither a json nor a valid date format: {}. Error: {}".format(past_time_str_from_state, err))
+                logging.info("Setting start time to get events for last 5 minutes for all activities.")
+                for activity_key_init in activities:
+                    temp_dict[activity_key_init] = default_initial_timestamp_str
+                activity_json_str = json.dumps(temp_dict)
+    else:
+        # No past_time state found or it's empty. Initialize all activities.
+        logging.info("No valid last time point in state, initializing all activities to fetch events for last 5 minutes.")
+        temp_dict = {}
+        for activity_key_init in activities:
+            temp_dict[activity_key_init] = default_initial_timestamp_str
+        activity_json_str = json.dumps(temp_dict)
+
+    # Convert the end_time_dt_obj (datetime object) to the required string format for returning
+    final_end_time_str = end_time_dt_obj.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + 'Z'
+
+    # activity_json_str now reliably holds a JSON string of a dictionary
+    loaded_activity_dict = json.loads(activity_json_str)
+
+    if isBlank(logType):
+        # Return the entire dictionary of activity timestamps
+        return loaded_activity_dict
+    else:
+        # Return the specific start time for the logType and the calculated end_time string
+        start_time_for_logtype = loaded_activity_dict.get(logType)
+        if start_time_for_logtype is None:
+            # This should ideally not happen if all activities are initialized correctly
+            start_time_for_logtype = default_initial_timestamp_str
+        return start_time_for_logtype, final_end_time_str
 
 def check_if_script_runs_too_long(script_start_time):
     now = int(time.time())


### PR DESCRIPTION
   Change(s):
   - Update __init__.py to fix TypeError: 'int' object is not subscriptable

   Reason for Change(s):
   - Our organization ran into the following error when running the current version of this script:

"Result: Failure Exception: TypeError: 'int' object is not subscriptable Stack: File "/azure-functions-host/workers/python/3.12/LINUX/X64/azure_functions_worker/dispatcher.py", line 676, in _handle__invocation_request call_result = await self._loop.run_in_executor( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/opt/python/3.12/lib/python3.12/concurrent/futures/thread.py", line 58, in run result = self.fn(*self.args, **self.kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/azure-functions-host/workers/python/3.12/LINUX/X64/azure_functions_worker/dispatcher.py", line 1006, in _run_sync_func return ExtensionManager.get_sync_invocation_wrapper(context, ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/azure-functions-host/workers/python/3.12/LINUX/X64/azure_functions_worker/extension.py", line 211, in _raw_invocation_wrapper result = function(**args) ^^^^^^^^^^^^^^^^ File "/home/site/wwwroot/GWorkspaceReports-TimeTrigger/__init__.py", line 197, in main start_time,end_time = GetDates(line) ^^^^^^^^^^^^^^ File "/home/site/wwwroot/GWorkspaceReports-TimeTrigger/__init__.py", line 155, in GetDates return json.loads(activity_list) if (isBlank(logType)) else (json.loads(activity_list)[logType],end_time) ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^"

This happens if the activity_list variable (which, within the GetDates function, is intended to be a JSON string) contains a string that represents a JSON integer (e.g., the string "123").

If past_time (the content of your state file) is a string like "123", and is_json(past_time) returns true, then activity_list becomes the string "123". Later, json.loads("123") correctly yields the integer 123. The subsequent attempt 123[logType] then fails.

The state file is expected to store a JSON representation of a dictionary, where keys are activity names and values are timestamps. If it somehow contains just a number as a JSON string, this error will occur.

To fix this, we needed to ensure that if past_time is JSON, it's specifically a JSON representation of a dictionary before it is used. If it's valid JSON but not a dictionary (e.g., just a number or a plain string), it needs to be treated as an invalid state and re-initialize.

Explanation of Changes:

1. When past_time_str_from_state (the string from your state file) is found to be JSON, it's now explicitly decoded using json.loads().

2. The decoded result (decoded_past_time) is checked to ensure it's a Python dict.

3. If it is a dictionary, the code now also iterates through the global activities list to ensure that every expected activity has a timestamp in the loaded state. If an activity is missing (e.g., newly added activity type), it's initialized with a default past timestamp. The (potentially modified) dictionary is then converted back to a JSON string (activity_json_str).

4. If decoded_past_time is not a dictionary (e.g., it's an int or str because the state file contained "123" or "some_string"), it's treated as an invalid state. A new dictionary is created with default timestamps for all activities, and this new dictionary is converted to activity_json_str.

5. The logic for handling non-JSON legacy state and empty state also ensures activity_json_str becomes a JSON string representation of a dictionary.

6. At the end, activity_json_str is parsed once into loaded_activity_dict.

7. If logType is blank, the full loaded_activity_dict is returned (as expected by postactivity_list = GetDates("")).

8. If logType is specified, loaded_activity_dict[logType] is used to get the specific start time (which is now safe because loaded_activity_dict is guaranteed to be a dictionary), and it's returned along with the final_end_time_str. A fallback is added in case logType is somehow not in the dictionary keys.

9. Variable names were slightly adjusted for clarity (e.g. end_time_dt_obj, past_time_str_from_state, activity_json_str).

10. The end_time being returned in the tuple for a specific logType is consistently the string-formatted version derived from GetEndTime(logType).

This revised logic ensures that the operation [logType] is always performed on a dictionary, thus resolving the TypeError. It also makes the state handling more robust by ensuring all known activities are accounted for in the timestamp map.

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No