### PR TITLE
Bug fix for invalid distinct on column names containing space characters in WatchList

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/NRT_AuthenticationMethodsChangedforVIPUsers.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/NRT_AuthenticationMethodsChangedforVIPUsers.yaml
@@ -15,7 +15,9 @@ tags:
   - AADSecOpsGuide
 query: |
   let security_info_actions = dynamic(["User registered security info", "User changed default security info", "User deleted security info", "Admin updated security info", "User reviewed security info", "Admin deleted security info", "Admin registered security info"]);
-  let VIPUsers = (_GetWatchlist('VIPUsers') | distinct ["User Principal Name"]);
+  let VIPUsers = _GetWatchlist('VIPUsers')
+    | extend ["User Principal Name"] = column_ifexists("User Principal Name","")
+    | distinct ["User Principal Name"];
   AuditLogs
   | where Category =~ "UserManagement"
   | where ActivityDisplayName in (security_info_actions)


### PR DESCRIPTION
  Change(s):
   - Updated syntax for distinct on Column in WatchList "VIPUsers" 

   Reason for Change(s):
   - ANR does not work if a column name containing space characters is escaped without brackets.

   Version Updated:
   - Yes

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes