### PR TITLE
Update requests dependency to 2.32.4 in /Solutions/Mulesoft/Data Connectors 

### DIFF
--- a/Solutions/Mulesoft/Data Connectors/requirements.txt
+++ b/Solutions/Mulesoft/Data Connectors/requirements.txt
@@ -4,4 +4,4 @@
 
 azure-storage-file-share==12.3.0
 azure-functions
-requests==2.31.0
+requests==2.32.4


### PR DESCRIPTION
Bumped requests from 2.31.0 to 2.32.4 in requirements.txt and updated MuleSoftCloudhubAPISentinelConn.zip

   Required items, please complete
   
   Change(s):
   - Update requests dependency to 2.32.4 in /Solutions/Mulesoft/Data Connectors 

   Reason for Change(s):
   -Dependabot cannot update to the required version