### PR TITLE
Adding missing Type field output

### DIFF
--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/imDns_IPEntity_DnsEvents.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/imDns_IPEntity_DnsEvents.yaml
@@ -80,7 +80,8 @@ query: |
   | extend Description = tostring(parse_json(Data).description)
   | extend ActivityGroupNames = extract(@"ActivityGroup:(\S+)", 1, tostring(parse_json(Data).labels))
   | extend ThreatType = tostring(Data.indicator_types[0])
-  | project imDns_mintime, imDns_maxtime, Description, ActivityGroupNames, IndicatorId, ThreatType, LatestIndicatorTime, ValidUntil, Confidence, SrcIpAddr, IoC, Dvc, EventVendor, EventProduct, DnsQuery, DnsResponseName
+  | project imDns_mintime, imDns_maxtime, Description, ActivityGroupNames, IndicatorId, ThreatType, LatestIndicatorTime, ValidUntil, Confidence, 
+  SrcIpAddr, IoC, Dvc, EventVendor, EventProduct, DnsQuery, DnsResponseName, Type
 entityMappings:
   - entityType: Host
     fieldMappings:
@@ -108,5 +109,5 @@ customDetails:
 alertDetailsOverride:
   alertDisplayNameFormat: The response {{IoC}} to DNS query matched an IoC 
   alertDescriptionFormat: The response address {{IoC}} to a DNS query matched a known indicator of compromise of {{Type}}. Consult the threat intelligence blade for more information on the indicator.
-version: 1.2.8
+version: 1.2.9
 kind: Scheduled


### PR DESCRIPTION
AlertDescription requires Type field to be output, adding.

   Required items, please complete
   
   Change(s):
   - Added Type in project statement

   Reason for Change(s):
   - AlertDescription requires Type to be available

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
