### PR TITLE
Version enforcement for powershell v7

### DIFF
--- a/DataConnectors/AWS-S3/ConfigAwsConnector.ps1
+++ b/DataConnectors/AWS-S3/ConfigAwsConnector.ps1
@@ -36,6 +36,13 @@ param (
 . ".\Utils\AwsSentinelTag.ps1"
 . ".\Enviornment\EnviornmentConstants.ps1"
 
+# Verify that powershell version 7 is being used
+if ($PSVersionTable.PSVersion.Major -lt 7) 
+{ 
+    Write-Error "This script requires PowerShell 7 or higher. You are running version $($PSVersionTable.PSVersion). Please install the latest version of PowerShell from https://aka.ms/powershell and try again."
+    exit
+}
+
 # Verify that the AWS CLI is available
 if ($null -eq (Get-Command "aws" -ErrorAction SilentlyContinue)) 
 { 

--- a/DataConnectors/AWS-S3/README.md
+++ b/DataConnectors/AWS-S3/README.md
@@ -25,8 +25,10 @@ At a high level, these scripts do the following:
 You must have PowerShell and the AWS CLI installed before using these scripts.
 
 - PowerShell [Installation instructions](https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-7.1)
+  - Please ensure you're not using Windows Powershell (is version 5 - will not work), use a version of powershell >= 7  
 - AWS CLI [Installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
   - Run from PowerShell `aws configure`. For more details please see [AWS configure documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+  - Please install the latest version as older versions (e.g 2.0.9) have failed to work with these scripts
 
 ## Using the scripts
 For Microsoft Azure, please download and extract the `ConfigAwsS3DataConnectorScripts.zip` file to your computer.


### PR DESCRIPTION
Change(s):
  - Added powershell version check to ensure user is not using a powershell version < 7
  - Updated README.md to be explicit in using the up to date versions of aws cli and powershell.

Reason for Change(s):
   - There was a CRI in which a consumer ran into this issue. However, while they did install the correct powershell, they had used a prior command of `powershell.exe -ExecutionPolicy Bypass ...` which references the windows powershell executable (pwsh.exe is v7+). They effectively ran powershell v5 on the powershell v7 cli which caused a lot of confusion. This check helps prevent this.

Check was tested and blocks if using windows powershell.