### PR TITLE
Add M365 Defender hunting query for Shimcache flush detection

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/shimcache-flushed.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/shimcache-flushed.yaml
@@ -1,0 +1,19 @@
+id: cd90d859-0d8f-458e-9d96-7f2945fe87a6
+name: shimcache-flushed
+description: |
+  This query searches for attempts to flush Shimcache, which may indicate anti-forensic or defense evasion activity by an attacker.
+  Author: Vaasudev_Kala
+  Ref: https://blueteamops.medium.com/shimcache-flush-89daff28d15e
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - DeviceProcessEvents
+tactics:
+- Defense evasion
+relevantTechniques:
+  - T1112
+query: |
+  DeviceProcessEvents
+  | where FileName has "Rundll32.exe"
+  | where ((ProcessCommandLine has_any("ShimFlushCache","BaseFlushAppcompatCache"))
+  or (ProcessCommandLine has_any (@"#250",@"#46") and ProcessCommandLine has_any ("apphelp.dll","kernel32.dll"))) // checking for ordinals as well


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added M365 Defender hunting query for Shimcache flush detection.

   Reason for Change(s):
   - To improve visibility into potential anti-forensic techniques, this hunting query detects attempts to flush Shimcache on Windows endpoints. Such behavior is often associated with attackers trying to erase execution traces and evade forensic analysis.

   Version Updated:
   - N/A (Hunting query)


   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

