### PR TITLE
Update requests dependency to 2.32.4 in /Solutions/Sophos Endpoint Protection/Data Connectors

### DIFF
--- a/Solutions/Sophos Endpoint Protection/Data Connectors/requirements.txt
+++ b/Solutions/Sophos Endpoint Protection/Data Connectors/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.31.0
+requests==2.32.4
 azure-storage-file-share==12.3.0
 azure-functions==1.6.0


### PR DESCRIPTION
 Bumped requests dependency from 2.31.0 to 2.32.4 in requirements.txt. Updated SophosConn.zip to reflect dependency changes.
   
   Change(s):
   - Update requests dependency to 2.32.4 in /Solutions/Sophos Endpoint Protection/Data Connectors

   Reason for Change(s):
   - Dependabot cannot update to the required version