### PR TITLE
Adding User Submission queries for MDO

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submission Accuracy versus Admin Verdicts.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submission Accuracy versus Admin Verdicts.yaml
@@ -1,0 +1,34 @@
+id: 0d03314a-ecbe-47f0-b411-2a9471f26b46
+name: User Email Submissions accuracy vs Admin review verdict
+description: |
+  This query visualises user submissions type compared to admin review verdict
+description-detailed: |
+  This query visualises user submissions type compared to admin review verdict, such as a User reporting a message as Phish but admin review is 'No threat found'
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let ReviewResults = CloudAppEvents | where ActionType == "SubmissionNotification" 
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId)
+  | extend Properties = parse_json(RawEventData.ExtendedProperties)
+  | mv-expand element = Properties
+  | where element.Name == "AdminReviewResult"
+  | project SubmissionId, AdminReviewResult = element.Value;
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId), SubmissionType = parse_json(RawEventData).SubmissionType
+  | join kind=leftouter ReviewResults on SubmissionId
+  | extend UserReportedAs=iif(SubmissionType == 1, "Phish",iif(SubmissionType == 2, "Junk",iif(SubmissionType == 3, "NotJunk","")))
+  | extend ReviewedAccuracy=iif(AdminReviewResult==UserReportedAs, "Correct", iif(AdminReviewResult=="Phish" and UserReportedAs == "Junk", "Phish reported as junk",iif(AdminReviewResult=="Junk" and UserReportedAs == "Phish","Junk reported as Phish",iif(AdminReviewResult=="NotJunk","Reported but not malicious or spam",iif(isempty(AdminReviewResult),"Not Reviewed","Not correct")))))
+  | extend Reviewed=iif(isempty(AdminReviewResult),"Not Reviewed","Reviewed")
+  | project SubmissionId,UserReportedAs,Reviewed,AdminReviewResult, ReviewedAccuracy
+  | where Reviewed=="Reviewed"
+  | summarize count() by ReviewedAccuracy
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
@@ -1,0 +1,30 @@
+id: 2adae71b-42b9-47b8-9cb7-ccea9fece3e2
+name: User Email Submissions (FN) - Top Intra-Org P2 Senders
+description: |
+  This query visualises top sender email addresses of intra-org emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top sender email addresses of intra-org emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Intra-org"
+  | summarize count() by SenderMailFromAddress
+  | project SenderMailFromAddress,UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
@@ -1,0 +1,30 @@
+id: 02949291-cc6c-48ff-bc99-bb3736a3c967
+name: User Email Submissions (FN) - Top Intra-Org Subjects
+description: |
+  This query visualises top 10 subjects of intra-org emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top 10 subjects of intra-org emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Intra-org"
+  | summarize count() by Subject
+  | project Subject,UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
@@ -1,0 +1,30 @@
+id: a52e4273-cf3c-4125-b03d-41b99f64197f
+name: User Email Submissions (FN) - Top Detection Overrides by Admins
+description: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was an admin definded policy override
+description-detailed: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was an admin definded (tenant-level) policy override
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where ThreatTypes !=""and OrgLevelAction!=""
+  | summarize count() by OrgLevelAction, OrgLevelPolicy,ThreatTypes,User_SubmissionType
+  | project OrgLevelAction, OrgLevelPolicy,ThreatTypes,User_SubmissionType, UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
@@ -1,0 +1,30 @@
+id: 764c0e82-33af-4694-a552-b2de24d1d477
+name: User Email Submissions (FN) - Top Detection Overrides by Users
+description: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was a policy override.
+description-detailed: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was a policy override configured by the end-user (mailbox-level).
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where ThreatTypes !=""and UserLevelAction!=""
+  | summarize count() by UserLevelAction, UserLevelPolicy,ThreatTypes,User_SubmissionType
+  | project UserLevelAction, UserLevelPolicy,ThreatTypes,User_SubmissionType, UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
@@ -1,0 +1,31 @@
+id: d7822efc-9a33-4120-8c60-661396764af1
+name: User Email Submissions (FN) - Top Inbound P2 Senders domains
+description: |
+  This query visualises top sender domains of inbound emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top sender domains of inbound emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TotalInboundbySender = EmailEvents
+  | where EmailDirection =="Inbound"
+  | summarize count() by SenderFromDomain;
+  CloudAppEvents 
+  | where ActionType == "UserSubmission" 
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType),RecipientObjectId=AccountObjectId,NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  | summarize UserSubmissions=count() by SenderFromDomain
+  | join TotalInboundbySender on SenderFromDomain
+  | extend UserSubmissions_Percentage = todouble(round(UserSubmissions / todouble(count_) * 100, 2))
+  | project SenderFromDomain, UserSubmissions, TotalInboundEmail=count_,UserSubmissions_Percentage
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
@@ -1,0 +1,31 @@
+id: 4e8ea1c2-723d-4f72-bac6-82c464b6731e
+name: User Email Submissions (FN) - Top Inbound P2 Senders
+description: |
+  This query visualises top sender email addresses of inbound emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top sender email addresses of inbound emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TotalInboundbySender = EmailEvents
+  | where EmailDirection =="Inbound"
+  | summarize count() by SenderFromAddress;
+  CloudAppEvents 
+  | where ActionType == "UserSubmission" 
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType),P2SenderDomain=tostring((parse_json(RawEventData)).P2SenderDomain),RecipientObjectId=AccountObjectId,NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  | summarize UserSubmissions=count() by SenderFromAddress
+  | join TotalInboundbySender on SenderFromAddress
+  | extend UserSubmissions_Percentage = todouble(round(UserSubmissions / todouble(count_) * 100, 2))
+  | project SenderFromAddress, UserSubmissions, TotalInboundEmail=count_,UserSubmissions_Percentage
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions Trend - FN.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions Trend - FN.yaml
@@ -1,0 +1,34 @@
+id: 395047c1-254e-43fb-ad6e-ae74c8e0a873
+name: User Email Submission Trend (FN)
+description: |
+  This query visualises the daily ammount of users false negative submission by submission type, including phish simulations reported by users.
+description-detailed: |
+  This query visualises the daily ammount of users false negative submission by submission type, including phish simulations reported by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = CloudAppEvents
+  | where ActionType contains "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType);
+  let User_Phish_FN=baseQuery
+  | make-series Count= countif(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail" ) default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "User_Phish_FN";
+  let User_Spam_FN=baseQuery
+  | make-series Count= countif(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail" ) default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "User_Spam_FN";
+  let User_AttackSim_Submission=baseQuery
+  | make-series Count= countif(ActionType == "AttackSimUserSubmission" and SubmissionContentType=="Mail" ) default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "User_AttackSim_Submission";
+  union User_Phish_FN,User_Spam_FN,User_AttackSim_Submission
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Admin review status.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Admin review status.yaml
@@ -1,0 +1,33 @@
+id: 6923a80a-e3df-4d81-a90d-63fc5b7f0bb5
+name: User Email Submissions by Admin review status (Mark and Notify)
+description: |
+  This query visualises user submissions where admin also performed 'mark and notify' action on the submission
+description-detailed: |
+  This query visualises user submissions where admin also performed 'mark and notify' action on the submission
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let ReviewResults = CloudAppEvents | where ActionType == "SubmissionNotification" 
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId)
+  | extend Properties = parse_json(RawEventData.ExtendedProperties)
+  | mv-expand element = Properties
+  | where element.Name == "AdminReviewResult"
+  | project SubmissionId, AdminReviewResult = element.Value;
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId), SubmissionType = parse_json(RawEventData).SubmissionType
+  | join kind=leftouter ReviewResults on SubmissionId
+  | extend UserReportedAs=iif(SubmissionType == 1, "Phish",iif(SubmissionType == 2, "Junk",iif(SubmissionType == 3, "NotJunk","")))
+  | extend ReviewedAccuracy=iif(UserReportedAs==AdminReviewResult, 1,0)
+  | extend Reviewed=iif(isempty(AdminReviewResult),"Not Reviewed","Reviewed")
+  | project SubmissionId,UserReportedAs,Reviewed,AdminReviewResult, ReviewedAccuracy
+  | summarize count() by Reviewed
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Grading Verdict - FN-FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Grading Verdict - FN-FP.yaml
@@ -1,0 +1,22 @@
+id: 3b9e6da0-3504-463f-80d3-31fe3f0261ff
+name: User Email Submissions (FN-FP) by Grading verdict
+description: |
+  This query visualises the total ammount of user false negative or false positive submissions by the verdict of the submission grading.
+description-detailed: |
+  This query visualises the total ammount of user false negative or false positive submissions by the verdict of the submission grading.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType contains "UserSubmissionTriage" 
+  | extend UserKey = (parse_json(RawEventData)).UserKey, SubmissionState = (parse_json(RawEventData)).SubmissionState,  SubmissionId=(parse_json(RawEventData)).SubmissionId, TriageVerdict=(parse_json(RawEventData)).GradingResult.TriageVerdict 
+  | summarize count() by tostring(TriageVerdict)
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Submission State - FN
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Submission State - FN
@@ -1,0 +1,23 @@
+id: b1a40a5e-3378-4ba9-af74-9c67c6fe704c
+name: User Email Submissions (FN) by Submission State
+description: |
+  This query visualises the total ammount of user false negative submissions by the state of the submission.
+description-detailed: |
+  This query visualises the total ammount of user false negative submissions by the state of the submission.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType contains "UserSubmission" 
+  | extend Record = (parse_json(RawEventData)).RecordType,SubmissionState = parse_json(RawEventData).SubmissionState,SubmissionId=parse_json(RawEventData).SubmissionId,SubmissionType = parse_json(RawEventData).SubmissionType,SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType)
+  | where Record == 29 and SubmissionType in ("0","1")
+  | summarize count() by tostring(SubmissionState)
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Submission Type.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions by Submission Type.yaml
@@ -1,0 +1,28 @@
+id: 0b2cbdf4-12e4-46e9-a8f6-99e559583cd7
+name: User Email Submissions (FN) by Submission Type
+description: |
+  This query visualises the total ammount of user false negative submission by submission type, including the phish simulations reported emails
+description-detailed: |
+  This query visualises the total ammount of user false negative submission by submission type, including the phish simulations reported emails
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType contains "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType)
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN",
+  iff(ActionType == "AttackSimUserSubmission" and SubmissionContentType=="Mail","User_AttackSim_Submission",
+  "Other")))
+  | where User_SubmissionType!="Other"
+  | summarize count() by User_SubmissionType
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions from Junk Folder.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions from Junk Folder.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions from Junk Folder.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Submissions/User Submissions from Junk Folder.yaml
@@ -1,0 +1,29 @@
+id: a1eb19d6-9d86-425c-bd1d-86495c2ca714
+name: User email submissions (FN) from Junk Folder
+description: |
+  This query visualises the total ammount of user false negative submissions from the junk folder
+description-detailed: |
+  This query visualises the total ammount of user false negative submissions that are already detected by MDO and already delivered in the junk folder
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where DeliveryLocation == "Junk folder"
+  | summarize count() by ThreatTypes,User_SubmissionType
+  | project ThreatTypes,User_SubmissionType, Emails = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submission Accuracy versus Admin Verdicts.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submission Accuracy versus Admin Verdicts.yaml
@@ -1,0 +1,34 @@
+id: d78bad8c-3d94-4a73-bdbe-1c567e3d6d62
+name: User Email Submissions accuracy vs Admin review verdict
+description: |
+  This query visualises user submissions type compared to admin review verdict
+description-detailed: |
+  This query visualises user submissions type compared to admin review verdict, such as a User reporting a message as Phish but admin review is 'No threat found'
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let ReviewResults = CloudAppEvents | where ActionType == "SubmissionNotification" 
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId)
+  | extend Properties = parse_json(RawEventData.ExtendedProperties)
+  | mv-expand element = Properties
+  | where element.Name == "AdminReviewResult"
+  | project SubmissionId, AdminReviewResult = element.Value;
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId), SubmissionType = parse_json(RawEventData).SubmissionType
+  | join kind=leftouter ReviewResults on SubmissionId
+  | extend UserReportedAs=iif(SubmissionType == 1, "Phish",iif(SubmissionType == 2, "Junk",iif(SubmissionType == 3, "NotJunk","")))
+  | extend ReviewedAccuracy=iif(AdminReviewResult==UserReportedAs, "Correct", iif(AdminReviewResult=="Phish" and UserReportedAs == "Junk", "Phish reported as junk",iif(AdminReviewResult=="Junk" and UserReportedAs == "Phish","Junk reported as Phish",iif(AdminReviewResult=="NotJunk","Reported but not malicious or spam",iif(isempty(AdminReviewResult),"Not Reviewed","Not correct")))))
+  | extend Reviewed=iif(isempty(AdminReviewResult),"Not Reviewed","Reviewed")
+  | project SubmissionId,UserReportedAs,Reviewed,AdminReviewResult, ReviewedAccuracy
+  | where Reviewed=="Reviewed"
+  | summarize count() by ReviewedAccuracy
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
@@ -1,0 +1,30 @@
+id: b78eddd9-ebe5-42ab-95b4-928a782b52b5
+name: User Email Submissions (FN) - Top Intra-Org P2 Senders
+description: |
+  This query visualises top sender email addresses of intra-org emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top sender email addresses of intra-org emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Intra-org"
+  | summarize count() by SenderMailFromAddress
+  | project SenderMailFromAddress,UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org P2 senders.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
@@ -1,0 +1,30 @@
+id: cbf3abc0-2b2d-4852-ab7a-9f7a1231997e
+name: User Email Submissions (FN) - Top Intra-Org Subjects
+description: |
+  This query visualises top 10 subjects of intra-org emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top 10 subjects of intra-org emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Intra-org"
+  | summarize count() by Subject
+  | project Subject,UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top Intra-Org Subjects.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
@@ -1,0 +1,30 @@
+id: 58acf93f-27de-4af4-8a5f-d87ee59326f9
+name: User Email Submissions (FN) - Top Detection Overrides by Admins
+description: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was an admin definded policy override
+description-detailed: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was an admin definded (tenant-level) policy override
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where ThreatTypes !=""and OrgLevelAction!=""
+  | summarize count() by OrgLevelAction, OrgLevelPolicy,ThreatTypes,User_SubmissionType
+  | project OrgLevelAction, OrgLevelPolicy,ThreatTypes,User_SubmissionType, UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Admins.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
@@ -1,0 +1,30 @@
+id: 0a9385bc-2ef9-4b0e-8834-12f796b08ca8
+name: User Email Submissions (FN) - Top Detection Overrides by Users
+description: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was a policy override.
+description-detailed: |
+  This query visualises emails submitted as false negatives by users where emails were already detected by MDO but there was a policy override configured by the end-user (mailbox-level).
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where ThreatTypes !=""and UserLevelAction!=""
+  | summarize count() by UserLevelAction, UserLevelPolicy,ThreatTypes,User_SubmissionType
+  | project UserLevelAction, UserLevelPolicy,ThreatTypes,User_SubmissionType, UserSubmissions = count_
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top detection overrides by Users.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
@@ -1,0 +1,31 @@
+id: 385aca1d-2135-40c6-af8e-030c9e086cf5
+name: User Email Submissions (FN) - Top Inbound P2 Senders domains
+description: |
+  This query visualises top sender domains of inbound emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top sender domains of inbound emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TotalInboundbySender = EmailEvents
+  | where EmailDirection =="Inbound"
+  | summarize count() by SenderFromDomain;
+  CloudAppEvents 
+  | where ActionType == "UserSubmission" 
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType),RecipientObjectId=AccountObjectId,NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  | summarize UserSubmissions=count() by SenderFromDomain
+  | join TotalInboundbySender on SenderFromDomain
+  | extend UserSubmissions_Percentage = todouble(round(UserSubmissions / todouble(count_) * 100, 2))
+  | project SenderFromDomain, UserSubmissions, TotalInboundEmail=count_,UserSubmissions_Percentage
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders domains.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
@@ -1,0 +1,31 @@
+id: 12798858-1916-4b59-a85e-8a7a4f7b43cf
+name: User Email Submissions (FN) - Top Inbound P2 Senders
+description: |
+  This query visualises top sender email addresses of inbound emails submitted as false negatives by users.
+description-detailed: |
+  This query visualises top sender email addresses of inbound emails submitted as false negatives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TotalInboundbySender = EmailEvents
+  | where EmailDirection =="Inbound"
+  | summarize count() by SenderFromAddress;
+  CloudAppEvents 
+  | where ActionType == "UserSubmission" 
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType),P2SenderDomain=tostring((parse_json(RawEventData)).P2SenderDomain),RecipientObjectId=AccountObjectId,NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  | summarize UserSubmissions=count() by SenderFromAddress
+  | join TotalInboundbySender on SenderFromAddress
+  | extend UserSubmissions_Percentage = todouble(round(UserSubmissions / todouble(count_) * 100, 2))
+  | project SenderFromAddress, UserSubmissions, TotalInboundEmail=count_,UserSubmissions_Percentage
+  | top 10 by UserSubmissions desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions - Top email (P2) senders.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions Trend - FN.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions Trend - FN.yaml
@@ -1,0 +1,34 @@
+id: 9c4359a1-0bf9-45b3-9a1a-f333c437a061
+name: User Email Submission Trend (FN)
+description: |
+  This query visualises the daily ammount of users false negative submission by submission type, including phish simulations reported by users.
+description-detailed: |
+  This query visualises the daily ammount of users false negative submission by submission type, including phish simulations reported by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = CloudAppEvents
+  | where ActionType contains "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType);
+  let User_Phish_FN=baseQuery
+  | make-series Count= countif(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail" ) default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "User_Phish_FN";
+  let User_Spam_FN=baseQuery
+  | make-series Count= countif(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail" ) default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "User_Spam_FN";
+  let User_AttackSim_Submission=baseQuery
+  | make-series Count= countif(ActionType == "AttackSimUserSubmission" and SubmissionContentType=="Mail" ) default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "User_AttackSim_Submission";
+  union User_Phish_FN,User_Spam_FN,User_AttackSim_Submission
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Admin review status.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Admin review status.yaml
@@ -1,0 +1,33 @@
+id: 201cb524-b4b4-479a-9637-da35cfa1e30a
+name: User Email Submissions by Admin review status (Mark and Notify)
+description: |
+  This query visualises user submissions where admin also performed 'mark and notify' action on the submission
+description-detailed: |
+  This query visualises user submissions where admin also performed 'mark and notify' action on the submission
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let ReviewResults = CloudAppEvents | where ActionType == "SubmissionNotification" 
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId)
+  | extend Properties = parse_json(RawEventData.ExtendedProperties)
+  | mv-expand element = Properties
+  | where element.Name == "AdminReviewResult"
+  | project SubmissionId, AdminReviewResult = element.Value;
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionId = tostring(parse_json(RawEventData).SubmissionId), SubmissionType = parse_json(RawEventData).SubmissionType
+  | join kind=leftouter ReviewResults on SubmissionId
+  | extend UserReportedAs=iif(SubmissionType == 1, "Phish",iif(SubmissionType == 2, "Junk",iif(SubmissionType == 3, "NotJunk","")))
+  | extend ReviewedAccuracy=iif(UserReportedAs==AdminReviewResult, 1,0)
+  | extend Reviewed=iif(isempty(AdminReviewResult),"Not Reviewed","Reviewed")
+  | project SubmissionId,UserReportedAs,Reviewed,AdminReviewResult, ReviewedAccuracy
+  | summarize count() by Reviewed
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Grading Verdict - FN-FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Grading Verdict - FN-FP.yaml
@@ -1,0 +1,22 @@
+id: abdca3e6-c198-404a-b95c-f09ddfed2027
+name: User Email Submissions (FN-FP) by Grading verdict
+description: |
+  This query visualises the total ammount of user false negative or false positive submissions by the verdict of the submission grading.
+description-detailed: |
+  This query visualises the total ammount of user false negative or false positive submissions by the verdict of the submission grading.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType contains "UserSubmissionTriage" 
+  | extend UserKey = (parse_json(RawEventData)).UserKey, SubmissionState = (parse_json(RawEventData)).SubmissionState,  SubmissionId=(parse_json(RawEventData)).SubmissionId, TriageVerdict=(parse_json(RawEventData)).GradingResult.TriageVerdict 
+  | summarize count() by tostring(TriageVerdict)
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Submission State - FN
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Submission State - FN
@@ -1,0 +1,23 @@
+id: fb193897-6ede-44c3-85e3-f45acd762017
+name: User Email Submissions (FN) by Submission State
+description: |
+  This query visualises the total ammount of user false negative submissions by the state of the submission.
+description-detailed: |
+  This query visualises the total ammount of user false negative submissions by the state of the submission.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType contains "UserSubmission" 
+  | extend Record = (parse_json(RawEventData)).RecordType,SubmissionState = parse_json(RawEventData).SubmissionState,SubmissionId=parse_json(RawEventData).SubmissionId,SubmissionType = parse_json(RawEventData).SubmissionType,SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType)
+  | where Record == 29 and SubmissionType in ("0","1")
+  | summarize count() by tostring(SubmissionState)
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Submission Type.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions by Submission Type.yaml
@@ -1,0 +1,28 @@
+id: 289283e9-9f63-488c-8d62-fe9c598f3cd5
+name: User Email Submissions (FN) by Submission Type
+description: |
+  This query visualises the total ammount of user false negative submission by submission type, including the phish simulations reported emails
+description-detailed: |
+  This query visualises the total ammount of user false negative submission by submission type, including the phish simulations reported emails
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType contains "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType)
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN",
+  iff(ActionType == "AttackSimUserSubmission" and SubmissionContentType=="Mail","User_AttackSim_Submission",
+  "Other")))
+  | where User_SubmissionType!="Other"
+  | summarize count() by User_SubmissionType
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions from Junk Folder.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions from Junk Folder.yaml
@@ -1,0 +1,29 @@
+id: 300b0d05-e99e-4349-ab2b-ec12ff5c2da1
+name: User email submissions (FN) from Junk Folder
+description: |
+  This query visualises the total ammount of user false negative submissions from the junk folder
+description-detailed: |
+  This query visualises the total ammount of user false negative submissions that are already detected by MDO and already delivered in the junk folder
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents 
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId=AccountObjectId
+  | extend User_SubmissionType=
+  iff(SubmissionType == "1" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Phish_FN",
+  iff(SubmissionType == "0" and ActionType == "UserSubmission" and SubmissionContentType=="Mail","User_Spam_FN","Other")),
+  NetworkMessageId=tostring((parse_json(RawEventData).ObjectId))
+  | where SubmissionContentType == "Mail" and SubmissionType in ("1","0")
+  | join EmailEvents on NetworkMessageId, RecipientObjectId
+  | where DeliveryLocation == "Junk folder"
+  | summarize count() by ThreatTypes,User_SubmissionType
+  | project ThreatTypes,User_SubmissionType, Emails = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions from Junk Folder.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Submissions/User Submissions from Junk Folder.yaml
@@ -9,6 +9,7 @@ requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
   - CloudAppEvents
+  - EmailEvents
 tactics:
   - InitialAccess
 relevantTechniques:


### PR DESCRIPTION
   Change(s):
   - Add 13 new queries, to summarize data related to User Submissions. Added into section for standalone AH queries, as well as Sentinel queries.

   Reason for Change(s):
   - Adding new community queries within Advanced Hunting for customers that do not use Sentinel. Based on queries that are included within the 'Defender for Office 365 Detections and Insights' workbook included with the Defender for Office 365 solution.

   Version Updated:
   - Not Applicable

   Testing Completed:
   - Tested in Advanced Hunting within test tenants

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes