### PR TITLE
Teams adaptive playbook readme file Updation

### DIFF
--- a/Solutions/Teams/Playbooks/Send-Teams-adaptive-card-on-incident-creation/readme.md
+++ b/Solutions/Teams/Playbooks/Send-Teams-adaptive-card-on-incident-creation/readme.md
@@ -22,7 +22,18 @@ After deployment, attach this playbook to an **automation rule** so it runs when
 # Post-deployment
 1. Assign Microsoft Sentinel Responder role to the Playbook's Managed Identity
 2. Authorize Microsoft Teams connector
-
+3. Make the playbook selectable in Sentinel Automation Rules
+After assigning the required role, the playbook might still appear unavailable (grayed out) when you try to attach it to an automation rule. This is due to Sentinel not having explicit access yet, even though the role was assigned.
+To fix this:
+    a. Go to **Microsoft Sentinel → Automation → Playbooks**
+    b. Locate your playbook (e.g., `Send-Teams-adaptive-card-on-incident-creation`)
+    c. Click the **three dots (...) → Manage playbook permissions**
+    d. In the side panel that opens, select the **Resource Group** where your playbook is deployed
+    e. Click **Apply**
+This allows Sentinel to explicitly recognize the playbook's permissions. After completing this step, the playbook will become selectable when configuring automation rules.
+Note: When selecting a playbook in the Automation rule, you may see a note saying:  
+“**Only playbooks configured for the incident trigger can be selected. If a playbook appears unavailable, it means Microsoft Sentinel does not have explicit permissions to run it.**”  
+Click **“Manage playbook permissions”** from there if needed.
 
 ## Screenshots
 **Incident Trigger**

--- a/Solutions/Teams/Playbooks/Send-Teams-adaptive-card-on-incident-creation/readme.md
+++ b/Solutions/Teams/Playbooks/Send-Teams-adaptive-card-on-incident-creation/readme.md
@@ -22,19 +22,14 @@ After deployment, attach this playbook to an **automation rule** so it runs when
 # Post-deployment
 1. Assign Microsoft Sentinel Responder role to the Playbook's Managed Identity
 2. Authorize Microsoft Teams connector
-3. Make the playbook selectable in Sentinel Automation Rules
-After assigning the required role, the playbook might still appear unavailable (grayed out) when you try to attach it to an automation rule. This is due to Sentinel not having explicit access yet, even though the role was assigned.
-To fix this:
-    a. Go to **Microsoft Sentinel → Automation → Playbooks**
-    b. Locate your playbook (e.g., `Send-Teams-adaptive-card-on-incident-creation`)
-    c. Click the **three dots (...) → Manage playbook permissions**
-    d. In the side panel that opens, select the **Resource Group** where your playbook is deployed
-    e. Click **Apply**
-This allows Sentinel to explicitly recognize the playbook's permissions. After completing this step, the playbook will become selectable when configuring automation rules.
-Note: When selecting a playbook in the Automation rule, you may see a note saying:  
-“**Only playbooks configured for the incident trigger can be selected. If a playbook appears unavailable, it means Microsoft Sentinel does not have explicit permissions to run it.**”  
-Click **“Manage playbook permissions”** from there if needed.
-
+# If the Playbook is Grayed Out, Follow These Steps
+1. Navigate to `Microsoft Sentinel → Settings → Settings `
+2. Scroll down to the **Playbook permissions** section
+3. Click the **Configure permissions** button
+4. In the **Manage permissions** side panel:
+   - Under the **Browse** tab, search and select the **Resource Group** that contains your Logic App Playbook
+5. Click **Apply**
+6. Return to your **Automation Rule** and try adding the playbook again – it should now be selectable (no longer grayed out)
 ## Screenshots
 **Incident Trigger**
 ![Incident Trigger](./images/incidentTrigger-light.png)


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - In raedme file they haven't mentioned about while creating automation rule choose the playbook....while selecting even playbook have sentinel responder it's not populating so have to instrut them to give permissions for playbook resource group.

   Reason for Change(s):
   - To resolve the failng count of playbook

   Version Updated:
   -no becuase in readme there is no version

   Testing Completed:
   - yes

   Checked that the validations are passing and have addressed any issues that are present:
   - yes
   after doing that extra step i'm getting adaptive card in teams and based on the selection in adaptive card ..playbook running sucessfully.
   

<img width="281" alt="teamsplaybookScuessfull" src="https://github.com/user-attachments/assets/b97b1a71-a6aa-4e2b-a588-cc225922388c" />
