### PR TITLE
Add Email – Top Users/Senders queries for Defender for Office 365 sol…

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 Domains sending Malicious Emails (Malware+Phish+Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 Domains sending Malicious Emails (Malware+Phish+Spam).yaml
@@ -1,0 +1,30 @@
+id: af183f01-6d98-4fca-8ca4-63577b78a26e
+name: Top 10 Domains sending Malicious Emails (Malware+Phish+Spam)
+description: |
+  Identifies the top domains sending emails with malware, phishing, or spam threats.
+description-detailed: |
+  This query summarizes inbound email events to identify the top domains sending malicious emails (malware, phishing, or spam).
+  By default, results are limited to the top 10 domains; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has_any ("Malware", "Phish", "Spam")
+  | where EmailDirection == "Inbound"
+  //| where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"  // Uncomment to exclude simulations/SecOps
+  | summarize MaliciousCount = count() by Domain = SenderFromDomain
+  | sort by MaliciousCount desc
+  | top 10 by MaliciousCount  // Remove or adjust this line to see all domains or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare domains
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders (Malware).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders (Malware).yaml
@@ -1,0 +1,31 @@
+id: 530ef5e4-7ee4-4d70-a8e2-a06459605c02
+name: Top 10 External Senders (Malware)
+description: |
+  Identifies the top 10 external email senders to your organization whose emails contained malware.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails flagged as malware, helping identify frequent malware sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | where ThreatTypes has "Malware"
+  | summarize MalwareCount = count() by Sender = SenderFromAddress
+  | sort by MalwareCount desc
+  | top 10 by MalwareCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders (Phish).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders (Phish).yaml
@@ -1,0 +1,31 @@
+id: db9789ab-0636-4ea6-b779-1b72b4b64aac
+name: Top 10 External Senders (Phish)
+description: |
+  Identifies the top 10 external email senders to your organization whose emails contained phishing threats.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails flagged as phishing, helping identify frequent phishing sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | where ThreatTypes has "Phish"
+  | summarize PhishCount = count() by Sender = SenderFromAddress
+  | sort by PhishCount desc
+  | top 10 by PhishCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders (Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders (Spam).yaml
@@ -1,0 +1,31 @@
+id: 86c7d21b-2081-419d-bc2e-7bc909d61eef
+name: Top 10 External Senders (Spam)
+description: |
+  Identifies the top 10 external email senders to your organization whose emails contained spam.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails flagged as spam, helping identify frequent spam sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | where ThreatTypes has "Spam"
+  | summarize SpamCount = count() by Sender = SenderFromAddress
+  | sort by SpamCount desc
+  | top 10 by SpamCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 External Senders.yaml
@@ -1,0 +1,30 @@
+id: 6f606826-b995-4a8d-8c2c-ee08e3d1194a
+name: Top 10 External Senders
+description: |
+  Identifies the top 10 external email senders to your organization.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails, helping to identify frequently communicating external sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | summarize SentCount = count() by Sender = SenderFromAddress
+  | sort by SentCount desc
+  | top 10 by SentCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 Targeted Users (Malware+Phish+Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 Targeted Users (Malware+Phish+Spam).yaml
@@ -1,0 +1,30 @@
+id: 504814de-581d-4f8b-8f4b-95a24d188e22
+name: Top 10 Targeted Users (Malware+Phish+Spam)
+description: |
+  Identifies the top 10 users receiving emails with malware, phishing, or spam threats.
+description-detailed: |
+  This query identifies the top 10 users targeted by malicious emails (malware, phishing, or spam) based on inbound email events.
+  By default, results are limited to the top 10 users; remove or adjust the limit to see all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where ThreatTypes has_any ("Malware", "Phish", "Spam")
+  //| where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"  // Uncomment to exclude simulations/SecOps
+  | summarize TargetedCount = count() by User = RecipientEmailAddress
+  | sort by TargetedCount desc
+  | top 10 by TargetedCount  // Uncomment to limit to top 10 users; remove to see all
+  //| render columnchart  // Compare users
+  //| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 Users clicking on Malicious URLs (Malware+Phish+Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/General/Top 10 Users clicking on Malicious URLs (Malware+Phish+Spam).yaml
@@ -1,0 +1,28 @@
+id: 7d7a3d3f-22db-4cdf-ba67-c57215777a3c
+name: Top 10 Users clicking on Malicious URLs (Malware+Phish+Spam)
+description: |
+  Identifies users with the highest click counts on URLs classified as malware, phishing, or spam.
+description-detailed: |
+  This query summarizes malicious URL click events across all threat types (malware, phishing, spam) to identify high-risk users. 
+  By default limited to top 10 users; adjust or remove the limit for full results. Part of the Defender for Office 365 solution.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has_any ("Malware", "Phish", "Spam")
+  //| where ActionType != "ClickSimulated"  // Uncomment to exclude phishing simulations
+  | summarize ClickCount = count() by User = AccountUpn
+  | sort by ClickCount desc
+  | top 10 by ClickCount  // Uncomment to limit to top 10; remove to see all
+  //| render columnchart  // Compare users
+  //| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 Domains sending Malicious Emails (Malware+Phish+Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 Domains sending Malicious Emails (Malware+Phish+Spam).yaml
@@ -1,0 +1,30 @@
+id: af183f01-6d98-4fca-8ca4-63577b78a26e
+name: Top 10 Domains sending Malicious Emails (Malware+Phish+Spam)
+description: |
+  Identifies the top domains sending emails with malware, phishing, or spam threats.
+description-detailed: |
+  This query summarizes inbound email events to identify the top domains sending malicious emails (malware, phishing, or spam).
+  By default, results are limited to the top 10 domains; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has_any ("Malware", "Phish", "Spam")
+  | where EmailDirection == "Inbound"
+  //| where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"  // Uncomment to exclude simulations/SecOps
+  | summarize MaliciousCount = count() by Domain = SenderFromDomain
+  | sort by MaliciousCount desc
+  | top 10 by MaliciousCount  // Remove or adjust this line to see all domains or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare domains
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders (Malware).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders (Malware).yaml
@@ -1,0 +1,31 @@
+id: 530ef5e4-7ee4-4d70-a8e2-a06459605c02
+name: Top 10 External Senders (Malware)
+description: |
+  Identifies the top 10 external email senders to your organization whose emails contained malware.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails flagged as malware, helping identify frequent malware sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | where ThreatTypes has "Malware"
+  | summarize MalwareCount = count() by Sender = SenderFromAddress
+  | sort by MalwareCount desc
+  | top 10 by MalwareCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders (Phish).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders (Phish).yaml
@@ -1,0 +1,31 @@
+id: db9789ab-0636-4ea6-b779-1b72b4b64aac
+name: Top 10 External Senders (Phish)
+description: |
+  Identifies the top 10 external email senders to your organization whose emails contained phishing threats.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails flagged as phishing, helping identify frequent phishing sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | where ThreatTypes has "Phish"
+  | summarize PhishCount = count() by Sender = SenderFromAddress
+  | sort by PhishCount desc
+  | top 10 by PhishCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders (Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders (Spam).yaml
@@ -1,0 +1,31 @@
+id: 86c7d21b-2081-419d-bc2e-7bc909d61eef
+name: Top 10 External Senders (Spam)
+description: |
+  Identifies the top 10 external email senders to your organization whose emails contained spam.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails flagged as spam, helping identify frequent spam sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | where ThreatTypes has "Spam"
+  | summarize SpamCount = count() by Sender = SenderFromAddress
+  | sort by SpamCount desc
+  | top 10 by SpamCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 External Senders.yaml
@@ -1,0 +1,30 @@
+id: 6f606826-b995-4a8d-8c2c-ee08e3d1194a
+name: Top 10 External Senders
+description: |
+  Identifies the top 10 external email senders to your organization.
+description-detailed: |
+  This query lists the top 10 external senders of inbound emails, helping to identify frequently communicating external sources.
+  By default, results are limited to the top 10 senders; remove or adjust the limit to see all results, or change the number for a different top N (e.g., Top 5).
+  Update the domain exclusion filter to match your organization's internal email domain.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where SenderFromDomain !endswith "yourcompany.com"  // Replace with your internal domain
+  | summarize SentCount = count() by Sender = SenderFromAddress
+  | sort by SentCount desc
+  | top 10 by SentCount  // Remove or adjust this line to see all senders or change the number for a different top N (e.g., Top 5)
+//| render columnchart  // Compare senders
+//| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 Targeted Users (Malware+Phish+Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 Targeted Users (Malware+Phish+Spam).yaml
@@ -1,0 +1,30 @@
+id: 504814de-581d-4f8b-8f4b-95a24d188e22
+name: Top 10 Targeted Users (Malware+Phish+Spam)
+description: |
+  Identifies the top 10 users receiving emails with malware, phishing, or spam threats.
+description-detailed: |
+  This query identifies the top 10 users targeted by malicious emails (malware, phishing, or spam) based on inbound email events.
+  By default, results are limited to the top 10 users; remove or adjust the limit to see all results.
+  Part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where EmailDirection == "Inbound"
+  | where ThreatTypes has_any ("Malware", "Phish", "Spam")
+  //| where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"  // Uncomment to exclude simulations/SecOps
+  | summarize TargetedCount = count() by User = RecipientEmailAddress
+  | sort by TargetedCount desc
+  | top 10 by TargetedCount  // Uncomment to limit to top 10 users; remove to see all
+  //| render columnchart  // Compare users
+  //| render piechart  // Proportional breakdown
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 Users clicking on Malicious URLs (Malware+Phish+Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/General/Top 10 Users clicking on Malicious URLs (Malware+Phish+Spam).yaml
@@ -1,0 +1,28 @@
+id: 7d7a3d3f-22db-4cdf-ba67-c57215777a3c
+name: Top 10 Users clicking on Malicious URLs (Malware+Phish+Spam)
+description: |
+  Identifies users with the highest click counts on URLs classified as malware, phishing, or spam.
+description-detailed: |
+  This query summarizes malicious URL click events across all threat types (malware, phishing, spam) to identify high-risk users. 
+  By default limited to top 10 users; adjust or remove the limit for full results. Part of the Defender for Office 365 solution.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+    - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp between (TimeStart .. TimeEnd)
+  | where ThreatTypes has_any ("Malware", "Phish", "Spam")
+  //| where ActionType != "ClickSimulated"  // Uncomment to exclude phishing simulations
+  | summarize ClickCount = count() by User = AccountUpn
+  | sort by ClickCount desc
+  | top 10 by ClickCount  // Uncomment to limit to top 10; remove to see all
+  //| render columnchart  // Compare users
+  //| render piechart  // Proportional breakdown
+version: 1.0.0


### PR DESCRIPTION
Change(s):
- Added 7 new hunting queries for the "Email – Top Users/Senders" section of the Defender for Office 365 solution in Sentinel.

Reason for Change(s):
- Adding new community queries within Advanced Hunting for customers that do not use Sentinel. Based on queries that are included within the 'Defender for Office 365 Detections and Insights' workbook included with the Defender for Office 365 solution.
- Enhances community hunting capabilities for email-based threats and user/sender analysis.

Version Updated:
- Not Applicable

Testing Completed:
- All queries were validated in Defender XDR Advanced Hunting and return expected results.

Checked that validations are passing and have addressed any issues that are present:
- Yes

References:
- [Defender for Office 365 solution blog post](https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303)
- Related PR: #12285
