### PR TITLE
Add Netskope multiple instance deployment solution

### DIFF
--- a/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /Deploy-NetskopeDevInstance.ps1
+++ b/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /Deploy-NetskopeDevInstance.ps1
@@ -1,0 +1,259 @@
+#Requires -Version 5.1
+#Requires -Modules Az.Accounts, Az.Resources, Az.OperationalInsights
+
+<#
+.SYNOPSIS
+    Deploys a second Netskope Alerts and Events data connector instance for DEV environment
+
+.DESCRIPTION
+    This script creates a duplicate set of Netskope data pollers with "DEV" prefix to enable
+    multiple Netskope environments (PROD and DEV) to send data to the same Microsoft Sentinel workspace.
+    
+    The script creates 21 separate data collection endpoints (DCEs) and data collection rules (DCRs)
+    for all Netskope event types, allowing both PROD and DEV data to coexist in the same tables.
+
+.PARAMETER SubscriptionId
+    Azure subscription ID where the resources will be deployed
+
+.PARAMETER ResourceGroupName
+    Name of the resource group containing the Log Analytics workspace
+
+.PARAMETER WorkspaceName
+    Name of the Log Analytics workspace
+
+.PARAMETER Location
+    Azure region where resources will be deployed (e.g., "eastus", "westus2")
+
+.PARAMETER DevPrefix
+    Prefix for DEV resources (default: "DEV")
+
+.PARAMETER ProdPrefix
+    Prefix for PROD resources (default: "PROD")
+
+.EXAMPLE
+    .\Deploy-NetskopeDevInstance.ps1 -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "rg-sentinel" -WorkspaceName "law-sentinel" -Location "eastus"
+
+.NOTES
+    Author: Microsoft Sentinel Community
+    Version: 1.0
+    Last Modified: 2024-12-24
+    
+    Prerequisites:
+    - Az PowerShell modules installed
+    - Authenticated to Azure with appropriate permissions
+    - Existing Log Analytics workspace
+    - PROD Netskope connector already deployed via Content Hub
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$SubscriptionId,
+    
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ResourceGroupName,
+    
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$WorkspaceName,
+    
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Location,
+    
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DevPrefix = "DEV",
+    
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ProdPrefix = "PROD"
+)
+
+# Error handling
+$ErrorActionPreference = "Stop"
+
+# Define all Netskope data connector types
+$NetskopeConnectorTypes = @(
+    "NetskopeAlertsEvents-ApplicationEvents",
+    "NetskopeAlertsEvents-AuditEvents", 
+    "NetskopeAlertsEvents-ConnectionEvents",
+    "NetskopeAlertsEvents-InfrastructureEvents",
+    "NetskopeAlertsEvents-NetworkEvents",
+    "NetskopeAlertsEvents-PagesEvents",
+    "NetskopeAlertsEvents-AlertsEvents",
+    "NetskopeAlertsEvents-BehaviorAnalyticsAlertsEvents",
+    "NetskopeAlertsEvents-CompromisedCredentialsAlertsEvents",
+    "NetskopeAlertsEvents-DLPAlertsEvents",
+    "NetskopeAlertsEvents-LegalHoldAlertsEvents",
+    "NetskopeAlertsEvents-MalsiteAlertsEvents",
+    "NetskopeAlertsEvents-MalwareAlertsEvents",
+    "NetskopeAlertsEvents-PolicyAlertsEvents",
+    "NetskopeAlertsEvents-QuarantineAlertsEvents",
+    "NetskopeAlertsEvents-RemediationAlertsEvents",
+    "NetskopeAlertsEvents-SecurityAssessmentAlertsEvents",
+    "NetskopeAlertsEvents-UBAAlertsEvents",
+    "NetskopeAlertsEvents-WatchlistAlertsEvents",
+    "NetskopeAlertsEvents-WebTxAlertsEvents",
+    "NetskopeAlertsEvents-CTEPAlertsEvents"
+)
+
+try {
+    Write-Host "Starting Netskope DEV instance deployment..." -ForegroundColor Green
+    
+    # Connect to Azure
+    Write-Host "Setting Azure context..." -ForegroundColor Yellow
+    Set-AzContext -SubscriptionId $SubscriptionId
+    
+    # Verify resource group exists
+    Write-Host "Verifying resource group exists..." -ForegroundColor Yellow
+    $resourceGroup = Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+    if (-not $resourceGroup) {
+        throw "Resource group '$ResourceGroupName' not found."
+    }
+    
+    # Verify workspace exists
+    Write-Host "Verifying Log Analytics workspace exists..." -ForegroundColor Yellow
+    $workspace = Get-AzOperationalInsightsWorkspace -ResourceGroupName $ResourceGroupName -Name $WorkspaceName -ErrorAction SilentlyContinue
+    if (-not $workspace) {
+        throw "Log Analytics workspace '$WorkspaceName' not found in resource group '$ResourceGroupName'."
+    }
+    
+    $workspaceId = $workspace.ResourceId
+    Write-Host "Using workspace: $WorkspaceName (ID: $workspaceId)" -ForegroundColor Green
+    
+    # Deploy each connector type
+    $successCount = 0
+    $failedCount = 0
+    
+    foreach ($connectorType in $NetskopeConnectorTypes) {
+        try {
+            Write-Host "Deploying $connectorType..." -ForegroundColor Yellow
+            
+            # Create unique names for DEV instance
+            $devConnectorName = "$DevPrefix-$connectorType"
+            $dceResourceName = "dce-$devConnectorName"
+            $dcrResourceName = "dcr-$devConnectorName"
+            
+            # Create Data Collection Endpoint (DCE)
+            Write-Host "  Creating DCE: $dceResourceName" -ForegroundColor Cyan
+            $dceProperties = @{
+                location = $Location
+                properties = @{
+                    networkAcls = @{
+                        publicNetworkAccess = "Enabled"
+                    }
+                }
+            }
+            
+            $dce = New-AzResource -ResourceGroupName $ResourceGroupName -ResourceType "Microsoft.Insights/dataCollectionEndpoints" -Name $dceResourceName -Properties $dceProperties.properties -Location $Location -Force
+            
+            if ($dce) {
+                Write-Host "  ✓ DCE created successfully" -ForegroundColor Green
+            }
+            
+            # Create Data Collection Rule (DCR)
+            Write-Host "  Creating DCR: $dcrResourceName" -ForegroundColor Cyan
+            
+            # Determine target table based on connector type
+            $targetTable = switch -Regex ($connectorType) {
+                "ApplicationEvents" { "NetskopeApplicationEvents_CL" }
+                "AuditEvents" { "NetskopeAuditEvents_CL" }
+                "ConnectionEvents" { "NetskopeConnectionEvents_CL" }
+                "InfrastructureEvents" { "NetskopeInfrastructureEvents_CL" }
+                "NetworkEvents" { "NetskopeNetworkEvents_CL" }
+                "PagesEvents" { "NetskopePagesEvents_CL" }
+                "AlertsEvents$" { "NetskopeAlertsEvents_CL" }
+                "BehaviorAnalyticsAlertsEvents" { "NetskopeBehaviorAnalyticsAlertsEvents_CL" }
+                "CompromisedCredentialsAlertsEvents" { "NetskopeCompromisedCredentialsAlertsEvents_CL" }
+                "DLPAlertsEvents" { "NetskopeDLPAlertsEvents_CL" }
+                "LegalHoldAlertsEvents" { "NetskopeLegalHoldAlertsEvents_CL" }
+                "MalsiteAlertsEvents" { "NetskopeMalsiteAlertsEvents_CL" }
+                "MalwareAlertsEvents" { "NetskopeMalwareAlertsEvents_CL" }
+                "PolicyAlertsEvents" { "NetskopePolicyAlertsEvents_CL" }
+                "QuarantineAlertsEvents" { "NetskopeQuarantineAlertsEvents_CL" }
+                "RemediationAlertsEvents" { "NetskopeRemediationAlertsEvents_CL" }
+                "SecurityAssessmentAlertsEvents" { "NetskopeSecurityAssessmentAlertsEvents_CL" }
+                "UBAAlertsEvents" { "NetskopeUBAAlertsEvents_CL" }
+                "WatchlistAlertsEvents" { "NetskopeWatchlistAlertsEvents_CL" }
+                "WebTxAlertsEvents" { "NetskopeWebTxAlertsEvents_CL" }
+                "CTEPAlertsEvents" { "NetskopeCTEPAlertsEvents_CL" }
+                default { "NetskopeEvents_CL" }
+            }
+            
+            $dcrProperties = @{
+                location = $Location
+                properties = @{
+                    dataCollectionEndpointId = $dce.ResourceId
+                    streamDeclarations = @{
+                        "Custom-$targetTable" = @{
+                            columns = @(
+                                @{ name = "TimeGenerated"; type = "datetime" }
+                                @{ name = "RawData"; type = "string" }
+                            )
+                        }
+                    }
+                    destinations = @{
+                        logAnalytics = @(
+                            @{
+                                workspaceResourceId = $workspaceId
+                                name = "law-destination"
+                            }
+                        )
+                    }
+                    dataFlows = @(
+                        @{
+                            streams = @("Custom-$targetTable")
+                            destinations = @("law-destination")
+                            transformKql = "source | extend TimeGenerated = now()"
+                            outputStream = "Custom-$targetTable"
+                        }
+                    )
+                }
+            }
+            
+            $dcr = New-AzResource -ResourceGroupName $ResourceGroupName -ResourceType "Microsoft.Insights/dataCollectionRules" -Name $dcrResourceName -Properties $dcrProperties.properties -Location $Location -Force
+            
+            if ($dcr) {
+                Write-Host "  ✓ DCR created successfully" -ForegroundColor Green
+                Write-Host "  ✓ Target table: $targetTable" -ForegroundColor Green
+            }
+            
+            $successCount++
+            Write-Host "✓ Successfully deployed $connectorType" -ForegroundColor Green
+            
+        }
+        catch {
+            Write-Warning "Failed to deploy $connectorType`: $($_.Exception.Message)"
+            $failedCount++
+        }
+    }
+    
+    # Summary
+    Write-Host "`n" -NoNewline
+    Write-Host "=== DEPLOYMENT SUMMARY ===" -ForegroundColor Cyan
+    Write-Host "Successfully deployed: $successCount connectors" -ForegroundColor Green
+    Write-Host "Failed deployments: $failedCount connectors" -ForegroundColor Red
+    Write-Host "Total connectors: $($NetskopeConnectorTypes.Count)" -ForegroundColor Yellow
+    
+    if ($failedCount -eq 0) {
+        Write-Host "`nAll Netskope DEV connectors deployed successfully! 🎉" -ForegroundColor Green
+        Write-Host "You can now configure your DEV Netskope tenant to send data using the '$DevPrefix-' prefixed policy names." -ForegroundColor Green
+    } else {
+        Write-Host "`nDeployment completed with $failedCount failures. Check the logs above for details." -ForegroundColor Yellow
+    }
+    
+    Write-Host "`nNext steps:" -ForegroundColor Cyan
+    Write-Host "1. Configure your DEV Netskope tenant with policy names prefixed with '$DevPrefix-'" -ForegroundColor White
+    Write-Host "2. Configure data endpoints to use the newly created DCEs" -ForegroundColor White
+    Write-Host "3. Verify data ingestion using the verification queries" -ForegroundColor White
+    Write-Host "4. Update your analytics rules to filter by policy name prefixes" -ForegroundColor White
+    
+}
+catch {
+    Write-Error "Deployment failed: $($_.Exception.Message)"
+    Write-Host "Stack trace: $($_.ScriptStackTrace)" -ForegroundColor Red
+    exit 1
+}

--- a/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /README.md
+++ b/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /README.md
@@ -1,0 +1,288 @@
+# Netskope Multiple Instance Deployment Solution
+
+This folder contains scripts and documentation for deploying multiple Netskope data connector instances in the same Microsoft Sentinel workspace.
+
+## Problem Statement
+
+By design, Microsoft Sentinel's Content Hub only allows deploying one instance of the Netskope Alerts and Events data connector per workspace. However, many organizations need to collect data from multiple Netskope environments (e.g., PROD and DEV) in a single Sentinel workspace while maintaining data separation and identical table schemas.
+
+## Solution Overview
+
+This PowerShell-based deployment solution creates a second set of Netskope data pollers with unique names, allowing both PROD and DEV environments to send data to the same Log Analytics tables. Environment separation is achieved through policy name prefixes rather than separate connectors.
+
+### Key Benefits
+
+- ✅ **Same Table Schema**: Both environments write to identical Log Analytics tables
+- ✅ **Environment Separation**: Uses policy name prefixes (PROD-/DEV-) for clear identification
+- ✅ **Simple Deployment**: Single PowerShell script handles all 21 connector types
+- ✅ **Cost Effective**: No duplicate storage or complex data transformation
+- ✅ **Analytics Compatibility**: Existing queries work with simple filtering additions
+
+## Files in This Solution
+
+| File | Description |
+|------|-------------|
+| `Deploy-NetskopeDevInstance.ps1` | Main deployment script that creates DEV data pollers |
+| `parameters.json` | Template for deployment parameters |
+| `VerificationQueries.kql` | KQL queries to validate deployment and data ingestion |
+| `README.md` | This documentation file |
+
+## Prerequisites
+
+Before running the deployment script, ensure you have:
+
+1. **Azure PowerShell Modules**:
+   ```powershell
+   Install-Module -Name Az.Accounts, Az.Resources, Az.OperationalInsights -Force
+   ```
+
+2. **Azure Authentication**:
+   ```powershell
+   Connect-AzAccount
+   ```
+
+3. **Existing Resources**:
+   - Log Analytics workspace
+   - PROD Netskope connector already deployed via Content Hub
+   - Appropriate Azure permissions (Contributor role on resource group)
+
+4. **Netskope Configuration**:
+   - Access to both PROD and DEV Netskope tenants
+   - Ability to configure data export policies
+
+## Deployment Steps
+
+### Step 1: Prepare Parameters
+
+Edit the `parameters.json` file or prepare the following information:
+
+```json
+{
+  "subscriptionId": "your-subscription-id",
+  "resourceGroupName": "your-resource-group",
+  "workspaceName": "your-log-analytics-workspace",
+  "location": "eastus"
+}
+```
+
+### Step 2: Run Deployment Script
+
+Execute the PowerShell script with your parameters:
+
+```powershell
+.\Deploy-NetskopeDevInstance.ps1 `
+  -SubscriptionId "12345678-1234-1234-1234-123456789012" `
+  -ResourceGroupName "rg-sentinel" `
+  -WorkspaceName "law-sentinel" `
+  -Location "eastus"
+```
+
+Optional parameters:
+- `-DevPrefix "DEV"` (default)
+- `-ProdPrefix "PROD"` (default)
+
+### Step 3: Configure Netskope Tenants
+
+After successful deployment:
+
+1. **PROD Environment**: Configure policies with prefix `PROD-`
+   - Example: `PROD-WebPolicy`, `PROD-DLPPolicy`
+
+2. **DEV Environment**: Configure policies with prefix `DEV-`
+   - Example: `DEV-WebPolicy`, `DEV-DLPPolicy`
+
+3. **Data Export**: Configure both tenants to send data to their respective endpoints
+
+### Step 4: Verify Deployment
+
+Use the queries in `VerificationQueries.kql` to confirm:
+- Data collection rules are created
+- Data is flowing from both environments
+- Policy name prefixes are working correctly
+
+## Architecture
+
+The solution creates the following resources for each of the 21 Netskope event types:
+
+```
+PROD Environment (via Content Hub):
+├── DCE: dce-NetskopeAlertsEvents-ApplicationEvents
+├── DCR: dcr-NetskopeAlertsEvents-ApplicationEvents
+└── Target: NetskopeApplicationEvents_CL
+
+DEV Environment (via this script):
+├── DCE: dce-DEV-NetskopeAlertsEvents-ApplicationEvents  
+├── DCR: dcr-DEV-NetskopeAlertsEvents-ApplicationEvents
+└── Target: NetskopeApplicationEvents_CL (same table!)
+```
+
+## Supported Event Types
+
+The script deploys connectors for all 21 Netskope event types:
+
+| Event Type | Target Table |
+|------------|--------------|
+| Application Events | NetskopeApplicationEvents_CL |
+| Audit Events | NetskopeAuditEvents_CL |
+| Connection Events | NetskopeConnectionEvents_CL |
+| Infrastructure Events | NetskopeInfrastructureEvents_CL |
+| Network Events | NetskopeNetworkEvents_CL |
+| Pages Events | NetskopePagesEvents_CL |
+| Alerts Events | NetskopeAlertsEvents_CL |
+| Behavior Analytics | NetskopeBehaviorAnalyticsAlertsEvents_CL |
+| Compromised Credentials | NetskopeCompromisedCredentialsAlertsEvents_CL |
+| DLP Alerts | NetskopeDLPAlertsEvents_CL |
+| Legal Hold | NetskopeLegalHoldAlertsEvents_CL |
+| Malsite Alerts | NetskopeMalsiteAlertsEvents_CL |
+| Malware Alerts | NetskopeMalwareAlertsEvents_CL |
+| Policy Alerts | NetskopePolicyAlertsEvents_CL |
+| Quarantine Alerts | NetskopeQuarantineAlertsEvents_CL |
+| Remediation Alerts | NetskopeRemediationAlertsEvents_CL |
+| Security Assessment | NetskopeSecurityAssessmentAlertsEvents_CL |
+| UBA Alerts | NetskopeUBAAlertsEvents_CL |
+| Watchlist Alerts | NetskopeWatchlistAlertsEvents_CL |
+| WebTx Alerts | NetskopeWebTxAlertsEvents_CL |
+| CTEP Alerts | NetskopeCTEPAlertsEvents_CL |
+
+## Data Separation Strategy
+
+Instead of using separate tables or workspaces, this solution uses **policy name prefixes** for environment separation:
+
+### Analytics Rule Example
+
+Update your existing analytics rules to filter by environment:
+
+```kql
+// Original query
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| where RiskLevel == "High"
+
+// Updated query for PROD only
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| where RiskLevel == "High"
+| where PolicyName startswith "PROD-"
+
+// Updated query for DEV only  
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| where RiskLevel == "High"
+| where PolicyName startswith "DEV-"
+
+// Query both environments
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| where RiskLevel == "High"
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission Errors**
+   ```
+   Error: Insufficient privileges to complete the operation
+   ```
+   **Solution**: Ensure you have Contributor role on the resource group
+
+2. **Workspace Not Found**
+   ```
+   Error: Log Analytics workspace 'workspace-name' not found
+   ```
+   **Solution**: Verify workspace name and resource group are correct
+
+3. **Resource Already Exists**
+   ```
+   Error: Resource with name 'dce-DEV-...' already exists
+   ```
+   **Solution**: Run the script with `-Force` parameter or manually delete existing resources
+
+4. **Module Not Found**
+   ```
+   Error: The term 'New-AzResource' is not recognized
+   ```
+   **Solution**: Install required Azure PowerShell modules
+
+### Validation Queries
+
+Check resource creation:
+```powershell
+# List all DCEs
+Get-AzResource -ResourceGroupName $ResourceGroupName -ResourceType "Microsoft.Insights/dataCollectionEndpoints" | Where-Object {$_.Name -like "*DEV*"}
+
+# List all DCRs  
+Get-AzResource -ResourceGroupName $ResourceGroupName -ResourceType "Microsoft.Insights/dataCollectionRules" | Where-Object {$_.Name -like "*DEV*"}
+```
+
+### Data Flow Verification
+
+Use KQL queries in `VerificationQueries.kql` to verify data is flowing correctly from both environments.
+
+## Cost Considerations
+
+This solution has minimal additional cost impact:
+
+- **Data Collection Endpoints (DCE)**: ~$0.50/month each
+- **Data Collection Rules (DCR)**: No additional charge
+- **Data Ingestion**: Same cost as single environment (no duplication)
+- **Storage**: Same tables, no additional storage cost
+
+**Total Additional Cost**: ~$10-15/month for 21 DCEs
+
+## Support and Maintenance
+
+### Updates
+
+When updating Netskope connector configurations:
+
+1. Update PROD environment via Content Hub as usual
+2. Re-run this script if schema changes require DCR updates
+3. Test with DEV environment first
+
+### Monitoring
+
+Set up monitoring for both environments:
+
+```kql
+// Monitor data ingestion by environment
+union NetskopePl*_CL
+| where TimeGenerated > ago(1h) 
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development",
+    "Unknown"
+)
+| summarize EventCount = count() by Environment, bin(TimeGenerated, 5m)
+| render timechart
+```
+
+## Contributing
+
+This solution is part of the Microsoft Sentinel community repository. To contribute improvements:
+
+1. Test changes in a development environment
+2. Update documentation as needed
+3. Submit pull requests with clear descriptions
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2024-12-24 | Initial release with support for all 21 Netskope event types |
+
+## License
+
+This solution is provided under the same license as the Microsoft Sentinel community repository.
+
+---
+
+**Questions or Issues?** 
+- Review the troubleshooting section above
+- Check the verification queries for data flow issues
+- Consult Microsoft Sentinel documentation for DCE/DCR concepts

--- a/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /VerificationQueries.kql
+++ b/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /VerificationQueries.kql
@@ -1,0 +1,332 @@
+// Netskope Multiple Instance Deployment - Verification Queries
+// Use these KQL queries to verify successful deployment and data ingestion
+
+//============================================================================
+// 1. DEPLOYMENT VERIFICATION QUERIES
+//============================================================================
+
+// Check if Data Collection Rules (DCRs) were created successfully
+// This query verifies that all 21 DEV DCRs exist
+Resources
+| where type == "microsoft.insights/datacollectionrules"
+| where resourceGroup == "YOUR_RESOURCE_GROUP_NAME"  // Replace with your resource group
+| where name startswith "dcr-DEV-NetskopeAlertsEvents"
+| project name, location, resourceGroup
+| sort by name asc
+
+// Check if Data Collection Endpoints (DCEs) were created successfully  
+Resources
+| where type == "microsoft.insights/datacollectionendpoints"
+| where resourceGroup == "YOUR_RESOURCE_GROUP_NAME"  // Replace with your resource group
+| where name startswith "dce-DEV-NetskopeAlertsEvents"
+| project name, location, resourceGroup
+| sort by name asc
+
+// Count total DEV resources created (should be 42 - 21 DCEs + 21 DCRs)
+Resources
+| where type in ("microsoft.insights/datacollectionrules", "microsoft.insights/datacollectionendpoints")
+| where resourceGroup == "YOUR_RESOURCE_GROUP_NAME"  // Replace with your resource group
+| where name contains "DEV-NetskopeAlertsEvents"
+| summarize TotalDevResources = count() by type
+| extend ResourceType = case(
+    type == "microsoft.insights/datacollectionrules", "Data Collection Rules (DCRs)",
+    type == "microsoft.insights/datacollectionendpoints", "Data Collection Endpoints (DCEs)",
+    type
+)
+| project ResourceType, TotalDevResources
+
+//============================================================================
+// 2. DATA INGESTION VERIFICATION QUERIES
+//============================================================================
+
+// Verify data is flowing from both PROD and DEV environments
+// Check Application Events (replace with your actual table if different)
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(24h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize EventCount = count(), 
+           FirstEvent = min(TimeGenerated),
+           LastEvent = max(TimeGenerated) 
+    by Environment
+| order by EventCount desc
+
+// Monitor data ingestion rates by environment (last 4 hours)
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(4h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize EventCount = count() by Environment, bin(TimeGenerated, 15m)
+| render timechart 
+
+// Check all Netskope tables for environment distribution
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| extend TableName = split(Type, "_")[0]
+| summarize EventCount = count() by TableName, Environment
+| sort by TableName, Environment
+
+//============================================================================
+// 3. POLICY NAME PREFIX VALIDATION
+//============================================================================
+
+// Verify policy name prefixes are working correctly
+// Check for events without proper prefixes (these may need attention)
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| where not(PolicyName startswith "PROD-" or PolicyName startswith "DEV-")
+| extend TableName = split(Type, "_")[0]
+| summarize UnprefixedEvents = count(), 
+           SamplePolicyNames = make_set(PolicyName, 10)
+    by TableName
+| where UnprefixedEvents > 0
+
+// Show distribution of policy name prefixes across all tables
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Other"
+)
+| extend TableName = split(Type, "_")[0]
+| summarize EventCount = count() by TableName, Environment
+| evaluate pivot(Environment)
+
+//============================================================================
+// 4. SPECIFIC EVENT TYPE VERIFICATION
+//============================================================================
+
+// Application Events - Environment separation check
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize count() by Environment, Activity
+| sort by Environment, count_ desc
+
+// Audit Events - Environment separation check  
+NetskopeAuditEvents_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize count() by Environment, AuditType
+| sort by Environment, count_ desc
+
+// DLP Alerts - Environment separation check
+NetskopeDLPAlertsEvents_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize count() by Environment, Severity
+| sort by Environment, count_ desc
+
+//============================================================================
+// 5. DATA QUALITY VALIDATION
+//============================================================================
+
+// Check for duplicate events between PROD and DEV
+// This query identifies potential duplicate events (same timestamp, user, activity)
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize Environments = make_set(Environment), 
+           EventCount = count()
+    by TimeGenerated, User, Activity
+| where EventCount > 1 and array_length(Environments) > 1
+| project TimeGenerated, User, Activity, Environments, EventCount
+| sort by TimeGenerated desc
+
+// Monitor schema consistency between environments
+// Check if field presence is consistent across PROD and DEV
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| extend HasUser = isnotempty(User),
+         HasActivity = isnotempty(Activity),
+         HasSeverity = isnotempty(Severity)
+| summarize 
+    TotalEvents = count(),
+    EventsWithUser = countif(HasUser),
+    EventsWithActivity = countif(HasActivity),
+    EventsWithSeverity = countif(HasSeverity)
+    by Environment
+| extend 
+    UserFieldPercentage = round(EventsWithUser * 100.0 / TotalEvents, 2),
+    ActivityFieldPercentage = round(EventsWithActivity * 100.0 / TotalEvents, 2),
+    SeverityFieldPercentage = round(EventsWithSeverity * 100.0 / TotalEvents, 2)
+
+//============================================================================
+// 6. PERFORMANCE MONITORING
+//============================================================================
+
+// Monitor ingestion latency by environment
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| extend TableName = split(Type, "_")[0]
+| extend IngestionDelay = datetime_diff('second', ingestion_time(), TimeGenerated)
+| summarize 
+    AvgDelaySeconds = avg(IngestionDelay),
+    MaxDelaySeconds = max(IngestionDelay),
+    EventCount = count()
+    by Environment, TableName
+| sort by AvgDelaySeconds desc
+
+// Check for any ingestion errors or gaps
+union Netskope*_CL
+| where TimeGenerated > ago(4h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize EventCount = count() by Environment, bin(TimeGenerated, 10m)
+| sort by TimeGenerated desc
+| extend TimeSinceLastEvent = datetime_diff('minute', now(), TimeGenerated)
+| where TimeSinceLastEvent > 20  // Flag gaps longer than 20 minutes
+
+//============================================================================
+// 7. ANALYTICS RULE TESTING
+//============================================================================
+
+// Test environment-specific filtering for analytics rules
+// Example: High-risk application access in PROD environment only
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)
+| where PolicyName startswith "PROD-"  // PROD environment filter
+| where RiskLevel == "High" or Risk_Score > 70
+| project TimeGenerated, User, Application, RiskLevel, Risk_Score, PolicyName
+| sort by TimeGenerated desc
+
+// Example: Monitor DEV environment for unusual activity patterns
+NetskopeApplicationEvents_CL
+| where TimeGenerated > ago(1h)  
+| where PolicyName startswith "DEV-"   // DEV environment filter
+| summarize UniqueUsers = dcount(User),
+           UniqueApps = dcount(Application),
+           TotalEvents = count()
+    by bin(TimeGenerated, 5m)
+| where UniqueUsers > 10 or TotalEvents > 100  // Adjust thresholds as needed
+
+//============================================================================
+// 8. DASHBOARD QUERIES
+//============================================================================
+
+// Environment Overview Dashboard Query
+union Netskope*_CL
+| where TimeGenerated > ago(24h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| extend TableName = split(Type, "_")[0]
+| summarize 
+    EventCount = count(),
+    UniqueUsers = dcount(User),
+    FirstEvent = min(TimeGenerated),
+    LastEvent = max(TimeGenerated)
+    by Environment, TableName
+| sort by Environment, EventCount desc
+
+// Top Users by Environment
+union Netskope*_CL
+| where TimeGenerated > ago(24h)
+| extend Environment = case(
+    PolicyName startswith "PROD-", "Production",
+    PolicyName startswith "DEV-", "Development", 
+    "Unknown"
+)
+| summarize EventCount = count() by Environment, User
+| sort by Environment, EventCount desc
+| take 50
+
+//============================================================================
+// 9. TROUBLESHOOTING QUERIES  
+//============================================================================
+
+// Find events with missing policy names
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| where isempty(PolicyName) or PolicyName == ""
+| extend TableName = split(Type, "_")[0]
+| summarize EventsWithoutPolicy = count() by TableName
+| where EventsWithoutPolicy > 0
+
+// Check for unexpected policy name patterns
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| where not(PolicyName startswith "PROD-" or PolicyName startswith "DEV-")
+| where isnotempty(PolicyName)
+| summarize UnexpectedPolicies = make_set(PolicyName, 20), 
+           EventCount = count()
+| where EventCount > 0
+
+// Monitor for schema changes or parsing errors
+union Netskope*_CL
+| where TimeGenerated > ago(1h)
+| extend ParseErrors = column_ifexists("_ResourceId", ""),
+         RawDataLength = strlen(column_ifexists("RawData", ""))
+| where isnotempty(ParseErrors) or RawDataLength > 50000
+| extend TableName = split(Type, "_")[0]
+| summarize PotentialIssues = count() by TableName
+| where PotentialIssues > 0
+
+//============================================================================
+// USAGE NOTES:
+//============================================================================
+/*
+1. Replace "YOUR_RESOURCE_GROUP_NAME" with your actual resource group name in queries 1-3
+
+2. Adjust time ranges in "ago()" functions based on your data volume:
+   - High volume: ago(1h) or ago(30m) 
+   - Low volume: ago(24h) or ago(7d)
+
+3. Policy name prefixes can be customized:
+   - Change "PROD-" and "DEV-" to match your actual prefixes
+   - Add additional environments if needed (e.g., "TEST-", "STAGING-")
+
+4. For automated monitoring, save these queries as:
+   - Alert rules for missing data or errors
+   - Scheduled searches for regular validation
+   - Dashboard tiles for operational visibility
+
+5. Run verification queries after:
+   - Initial deployment
+   - Netskope configuration changes  
+   - Schema updates or connector modifications
+   - Suspected data ingestion issues
+*/

--- a/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /parameters.json
+++ b/Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/DeploymentScripts /parameters.json
@@ -1,0 +1,148 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "description": "Parameter template for Netskope DEV instance deployment",
+        "author": "Microsoft Sentinel Community",
+        "version": "1.0"
+    },
+    "parameters": {
+        "subscriptionId": {
+            "value": "12345678-1234-1234-1234-123456789012",
+            "metadata": {
+                "description": "Azure subscription ID where resources will be deployed",
+                "example": "12345678-1234-1234-1234-123456789012"
+            }
+        },
+        "resourceGroupName": {
+            "value": "rg-sentinel",
+            "metadata": {
+                "description": "Name of the resource group containing the Log Analytics workspace",
+                "example": "rg-sentinel"
+            }
+        },
+        "workspaceName": {
+            "value": "law-sentinel",
+            "metadata": {
+                "description": "Name of the Log Analytics workspace",
+                "example": "law-sentinel"
+            }
+        },
+        "location": {
+            "value": "eastus",
+            "metadata": {
+                "description": "Azure region where resources will be deployed",
+                "allowedValues": [
+                    "eastus",
+                    "eastus2", 
+                    "westus",
+                    "westus2",
+                    "centralus",
+                    "northcentralus",
+                    "southcentralus",
+                    "westcentralus",
+                    "canadacentral",
+                    "canadaeast",
+                    "brazilsouth",
+                    "northeurope",
+                    "westeurope",
+                    "uksouth",
+                    "ukwest",
+                    "francecentral",
+                    "germanywestcentral",
+                    "norwayeast",
+                    "switzerlandnorth",
+                    "swedencentral",
+                    "australiaeast",
+                    "australiasoutheast",
+                    "japaneast",
+                    "japanwest",
+                    "koreacentral",
+                    "koreasouth",
+                    "southeastasia",
+                    "eastasia",
+                    "centralindia",
+                    "southindia",
+                    "westindia",
+                    "southafricanorth",
+                    "uaenorth"
+                ],
+                "example": "eastus"
+            }
+        },
+        "devPrefix": {
+            "value": "DEV",
+            "metadata": {
+                "description": "Prefix for DEV environment resources",
+                "example": "DEV"
+            }
+        },
+        "prodPrefix": {
+            "value": "PROD", 
+            "metadata": {
+                "description": "Prefix for PROD environment resources (for reference only)",
+                "example": "PROD"
+            }
+        }
+    },
+    "variables": {
+        "deploymentInfo": {
+            "description": "This parameter file is used with Deploy-NetskopeDevInstance.ps1 to create a second set of Netskope data connectors for DEV environment",
+            "supportedEventTypes": [
+                "ApplicationEvents",
+                "AuditEvents", 
+                "ConnectionEvents",
+                "InfrastructureEvents",
+                "NetworkEvents",
+                "PagesEvents",
+                "AlertsEvents",
+                "BehaviorAnalyticsAlertsEvents",
+                "CompromisedCredentialsAlertsEvents",
+                "DLPAlertsEvents",
+                "LegalHoldAlertsEvents",
+                "MalsiteAlertsEvents",
+                "MalwareAlertsEvents",
+                "PolicyAlertsEvents",
+                "QuarantineAlertsEvents",
+                "RemediationAlertsEvents",
+                "SecurityAssessmentAlertsEvents",
+                "UBAAlertsEvents",
+                "WatchlistAlertsEvents",
+                "WebTxAlertsEvents",
+                "CTEPAlertsEvents"
+            ],
+            "totalConnectors": 21,
+            "estimatedDeploymentTime": "10-15 minutes"
+        }
+    },
+    "outputs": {
+        "deploymentGuide": {
+            "type": "object",
+            "value": {
+                "step1": "Update the parameter values above with your environment details",
+                "step2": "Run: .\\Deploy-NetskopeDevInstance.ps1 -SubscriptionId '<subscriptionId>' -ResourceGroupName '<resourceGroupName>' -WorkspaceName '<workspaceName>' -Location '<location>'",
+                "step3": "Configure your DEV Netskope tenant with policy names prefixed with the devPrefix value",
+                "step4": "Use VerificationQueries.kql to validate deployment and data ingestion",
+                "step5": "Update analytics rules to filter by policy name prefixes for environment separation"
+            }
+        },
+        "requiredPermissions": {
+            "type": "array",
+            "value": [
+                "Microsoft.Insights/dataCollectionEndpoints/write",
+                "Microsoft.Insights/dataCollectionRules/write", 
+                "Microsoft.OperationalInsights/workspaces/read",
+                "Microsoft.Resources/resourceGroups/read"
+            ]
+        },
+        "resourcesCreated": {
+            "type": "object",
+            "value": {
+                "dataCollectionEndpoints": "21 DCEs with names like 'dce-DEV-NetskopeAlertsEvents-<EventType>'",
+                "dataCollectionRules": "21 DCRs with names like 'dcr-DEV-NetskopeAlertsEvents-<EventType>'",
+                "targetTables": "Same tables as PROD environment (e.g., NetskopeApplicationEvents_CL)",
+                "totalResources": 42
+            }
+        }
+    }
+}


### PR DESCRIPTION
     ## Add Netskope multiple instance deployment solution



**Change(s):**
- Added PowerShell deployment script `Deploy-NetskopeDevInstance.ps1` to create multiple Netskope data connector instances
- Added comprehensive documentation in `README.md` explaining the deployment solution and usage
- Added verification queries in `VerificationQueries.kql` to validate successful deployment
- Added parameter template file `parameters.json` for easy configuration
- Created new `DeploymentScripts` folder under `Solutions/Netskopev2/Data Connectors/NetskopeAlertsEvents_RestAPI_CCP/`

**Reason for Change(s):**
- Content Hub only allows deploying one Netskope connector instance per workspace, but customers need both PROD and DEV environments in the same workspace
- ARM template deployment is complex for customers wanting multiple instances with identical schemas
- Provides simplified PowerShell-based alternative for deploying second Netskope instance
- Enables environment separation through policy name prefixes while maintaining same table schemas
- Addresses customer requirement for consolidated Netskope data from multiple environments

**Version Updated:**
- N/A - This is a new deployment utility, not a data connector/detection/analytic rule template

## Solution Overview

This PR provides a complete deployment solution for customers who need multiple Netskope data connector instances in the same Microsoft Sentinel workspace. The solution includes:

1. **Automated PowerShell deployment** - Creates 21 DEV data pollers matching existing PROD structure
2. **Environment separation strategy** - Uses policy name prefixes (PROD-/DEV-) for clear identification
3. **Same table schema** - Both environments write to identical Log Analytics tables
4. **Comprehensive documentation** - Step-by-step deployment and troubleshooting guide
5. **Verification tools** - KQL queries to validate successful deployment and data ingestion

This addresses the limitation where Content Hub only allows one connector instance per workspace, providing customers with a simple alternative to complex ARM template modifications.