### PR TITLE
Skip validation if dataTypes in data connector file is empty

### DIFF
--- a/.script/dataConnectorValidator.ts
+++ b/.script/dataConnectorValidator.ts
@@ -47,7 +47,7 @@ export async function IsValidDataConnectorSchema(filePath: string): Promise<Exit
   }
 
 function isPotentialConnectorJson(jsonFile: any) {
-  if(typeof jsonFile.id != "undefined" && typeof jsonFile.connectivityCriterias != "undefined")
+  if(typeof jsonFile.id != "undefined" && typeof jsonFile.connectivityCriterias != "undefined" && jsonFile.dataTypes.length > 0)
   {
     return true;
   }


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - For M365 Assets solution we can have `dataTypes: []` so this is failing the validation so skipping this validation if its empty. 

   Reason for Change(s):
   - Specified aboove

   Version Updated:
   - NA

   Testing Completed:
   - NA, as we have added additional condition to skip if dataTypes count is zero.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


