### PR TITLE
Add new CDR example for messages with URL listed on OpenPhish

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email Queries/Custom Detections/Message with URL listed on OpenPhish delivered into Inbox.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email Queries/Custom Detections/Message with URL listed on OpenPhish delivered into Inbox.yaml
@@ -17,7 +17,7 @@ query: |
   [
       "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt"
   ]
-  with (format="txt");
+  with (format="txt"); // CSV and JSON formats are also valid formats if using the premium feeds
   EmailUrlInfo
   | where Url in (PhishingURLs)
   | join EmailEvents on NetworkMessageId

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Custom Detections/Message with URL listed on OpenPhish delivered into Inbox.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email Queries/Custom Detections/Message with URL listed on OpenPhish delivered into Inbox.yaml
@@ -17,7 +17,7 @@ query: |
   [
       "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt"
   ]
-  with (format="txt");
+  with (format="txt"); // CSV and JSON formats are also valid formats if using the premium feeds
   EmailUrlInfo
   | where Url in (PhishingURLs)
   | join EmailEvents on NetworkMessageId


### PR DESCRIPTION
   Change(s):
   - Adding a new example Custom Detection Rule to detect when a message contains a URL which is listed on an external threat intel site, such as OpenPhish, and the message has been delivered into an Inbox. The CDR can trigger an automated action to Soft Delete the email.

   Reason for Change(s):
   - Adding new community queries within Advanced Hunting for customers that do not use Sentinel. Based on queries that are included within the 'Defender for Office 365 Detections and Insights' workbook included with the Defender for Office 365 solution.

   Version Updated:
   - Not Applicable

   Testing Completed:
   - Tested in Advanced Hunting within test tenants

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes