### PR TITLE
Update Cisco Umbrella elastic premium connector to match old connector data types and table names

### DIFF
--- a/Solutions/CiscoUmbrella/Data Connectors/CiscoUmbrella_API_FunctionApp_elasticpremium.json
+++ b/Solutions/CiscoUmbrella/Data Connectors/CiscoUmbrella_API_FunctionApp_elasticpremium.json
@@ -1,51 +1,123 @@
 {
     "id": "CiscoUmbrellaDataConnectorelasticpremium",
-    "title": "Cisco Umbrella (using elastic premium plan)",
+    "title": "Cisco Cloud Security (using elastic premium plan)",
     "publisher": "Cisco",
     "descriptionMarkdown": "The Cisco Umbrella data connector provides the capability to ingest [Cisco Umbrella](https://docs.umbrella.com/) events stored in Amazon S3 into Microsoft Sentinel using the Amazon S3 REST API. Refer to [Cisco Umbrella log management documentation](https://docs.umbrella.com/deployment-umbrella/docs/log-management) for more information.\n\n**NOTE:** This data connector uses the [Azure Functions Premium Plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan?tabs=portal) to enable secure ingestion capabilities and will incur additional costs. More pricing details are [here](https://azure.microsoft.com/pricing/details/functions/?msockid=2f4366822d836a7c2ac673462cfc6ba8#pricing).",
     "additionalRequirementBanner": "These queries and workbooks are dependent on a parser based on Kusto to work as expected. Follow the steps to use this Kusto functions alias **Cisco_Umbrella** in queries and workbooks. [Follow steps to get this Kusto functions>](https://aka.ms/sentinel-ciscoumbrella-function) ",
     "graphQueries": [
         {
-            "metricName": "Cisco Umbrella DNS Logs",
+            "metricName": "Cisco Cloud Security DNS Logs",
             "legend": "Cisco_Umbrella_dns_CL",
             "baseQuery": "Cisco_Umbrella_dns_CL"
         },
         {
-            "metricName": "Cisco Umbrella Proxy Logs",
+            "metricName": "Cisco Cloud Security Proxy Logs",
             "legend": "Cisco_Umbrella_proxy_CL",
             "baseQuery": "Cisco_Umbrella_proxy_CL"
         },
         {
-            "metricName": "Cisco Umbrella IP Logs",
+            "metricName": "Cisco Cloud Security IP Logs",
             "legend": "Cisco_Umbrella_ip_CL",
             "baseQuery": "Cisco_Umbrella_ip_CL"
         },
         {
-            "metricName": "Cisco Umbrella Cloud Firewall Logs",
+            "metricName": "Cisco Cloud Security Cloud Firewall Logs",
             "legend": "Cisco_Umbrella_cloudfirewall_CL",
             "baseQuery": "Cisco_Umbrella_cloudfirewall_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security Firewall Logs",
+            "legend": "Cisco_Umbrella_firewall_CL",
+            "baseQuery": "Cisco_Umbrella_firewall_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security DLP Logs",
+            "legend": "Cisco_Umbrella_dlp_CL",
+            "baseQuery": "Cisco_Umbrella_dlp_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security Cloud RAVPN Logs",
+            "legend": "Cisco_Umbrella_ravpnlogs_CL",
+            "baseQuery": "Cisco_Umbrella_ravpnlogs_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security Audit Logs",
+            "legend": "Cisco_Umbrella_audit_CL",
+            "baseQuery": "Cisco_Umbrella_audit_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security ZTNA Logs",
+            "legend": "Cisco_Umbrella_ztna_CL",
+            "baseQuery": "Cisco_Umbrella_ztna_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security Intrusion Logs",
+            "legend": "Cisco_Umbrella_intrusion_CL",
+            "baseQuery": "Cisco_Umbrella_intrusion_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security ZTA flow Logs",
+            "legend": "Cisco_Umbrella_ztaflow_CL",
+            "baseQuery": "Cisco_Umbrella_ztaflow_CL"
+        },
+        {
+            "metricName": "Cisco Cloud Security File Event Logs",
+            "legend": "Cisco_Umbrella_fileevent_CL",
+            "baseQuery": "Cisco_Umbrella_fileevent_CL"
         }
     ],
     "sampleQueries": [
         {
-            "description": "All Cisco Umbrella Logs",
+            "description": "All Cisco Cloud Security Logs",
             "query": "Cisco_Umbrella\n| sort by TimeGenerated desc"
         },
         {
-            "description": "Cisco Umbrella DNS Logs",
+            "description": "Cisco Cloud Security DNS Logs",
             "query": "Cisco_Umbrella\n | where EventType == 'dnslogs'\n| sort by TimeGenerated desc"
         },
         {
-            "description": "Cisco Umbrella Proxy Logs",
+            "description": "Cisco Cloud Security Proxy Logs",
             "query": "Cisco_Umbrella\n | where EventType == 'proxylogs'\n| sort by TimeGenerated desc"
         },
         {
-            "description": "Cisco Umbrella IP Logs",
+            "description": "Cisco Cloud Security IP Logs",
             "query": "Cisco_Umbrella\n | where EventType == 'iplogs'\n| sort by TimeGenerated desc"
         },
         {
-            "description": "Cisco Umbrella Cloud Firewall Logs",
+            "description": "Cisco Cloud Security Cloud Firewall Logs",
             "query": "Cisco_Umbrella\n | where EventType == 'cloudfirewalllogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security Firewall Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'firewalllogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security DLP Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'dlplogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security Cloud RAVPN Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'ravpnlogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security Audit Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'auditlogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security ZTNA Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'ztnalogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security Cloud Intrusion Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'intrusionlogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security Cloud ZTA Flow Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'ztaflowlogs'\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "Cisco Cloud Security Cloud File Event Logs",
+            "query": "Cisco_Umbrella\n | where EventType == 'fileeventlogs'\n| sort by TimeGenerated desc"
         }
     ],
     "dataTypes": [
@@ -64,16 +136,56 @@
         {
             "name": "Cisco_Umbrella_cloudfirewall_CL",
             "lastDataReceivedQuery": "Cisco_Umbrella_cloudfirewall_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_firewall_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_firewall_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_dlp_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_dlp_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_ravpnlogs_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_ravpnlogs_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_audit_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_audit_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_ztna_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_ztna_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_intrusion_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_intrusion_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_ztaflow_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_ztaflow_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+        },
+        {
+            "name": "Cisco_Umbrella_fileevent_CL",
+            "lastDataReceivedQuery": "Cisco_Umbrella_fileevent_CL\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
         }
     ],
     "connectivityCriterias": [
         {
             "type": "IsConnectedQuery",
             "value": [
-                "Cisco_Umbrella_dns_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(1d)",
-                "Cisco_Umbrella_proxy_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(1d)",
-                "Cisco_Umbrella_ip_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(1d)",
-                "Cisco_Umbrella_cloudfirewall_CL\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(1d)"
+                "Cisco_Umbrella_dns_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_proxy_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_ip_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_cloudfirewall_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_firewall_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_dlp_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_ravpnlogs_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_audit_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_ztna_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_intrusion_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_ztaflow_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)",
+                "Cisco_Umbrella_fileevent_CL | summarize LastLogReceived = max(TimeGenerated) | project IsConnected = LastLogReceived > ago(1d)"
             ]
         }
     ],


### PR DESCRIPTION
## Description
This PR updates the Cisco Umbrella elastic premium connector to maintain consistency with the standard connector while preserving the elastic premium specific functionality.

### Key Changes:
1. Query Structure Alignment
   - Updated graph queries to match standard connector format
   - Standardized sample queries to use EventType filtering
   - Maintained consistent table names with _CL suffix

2. Data Types and Connectivity
   - Aligned all data type definitions with standard connector
   - Standardized connectivity check timeframe to 1 day
   - Preserved all supported log types:
     - DNS logs
     - Proxy logs
     - IP logs
     - Cloud Firewall logs
     - Firewall logs
     - DLP logs
     - RAVPN logs
     - Audit logs
     - ZTNA logs
     - Intrusion logs
     - ZTA Flow logs
     - File Event logs