### PR TITLE
Reduce FP in Remote Desktop Network Brute force ASIM rule

### DIFF
--- a/Solutions/Network Session Essentials/Analytic Rules/Remote Desktop Network Brute force (ASIM Network Session schema).yaml
+++ b/Solutions/Network Session Essentials/Analytic Rules/Remote Desktop Network Brute force (ASIM Network Session schema).yaml
@@ -21,7 +21,7 @@ query: |
   _Im_NetworkSession(eventresult="Failure")
   // Filter out private source IP addresses and focus on specific destination port (3389)
   // Also, ensure that the source and destination IP addresses are not the same
-  | where not(ipv4_is_private(SrcIpAddr)) and tostring(DstPortNumber) has_any ("3389") and SrcIpAddr != DstIpAddr
+  | where not(ipv4_is_private(SrcIpAddr)) and tostring(DstPortNumber) has_any ("3389") and SrcIpAddr != DstIpAddr and DvcAction !in ("Deny", "Drop")
   // Summarize the data by source and destination IP addresses, destination port number, network protocol, and event result
   // Also, bin the time generated in 5-minute intervals
   // Calculate the minimum and maximum time generated, the sum of event counts, and a set of up to 10 event vendors
@@ -35,5 +35,5 @@ entityMappings:
         columnName: SrcIpAddr
 eventGroupingSettings:
   aggregationKind: AlertPerResult
-version: 1.0.0
+version: 1.0.1
 kind: Scheduled


### PR DESCRIPTION
   Change(s):
   - With a Palo Alto firewall, this rule triggers on traffic blocked/dropped by the firewall.  This change ignores traffic that doesn't get to the destination.

   Reason for Change(s):
   - Reduced false positives

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - I don't have a machine set up to perform validations.
