### PR TITLE
Clarify PowerShell version requirements and AWS CLI

### DIFF
--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -25,8 +25,10 @@ At a high level, these scripts do the following:
 You must have PowerShell and the AWS CLI installed before using these scripts.
 
 - PowerShell [Installation instructions](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.1)
-- AWS CLI [Installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+  - Please ensure you're not using windows powershell (can only have version 5 - will not work), use a version of powershell >= 7  
+- AWS CLI [Installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) (
   - Run from PowerShell `aws configure`. For more details please see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+  - Recommended you install the latest version as older versions (e.g 2.0.9) have failed to work with these scripts 
 
 ## Using the scripts
 For Microsoft Azure, please download and extract the `ConfigAwsS3DataConnectorScripts.zip` file to your computer.


### PR DESCRIPTION
Change(s):
   - Updated installation instructions for PowerShell and AWS CLI

Reason for Change(s):
   -  A CRI about this which resulted in invalid json being passed to `--tags` flag when creating sqs queue. This was investigated and was found because they were using an old version of aws cli.


CRI is pending completion. Will finalize this PR once its resolved.
