### PR TITLE
Update extension bundle version in host.json

### DIFF
--- a/Solutions/GitHub/Data Connectors/GithubWebhook/host.json
+++ b/Solutions/GitHub/Data Connectors/GithubWebhook/host.json
@@ -10,7 +10,7 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.3.0, 4.0.0)"
+    "version": "[4.*, 5.0.0)" 
   },
   "functionTimeout": "00:10:00",
   "extensions": {


### PR DESCRIPTION
Changed the Azure Functions extension bundle version range in host.json to [4.*, 5.0.0). Updated GithubWebhookConnector.zip to reflect these changes.

   Required items, please complete
   
   Change(s):
   - Update extension bundle version in host.json

   Reason for Change(s):
   - https://github.com/Azure/Azure-Sentinel/issues/13172
