### PR TITLE
Fixed validation issue for datatypes pipeline check

### DIFF
--- a/.script/package-automation/validateFieldTypes.ps1
+++ b/.script/package-automation/validateFieldTypes.ps1
@@ -71,7 +71,7 @@ try {
     }
 
     # identify in active resource parameters
-    $resourceContent = $mainTemplateFileContent.resources | Where-Object { $_.type -eq 'Microsoft.OperationalInsights/workspaces/providers/contentTemplates' }
+    $resourceContent = $mainTemplateFileContent.resources | Where-Object { $_.type -eq 'Microsoft.OperationalInsights/workspaces/providers/contentTemplates' -and $_.properties.contentKind -eq "ResourcesDataConnector"  }
 
     if ($null -ne $resourceContent -and $resourceContent.Count -gt 0) {
       $resourceLevelInvalidFields = @();


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - For playbook it is giving error to update parameters of playbookName to securestring and other fields but this validation is required only for ccp parameters so added condition.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes, tested running code in PowerShell locally.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


