### PR TITLE
Fix name for TemplateEmptyArray to TemplateEmptyObject

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -257,7 +257,7 @@ function removePropertiesRecursively ($resourceObj, $isWorkbook = $false, $isAct
                 if ($($val.PsObject.Properties).Count -eq 0) {
                     if ($key -eq "dataSources") {
                         $resourceObj.$key = "[variables('TemplateEmptyObject')]";
-                        if (!$global:baseMainTemplate.variables.TemplateEmptyArray) {
+                        if (!$global:baseMainTemplate.variables.TemplateEmptyObject) {
                             $global:baseMainTemplate.variables | Add-Member -NotePropertyName "TemplateEmptyObject" -NotePropertyValue "[json('{}')]"
                         }
                     } else {


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Fix naming for TemplateEmptyArray to TemplateEmptyObject in packaging tool.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   -Yes

