### PR TITLE
Update NRT_AuthenticationMethodsChangedforVIPUsers.yaml query syntax and version number

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/NRT_AuthenticationMethodsChangedforVIPUsers.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/NRT_AuthenticationMethodsChangedforVIPUsers.yaml
@@ -15,7 +15,7 @@ tags:
   - AADSecOpsGuide
 query: |
   let security_info_actions = dynamic(["User registered security info", "User changed default security info", "User deleted security info", "Admin updated security info", "User reviewed security info", "Admin deleted security info", "Admin registered security info"]);
-  let VIPUsers = (_GetWatchlist('VIPUsers') | distinct "User Principal Name");
+  let VIPUsers = (_GetWatchlist('VIPUsers') | distinct ["User Principal Name"]);
   AuditLogs
   | where Category =~ "UserManagement"
   | where ActivityDisplayName in (security_info_actions)
@@ -62,5 +62,5 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.5
+version: 1.0.6
 kind: NRT


### PR DESCRIPTION
   Change(s):
   - Updated syntax for NRT_AuthenticationMethodsChangedforVIPUsers.yaml, adding square brackets `[]`

   Reason for Change(s):
   - In this case, the use of square brackets is essential, since the field name in the watchlist contains spaces. Without them, only the string 'User Principal Name' will be selected instead of the real user principal names.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - No
