### PR TITLE
feat: add support for polling enterprise-level audit logs

### DIFF
--- a/Solutions/GitHub/Data Connectors/azuredeploy_GitHub_native_poller_connector.json
+++ b/Solutions/GitHub/Data Connectors/azuredeploy_GitHub_native_poller_connector.json
@@ -19,7 +19,7 @@
 			"id": "GitHubEcAuditLogPolling",
 			"title": "GitHub Enterprise Audit Log",
 			"publisher": "GitHub",
-			"descriptionMarkdown": "The GitHub audit log connector provides the capability to ingest GitHub logs into Microsoft Sentinel. By connecting GitHub audit logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. \n\n **Note:** If you intended to ingest GitHub subscribed events into Microsoft Sentinel, please refer to GitHub (using Webhooks) Connector from \"**Data Connectors**\" gallery.",
+			"descriptionMarkdown": "The GitHub audit log connector provides the capability to ingest GitHub logs into Microsoft Sentinel. By connecting GitHub audit logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. \n\n This connector supports both **Organization-level** and **Enterprise-level** audit logs. Choose the appropriate option based on your GitHub setup and access requirements. \n\n **Note:** If you intended to ingest GitHub subscribed events into Microsoft Sentinel, please refer to GitHub (using Webhooks) Connector from \"**Data Connectors**\" gallery.",
 			"graphQueriesTableName": "GitHubAuditLogPolling_CL",
 			"graphQueries": [
 				{
@@ -67,27 +67,33 @@
 				"customs": [
 					{
 						"name": "GitHub API personal access token",
-						"description": "You need a GitHub personal access token to enable polling for the organization audit log. You may use either a classic token with 'read:org' scope OR a fine-grained token with 'Administration: Read-only' scope."
+						"description": "You need a GitHub personal access token to enable polling for the audit log. For **Organization-level** audit logs: use either a classic token with 'read:org' scope OR a fine-grained token with 'Administration: Read-only' scope. For **Enterprise-level** audit logs: use either a classic token with 'read:audit_log' scope OR a fine-grained token with 'Enterprise administration: Read' scope."
 					},
 					{
 						"name": "GitHub Enterprise type",
-						"description": "This connector will only function with GitHub Enterprise Cloud; it will not support GitHub Enterprise Server. "
+						"description": "This connector will only function with GitHub Enterprise Cloud; it will not support GitHub Enterprise Server."
 					}
 				]
 			},
 			"instructionSteps": [
 				{
-					"title": "Connect the GitHub Enterprise Organization-level Audit Log to Microsoft Sentinel",
-					"description": "Enable GitHub audit logs. \n Follow [this guide](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to create or find your personal access token.",
+					"title": "Connect the GitHub Audit Log to Microsoft Sentinel",
+					"description": "Enable GitHub audit logs and configure the appropriate endpoint. \n\n**STEP 1: Choose your audit log level** \n\n**For Organization-level audit logs:** \n• Enter exactly: `organizations` (in the first field) \n• Enter your organization name (in the second field) \n• Token scope required: `read:org` (classic) or `Administration: Read-only` (fine-grained) \n\n**For Enterprise-level audit logs:** \n• Enter exactly: `enterprises` (in the first field) \n• Enter your enterprise slug (in the second field) \n• Token scope required: `read:audit_log` (classic) or `Enterprise administration: Read` (fine-grained) \n\n**STEP 2: Create your personal access token** \nFollow [this guide](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to create your personal access token with the appropriate scope.",
 					"instructions": [
 						{
 							"parameters": {
 								"enable": "true",
 								"userRequestPlaceHoldersInput": [
 									{
-										"displayText": "Organization Name",
-										"requestObjectKey": "apiEndpoint",
+										"displayText": "Endpoint Type (enter EXACTLY: 'organizations' or 'enterprises')",
+										"requestObjectKey": "endpointType",
 										"placeHolderName": "{{placeHolder1}}",
+										"placeHolderValue": "organizations"
+									},
+									{
+										"displayText": "Organization Name or Enterprise Slug",
+										"requestObjectKey": "orgOrEnterprise",
+										"placeHolderName": "{{placeHolder2}}",
 										"placeHolderValue": ""
 									}
 								]
@@ -110,7 +116,7 @@
 				"APIKeyIdentifier": "token"
 			},
 			"request": {
-				"apiEndpoint": "https://api.github.com/organizations/{{placeHolder1}}/audit-log?include=all",
+				"apiEndpoint": "https://api.github.com/{{placeHolder1}}/{{placeHolder2}}/audit-log?include=all",
 				"rateLimitQPS": 50,
 				"queryWindowInMin": 15,
 				"httpMethod": "Get",

--- a/Solutions/GitHub/Package/mainTemplate.json
+++ b/Solutions/GitHub/Package/mainTemplate.json
@@ -3123,7 +3123,7 @@
                   "id": "[variables('_uiConfigId1')]",
                   "title": "GitHub Enterprise Audit Log",
                   "publisher": "GitHub",
-                  "descriptionMarkdown": "The GitHub audit log connector provides the capability to ingest GitHub logs into Microsoft Sentinel. By connecting GitHub audit logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. \n\n **Note:** If you intended to ingest GitHub subscribed events into Microsoft Sentinel, please refer to GitHub (using Webhooks) Connector from \"**Data Connectors**\" gallery.",
+                  "descriptionMarkdown": "The GitHub audit log connector provides the capability to ingest GitHub logs into Microsoft Sentinel. By connecting GitHub audit logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. \n\n This connector supports both **Organization-level** and **Enterprise-level** audit logs. Choose the appropriate option based on your GitHub setup and access requirements. \n\n **Note:** If you intended to ingest GitHub subscribed events into Microsoft Sentinel, please refer to GitHub (using Webhooks) Connector from \"**Data Connectors**\" gallery.",
                   "graphQueriesTableName": "GitHubAuditLogPolling_CL",
                   "graphQueries": [
                     {
@@ -3323,7 +3323,7 @@
           "id": "[variables('_uiConfigId1')]",
           "title": "GitHub Enterprise Audit Log",
           "publisher": "GitHub",
-          "descriptionMarkdown": "The GitHub audit log connector provides the capability to ingest GitHub logs into Microsoft Sentinel. By connecting GitHub audit logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. \n\n **Note:** If you intended to ingest GitHub subscribed events into Microsoft Sentinel, please refer to GitHub (using Webhooks) Connector from \"**Data Connectors**\" gallery.",
+          "descriptionMarkdown": "The GitHub audit log connector provides the capability to ingest GitHub logs into Microsoft Sentinel. By connecting GitHub audit logs into Microsoft Sentinel, you can view this data in workbooks, use it to create custom alerts, and improve your investigation process. \n\n This connector supports both **Organization-level** and **Enterprise-level** audit logs. Choose the appropriate option based on your GitHub setup and access requirements. \n\n **Note:** If you intended to ingest GitHub subscribed events into Microsoft Sentinel, please refer to GitHub (using Webhooks) Connector from \"**Data Connectors**\" gallery.",
           "graphQueriesTableName": "GitHubAuditLogPolling_CL",
           "graphQueries": [
             {

--- a/Solutions/GitHub/ReleaseNotes.md
+++ b/Solutions/GitHub/ReleaseNotes.md
@@ -1,5 +1,6 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                                                       |
 |-------------|--------------------------------|--------------------------------------------------------------------------|
+| 3.0.7       | 14-07-2025                     | Enhanced GitHub Enterprise Audit Log connector to support both Organization-level and Enterprise-level audit logs with backward compatibility |
 | 3.0.6       | 26-04-2024                     | Repackaged for fix on parser in maintemplate to have old parsername and parentid                    |
 | 3.0.5       | 18-04-2024                     | Repackaged to fix parser issue                                                  |
 | 3.0.4       | 04-04-2024                     | Updated Entity Mappings                                                  |


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Enhanced GitHub Enterprise Audit Log connector to support both Organization-level and Enterprise-level audit logs, defaulting to Organization-level.

   Reason for Change(s):
   - Requested by customer

   Version Updated:
   - N/A

   Testing Completed:
   - Need help

   Checked that the validations are passing and have addressed any issues that are present:
   - Need Help