### PR TITLE
Change " DomainEntity_EmailUrlInfo_Updated.yaml" Rule under Threat intelligence (NEW) to use the New Threat intel table and remapped fields accordingly

### DIFF
--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -45,7 +45,7 @@ query: |
     | where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
     | where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
     | summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
-     extend Description = tostring(parse_json(Data).description)
+    | extend Description = tostring(parse_json(Data).description)
     | extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
     | project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
     let TI_Domains = ThreatIntelIndicators

--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -25,53 +25,53 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-	let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
-	let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
-	let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
-	| where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
-	| extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
-	| extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
-	let EmailEvents_ = EmailEvents
-	| where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
-	let TI_Urls = ThreatIntelIndicators
-	| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-	| extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
-	| where isnotempty(IndicatorType) and IndicatorType == "url"
-	| extend Url = ObservableValue
-	| where isnotempty(Url) // Filter for non-empty URLs
-	| extend Url = tolower(Url) // Convert URLs to lowercase
-	| join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
-	| where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
-	| where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
-	| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
-	| extend Description = tostring(parse_json(Data).description)
-	| extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
-	| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
-	let TI_Domains = ThreatIntelIndicators
-	| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-	| where isnotempty(ObservableValue) // Filter for non-empty domain names
-	| where ObservableKey == "domain-name:value"
-	| extend Active = IsActive
-	| extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
-	| extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
-	| extend IndicatorId = tostring(split(Id, "--")[2]);
-	let TI_Domains_UrlInfo = TI_Domains
-	| project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
-	| join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
-	| extend ExpirationDateTime = ValidUntil
-	| extend Description = Data.description
-	| extend ThreatType =  Data.type
-	| extend ConfidenceScore = Confidence
-	| extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
-	| where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
-	| where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
-	| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
-	| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
-	union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
-	| extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
-	| join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
-	| where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
-	| extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
+let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
+let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
+let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
+| where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
+| extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
+| extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
+let EmailEvents_ = EmailEvents
+| where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
+let TI_Urls = ThreatIntelIndicators
+| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+| extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
+| where isnotempty(IndicatorType) and IndicatorType == "url"
+| extend Url = ObservableValue
+| where isnotempty(Url) // Filter for non-empty URLs
+| extend Url = tolower(Url) // Convert URLs to lowercase
+| join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
+| where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
+| where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
+| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
+| extend Description = tostring(parse_json(Data).description)
+| extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
+| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
+let TI_Domains = ThreatIntelIndicators
+| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+| where isnotempty(ObservableValue) // Filter for non-empty domain names
+| where ObservableKey == "domain-name:value"
+| extend Active = IsActive
+| extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
+| extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
+| extend IndicatorId = tostring(split(Id, "--")[2]);
+let TI_Domains_UrlInfo = TI_Domains
+| project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
+| join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
+| extend ExpirationDateTime = ValidUntil
+| extend Description = Data.description
+| extend ThreatType =  Data.type
+| extend ConfidenceScore = Confidence
+| extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
+| where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
+| where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
+| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
+| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
+union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
+| extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
+| join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
+| where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
+| extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -27,7 +27,8 @@ relevantTechniques:
 query: |
     let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
     let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
-    let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
+    let EmailUrlInfo_ = EmailUrlInfo
+    | where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
     | where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
     | extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
     | extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated

--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -85,5 +85,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: Url
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -25,46 +25,53 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-    let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
-    let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
-    let EmailUrlInfo_ = EmailUrlInfo
-    | where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
-    | where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
-    | extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
-    | extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
-    let EmailEvents_ = EmailEvents
-    | where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
-    let TI_Urls = ThreatIntelIndicators
-    | where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-    | extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
-    | where isnotempty(IndicatorType) and IndicatorType == "url"
-    | extend Url = ObservableValue
-    | where isnotempty(Url) // Filter for non-empty URLs
-    | extend Url = tolower(Url) // Convert URLs to lowercase
-    | join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
-    | where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
-    | where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
-    | summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
-    | extend Description = tostring(parse_json(Data).description)
-    | extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
-    | project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
-    let TI_Domains = ThreatIntelligenceIndicator
-    | where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-    | where isnotempty(DomainName) // Filter for non-empty domain names
-    | extend DomainName = tolower(DomainName) // Convert domain names to lowercase
-    | extend IndicatorId = tostring(split(IndicatorId, "--")[2]);
-    TI_Domains
-    | project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Url, Type
-    | join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
-    | where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
-    | where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
-    | summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
-    | project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
-    union TI_Urls, TI_Domains // Combine URL and domain threat intelligence data
-    | extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
-    | join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
-    | where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
-    | extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address
+		let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
+		let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
+		let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
+		| where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
+		| extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
+		| extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
+		let EmailEvents_ = EmailEvents
+		| where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
+		let TI_Urls = ThreatIntelIndicators
+		| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+		| extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
+		| where isnotempty(IndicatorType) and IndicatorType == "url"
+		| extend Url = ObservableValue
+		| where isnotempty(Url) // Filter for non-empty URLs
+		| extend Url = tolower(Url) // Convert URLs to lowercase
+		| join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
+		| where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
+		| where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
+		| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
+		| extend Description = tostring(parse_json(Data).description)
+		| extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
+		| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
+		let TI_Domains = ThreatIntelIndicators
+		| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+		| where isnotempty(ObservableValue) // Filter for non-empty domain names
+		| where ObservableKey == "domain-name:value"
+		| extend Active = IsActive
+		| extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
+		| extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
+		| extend IndicatorId = tostring(split(Id, "--")[2]);
+		let TI_Domains_UrlInfo = TI_Domains
+		| project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
+		| join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
+		| extend ExpirationDateTime = ValidUntil
+		| extend Description = Data.description
+		| extend ThreatType =  Data.type
+		| extend ConfidenceScore = Confidence
+		| extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
+		| where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
+		| where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
+		| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
+		| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
+		union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
+		| extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
+		| join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
+		| where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
+		| extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -25,53 +25,53 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-		let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
-		let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
-		let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
-		| where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
-		| extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
-		| extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
-		let EmailEvents_ = EmailEvents
-		| where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
-		let TI_Urls = ThreatIntelIndicators
-		| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-		| extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
-		| where isnotempty(IndicatorType) and IndicatorType == "url"
-		| extend Url = ObservableValue
-		| where isnotempty(Url) // Filter for non-empty URLs
-		| extend Url = tolower(Url) // Convert URLs to lowercase
-		| join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
-		| where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
-		| where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
-		| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
-		| extend Description = tostring(parse_json(Data).description)
-		| extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
-		| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
-		let TI_Domains = ThreatIntelIndicators
-		| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-		| where isnotempty(ObservableValue) // Filter for non-empty domain names
-		| where ObservableKey == "domain-name:value"
-		| extend Active = IsActive
-		| extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
-		| extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
-		| extend IndicatorId = tostring(split(Id, "--")[2]);
-		let TI_Domains_UrlInfo = TI_Domains
-		| project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
-		| join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
-		| extend ExpirationDateTime = ValidUntil
-		| extend Description = Data.description
-		| extend ThreatType =  Data.type
-		| extend ConfidenceScore = Confidence
-		| extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
-		| where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
-		| where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
-		| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
-		| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
-		union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
-		| extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
-		| join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
-		| where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
-		| extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
+	let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
+	let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
+	let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
+	| where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
+	| extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
+	| extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
+	let EmailEvents_ = EmailEvents
+	| where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
+	let TI_Urls = ThreatIntelIndicators
+	| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+	| extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
+	| where isnotempty(IndicatorType) and IndicatorType == "url"
+	| extend Url = ObservableValue
+	| where isnotempty(Url) // Filter for non-empty URLs
+	| extend Url = tolower(Url) // Convert URLs to lowercase
+	| join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
+	| where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
+	| where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
+	| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
+	| extend Description = tostring(parse_json(Data).description)
+	| extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
+	| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
+	let TI_Domains = ThreatIntelIndicators
+	| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+	| where isnotempty(ObservableValue) // Filter for non-empty domain names
+	| where ObservableKey == "domain-name:value"
+	| extend Active = IsActive
+	| extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
+	| extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
+	| extend IndicatorId = tostring(split(Id, "--")[2]);
+	let TI_Domains_UrlInfo = TI_Domains
+	| project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
+	| join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
+	| extend ExpirationDateTime = ValidUntil
+	| extend Description = Data.description
+	| extend ThreatType =  Data.type
+	| extend ConfidenceScore = Confidence
+	| extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
+	| where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
+	| where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
+	| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
+	| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
+	union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
+	| extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
+	| join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
+	| where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
+	| extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
 entityMappings:
   - entityType: Account
     fieldMappings:

--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/DomainEntity_EmailUrlInfo_Updated.yaml
@@ -25,53 +25,53 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
-let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
-let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
-| where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
-| extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
-| extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
-let EmailEvents_ = EmailEvents
-| where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
-let TI_Urls = ThreatIntelIndicators
-| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-| extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
-| where isnotempty(IndicatorType) and IndicatorType == "url"
-| extend Url = ObservableValue
-| where isnotempty(Url) // Filter for non-empty URLs
-| extend Url = tolower(Url) // Convert URLs to lowercase
-| join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
-| where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
-| where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
-| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
-| extend Description = tostring(parse_json(Data).description)
-| extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
-| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
-let TI_Domains = ThreatIntelIndicators
-| where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
-| where isnotempty(ObservableValue) // Filter for non-empty domain names
-| where ObservableKey == "domain-name:value"
-| extend Active = IsActive
-| extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
-| extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
-| extend IndicatorId = tostring(split(Id, "--")[2]);
-let TI_Domains_UrlInfo = TI_Domains
-| project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
-| join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
-| extend ExpirationDateTime = ValidUntil
-| extend Description = Data.description
-| extend ThreatType =  Data.type
-| extend ConfidenceScore = Confidence
-| extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
-| where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
-| where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
-| summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
-| project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
-union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
-| extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
-| join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
-| where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
-| extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
+    let dt_lookBack = 1h; // Define the lookback period for email data as 1 hour
+    let ioc_lookBack = 14d; // Define the lookback period for threat intelligence data as 14 days
+    let EmailUrlInfo_ = EmailUrlInfo| where isnotempty(Url) or isnotempty(UrlDomain) // Filter for non-empty URLs or URL domains
+    | where TimeGenerated >= ago(dt_lookBack) // Filter for records within the lookback period
+    | extend Url = tolower(Url), UrlDomain = tolower(UrlDomain) // Convert URLs and domains to lowercase
+    | extend EmailUrlInfo_TimeGenerated = TimeGenerated; // Create a new column for the time generated
+    let EmailEvents_ = EmailEvents
+    | where TimeGenerated >= ago(dt_lookBack); // Filter email events within the lookback period
+    let TI_Urls = ThreatIntelIndicators
+    | where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+    | extend IndicatorType = replace(@"\[|\]|\""", "", tostring(split(ObservableKey, ":", 0)))
+    | where isnotempty(IndicatorType) and IndicatorType == "url"
+    | extend Url = ObservableValue
+    | where isnotempty(Url) // Filter for non-empty URLs
+    | extend Url = tolower(Url) // Convert URLs to lowercase
+    | join kind=innerunique (EmailUrlInfo_) on Url // Join with email URL info on URL
+    | where IsActive == true and ValidUntil > now() // Filter for active indicators that haven't expired
+    | where EmailUrlInfo_TimeGenerated < ValidUntil // Ensure email info was generated before the indicator expired
+    | summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by Id, Url // Get the latest email info for each indicator
+     extend Description = tostring(parse_json(Data).description)
+    | extend ActivityGroupNames = extract("ActivityGroup:([^,]+)", 1, tostring(parse_json(Data).labels))
+    | project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, Url, UrlLocation, NetworkMessageId; // Select relevant columns
+    let TI_Domains = ThreatIntelIndicators
+    | where TimeGenerated >= ago(ioc_lookBack) // Filter threat intelligence indicators within the lookback period
+    | where isnotempty(ObservableValue) // Filter for non-empty domain names
+    | where ObservableKey == "domain-name:value"
+    | extend Active = IsActive
+    | extend TrafficLightProtocolLevel = AdditionalFields.TLPLevel
+    | extend DomainName = tolower(ObservableValue) // Convert domain names to lowercase
+    | extend IndicatorId = tostring(split(Id, "--")[2]);
+    let TI_Domains_UrlInfo = TI_Domains
+    | project-reorder *, Active, Tags, TrafficLightProtocolLevel, DomainName, Type
+    | join kind=innerunique (EmailUrlInfo_) on $left.DomainName == $right.UrlDomain // Join with email URL info on domain name
+    | extend ExpirationDateTime = ValidUntil
+    | extend Description = Data.description
+    | extend ThreatType =  Data.type
+    | extend ConfidenceScore = Confidence
+    | extend ActivityGroupNames = replace_string(tostring(parse_json(tostring(Data.labels))[0]),"ActivityGroup:","")
+    | where Active == true and ExpirationDateTime > now() // Filter for active indicators that haven't expired
+    | where EmailUrlInfo_TimeGenerated < ExpirationDateTime // Ensure email info was generated before the indicator expired
+    | summarize EmailUrlInfo_TimeGenerated = arg_max(EmailUrlInfo_TimeGenerated, *) by IndicatorId, UrlDomain // Get the latest email info for each indicator
+    | project EmailUrlInfo_TimeGenerated, Description, ActivityGroupNames, IndicatorId, ThreatType, ExpirationDateTime, ConfidenceScore, UrlDomain, UrlLocation, NetworkMessageId; // Select relevant columns
+    union TI_Urls, TI_Domains_UrlInfo // Combine URL and domain threat intelligence data
+    | extend timestamp = EmailUrlInfo_TimeGenerated // Add a timestamp column
+    | join kind=inner (EmailEvents_) on NetworkMessageId // Join with email events on network message ID
+    | where DeliveryAction !has "Blocked" // Filter out blocked delivery actions
+    | extend Name = tostring(split(RecipientEmailAddress, '@', 0)[0]), UPNSuffix = tostring(split(RecipientEmailAddress, '@', 1)[0]); // Extract name and UPN suffix from recipient email address"
 entityMappings:
   - entityType: Account
     fieldMappings:


### PR DESCRIPTION
  
   Change(s):
   - Change " DomainEntity_EmailUrlInfo_Updated.yaml" Rule under Threat intelligence (NEW) to use the New Threat intel table and remapped fields accordingly

   Reason for Change(s):
   - One of the let statements refers to the legacy table line 51

   Version Updated:
   - Yes
   - Version changed from 1.0.3 to 1.0.4
   
   Testing Completed:
   -![image](https://github.com/user-attachments/assets/0267cbd6-de82-4fb2-8c5e-58f5a93cfbe0)

   Checked that the validations are passing and have addressed any issues that are present:
   - Checks Pass
   - checked rule is valid YAML file
