### PR TITLE
Remove harcoded reference from MDTI playbook templates

### DIFF
--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Automated-Triage/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Automated-Triage/azuredeploy.json
@@ -515,7 +515,6 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "/subscriptions/a2c2c31d-ebd4-4880-a60c-d615efa9d201/resourceGroups/Sentinel-CAT/providers/microsoft.OperationalInsights/Workspaces/sentinel-lab",
                 "hidden-SentinelTemplateName": "MDTI-Automated-Triage",
                 "hidden-SentinelTemplateVersion": "1.0"
             },

--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Data-WebComponents/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Data-WebComponents/azuredeploy.json
@@ -513,7 +513,6 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "/subscriptions/a2c2c31d-ebd4-4880-a60c-d615efa9d201/resourceGroups/Sentinel-CAT/providers/microsoft.OperationalInsights/Workspaces/sentinel-lab4",
                 "hidden-SentinelTemplateName": "MDTI-Data-WebComponents",
                 "hidden-SentinelTemplateVersion": "1.0"
             },

--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Intel-Reputation/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Intel-Reputation/azuredeploy.json
@@ -367,7 +367,6 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "/subscriptions/a2c2c31d-ebd4-4880-a60c-d615efa9d201/resourceGroups/Sentinel-CAT/providers/microsoft.OperationalInsights/Workspaces/sentinel-lab4",
                 "hidden-SentinelTemplateName": "MDTI-Intel-Reputation",
                 "hidden-SentinelTemplateVersion": "1.0"
             },

--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-PassiveDns/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-PassiveDns/azuredeploy.json
@@ -650,7 +650,6 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "/subscriptions/a2c2c31d-ebd4-4880-a60c-d615efa9d201/resourceGroups/Sentinel-CAT/providers/microsoft.OperationalInsights/Workspaces/sentinel-lab4",
                 "hidden-SentinelTemplateName": "MDTI-Data-PassiveDns",
                 "hidden-SentinelTemplateVersion": "1.0"
             },

--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-PassiveDnsReverse/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-PassiveDnsReverse/azuredeploy.json
@@ -652,7 +652,6 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "/subscriptions/a2c2c31d-ebd4-4880-a60c-d615efa9d201/resourceGroups/Sentinel-CAT/providers/microsoft.OperationalInsights/Workspaces/sentinel-lab4",
                 "hidden-SentinelTemplateName": "MDTI-Data-ReverseDnS",
                 "hidden-SentinelTemplateVersion": "1.0"
             },

--- a/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Trackers/azuredeploy.json
+++ b/Solutions/Microsoft Defender Threat Intelligence/Playbooks/MDTI-Trackers/azuredeploy.json
@@ -628,7 +628,6 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "Source": "MDTI",
-                "hidden-SentinelWorkspaceId": "/subscriptions/a2c2c31d-ebd4-4880-a60c-d615efa9d201/resourceGroups/Sentinel-CAT/providers/microsoft.OperationalInsights/Workspaces/sentinel-lab4",
                 "hidden-SentinelTemplateName": "MDTI-Data-Trackers",
                 "hidden-SentinelTemplateVersion": "1.0"
             },


### PR DESCRIPTION


   Required items, please complete
   
   Change(s):
   - Deleted the 'hidden-SentinelWorkspaceId' tag from azuredeploy.json files in all Microsoft Defender Threat Intelligence playbooks. 

   Reason for Change(s):
   - This streamlines template metadata and removes hardcoded workspace references.

   Version Updated:
   - NA

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - yes
