### PR TITLE
Correct Microsoft Purview file name in WorkbooksMetadata.json

### DIFF
--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -4165,7 +4165,7 @@
 		],
 		"version": "1.0.0",
 		"title": "Microsoft Purview",
-		"templateRelativePath": "MicrosoftPurview.json",
+		"templateRelativePath": "MicrosoftPurviewInformationProtection.json",
 		"subtitle": "",
 		"provider": "Microsoft"
 	},


### PR DESCRIPTION
MicrosoftPurview.json -> MicrosoftPurviewInformationProtection.json

   Required items, please complete
   
   Change(s):
   - Corrected file name for Microsoft Purview workbook

   Reason for Change(s):
   - File name was added incorrectly

   Version Updated:
   - Does the version need to be bumped for this change?  If so let me know and I'll amend.
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - N/A
