### PR TITLE
Add RunMRUWithNonASCIICharacters hunting query

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Execution/RunMRUWithNonASCIICharacters.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Execution/RunMRUWithNonASCIICharacters.yaml
@@ -1,6 +1,8 @@
 id: 6e8ee46f-80ee-46f6-be49-49a66f01edce
 name: RunMRU with non-ASCII characters
 description: |
+  Identifies non-ASCII data written to the RunMRU registry key by explorer.
+description-detailed: |
   Identifies non-ASCII data written to the RunMRU registry key by explorer. This may indicate user-pasted commands from social engineering tactics like "ClickFix", where users are tricked into executing code.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
@@ -11,6 +13,7 @@ tactics:
 relevantTechniques:
 - T1204.004
 query: |
+  //Identifies non-ASCII data written to the RunMRU registry key by explorer. This may indicate user-pasted commands from social engineering tactics like "ClickFix", where users are tricked into executing code.
   DeviceRegistryEvents
     | where InitiatingProcessFileName == "explorer.exe"
     | where ActionType == "RegistryValueSet"
@@ -18,4 +21,4 @@ query: |
     | where RegistryValueData matches regex "[^[:ascii]]"
     // If too noisy add the following filter
     // | where RegistryValueData contains "#"
-version: 1.0.0
+version: 1.0.1


### PR DESCRIPTION
   Change(s):
   - Added `RunMRUWithNonASCIICharacters.yaml` hunting query which includes detection logic for explorer.exe modifying RunMRU registry entries with non-ASCII characters

   Reason for Change(s):
   - Supports detection of user-driven execution via Run dialog, consistent with social engineering tactics like "ClickFix"

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes