### PR TITLE
Add C# support to CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python', 'ruby', 'actions' ]
+        language: [ 'javascript', 'python', 'ruby', 'actions', 'csharp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'actions' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
@@ -50,6 +50,16 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
         queries: security-extended,security-and-quality
+
+    # ℹ️ Setup DotNet Versions to building C# projects
+    - name: Setup DotNet Versions
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: | 
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Included 'csharp' in the language matrix and added DotNet setup steps for building C# projects. This enables CodeQL analysis for C# code alongside existing languages.

   Reason for Change(s):
   - Csharp code is not being CodeQL analyzed

   Version Updated:
   - NA
   
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
