### PR TITLE
Update requests dependency to 2.32.4 in /Solutions/Oracle Cloud Infrastructure/Data Connectors

### DIFF
--- a/Solutions/Oracle Cloud Infrastructure/Data Connectors/requirements.txt
+++ b/Solutions/Oracle Cloud Infrastructure/Data Connectors/requirements.txt
@@ -1,3 +1,3 @@
 azure-functions
 oci==2.43.2
-requests==2.31.0
+requests==2.32.4


### PR DESCRIPTION
Updated OCILogsConn.zip and bumped requests library from 2.31.0 to 2.32.4 in requirements.txt to ensure compatibility.

   Required items, please complete
   
   Change(s):
   - Update requests dependency to 2.32.4 in /Solutions/Oracle Cloud Infrastructure/Data Connectors

   Reason for Change(s):
   - Dependabot cannot update to the required version

  