### PR TITLE
Reverting to the previous commit's API versions for the CCP/CCF solutions

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -246,10 +246,10 @@ function Get-ContentTemplateResource($contentResourceDetails, $TemplateCounter, 
 
 function Get-ArmResource($name, $type, $kind, $properties) {
     [hashtable]$apiVersion = @{
-        "Microsoft.SecurityInsights/dataConnectors"           = "2025-09-01";
-        "Microsoft.SecurityInsights/dataConnectorDefinitions" = "2025-09-01";
-        "Microsoft.OperationalInsights/workspaces/tables"     = "2025-07-01";
-        "Microsoft.Insights/dataCollectionRules"              = "2024-03-11";
+        "Microsoft.SecurityInsights/dataConnectors"           = "2023-02-01-preview";
+        "Microsoft.SecurityInsights/dataConnectorDefinitions" = "2022-09-01-preview";
+        "Microsoft.OperationalInsights/workspaces/tables"     = "2022-10-01";
+        "Microsoft.Insights/dataCollectionRules"              = "2022-06-01";
     }
 
     return [PSCustomObject]@{


### PR DESCRIPTION
These API versions are not the latest and most stable, but they have the push connector logic.

Reverting to the previous commit's version

   Required items, please complete
   
   Change(s):
   - Reverting to the previous commit's API versions for the CCP/CCF solutions

   Reason for Change(s):
   - These API versions are not the latest and most stable, but they have the push connector logic.

   Version Updated:
   - N/A

   Testing Completed:
   - yes

   Checked that the validations are passing and have addressed any issues that are present:
   - yes
