### PR TITLE
Update IPEntity_AppServiceHTTPLogs.yaml

### DIFF
--- a/Solutions/Threat Intelligence (NEW)/Analytic Rules/IPEntity_AppServiceHTTPLogs.yaml
+++ b/Solutions/Threat Intelligence (NEW)/Analytic Rules/IPEntity_AppServiceHTTPLogs.yaml
@@ -66,7 +66,7 @@ query: |
     // Select the desired output fields
     | extend Description = tostring(parse_json(Data).description)
     | extend ActivityGroupNames = extract(@"ActivityGroup:(\S+)", 1, tostring(parse_json(Data).labels))
-    | project AppService_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, TI_ipEntity, CsUsername, WebApp = split(_ResourceId, '/')[8], CIp, CsHost, NetworkSourceIP, _ResourceId, Type, Url
+    | project AppService_TimeGenerated, Description, ActivityGroupNames, Id, ValidUntil, Confidence, TI_ipEntity, CsUsername, WebApp = split(_ResourceId, '/')[8], CIp, CsHost, NetworkSourceIP, _ResourceId, Type, Url, AlertPriority
     // Extract hostname and DNS domain from the CsHost field
     | extend HostName = tostring(split(CsHost, '.', 0)[0]), DnsDomain = tostring(strcat_array(array_slice(split(CsHost, '.'), 1, -1), '.'))
     // Rename the timestamp field
@@ -96,6 +96,6 @@ entityMappings:
         columnName: _ResourceId
 alertDetailsOverride:
   alertSeverityColumnName: AlertPriority
-version: 1.5.6
+version: 1.5.7
 kind: Scheduled
  


### PR DESCRIPTION
Missing column added, alertSeverityColumnName rely on that field

   Required items, please complete
   
   Change(s):
   - Added missing column in IPEntity_AppServiceHTTPLogs.yaml

   Reason for Change(s):
   - Rule was broken, not able to install without the fix

   Version Updated:
   - Yes, updated

   Testing Completed:
   - Added column during installation from template and it worked.

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below

