### PR TITLE
Python version update- cisco umbrella 3.11

### DIFF
--- a/Solutions/CiscoUmbrella/Data Connectors/azuredeploy_CiscoUmbrella_API_FunctionApp.json
+++ b/Solutions/CiscoUmbrella/Data Connectors/azuredeploy_CiscoUmbrella_API_FunctionApp.json
@@ -143,7 +143,7 @@
                 "alwaysOn": true,
                 "reserved": true,
 				"siteConfig": {
-                    "linuxFxVersion": "python|3.9"
+                    "linuxFxVersion": "python|3.11"
                 }
             },
             "resources": [

--- a/Solutions/CiscoUmbrella/Data Connectors/requirements.txt
+++ b/Solutions/CiscoUmbrella/Data Connectors/requirements.txt
@@ -1,18 +1,17 @@
 # DO NOT include azure-functions-worker in this file
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
-
-azure-core==1.22.1
+azure-core>=1.31.0
 azure-functions==1.6.0
-azure-storage-file-share==12.5.0
-boto3==1.9.180
-botocore==1.12.253
-certifi==2023.7.22
-cffi==1.15.1
-charset-normalizer==3.1.0
-cryptography==36.0.0
+azure-storage-file-share>=12.5.0
+boto3==1.28.0
+botocore==1.31.0
+certifi>=2022.12.7
+cffi>=1.17.1
+chardet==3.0.4
+cryptography<45,>=42.0.0
+protobuf>=4.21.6
 docutils==0.15.2
-idna==2.8
 isodate==0.6.1
 jmespath==0.10.0
 msrest==0.6.21
@@ -21,7 +20,7 @@ pycparser==2.21
 python-dateutil==2.8.2
 requests==2.31.0
 requests-oauthlib==1.3.1
-s3transfer==0.2.1
+s3transfer>=0.6.0,<0.7.0
 six==1.16.0
-typing_extensions==4.0.0
-urllib3==1.25.11
+typing-extensions>=4.6.0
+urllib3>=1.26.15


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated Python Version from 3.9 to 3.11
   Reason for Change(s):
   - GitHub issue: https://github.com/Azure/Azure-Sentinel/issues/12274
   - https://github.com/Azure/Azure-Sentinel/issues/12477
   - Community support for python 3.9 will end in October.



