### PR TITLE
feat(mdo): add rare domains in external Teams messages query

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Rare Domains in External Teams Messages.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Rare Domains in External Teams Messages.yaml
@@ -1,0 +1,60 @@
+id: d4dd8c3f-d62b-4078-9dc7-8520c3adf1d5
+name: Rare Domains in External Teams Messages
+description: Detects rare domains (seen in fewer than 3 Teams messages) appearing in external Microsoft Teams threads within the last 24 hours.
+description-detailed: >
+  This query detects uncommon domains shared through external Microsoft Teams 
+  message threads. Domains are classified as "rare" if they appear in fewer than 3 
+  messages across your entire Teams environment, then filtered to show only those 
+  appearing in external (cross-organization) threads. Results include sender 
+  information, full URLs, and any user click actions from Teams, helping analysts 
+  identify potential phishing attempts or social engineering targeting external 
+  collaboration channels.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - MessageEvents
+  - MessageUrlInfo
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+  - Execution
+relevantTechniques:
+  - T1566
+  - T1204
+query: |
+  let lookback = 1d;
+  // External Teams messages 
+  let externalMsgs =
+    MessageEvents
+    | where Timestamp > ago(lookback) and IsExternalThread == true
+    | project MsgTime = Timestamp, TeamsMessageId, SenderEmailAddress, ME_ReportId = ReportId;
+  // URLs found in Teams messages 
+  let urlsInMsgs =
+    MessageUrlInfo
+    | where Timestamp > ago(lookback)
+    | project MUI_Time = Timestamp, TeamsMessageId, Url, UrlDomain, MUI_ReportId = ReportId;
+  // Clicks coming from Teams 
+  let clicks =
+    UrlClickEvents
+    | where Timestamp > ago(lookback) and Workload == "Teams"
+    | project ClickTime = Timestamp, Url, Clicker = AccountUpn, ClickAction = ActionType, UCE_ReportId = ReportId;
+  // Define "rare" domains in the period 
+  let rareDomains =
+    urlsInMsgs
+    | summarize msgCount = dcount(TeamsMessageId) by UrlDomain
+    | where msgCount < 3;
+  rareDomains
+    | join kind=inner (urlsInMsgs) on UrlDomain
+    | join kind=leftouter (externalMsgs) on TeamsMessageId
+    | join kind=leftouter (clicks) on Url
+    | project
+        Timestamp = coalesce(ClickTime, MUI_Time, MsgTime),
+        UrlDomain,
+        Url,
+        SenderEmailAddress,
+        Clicker,
+        ClickTime,
+        ClickAction,
+        TeamsMessageId,
+        ReportId = coalesce(UCE_ReportId, MUI_ReportId, ME_ReportId)
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Rare Domains in External Teams Messages.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Rare Domains in External Teams Messages.yaml
@@ -1,0 +1,60 @@
+id: b2a36ca5-b6a4-4f27-a7d8-7f044885cccf
+name: Rare Domains in External Teams Messages
+description: Detects rare domains (seen in fewer than 3 Teams messages) appearing in external Microsoft Teams threads within the last 24 hours.
+description-detailed: >
+  This query detects uncommon domains shared through external Microsoft Teams 
+  message threads. Domains are classified as "rare" if they appear in fewer than 3 
+  messages across your entire Teams environment, then filtered to show only those 
+  appearing in external (cross-organization) threads. Results include sender 
+  information, full URLs, and any user click actions from Teams, helping analysts 
+  identify potential phishing attempts or social engineering targeting external 
+  collaboration channels.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - MessageEvents
+  - MessageUrlInfo
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+  - Execution
+relevantTechniques:
+  - T1566
+  - T1204
+query: |
+  let lookback = 1d;
+  // External Teams messages 
+  let externalMsgs =
+    MessageEvents
+    | where Timestamp > ago(lookback) and IsExternalThread == true
+    | project MsgTime = Timestamp, TeamsMessageId, SenderEmailAddress, ME_ReportId = ReportId;
+  // URLs found in Teams messages 
+  let urlsInMsgs =
+    MessageUrlInfo
+    | where Timestamp > ago(lookback)
+    | project MUI_Time = Timestamp, TeamsMessageId, Url, UrlDomain, MUI_ReportId = ReportId;
+  // Clicks coming from Teams 
+  let clicks =
+    UrlClickEvents
+    | where Timestamp > ago(lookback) and Workload == "Teams"
+    | project ClickTime = Timestamp, Url, Clicker = AccountUpn, ClickAction = ActionType, UCE_ReportId = ReportId;
+  // Define "rare" domains in the period 
+  let rareDomains =
+    urlsInMsgs
+    | summarize msgCount = dcount(TeamsMessageId) by UrlDomain
+    | where msgCount < 3;
+  rareDomains
+    | join kind=inner (urlsInMsgs) on UrlDomain
+    | join kind=leftouter (externalMsgs) on TeamsMessageId
+    | join kind=leftouter (clicks) on Url
+    | project
+        Timestamp = coalesce(ClickTime, MUI_Time, MsgTime),
+        UrlDomain,
+        Url,
+        SenderEmailAddress,
+        Clicker,
+        ClickTime,
+        ClickAction,
+        TeamsMessageId,
+        ReportId = coalesce(UCE_ReportId, MUI_ReportId, ME_ReportId)
+version: 1.0.0


### PR DESCRIPTION
Detects uncommon domains shared in external Microsoft Teams threads. Identifies domains appearing in fewer than 3 messages across the environment and correlates with sender information and user click actions to support phishing and social engineering investigations.
   
   Change(s):
   - Added new advanced hunting query: `Rare Domains in External Teams Messages`
   - Query files: 
     - `Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Rare Domains in External Teams Messages.yaml`
     - `Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Rare Domains in External Teams Messages.yaml`
   - Utilizes `MessageEvents`, `MessageUrlInfo`, and `UrlClickEvents` tables from Microsoft Defender for Office 365

   Reason for Change(s):
   - Provides threat hunters with capability to identify potential phishing attempts in external Teams collaboration
   - Addresses detection gap for rare/malicious domains shared through cross-organization Teams threads
   - Supports investigation of social engineering attacks targeting external communication channels

   Version Updated:
   - Initial version 1.0.0

   Testing Completed:
   - Verified query executes successfully against `MessageEvents`, `MessageUrlInfo`, and `UrlClickEvents` tables
   - Confirmed results align with expected detection logic (rare domains in external threads)
   - No custom parsers, functions, or tables required

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
   - KQL syntax validation: Passed
   - YAML schema validation: Passed
   - No validation errors present

