### PR TITLE
Update urllib3 dependency to 2.5.0 in /Solutions/Box/Data Connectors

### DIFF
--- a/Solutions/Box/Data Connectors/requirements.txt
+++ b/Solutions/Box/Data Connectors/requirements.txt
@@ -9,4 +9,4 @@ cryptography==44.0.1
 boxsdk==3.3.0
 azure-storage-file-share==12.7.0
 python-dateutil==2.8.2
-urllib3==1.26.19
+urllib3==2.5.0


### PR DESCRIPTION
Bumped urllib3 version from 1.26.19 to 2.5.0 in requirements.txt. Updated BoxConn.zip to reflect dependency changes.

   
   Change(s):
   - Update urllib3 dependency to 2.5.0 in /Solutions/Box/Data Connectors

   Reason for Change(s):
   - Dependabot cannot update to the required version