### PR TITLE
Add ProofpointPOD CCP analytics rule for data exfiltration detection - Fixes #12553

### DIFF
--- a/Solutions/Proofpoint On demand(POD) Email Security/Analytic Rules/CCP/MIGRATION_SUMMARY.md
+++ b/Solutions/Proofpoint On demand(POD) Email Security/Analytic Rules/CCP/MIGRATION_SUMMARY.md
@@ -1,0 +1,64 @@
+# ProofpointPOD Analytics Rules Migration Summary
+
+## Overview
+This document summarizes the migration of ProofpointPOD analytics rules from the legacy Azure Functions connector to the new Codeless Connector Platform (CCP) connector.
+
+## Key Changes
+
+### Table Name Changes
+- **Old (Azure Functions):** `ProofpointPOD_message_CL` 
+- **New (CCP):** `ProofpointPODMessage_CL`
+
+### Data Connector Changes
+- **Old Connector ID:** `ProofpointPOD`
+- **New Connector ID:** `ProofpointPODEmailSecurity_CCP`
+
+### Field Access Changes
+The new CCP connector stores data in dynamic columns rather than flattened fields:
+
+| Old Field Access | New Field Access |
+|------------------|------------------|
+| `EventType == 'message'` | Not needed (table is message-specific) |
+| `NetworkDirection == 'outbound'` | `tostring(filter.routeDirection) == 'outbound'` |
+| `SrcUserUpn` | `tostring(envelope.from)` |
+| `DstUserUpn` | `tostring(envelope.rcpts)` |
+
+## Migrated Analytics Rules
+
+### 1. ProofpointPOD CCP - Possible data exfiltration to private email
+
+**Purpose:** Detects when sender sent email to the non-corporate domain and recipient's username is the same as sender's username.
+
+**Key Changes:**
+- Updated table name to `ProofpointPODMessage_CL`
+- Updated connector ID to `ProofpointPODEmailSecurity_CCP`
+- Updated field access patterns to use dynamic objects
+- Maintained same detection logic and entity mappings
+
+**File:** `/Analytic Rules/CCP/ProofpointPOD_CCP_DataExfiltrationToPrivateEmail.yaml`
+
+## Migration Notes
+
+1. **Table Structure:** The CCP connector uses a more structured approach with dynamic columns (`envelope`, `filter`, `msg`, etc.) rather than flattened fields.
+
+2. **Data Access:** Fields are accessed using dynamic object notation (e.g., `envelope.from` instead of direct field names).
+
+3. **Event Type Filtering:** The old connector required filtering by `EventType == 'message'`, but the new CCP connector has separate tables for different event types.
+
+4. **Backward Compatibility:** The old analytics rules will continue to work with the legacy Azure Functions connector until it's deprecated.
+
+## Testing Recommendations
+
+1. Deploy the new CCP connector alongside the existing one
+2. Test the new analytics rules with actual data
+3. Compare detection results between old and new rules
+4. Gradually migrate detection rules once validated
+5. Monitor for any false positives or missing detections
+
+## Future Work
+
+Additional analytics rules can be migrated following the same pattern:
+- Update table names
+- Update connector IDs  
+- Update field access patterns
+- Test thoroughly before deployment

--- a/Solutions/Proofpoint On demand(POD) Email Security/Analytic Rules/CCP/ProofpointPOD_CCP_DataExfiltrationToPrivateEmail.yaml
+++ b/Solutions/Proofpoint On demand(POD) Email Security/Analytic Rules/CCP/ProofpointPOD_CCP_DataExfiltrationToPrivateEmail.yaml
@@ -1,0 +1,39 @@
+id: aedc5b33-2d7c-42cb-a692-f25ef637cbb2
+name: ProofpointPOD CCP - Possible data exfiltration to private email
+description: |
+  'Detects when sender sent email to the non-corporate domain and recipient's username is the same as sender's username.'
+severity: Medium
+status: Available 
+requiredDataConnectors:
+  - connectorId: ProofpointPODEmailSecurity_CCP
+    dataTypes:
+      - ProofpointPODMessage_CL
+queryFrequency: 10m
+queryPeriod: 10m
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1078
+query: |
+  let lbtime = 10m;
+  ProofpointPODMessage_CL
+  | where TimeGenerated > ago(lbtime)
+  | where tostring(filter.routeDirection) == 'outbound'
+  | where array_length(todynamic(tostring(envelope.rcpts))) == 1
+  | extend sender = extract(@'\A(.*?)@', 1, tostring(envelope.from))
+  | extend sender_domain = extract(@'@(.*)$', 1, tostring(envelope.from))
+  | extend recipient = extract(@'\A(.*?)@', 1, tostring(todynamic(tostring(envelope.rcpts))[0]))
+  | extend recipient_domain = extract(@'@(.*)$', 1, tostring(todynamic(tostring(envelope.rcpts))[0]))
+  | where sender =~ recipient
+  | where sender_domain != recipient_domain
+  | project SrcUserUpn = tostring(envelope.from), DstUserUpn = tostring(envelope.rcpts)
+  | extend AccountCustomEntity = SrcUserUpn
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+version: 1.0.1
+kind: Scheduled


### PR DESCRIPTION
  ## Summary
This PR adds a new analytics rule for the Proofpoint On Demand Email Security Codeless Connector Platform (CCP) to detect data exfiltration to private email addresses.
Fixes #12553 #Analytic Rules

## Problem Statement
The existing analytics rules for Proofpoint On Demand Email Security still use tables from the deprecated Azure Functions connector (`ProofpointPOD_message_CL`). With the new CCP connector now available (`ProofpointPODEmailSecurity_CCP`), analytics rules need to be updated to use the new table structure (`ProofpointPODMessage_CL`).

## Changes Made
- **New Analytics Rule**: ProofpointPOD CCP - Possible data exfiltration to private email
- **Migration Documentation**: Comprehensive migration summary for transitioning from legacy Azure Functions connector to CCP

## Key Updates
- Updated table name from `ProofpointPOD_message_CL` to `ProofpointPODMessage_CL`
- Updated connector ID from `ProofpointPOD` to `ProofpointPODEmailSecurity_CCP`
- Updated field access patterns to use CCP dynamic object structure:
  - `NetworkDirection == 'outbound'` → `tostring(filter.routeDirection) == 'outbound'`
  - `SrcUserUpn` → `tostring(envelope.from)`
  - `DstUserUpn` → `tostring(envelope.rcpts)`
- Maintained same detection logic and entity mappings as original rule

## Technical Details
The new CCP connector uses a structured approach with dynamic columns (`envelope`, `filter`, `msg`, etc.) rather than flattened fields. This rule demonstrates the migration pattern for other analytics rules that need to be updated for CCP compatibility.

## Files Added
- `Solutions/Proofpoint On demand(POD) Email Security/Analytic Rules/CCP/ProofpointPOD_CCP_DataExfiltrationToPrivateEmail.yaml`
- `Solutions/Proofpoint On demand(POD) Email Security/Analytic Rules/CCP/MIGRATION_SUMMARY.md`

## Detection Logic
The rule detects potential data exfiltration by identifying when:
1. An email is sent outbound
2. The sender's username matches the recipient's username
3. The sender and recipient domains are different (indicating external domains)

This pattern suggests possible data exfiltration to personal email accounts.

## Testing
- Rule maintains same detection logic as original
- Compatible with new CCP connector table structure
- Ready for validation with actual ProofpointPOD CCP data
- Includes comprehensive migration documentation for future rule updates

## Impact
- Enables detection capabilities for customers using the new CCP connector
- Provides migration template for remaining ProofpointPOD analytics rules
- Maintains security coverage during connector transition period

This addresses the need for analytics rules compatible with the new Codeless Connector Platform while maintaining detection capabilities.