### PR TITLE
Update vimWebSessionSquidProxy.yaml

### DIFF
--- a/Parsers/ASimWebSession/Parsers/vimWebSessionSquidProxy.yaml
+++ b/Parsers/ASimWebSession/Parsers/vimWebSessionSquidProxy.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: Web Session ASIM filtering parser for Squid Proxy
-  Version: '0.6.1'
-  LastUpdated: Dec 29 2022
+  Version: '0.6.2'
+  LastUpdated: June 12 2025
 Product:
   Name: Squid Proxy
 Normalization:
@@ -80,7 +80,7 @@ ParserQuery: |
     | where eventresult == "*" or eventresult == EventResult
     // -- Map
     | project-rename
-      Dvc = Computer
+      Dvc = 'Squid Proxy'
     | extend
       EventEndTime = unixtime_milliseconds_todatetime(todouble(tostring(AccessRawLog[0]))*1000), 
       NetworkDuration = toint(AccessRawLog[1]), 


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - updated breaking change to Dvc not to reference Computer column but defined string

   Reason for Change(s):
   - Current parser version does not work since Dvc refers to Computer which is not a value and thus the parser does not work

   Version Updated:
   - yes

   Testing Completed:
   - Need help

   Checked that the validations are passing and have addressed any issues that are present:
   - Need help



