### PR TITLE
Add URL Detections and Clicks queries 

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Blocked Clicks Trend.yml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Blocked Clicks Trend.yml
@@ -1,0 +1,26 @@
+id: ac738108-451b-4341-ba38-021a00665415
+name: Blocked Clicks Trend
+description: |
+  Visualizes the daily trend of URL clicks that were blocked by Safe Links or policy controls.
+description-detailed: |
+  This query visualizes the number of URL clicks blocked by Safe Links or tenant policy controls over time, helping security teams monitor the effectiveness of click protection and user exposure to malicious links.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp >= TimeStart and Timestamp <= TimeEnd
+  | where ActionType == "ClickBlocked"
+  | summarize BlockedClicks = count() by bin(Timestamp, 1d)
+  | order by Timestamp asc
+  //| render timechart // Uncomment to display as a timechart
+  //| render columnchart // Uncomment to display as a column chart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Malicious Clicks allowed (click-through).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Malicious Clicks allowed (click-through).yaml
@@ -1,0 +1,25 @@
+id: ba4f7e56-a2f8-4a30-b848-200fdc7fc3a2
+name: Malicious Clicks allowed (click-through)
+description: |
+  Identifies users who clicked through malicious URLs despite Safe Links warnings.
+description-detailed: |
+  This query detects users who clicked through malicious URLs (phishing, malware, or spam) after Safe Links warnings, highlighting potential gaps in user awareness or policy enforcement. By default, results are limited to the top 10 users with the highest click-through counts to prioritize remediation; you can remove or adjust the limit to view all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  UrlClickEvents
+  | where IsClickedThrough == true
+  | where ThreatTypes has_any ("Phish", "Malware", "Spam")
+  | summarize Count = count() by User = AccountUpn, ThreatType = tostring(ThreatTypes)
+  | sort by Count desc
+  | top 10 by Count  // Uncomment to visualize only the top 10; remove to see all results
+  //| render piechart // Uncomment to visualize user distribution
+  //| render columnchart // Uncomment to compare click-through rates
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Malicious Emails with QR code Urls.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Malicious Emails with QR code Urls.yaml
@@ -1,0 +1,42 @@
+id: 13260191-fb10-4a36-9ca1-2bbc0aaf77d0
+name: Malicious Emails with QR code Urls
+description: |
+  Identifies inbound emails containing QR code URLs associated with phishing, malware, or spam threats.
+description-detailed: |
+  This query detects inbound emails with QR code URLs linked to phishing, malware, or spam threats, helping security teams monitor QR-based attack vectors over time.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+    - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = EmailEvents
+    | where Timestamp >= TimeStart and Timestamp <= TimeEnd
+    | where EmailDirection == "Inbound"
+    | join (
+        EmailUrlInfo
+        | where UrlLocation == "QRCode"
+    ) on NetworkMessageId;
+  let qrphishh = baseQuery
+    | where parse_json(DetectionMethods).Phish has "URL"
+    | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+    | extend Details = "Phish QR Detection";
+  let qrmalww = baseQuery
+    | where parse_json(DetectionMethods).Malware has "URL"
+    | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+    | extend Details = "Malware QR Detection";
+  let qrspamm = baseQuery
+    | where parse_json(DetectionMethods).Spam has "URL"
+    | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+    | extend Details = "Spam QR Detection";
+  union qrphishh, qrmalww, qrspamm
+  //| render timechart // Uncomment to display as a timechart
+  //| render columnchart // Uncomment to display as a column chart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Malicious URL Clicks by workload.yml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Malicious URL Clicks by workload.yml
@@ -1,0 +1,28 @@
+id: c2b4ef3a-216d-4506-8b35-6a1b0f2a3bf7
+name: Malicious URL Clicks by workload
+description: |
+  Summarizes malicious URL click events by Microsoft 365 workload to help identify which services are most targeted or impacted.
+description-detailed: |
+  This query provides a breakdown of malicious URL clicks (phishing, malware, or spam) by Microsoft 365 workload (e.g., Exchange, Teams, SharePoint), helping security teams identify which services are being targeted or impacted by user click activity.
+  By default, results are limited to the top 10 workloads; you can remove or adjust the limit to view all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has_any ("Phish", "Malware", "Spam")
+  | summarize MaliciousClicks = count() by Workload
+  | sort by MaliciousClicks desc
+  | top 10 by MaliciousClicks  // Uncomment to limit to top 10 workloads; remove to see all
+  //| render piechart // Uncomment to visualize proportional breakdown by workload
+  //| render columnchart // Uncomment to compare workloads
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
@@ -1,0 +1,28 @@
+id: 5a84e13a-bb17-4124-9564-d74cdb84c124
+name: Top 10 Users clicking on Malicious URLs (Malware)
+description: |
+  Identifies the top 10 users who have clicked on URLs classified as malware, helping prioritize user awareness and response.
+description-detailed: |
+  This query identifies the top 10 users who have clicked on URLs detected as malware by Safe Links or other Defender for Office 365 protections.
+  By default, results are limited to the top 10 users with the highest click counts for malware URLs; you can remove or adjust this limit to see all users.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has "Malware"
+  | summarize MalwareClicks = count() by User = AccountUpn
+  | sort by MalwareClicks desc
+  | top 10 by MalwareClicks  // Uncomment to limit to top 10 users; remove to see all results
+  //| render columnchart // Uncomment to visualize as a column chart
+  //| render piechart // Uncomment to visualize as a pie chart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
@@ -1,0 +1,29 @@
+id: a937905e-ee5c-406c-ab86-8e2581240112
+name: Top 10 Users clicking on Malicious URLs (Phish)
+description: |
+  Identifies the top 10 users who have clicked on URLs classified as phishing, helping prioritize user training and response.
+description-detailed: |
+  This query identifies the top 10 users who have clicked on URLs detected as phishing by Safe Links or other Defender for Office 365 protections.
+  By default, results are limited to the top 10 users with the highest click counts for phishing URLs; you can remove or adjust this limit to see all users.
+  Recommended visualization: columnchart for comparing users, or piechart for proportional breakdown if there are few users.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has "Phish"
+  | summarize PhishClicks = count() by User = AccountUpn
+  | sort by PhishClicks desc
+  | top 10 by PhishClicks  // Uncomment to limit to top 10 users; remove to see all results
+  //| render columnchart // Recommended for comparing top users
+  //| render piechart // Use for proportional breakdown if user count is small
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
@@ -1,0 +1,29 @@
+id: 3a2fdf32-ebe7-4f65-a1c3-fc7faf23ae90
+name: Top 10 Users clicking on Malicious URLs (Spam)
+description: |
+  Identifies the top 10 users who have clicked on URLs classified as spam, helping prioritize user awareness and policy reviews.
+description-detailed: |
+  This query identifies the top 10 users who have clicked on URLs detected as spam by Safe Links or other Defender for Office 365 protections.
+  By default, results are limited to the top 10 users with the highest click counts for spam URLs; you can remove or adjust this limit to see all users.
+  Recommended visualization: columnchart for comparing users, or piechart for proportional breakdown if there are few users.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has "Spam"
+  | summarize SpamClicks = count() by User = AccountUpn
+  | sort by SpamClicks desc
+  | top 10 by SpamClicks  // Uncomment to limit to top 10 users; remove to see all results
+  //| render columnchart // Recommended for comparing top users
+  //| render piechart // Use for proportional breakdown if user count is small
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/URL Click attempts by threat type.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/URL Click attempts by threat type.yaml
@@ -1,0 +1,28 @@
+id: 3eef362d-3aee-4950-9208-4afa6f7afbe9
+name: URL Click attempts by threat type
+description: |
+  Summarizes URL click attempts by threat type to help identify which threats users are most exposed to.
+description-detailed: |
+  This query provides a breakdown of URL click attempts by threat type (Phish, Malware, Spam), enabling security teams to assess user exposure to different categories of malicious content.
+  By default, results are limited to the top 10 threat types; you can remove or adjust the limit to view all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where isnotempty(ThreatTypes)
+  | summarize ClickAttempts = count() by ThreatType = tostring(ThreatTypes)
+  | sort by ClickAttempts desc
+  | top 10 by ClickAttempts  // Uncomment to limit to top 10 threat types; remove to see all
+  //| render piechart // Uncomment to visualize proportional breakdown by threat type
+  //| render columnchart // Uncomment to compare threat types
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/URL Clicks by Action.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/URL Clicks by Action.yaml
@@ -1,0 +1,30 @@
+id: 4620ece3-dceb-4151-8621-5a56351c97cd
+name: URL Clicks by Action
+description: |
+  Categorizes URL clicks by action type (Allowed/Blocked) and threat type for analysis.
+description-detailed: |
+  Summarizes URL click events by action type (Allowed, Blocked) and threat type (Phish, Malware), 
+  enabling analysis of click-through rates and policy enforcement effectiveness. Part of the Defender for Office 365 
+  solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | extend ActionCategory = case(
+      ActionType == "ClickBlocked", "Blocked",
+      ActionType == "ClickAllowed", "Allowed",
+      "Other"
+    )
+  | summarize Count = count() by ActionCategory, ThreatType = tostring(ThreatTypes)
+  | sort by Count desc
+  //| render piechart // Works for proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/URLs by location.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/URL/URLs by location.yaml
@@ -1,0 +1,22 @@
+id: ab006655-d723-4844-9d5d-91cb3b020555
+name: URLs by location
+description: |
+  Visualizes URLs found in emails by their location (body, QR code, etc.).
+description-detailed: |
+  This query summarizes the distribution of URLs in emails by their detected location, helping analysts identify trends in how malicious links are delivered.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailUrlInfo
+tactics:
+- InitialAccess
+relevantTechniques:
+- T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailUrlInfo
+  | where TimeGenerated >= TimeStart and TimeGenerated <= TimeEnd
+  | summarize count() by UrlLocation, bin(TimeGenerated, 1d)
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Blocked Clicks Trend.yml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Blocked Clicks Trend.yml
@@ -1,0 +1,26 @@
+id: ac738108-451b-4341-ba38-021a00665415
+name: Blocked Clicks Trend
+description: |
+  Visualizes the daily trend of URL clicks that were blocked by Safe Links or policy controls.
+description-detailed: |
+  This query visualizes the number of URL clicks blocked by Safe Links or tenant policy controls over time, helping security teams monitor the effectiveness of click protection and user exposure to malicious links.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp >= TimeStart and Timestamp <= TimeEnd
+  | where ActionType == "ClickBlocked"
+  | summarize BlockedClicks = count() by bin(Timestamp, 1d)
+  | order by Timestamp asc
+  //| render timechart // Uncomment to display as a timechart
+  //| render columnchart // Uncomment to display as a column chart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Malicious Clicks allowed (click-through).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Malicious Clicks allowed (click-through).yaml
@@ -1,0 +1,25 @@
+id: ba4f7e56-a2f8-4a30-b848-200fdc7fc3a2
+name: Malicious Clicks allowed (click-through)
+description: |
+  Identifies users who clicked through malicious URLs despite Safe Links warnings.
+description-detailed: |
+  This query detects users who clicked through malicious URLs (phishing, malware, or spam) after Safe Links warnings, highlighting potential gaps in user awareness or policy enforcement. By default, results are limited to the top 10 users with the highest click-through counts to prioritize remediation; you can remove or adjust the limit to view all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  UrlClickEvents
+  | where IsClickedThrough == true
+  | where ThreatTypes has_any ("Phish", "Malware", "Spam")
+  | summarize Count = count() by User = AccountUpn, ThreatType = tostring(ThreatTypes)
+  | sort by Count desc
+  | top 10 by Count  // Uncomment to visualize only the top 10; remove to see all results
+  //| render piechart // Uncomment to visualize user distribution
+  //| render columnchart // Uncomment to compare click-through rates
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Malicious Emails with QR code Urls.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Malicious Emails with QR code Urls.yaml
@@ -1,0 +1,42 @@
+id: 13260191-fb10-4a36-9ca1-2bbc0aaf77d0
+name: Malicious Emails with QR code Urls
+description: |
+  Identifies inbound emails containing QR code URLs associated with phishing, malware, or spam threats.
+description-detailed: |
+  This query detects inbound emails with QR code URLs linked to phishing, malware, or spam threats, helping security teams monitor QR-based attack vectors over time.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+    - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = EmailEvents
+    | where Timestamp >= TimeStart and Timestamp <= TimeEnd
+    | where EmailDirection == "Inbound"
+    | join (
+        EmailUrlInfo
+        | where UrlLocation == "QRCode"
+    ) on NetworkMessageId;
+  let qrphishh = baseQuery
+    | where parse_json(DetectionMethods).Phish has "URL"
+    | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+    | extend Details = "Phish QR Detection";
+  let qrmalww = baseQuery
+    | where parse_json(DetectionMethods).Malware has "URL"
+    | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+    | extend Details = "Malware QR Detection";
+  let qrspamm = baseQuery
+    | where parse_json(DetectionMethods).Spam has "URL"
+    | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+    | extend Details = "Spam QR Detection";
+  union qrphishh, qrmalww, qrspamm
+  //| render timechart // Uncomment to display as a timechart
+  //| render columnchart // Uncomment to display as a column chart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Malicious URL Clicks by workload.yml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Malicious URL Clicks by workload.yml
@@ -1,0 +1,28 @@
+id: c2b4ef3a-216d-4506-8b35-6a1b0f2a3bf7
+name: Malicious URL Clicks by workload
+description: |
+  Summarizes malicious URL click events by Microsoft 365 workload to help identify which services are most targeted or impacted.
+description-detailed: |
+  This query provides a breakdown of malicious URL clicks (phishing, malware, or spam) by Microsoft 365 workload (e.g., Exchange, Teams, SharePoint), helping security teams identify which services are being targeted or impacted by user click activity.
+  By default, results are limited to the top 10 workloads; you can remove or adjust the limit to view all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has_any ("Phish", "Malware", "Spam")
+  | summarize MaliciousClicks = count() by Workload
+  | sort by MaliciousClicks desc
+  | top 10 by MaliciousClicks  // Uncomment to limit to top 10 workloads; remove to see all
+  //| render piechart // Uncomment to visualize proportional breakdown by workload
+  //| render columnchart // Uncomment to compare workloads
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
@@ -1,0 +1,28 @@
+id: 5a84e13a-bb17-4124-9564-d74cdb84c124
+name: Top 10 Users clicking on Malicious URLs (Malware)
+description: |
+  Identifies the top 10 users who have clicked on URLs classified as malware, helping prioritize user awareness and response.
+description-detailed: |
+  This query identifies the top 10 users who have clicked on URLs detected as malware by Safe Links or other Defender for Office 365 protections.
+  By default, results are limited to the top 10 users with the highest click counts for malware URLs; you can remove or adjust this limit to see all users.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has "Malware"
+  | summarize MalwareClicks = count() by User = AccountUpn
+  | sort by MalwareClicks desc
+  | top 10 by MalwareClicks  // Uncomment to limit to top 10 users; remove to see all results
+  //| render columnchart // Uncomment to visualize as a column chart
+  //| render piechart // Uncomment to visualize as a pie chart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
@@ -1,0 +1,29 @@
+id: a937905e-ee5c-406c-ab86-8e2581240112
+name: Top 10 Users clicking on Malicious URLs (Phish)
+description: |
+  Identifies the top 10 users who have clicked on URLs classified as phishing, helping prioritize user training and response.
+description-detailed: |
+  This query identifies the top 10 users who have clicked on URLs detected as phishing by Safe Links or other Defender for Office 365 protections.
+  By default, results are limited to the top 10 users with the highest click counts for phishing URLs; you can remove or adjust this limit to see all users.
+  Recommended visualization: columnchart for comparing users, or piechart for proportional breakdown if there are few users.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has "Phish"
+  | summarize PhishClicks = count() by User = AccountUpn
+  | sort by PhishClicks desc
+  | top 10 by PhishClicks  // Uncomment to limit to top 10 users; remove to see all results
+  //| render columnchart // Recommended for comparing top users
+  //| render piechart // Use for proportional breakdown if user count is small
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
@@ -1,0 +1,29 @@
+id: 3a2fdf32-ebe7-4f65-a1c3-fc7faf23ae90
+name: Top 10 Users clicking on Malicious URLs (Spam)
+description: |
+  Identifies the top 10 users who have clicked on URLs classified as spam, helping prioritize user awareness and policy reviews.
+description-detailed: |
+  This query identifies the top 10 users who have clicked on URLs detected as spam by Safe Links or other Defender for Office 365 protections.
+  By default, results are limited to the top 10 users with the highest click counts for spam URLs; you can remove or adjust this limit to see all users.
+  Recommended visualization: columnchart for comparing users, or piechart for proportional breakdown if there are few users.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has "Spam"
+  | summarize SpamClicks = count() by User = AccountUpn
+  | sort by SpamClicks desc
+  | top 10 by SpamClicks  // Uncomment to limit to top 10 users; remove to see all results
+  //| render columnchart // Recommended for comparing top users
+  //| render piechart // Use for proportional breakdown if user count is small
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/URL Click attempts by threat type.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/URL Click attempts by threat type.yaml
@@ -1,0 +1,28 @@
+id: 3eef362d-3aee-4950-9208-4afa6f7afbe9
+name: URL Click attempts by threat type
+description: |
+  Summarizes URL click attempts by threat type to help identify which threats users are most exposed to.
+description-detailed: |
+  This query provides a breakdown of URL click attempts by threat type (Phish, Malware, Spam), enabling security teams to assess user exposure to different categories of malicious content.
+  By default, results are limited to the top 10 threat types; you can remove or adjust the limit to view all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where isnotempty(ThreatTypes)
+  | summarize ClickAttempts = count() by ThreatType = tostring(ThreatTypes)
+  | sort by ClickAttempts desc
+  | top 10 by ClickAttempts  // Uncomment to limit to top 10 threat types; remove to see all
+  //| render piechart // Uncomment to visualize proportional breakdown by threat type
+  //| render columnchart // Uncomment to compare threat types
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/URL Clicks by Action.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/URL Clicks by Action.yaml
@@ -1,0 +1,30 @@
+id: 4620ece3-dceb-4151-8621-5a56351c97cd
+name: URL Clicks by Action
+description: |
+  Categorizes URL clicks by action type (Allowed/Blocked) and threat type for analysis.
+description-detailed: |
+  Summarizes URL click events by action type (Allowed, Blocked) and threat type (Phish, Malware), 
+  enabling analysis of click-through rates and policy enforcement effectiveness. Part of the Defender for Office 365 
+  solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | extend ActionCategory = case(
+      ActionType == "ClickBlocked", "Blocked",
+      ActionType == "ClickAllowed", "Allowed",
+      "Other"
+    )
+  | summarize Count = count() by ActionCategory, ThreatType = tostring(ThreatTypes)
+  | sort by Count desc
+  //| render piechart // Works for proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/URLs by location.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/URL/URLs by location.yaml
@@ -1,0 +1,22 @@
+id: ab006655-d723-4844-9d5d-91cb3b020555
+name: URLs by location
+description: |
+  Visualizes URLs found in emails by their location (body, QR code, etc.).
+description-detailed: |
+  This query summarizes the distribution of URLs in emails by their detected location, helping analysts identify trends in how malicious links are delivered.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailUrlInfo
+tactics:
+- InitialAccess
+relevantTechniques:
+- T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailUrlInfo
+  | where TimeGenerated >= TimeStart and TimeGenerated <= TimeEnd
+  | summarize count() by UrlLocation, bin(TimeGenerated, 1d)
+version: 1.0.0


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added 10 new hunting queries for the "URL Detections and Clicks" sections of the Defender for Office 365 solution in Sentinel.

   Reason for Change(s):
   - Adding new community queries within Advanced Hunting for customers that do not use Sentinel. Based on queries that are included within the 'Defender for Office 365 Detections and Insights' workbook included with the Defender for Office 365 solution.

   Version Updated:
   - Not Applicable

   Testing Completed:
   - All queries were validated in Defender XDR Advanced Hunting and return expected results.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
