### PR TITLE
Resolved VPC Flow Log Location aware issue

### DIFF
--- a/DataConnectors/AWS-S3/Utils/AwsResourceCreator.ps1
+++ b/DataConnectors/AWS-S3/Utils/AwsResourceCreator.ps1
@@ -157,8 +157,9 @@ function New-S3Bucket
                 }
                 else
                 {
+                    $locationConfig = "{""LocationConstraint"":""$regionConfiguration""}"
                     Write-Log "Executing: aws s3api create-bucket --bucket $bucketName --create-bucket-configuration LocationConstraint=$regionConfiguration 2>&1" -LogFileName $LogFileName -Severity Verbose
-                    $tempForOutput = aws s3api create-bucket --bucket $bucketName --create-bucket-configuration LocationConstraint=$regionConfiguration 2>&1
+                    $tempForOutput = aws s3api create-bucket --bucket $bucketName --create-bucket-configuration $locationConfig 2>&1
                     Write-Log -Message $tempForOutput -LogFileName $LogFileName -Severity Verbose
                 }
                     


### PR DESCRIPTION

   
   Change(s):
   - The change introduces a new `$locationConfig` variable to store the `LocationConstraint` value as a JSON-formatted string, which is then used in the `aws s3api create-bucket` command. 

   Reason for Change(s):
   - As described in issue when Customer tried to create resource with different location for VPC then script is failed with error to create new bucket. 

   Version Updated:
   - NA

   Testing Completed:
   - Yes

