### PR TITLE
Add new MDO reports on Spam/Phish detections based on delivery locations

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Mailflow/Spam Detections by Delivery Location - High.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Mailflow/Spam Detections by Delivery Location - High.yaml
@@ -1,0 +1,23 @@
+id: 42b9d582-8519-4217-a6b3-996326e55257
+name: Spam Detections (High) by delivery location
+description: |
+  This query visualises emails with Spam detections (High confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Spam detections (High confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Spam":"High')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Mailflow/Spam Detections by Delivery Location - Medium.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Mailflow/Spam Detections by Delivery Location - Medium.yaml
@@ -1,0 +1,23 @@
+id: 3f314fd9-332a-4d41-93f1-e9fca59e9bb0
+name: Spam Detections (Normal) by delivery location
+description: |
+  This query visualises emails with Spam detections (Normal confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Spam detections (Normal confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Spam":"Normal')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
@@ -3,7 +3,7 @@ name: Phish Detections (High) by delivery location
 description: |
   This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location.
 description-detailed: |
-  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location.
   Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
@@ -1,0 +1,23 @@
+id: 1617b8b1-df75-4b28-8379-29930c0f46fc
+name: Phish Detections (High) by delivery location
+description: |
+  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Phish":"High')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location - Medium.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location - Medium.yaml
@@ -1,0 +1,23 @@
+id: bfdb25dd-1cc0-46da-9545-9aa92d53e2c8
+name: Phish Detections (Normal) by delivery location
+description: |
+  This query visualises emails with Phish detections (Normal confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Phish detections (Normal confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Phish":"Normal')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Phish/Phish Detections by Delivery Location Trend.yaml
@@ -1,5 +1,5 @@
 id: fbe8abde-83b3-4e16-af08-f8f7db9a9028
-name: Phish Detections by delivery location
+name: Phish Detections by delivery location trend
 description: |
   This query visualises total emails with Phish detections over time summarizing the data daily by Delivery Location.
 description-detailed: |

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Mailflow/Spam Detections by Delivery Location - High.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Mailflow/Spam Detections by Delivery Location - High.yaml
@@ -1,0 +1,23 @@
+id: 45c47684-6650-44b6-81c0-951522d0c435
+name: Spam Detections (High) by delivery location
+description: |
+  This query visualises emails with Spam detections (High confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Spam detections (High confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Spam":"High')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Mailflow/Spam Detections by Delivery Location - Medium.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Mailflow/Spam Detections by Delivery Location - Medium.yaml
@@ -1,0 +1,23 @@
+id: 99e1246e-c1a9-4794-8e96-eb906c73c529
+name: Spam Detections (Normal) by delivery location
+description: |
+  This query visualises emails with Spam detections (Normal confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Spam detections (Normal confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Spam":"Normal')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
@@ -1,0 +1,23 @@
+id: 76c77c8a-bd2a-489a-af52-97291211e4e4
+name: Phish Detections (High) by delivery location
+description: |
+  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Phish":"High')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location - High.yaml
@@ -3,7 +3,7 @@ name: Phish Detections (High) by delivery location
 description: |
   This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location.
 description-detailed: |
-  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  This query visualises emails with Phish detections (High confidence) summarizing the data by Delivery Location.
   Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location - Medium.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location - Medium.yaml
@@ -1,0 +1,23 @@
+id: 4d86021c-cad7-489b-a8c8-dddecb87a2ef
+name: Phish Detections (Normal) by delivery location
+description: |
+  This query visualises emails with Phish detections (Normal confidence) summarizing the data by Delivery Location.
+description-detailed: |
+  This query visualises emails with Phish detections (Normal confidence) summarizing the data by Delivery Location which are subject to User/Admin overrides and Policy actions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ConfidenceLevel has_any ('Phish":"Normal')
+  | summarize count() by LatestDeliveryLocation
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Phish/Phish Detections by Delivery Location Trend.yaml
@@ -1,5 +1,5 @@
 id: b20e56b8-e335-43d9-b7b3-43c034c43aea
-name: Phish Detections by delivery location
+name: Phish Detections by delivery location trend
 description: |
   This query visualises total emails with Phish detections over time summarizing the data daily by Delivery Location.
 description-detailed: |


### PR DESCRIPTION
   Change(s):
   - Adding 4 new queries on Spam and Phish detections from MDO, but compared against where are the messages currently delivered (Inbox/Junk/Quarantine/etc) as an indication of possible config issues, or overrides. Added into section for standalone AH queries, as well as Sentinel queries.

   Reason for Change(s):
   - Adding new community queries within Advanced Hunting for customers that do not use Sentinel. Based on queries that are included within the 'Defender for Office 365 Detections and Insights' workbook included with the Defender for Office 365 solution.

   Version Updated:
   - Not Applicable

   Testing Completed:
   - Tested in Advanced Hunting within test tenants

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes