### PR TITLE
Limit fetch-depth to 10 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/arm-ttk-validations.yaml
+++ b/.github/workflows/arm-ttk-validations.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 10
       - shell: pwsh
         id: step1
         name: Identify Changes in PR

--- a/.github/workflows/hyperlinkValidator.yaml
+++ b/.github/workflows/hyperlinkValidator.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           GeneratedToken: ${{ steps.generate_token.outputs.token }}
         with:
-          fetch-depth: 0
+          fetch-depth: 10
           token: ${{ env.GeneratedToken }}
       - shell: pwsh
         id: step1

--- a/.github/workflows/slash-command-armttk.yaml
+++ b/.github/workflows/slash-command-armttk.yaml
@@ -46,7 +46,7 @@ jobs:
         if: steps.get-pr.outputs.is_fork == 'false'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 10
           ref: ${{ steps.get-pr.outputs.head_sha }}
           persist-credentials: false
       - shell: pwsh


### PR DESCRIPTION

   Change(s):
   - Updated the fetch-depth parameter from 0 (full history) to 10 in arm-ttk-validations.yaml, hyperlinkValidator.yaml, and slash-command-armttk.yaml workflows to improve performance and reduce unnecessary data transfer.

   Reason for Change(s):
   - To resolve out of space issue.

   Version Updated:
   - NA
   
   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes