### PR TITLE
Skip workflow failure for excluded ASIM parsers

### DIFF
--- a/.script/tests/asimParsersTest/runAsimTesters.ps1
+++ b/.script/tests/asimParsersTest/runAsimTesters.ps1
@@ -166,6 +166,12 @@ function invokeAsimTester([string] $test, [string] $name, [string] $kind) {
             }
         }
     } catch {
+        $IgnoreParserIsSet = IgnoreValidationForASIMParsers | Where-Object { $name -like "$_*" }
+        if ($IgnoreParserIsSet) {
+            Write-Host "::warning::The parser '$name' is listed in the parser exclusions file. Therefore, this workflow run will not fail because of it. To allow this parser to cause the workflow to fail, please remove its name from the exclusions list file located at: '$ParserExclusionsFilePath'"
+            return
+        }
+        
         Write-Host "::error::  -- $_"
         Write-Host "::error::     $(((Get-Error -Newest 1)?.Exception)?.Response?.Content)"
         throw $_ # Commented out to allow the script to continue running


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Adds logic to check if a parser is listed in the exclusions file and, if so, prevents the workflow from failing for that parser. A warning message is displayed to inform users about the exclusion and how to remove it if needed.

   Reason for Change(s):
   - Specified above

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

