### PR TITLE
Add new CDR for domains with DMARC TempError result

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Custom Detections/Message from Accepted Domain with DMARC TempError.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Custom Detections/Message from Accepted Domain with DMARC TempError.yaml
@@ -3,7 +3,7 @@ name: Message from an Accepted Domain with DMARC TempError
 description: |
   This query can be used as a Custom Detection Rule (CDR) to trigger when a potentially malicious email appearing to come from an Accepted Domain but DMARC had a (transient) TempError result.
 description-detailed: |
-  This query can be used as a Custom Detection Rule (CDR) to trigger when a potentially malicious email appearing to come from an Accepted Domain but DMARC had a (transient) TempError result. DMARC or SPF results can be modified to trigger on "temperror", "permerror", "softfail" or "fail" depending on requirements. https://learn.microsoft.com/en-us/defender-xdr/custom-detection-rules
+  This query can be used as a Custom Detection Rule (CDR) to trigger when a potentially malicious email appearing to come from an Accepted Domain but DMARC had a (transient) TempError result. DMARC or SPF results can be modified to trigger on "temperror", "permerror", "softfail" or "fail" depending on requirements. Can be run in Continuous (NRT) frequency. https://learn.microsoft.com/en-us/defender-xdr/custom-detection-rules
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Custom Detections/Message from Accepted Domain with DMARC TempError.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Custom Detections/Message from Accepted Domain with DMARC TempError.yaml
@@ -3,7 +3,7 @@ name: Message from an Accepted Domain with DMARC TempError
 description: |
   This query can be used as a Custom Detection Rule (CDR) to trigger when a potentially malicious email appearing to come from an Accepted Domain but DMARC had a (transient) TempError result.
 description-detailed: |
-  This query can be used as a Custom Detection Rule (CDR) to trigger when a potentially malicious email appearing to come from an Accepted Domain but DMARC had a (transient) TempError result. DMARC or SPF results can be modified to trigger on "temperror", "permerror", "softfail" or "fail" depending on requirements. https://learn.microsoft.com/en-us/defender-xdr/custom-detection-rules
+  This query can be used as a Custom Detection Rule (CDR) to trigger when a potentially malicious email appearing to come from an Accepted Domain but DMARC had a (transient) TempError result. DMARC or SPF results can be modified to trigger on "temperror", "permerror", "softfail" or "fail" depending on requirements. Can be run in Continuous (NRT) frequency. https://learn.microsoft.com/en-us/defender-xdr/custom-detection-rules
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:


### PR DESCRIPTION
Change(s):

- Adding a new example query to detect when emails from certain domains, such as the accepted domains of the org, have come from external and have either a SPF or DMARC with TempError, indicating a (transient) DNS lookup issue. Create a NRT Custom Detection Rule which removes these emails automatically from inboxes.

Reason for Change(s):

- Adding new community query within Advanced Hunting for customers that do not use Sentinel. 

Version Updated:

- Not Applicable

Testing Completed:

- Tested in Advanced Hunting within test tenants

Checked that the validations are passing and have addressed any issues that are present:

- Yes