### PR TITLE
Ensure AWS_ChangeToVPC does not generate false positives

### DIFF
--- a/Solutions/Amazon Web Services/Analytic Rules/AWS_ChangeToVPC.yaml
+++ b/Solutions/Amazon Web Services/Analytic Rules/AWS_ChangeToVPC.yaml
@@ -28,6 +28,7 @@ query: |
   let EventNameList = dynamic(["CreateNetworkAclEntry","CreateRoute","CreateRouteTable","CreateInternetGateway","CreateNatGateway"]);
   AWSCloudTrail
   | where EventName in~ (EventNameList)
+  | where EventSource != "apigateway.amazonaws.com"
   | extend UserIdentityArn = iif(isempty(UserIdentityArn), tostring(parse_json(Resources)[0].ARN), UserIdentityArn)
   | extend UserName = tostring(split(UserIdentityArn, '/')[-1])
   | extend AccountName = case( UserIdentityPrincipalid == "Anonymous", "Anonymous", isempty(UserIdentityUserName), UserName, UserIdentityUserName)

--- a/Solutions/Amazon Web Services/ReleaseNotes.md
+++ b/Solutions/Amazon Web Services/ReleaseNotes.md
@@ -1,5 +1,6 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                          |
 |-------------|--------------------------------|---------------------------------------------|
+| 3.0.7       | 11-07-2025                     | Fix ChangeToVPC rule to ensure it excludes changes to API Gateway |
 | 3.0.6       | 13-06-2025                     | Updated Amazon Web Services S3 Data connector to include details for the default output format. |
 | 3.0.5       | 10-02-2025                     | Repackaged to fix ccp grid showing only 1 record and rename of file   |
 | 3.0.4       | 13-12-2024                     | Updated title of **Analytic Rule** - AWS_LogTampering.yaml   |


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Exclude apigateway.amazonaws.com from AWS_ChangeToVPC
   
   Reason for Change(s):
   - this EventSource generates CreateRoute events which are API Gateway and not VPC related.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes