### PR TITLE
Url commented out in Project statement, causes entity mapping failure

### DIFF
--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/IPEntity_AzureFirewall.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/IPEntity_AzureFirewall.yaml
@@ -68,9 +68,7 @@ query: |
     | extend ActivityGroupNames = extract(@"ActivityGroup:(\S+)", 1, tostring(parse_json(Data).labels))
     | project LatestIndicatorTime, Description, ActivityGroupNames, Id, ValidUntil, Confidence,
       AzureFirewall_TimeGenerated, TI_ipEntity, Resource, Category, msg_s, SourceAddress, DestinationAddress, Firewall_Action, Protocol,
-      NetworkSourceIP, Type//, Url, NetworkIP, NetworkDestinationIP, DomainName, EmailSourceIpAddress
-    // Rename the timestamp field
-    | extend timestamp = AzureFirewall_TimeGenerated
+      NetworkSourceIP, Type, Url
 entityMappings:
   - entityType: IP
     fieldMappings:
@@ -80,5 +78,5 @@ entityMappings:
     fieldMappings:
       - identifier: Url
         columnName: Url
-version: 1.3.5
+version: 1.3.6
 kind: Scheduled


### PR DESCRIPTION
Url in the project statement was commented out...not clear why

   Required items, please complete
   
   Change(s):
   - Removed comment lines in front of Url in the Project statement
   - Dropped other fields in project statement after the comment as they are not needed.
   - removed spurious additional extend for timestamp

   Reason for Change(s):
   - Required for entity mapping

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
