### PR TITLE
Adding more MDO queries on BEC Phish and Spoof

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/CompAuth Failure Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/CompAuth Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: 9d5d0ba9-e1b3-4dbb-9beb-e0f4c7fb6524
+name: CompAuth Failure Trend
+description: |
+  This query visualises total emails with Spoof - Composite Authentication fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - Composite Authentication fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend CompAuthFail = AuthenticationDetails has_any ('CompAuth":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/DKIM Failure Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/DKIM Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: b49ef73f-71c3-4dce-a433-1c89c9ab8935
+name: DKIM Failure Trend
+description: |
+  This query visualises total emails with Spoof - DKIM fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - DKIM fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend DMARCFail = AuthenticationDetails has_any ('DKIM":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/DMARC Failure Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/DMARC Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: 26ca6908-d5f1-43fa-a12b-103ba59841b5
+name: DMARC Failure Trend
+description: |
+  This query visualises total emails with Spoof - DMARC fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - DMARC fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend DMARCFail = AuthenticationDetails has_any ('DMARC":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/SPF Failure Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/SPF Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: 1c76c9d2-a8f3-4a22-be48-0d3454326cca
+name: SPF Failure Trend
+description: |
+  This query visualises total emails with Spoof - SPF fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - SPF fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend DMARCFail = AuthenticationDetails has_any ('SPF":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/Top Spoof DMARC detections by Sender Domain.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/Top Spoof DMARC detections by Sender Domain.yaml
@@ -1,0 +1,26 @@
+id: 633f848f-bb17-4813-81b4-098d277b00f7
+name: Top Spoof DMARC detections by Sender domain (P1/P2)
+description: |
+  This query visualises total emails with Spoof-DMARC fails detections summarizing the data by the top email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain).
+description-detailed: |
+  This query visualises total emails with Spoof-DMARC fails detections summarizing the data by the top email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain). Adding additional insights for total inbound emails and DMARC fail traffic percentage for each sender domain.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Inbound"
+  | summarize TotalEmailCount = count(),
+  DMARCFailCount = countif(DetectionMethods has_any ('Phish":["Spoof DMARC"]')) by P1Sender=SenderMailFromDomain, P2Sender=SenderFromDomain
+  | extend DMARCFail_Traffic_Percentage = todouble(round(DMARCFailCount / todouble(TotalEmailCount) * 100, 2))
+  | where DMARCFailCount !=0
+  | sort by DMARCFailCount desc 
+  | project P1Sender,P2Sender,DMARCFailCount,TotalEmailCount,DMARCFail_Traffic_Percentage
+  | top 10 by DMARCFailCount
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/Top Spoof Intra-Org detections by SenderDomain.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/Top Spoof Intra-Org detections by SenderDomain.yaml
@@ -1,0 +1,26 @@
+id: 11c4556a-0d77-47ba-9564-0818065c270d
+name: Top Spoof intra-org detections by Sender domain (P1/P2)
+description: |
+  This query visualises total emails with Phish-Spoof-internal domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain).
+description-detailed: |
+  This query visualises total emails with Phish-Spoof-internal domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain). Adding additional insights for total inbound emails and Spoof internal domain detection traffic percentage for each sender domain.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Inbound"
+  | summarize TotalEmailCount = count(),
+  SpoofInternalCount = countif(DetectionMethods has_any ('Phish":["Spoof intra-org"]')) by P1Sender=SenderMailFromDomain, P2Sender=SenderFromDomain
+  | extend SpoofInternal_Traffic_Percentage = todouble(round(SpoofInternalCount / todouble(TotalEmailCount) * 100, 2))
+  | where SpoofInternalCount !=0
+  | sort by SpoofInternalCount desc 
+  | project P1Sender,P2Sender,SpoofInternalCount,TotalEmailCount,SpoofInternal_Traffic_Percentage
+  | top 10 by SpoofInternalCount
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/Top Spoof detections by Sender Domain.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Authentication/Top Spoof detections by Sender Domain.yaml
@@ -1,0 +1,26 @@
+id: 09e1ca5e-cc4c-4b89-b585-448cfc1a6579
+name: Top Spoof external domain detections by Sender domain (P1/P2)
+description: |
+  This query visualises total emails with Phish-Spoof-external domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain).
+description-detailed: |
+  This query visualises total emails with Phish-Spoof-external domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain). Adding additional insights for total inbound emails and Spoof external domain detection traffic percentage for each sender domain.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Inbound"
+  | summarize TotalEmailCount = count(),
+  SpoofExternalCount = countif(DetectionMethods has_any ('Phish":["Spoof external domain"]')) by P1Sender=SenderMailFromDomain, P2Sender=SenderFromDomain
+  | extend SpoofExternal_Traffic_Percentage = todouble(round(SpoofExternalCount / todouble(TotalEmailCount) * 100, 2))
+  | where SpoofExternalCount !=0
+  | sort by SpoofExternalCount desc 
+  | project P1Sender,P2Sender,SpoofExternalCount,TotalEmailCount,SpoofExternal_Traffic_Percentage
+  | top 10 by SpoofExternalCount
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology Trend.yaml
@@ -1,0 +1,44 @@
+id: b0fb6dca-bd73-4852-8670-3235e56ffe4d
+name: Impersonation Detections by Detection Technology Trend
+description: |
+  This query visualises total emails with Phish (BEC) Impersonation detections by Detection Technology over time
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Impersonation detections over time summarizing the data daily by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = EmailEvents
+  | where DetectionMethods has "Phish";
+  let bimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Impersonation brand' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Impersonation brand";
+  let dimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Impersonation domain' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Impersonation domain";
+  let uimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Impersonation user' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Impersonation user";
+  let mimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Mailbox intelligence impersonation' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Mailbox intelligence impersonation";
+  union bimp,dimp,uimp,mimp
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology.yaml
@@ -1,0 +1,24 @@
+id: 7017c313-c778-4a23-a15a-9e2f277b216e
+name: Impersonation Detections by Detection Technology
+description: |
+  This query visualises total emails with Phish (BEC) Impersonation detections by Detection Technology
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Impersonation detections by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents 
+  | where DetectionMethods has 'Impersonation' 
+  | project Timestamp, DT=parse_json(DetectionMethods) 
+  | evaluate bag_unpack(DT) 
+  | summarize count() by Phish=tostring(column_ifexists('Phish', ''))
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Impersonation Phishing detections trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Impersonation Phishing detections trend.yaml
@@ -1,0 +1,24 @@
+id: 761e4ddd-6b87-4c00-b033-55c3d0e4fe2e
+name: Impersonation Detections Trend
+description: |
+  This query visualises total emails with Phish (BEC) - Impersonation detections over time.
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Impersonation detections over time summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents 
+  | where DetectionMethods has 'Impersonation' 
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "ImpersonatedEmails"
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology Trend.yaml
@@ -1,0 +1,39 @@
+id: 0f47b36b-0d8e-4a55-b9a7-3dfa4ad5b744
+name: Spoof Detections by Detection Technology Trend
+description: |
+  This query visualises total emails with Phish (BEC) Spoof detections by Detection Technology over time
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Spoof detections over time summarizing the data daily by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = EmailEvents
+  | where DetectionMethods has "Phish";
+  let sdmarc=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Spoof DMARC' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Spoof DMARC";
+  let spoofe=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Spoof external domain' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Spoof external domain";
+  let spoofi=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Spoof intra-org' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Spoof intra-org";
+  union sdmarc, spoofe, spoofi
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology.yaml
@@ -1,0 +1,24 @@
+id: 0d62d79a-38ef-43d5-a884-347024638250
+name: Spoof Detections by Detection Technology
+description: |
+  This query visualises total emails with Phish (BEC) Spoof detections by Detection Technology
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Spoof detections by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents 
+  | where DetectionMethods has 'Spoof' 
+  | project Timestamp, DT=parse_json(DetectionMethods) 
+  | evaluate bag_unpack(DT) 
+  | summarize count() by Phish=tostring(column_ifexists('Phish', ''))
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Spoof detections trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Spoof detections trend.yaml
@@ -1,0 +1,24 @@
+id: 61c73b2b-4c62-4015-8677-f569d1e83b57
+name: Spoof Detections Trend
+description: |
+  This query visualises total emails Business Email Compromise (BEC) Spoofing detections over time summarizing the data daily.
+description-detailed: |
+  This query visualises total emails Business Email Compromise (BEC) Spoofing detections over time summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents 
+  | where DetectionMethods has 'Spoof' 
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "SpoofEmails"
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Top Domains with BEC Threats inbound.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Spoof and Impersonation/Top Domains with BEC Threats inbound.yaml
@@ -1,0 +1,28 @@
+id: 195d52f8-7669-444a-9021-f30c140cb9ac
+name: Top Domains Outbound with Emails with Threats Inbound (Partner BEC)
+description: |
+  This query visualises top outbound recipient domains by outbound email volume and shows total number of inbound emails with Threats from the same domains (as inbound senders)
+description-detailed: |
+  This query visualises top outbound recipient domains by outbound email volume and shows total number of inbound emails with Threats from the same domains (as inbound senders)
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Outbound"
+  | project RecipientDomain = tostring(split(RecipientEmailAddress, "@")[1])
+  | summarize count() by RecipientDomain
+  | project OutboundCount=count_, RecipientDomain, SenderFromDomain=RecipientDomain
+  | join (EmailEvents | where EmailDirection == "Inbound" and isempty(ThreatTypes)==false) on SenderFromDomain
+  | summarize max(OutboundCount),count() by SenderFromDomain
+  | project SenderFromDomain, OutboundEmails=max_OutboundCount, IncomingEmailsWithThreats=count_
+  | sort by OutboundEmails
+version: 1.0.0
+
+

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/CompAuth Failure Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/CompAuth Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: eb560458-d96f-4c68-acbb-14b3c706ebe7
+name: CompAuth Failure Trend
+description: |
+  This query visualises total emails with Spoof - Composite Authentication fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - Composite Authentication fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend CompAuthFail = AuthenticationDetails has_any ('CompAuth":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/DKIM Failure Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/DKIM Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: 14d47b2a-62b3-4c7b-819c-699e264c581d
+name: DKIM Failure Trend
+description: |
+  This query visualises total emails with Spoof - DKIM fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - DKIM fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend DMARCFail = AuthenticationDetails has_any ('DKIM":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/DMARC Failure Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/DMARC Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: 62d6a2e6-4583-4538-a476-a5b3c672657b
+name: DMARC Failure Trend
+description: |
+  This query visualises total emails with Spoof - DMARC fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - DMARC fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend DMARCFail = AuthenticationDetails has_any ('DMARC":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/SPF Failure Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/SPF Failure Trend.yaml
@@ -1,0 +1,23 @@
+id: 79755078-7be8-4f13-a8e7-1ce87cb7d5c0
+name: SPF Failure Trend
+description: |
+  This query visualises total emails with Spoof - SPF fails summarizing the data daily.
+description-detailed: |
+  This query visualises total emails with Spoof - SPF fails summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | extend DMARCFail = AuthenticationDetails has_any ('SPF":"fail') 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/Top Spoof DMARC detections by Sender Domain.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/Top Spoof DMARC detections by Sender Domain.yaml
@@ -1,0 +1,26 @@
+id: 23b646e8-b885-4cde-a9ab-1e35fa5e37a7
+name: Top Spoof DMARC detections by Sender domain (P1/P2)
+description: |
+  This query visualises total emails with Spoof-DMARC fails detections summarizing the data by the top email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain).
+description-detailed: |
+  This query visualises total emails with Spoof-DMARC fails detections summarizing the data by the top email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain). Adding additional insights for total inbound emails and DMARC fail traffic percentage for each sender domain.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Inbound"
+  | summarize TotalEmailCount = count(),
+  DMARCFailCount = countif(DetectionMethods has_any ('Phish":["Spoof DMARC"]')) by P1Sender=SenderMailFromDomain, P2Sender=SenderFromDomain
+  | extend DMARCFail_Traffic_Percentage = todouble(round(DMARCFailCount / todouble(TotalEmailCount) * 100, 2))
+  | where DMARCFailCount !=0
+  | sort by DMARCFailCount desc 
+  | project P1Sender,P2Sender,DMARCFailCount,TotalEmailCount,DMARCFail_Traffic_Percentage
+  | top 10 by DMARCFailCount
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/Top Spoof Intra-Org detections by SenderDomain.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/Top Spoof Intra-Org detections by SenderDomain.yaml
@@ -1,0 +1,26 @@
+id: ba97d6b9-f82e-4917-9c07-4c0028bbd32d
+name: Top Spoof intra-org detections by Sender domain (P1/P2)
+description: |
+  This query visualises total emails with Phish-Spoof-internal domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain).
+description-detailed: |
+  This query visualises total emails with Phish-Spoof-internal domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain). Adding additional insights for total inbound emails and Spoof internal domain detection traffic percentage for each sender domain.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Inbound"
+  | summarize TotalEmailCount = count(),
+  SpoofInternalCount = countif(DetectionMethods has_any ('Phish":["Spoof intra-org"]')) by P1Sender=SenderMailFromDomain, P2Sender=SenderFromDomain
+  | extend SpoofInternal_Traffic_Percentage = todouble(round(SpoofInternalCount / todouble(TotalEmailCount) * 100, 2))
+  | where SpoofInternalCount !=0
+  | sort by SpoofInternalCount desc 
+  | project P1Sender,P2Sender,SpoofInternalCount,TotalEmailCount,SpoofInternal_Traffic_Percentage
+  | top 10 by SpoofInternalCount
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/Top Spoof detections by Sender Domain.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Authentication/Top Spoof detections by Sender Domain.yaml
@@ -1,0 +1,26 @@
+id: 3dbaa9c1-5e69-40a9-bacb-8cbdb4a0e6cb
+name: Top Spoof external domain detections by Sender domain (P1/P2)
+description: |
+  This query visualises total emails with Phish-Spoof-external domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain).
+description-detailed: |
+  This query visualises total emails with Phish-Spoof-external domain detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain) and sender P1 domain (SenderMailFromDomain). Adding additional insights for total inbound emails and Spoof external domain detection traffic percentage for each sender domain.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Inbound"
+  | summarize TotalEmailCount = count(),
+  SpoofExternalCount = countif(DetectionMethods has_any ('Phish":["Spoof external domain"]')) by P1Sender=SenderMailFromDomain, P2Sender=SenderFromDomain
+  | extend SpoofExternal_Traffic_Percentage = todouble(round(SpoofExternalCount / todouble(TotalEmailCount) * 100, 2))
+  | where SpoofExternalCount !=0
+  | sort by SpoofExternalCount desc 
+  | project P1Sender,P2Sender,SpoofExternalCount,TotalEmailCount,SpoofExternal_Traffic_Percentage
+  | top 10 by SpoofExternalCount
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology Trend.yaml
@@ -1,0 +1,44 @@
+id: 418e8859-b22a-4fd4-b273-5433e054cdc7
+name: Impersonation Detections by Detection Technology Trend
+description: |
+  This query visualises total emails with Phish (BEC) Impersonation detections by Detection Technology over time
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Impersonation detections over time summarizing the data daily by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = EmailEvents
+  | where DetectionMethods has "Phish";
+  let bimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Impersonation brand' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Impersonation brand";
+  let dimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Impersonation domain' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Impersonation domain";
+  let uimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Impersonation user' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Impersonation user";
+  let mimp=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Mailbox intelligence impersonation' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Mailbox intelligence impersonation";
+  union bimp,dimp,uimp,mimp
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Impersonation Phishing detections by Detection Technology.yaml
@@ -1,0 +1,24 @@
+id: 15a17150-811d-4829-a3d6-489139c9ff5e
+name: Impersonation Detections by Detection Technology
+description: |
+  This query visualises total emails with Phish (BEC) Impersonation detections by Detection Technology
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Impersonation detections by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents 
+  | where DetectionMethods has 'Impersonation' 
+  | project Timestamp, DT=parse_json(DetectionMethods) 
+  | evaluate bag_unpack(DT) 
+  | summarize count() by Phish=tostring(column_ifexists('Phish', ''))
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Impersonation Phishing detections trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Impersonation Phishing detections trend.yaml
@@ -1,0 +1,24 @@
+id: 416cd270-6327-441a-9304-940c832cf361
+name: Impersonation Detections Trend
+description: |
+  This query visualises total emails with Phish (BEC) - Impersonation detections over time.
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Impersonation detections over time summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents 
+  | where DetectionMethods has 'Impersonation' 
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "ImpersonatedEmails"
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology Trend.yaml
@@ -1,0 +1,39 @@
+id: 1dce39ec-8a64-4e49-9d6e-926ee6f04c39
+name: Spoof Detections by Detection Technology Trend
+description: |
+  This query visualises total emails with Phish (BEC) Spoof detections by Detection Technology over time
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Spoof detections over time summarizing the data daily by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let baseQuery = EmailEvents
+  | where DetectionMethods has "Phish";
+  let sdmarc=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Spoof DMARC' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Spoof DMARC";
+  let spoofe=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Spoof external domain' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Spoof external domain";
+  let spoofi=baseQuery
+  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
+  | where Phish has 'Spoof intra-org' 
+  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "Spoof intra-org";
+  union sdmarc, spoofe, spoofi
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Spoof detections by Detection Technology.yaml
@@ -1,0 +1,24 @@
+id: 53139a92-eb64-46d2-be97-e752a71e7021
+name: Spoof Detections by Detection Technology
+description: |
+  This query visualises total emails with Phish (BEC) Spoof detections by Detection Technology
+description-detailed: |
+  This query visualises total emails with Phish Business Email Compromise (BEC) Spoof detections by various Impersonation Detection technologies/controls in Microsoft Defender for Office 365.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents 
+  | where DetectionMethods has 'Spoof' 
+  | project Timestamp, DT=parse_json(DetectionMethods) 
+  | evaluate bag_unpack(DT) 
+  | summarize count() by Phish=tostring(column_ifexists('Phish', ''))
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Spoof detections trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Spoof detections trend.yaml
@@ -1,0 +1,24 @@
+id: 09b263e1-9c73-4585-a55c-bc209e148e14
+name: Spoof Detections Trend
+description: |
+  This query visualises total emails Business Email Compromise (BEC) Spoofing detections over time summarizing the data daily.
+description-detailed: |
+  This query visualises total emails Business Email Compromise (BEC) Spoofing detections over time summarizing the data daily.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents 
+  | where DetectionMethods has 'Spoof' 
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
+  | extend Details = "SpoofEmails"
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Top Domains with BEC Threats inbound.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Spoof and Impersonation/Top Domains with BEC Threats inbound.yaml
@@ -1,0 +1,28 @@
+id: f9442d20-eff8-4751-9a75-6451aeace687
+name: Top Domains Outbound with Emails with Threats Inbound (Partner BEC)
+description: |
+  This query visualises top outbound recipient domains by outbound email volume and shows total number of inbound emails with Threats from the same domains (as inbound senders)
+description-detailed: |
+  This query visualises top outbound recipient domains by outbound email volume and shows total number of inbound emails with Threats from the same domains (as inbound senders)
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where EmailDirection == "Outbound"
+  | project RecipientDomain = tostring(split(RecipientEmailAddress, "@")[1])
+  | summarize count() by RecipientDomain
+  | project OutboundCount=count_, RecipientDomain, SenderFromDomain=RecipientDomain
+  | join (EmailEvents | where EmailDirection == "Inbound" and isempty(ThreatTypes)==false) on SenderFromDomain
+  | summarize max(OutboundCount),count() by SenderFromDomain
+  | project SenderFromDomain, OutboundEmails=max_OutboundCount, IncomingEmailsWithThreats=count_
+  | sort by OutboundEmails
+version: 1.0.0
+
+


### PR DESCRIPTION
   Change(s):
   - Adding 14 new Phish Business Email Compromise (BEC) and Spoof hunting queries for MDO, to ensure full parity with the Sentinel workbook. Added into section for standalone AH queries, as well as Sentinel queries.

   Reason for Change(s):
   - Adding new community queries within Advanced Hunting for customers that do not use Sentinel. Based on queries that are included within the 'Defender for Office 365 Detections and Insights' workbook included with the Defender for Office 365 solution.

   Version Updated:
   - Not Applicable

   Testing Completed:
   - Tested in Advanced Hunting within test tenants

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes