### PR TITLE
Standalone aws data connector- 3.11 version update

### DIFF
--- a/DataConnectors/AWS-S3-AzureFunction/azuredeploy_awss3.json
+++ b/DataConnectors/AWS-S3-AzureFunction/azuredeploy_awss3.json
@@ -198,7 +198,7 @@
                 "alwaysOn": true,
                 "reserved": true,
                 "siteConfig": {
-                    "linuxFxVersion": "python|3.9"
+                    "linuxFxVersion": "python|3.11"
                 },
 				"serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('HostingPlanName'))]"				
 			},            

--- a/DataConnectors/AWS-S3-AzureFunction/host.json
+++ b/DataConnectors/AWS-S3-AzureFunction/host.json
@@ -11,6 +11,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.*, 4.0.0)"
+    "version": "[4.*, 5.0.0)"
   }
 }

--- a/DataConnectors/AWS-S3-AzureFunction/requirements.txt
+++ b/DataConnectors/AWS-S3-AzureFunction/requirements.txt
@@ -3,5 +3,5 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions
-boto3==1.9.180
+boto3>=1.26.0
 requests==2.31.0


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated packages to support 3.11 version 

   Reason for Change(s):
   - Deprecation of 3.9 version. 
   - GitHub Issue: https://github.com/Azure/Azure-Sentinel/issues/13111

   Version Updated:
   - 3.11

   Testing Completed:
   - Yes
   