### PR TITLE
Update Shodan playbooks deployment instructions and links

### DIFF
--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/azuredeploy.json
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/azuredeploy.json
@@ -6,11 +6,15 @@
         "description": "This playbook can be triggered manually from a Domain Entity context to fetch geo location and running services details from Shodan.io.",
         "prerequisites": [
             "1. Prior to the deployment of this playbook, Shodan Custom Connector needs to be deployed under the same subscription.",
-            "2. Refer to [Shodan Logic App Custom Connector](../../CustomConnector/ShodanCustomConnector/readme.md) documentation for deployment instructions."
+            "2. Refer to [Shodan Logic App Custom Connector](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/CustomConnector/ShodanCustomConnector/readme.md) documentation for deployment instructions."
         ],
-        "postDeployment": [ "None" ],
+        "postDeployment": [
+            "1. Authorize/Configure all the connections in the playbook.",
+            "2. Assign Microsoft Sentinel Responder role to the playbook.",
+            "[click here for detail instructions](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/readme.md)"
+        ],
         "prerequisitesDeployTemplateFile": "../../CustomConnector/ShodanCustomConnector/azuredeploy.json",
-        "lastUpdateTime": "2023-01-31T00:00:00Z",
+        "lastUpdateTime": "2025-07-08T00:00:00Z",
         "entities": [
             "dnsresolution"
         ],

--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/azuredeploy.json
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/azuredeploy.json
@@ -11,7 +11,7 @@
         "postDeployment": [
             "1. Authorize/Configure all the connections in the playbook.",
             "2. Assign Microsoft Sentinel Responder role to the playbook.",
-            "[click here for detail instructions](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/readme.md)"
+            "[click here for detail instructions](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/readme.md)"
         ],
         "prerequisitesDeployTemplateFile": "../../CustomConnector/ShodanCustomConnector/azuredeploy.json",
         "lastUpdateTime": "2025-07-08T00:00:00Z",

--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/readme.md
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichDomain-EntityTrigger/readme.md
@@ -48,7 +48,7 @@ Once deployment is complete, authorize each connection.
 7. Select Subscription - where Playbook has been created
 8. Select Resource group - where Playbook has been created
 9. Select Role - Microsoft Sentinel Responder
-10. Click Save (It takes 3-5 minutes to show the added role.)
+10. Click Save
 
 #  References
  - [Shodan API Quick Reference](https://developer.shodan.io/api)

--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/azuredeploy.json
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/azuredeploy.json
@@ -6,11 +6,15 @@
         "description": "This playbook can be triggered manually from an IP Address Entity context to fetch geo location and running services details from Shodan.io.",
         "prerequisites": [
             "1. Prior to the deployment of this playbook, Shodan Custom Connector needs to be deployed under the same subscription.",
-            "2. Refer to [Shodan Logic App Custom Connector](../../CustomConnector/ShodanCustomConnector/readme.md) documentation for deployment instructions."
+            "2. Refer to [Shodan Logic App Custom Connector](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/CustomConnector/ShodanCustomConnector/readme.md documentation for deployment instructions."
         ],
-        "postDeployment": ["None"],
+        "postDeployment": [
+            "1. Authorize/Configure all the connections in the playbook.",
+            "2. Assign Microsoft Sentinel Responder role to the playbook.",
+            "[click here for detail instructions](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/readme.md)"
+        ],
         "prerequisitesDeployTemplateFile": "../../CustomConnector/ShodanCustomConnector/azuredeploy.json",
-        "lastUpdateTime": "2023-01-31T00:00:00Z",
+        "lastUpdateTime": "2025-07-08T00:00:00Z",
         "entities": [
             "IP"
         ],

--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/readme.md
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIP-EntityTrigger/readme.md
@@ -48,7 +48,7 @@ Once deployment is complete, authorize each connection.
 7. Select Subscription - where Playbook has been created
 8. Select Resource group - where Playbook has been created
 9. Select Role - Microsoft Sentinel Responder
-10. Click Save (It takes 3-5 minutes to show the added role.)
+10. Click Save
 
 #  References
  - [Shodan API Quick Reference](https://developer.shodan.io/api)

--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIPAndDomain/azuredeploy.json
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIPAndDomain/azuredeploy.json
@@ -6,11 +6,15 @@
         "description": "When a new sentinel incident is created, this playbook gets triggered and fetches geo location and running services details for IP addresses and domain names from Shodan.io.",
         "prerequisites": [
             "1. Prior to the deployment of this playbook, Shodan Custom Connector needs to be deployed under the same subscription.",
-            "2. Refer to [Shodan Logic App Custom Connector](../../CustomConnector/ShodanCustomConnector/readme.md) documentation for deployment instructions."
+            "2. Refer to [Shodan Logic App Custom Connector](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/CustomConnector/ShodanCustomConnector/readme.md) documentation for deployment instructions."
         ],
-        "postDeployment": [ "None" ],
+        "postDeployment": [
+            "1. Authorize/Configure all the connections of the playbook.",
+            "2. Assign Microsoft Sentinel Responder role to the playbook.",
+            "[click here for detail instructions](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIPAndDomain/readme.md)"
+        ],
         "prerequisitesDeployTemplateFile": "../../CustomConnector/ShodanCustomConnector/azuredeploy.json",
-        "lastUpdateTime": "2023-01-31T00:00:00Z",
+        "lastUpdateTime": "2025-07-08T00:00:00Z",
         "entities": [
             "IP",
             "dnsresolution"

--- a/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIPAndDomain/readme.md
+++ b/Solutions/Shodan/Playbooks/ShodanPlaybooks/Shodan-EnrichIPAndDomain/readme.md
@@ -56,7 +56,7 @@ Once deployment is complete, authorize each connection.
 7. Select Subscription - where Playbook has been created
 8. Select Resource group - where Playbook has been created
 9. Select Role - Microsoft Sentinel Responder
-10. Click Save (It takes 3-5 minutes to show the added role.)
+10. Click Save
 
 #  References
  - [Shodan API Quick Reference](https://developer.shodan.io/api)


### PR DESCRIPTION
  
   Change(s):
   - Updated deployment templates and documentation for Shodan playbooks to use direct GitHub links for the Shodan Custom Connector documentation, added detailed post-deployment steps, and updated lastUpdateTime fields. Also clarified role assignment instructions in the readme files

   Reason for Change(s):
   - Update for clarity of instructions

   Version Updated:
   - NA
 
   Testing Completed:
   - Yes

   