### PR TITLE
Add Classic Automation Migration detection tool

### DIFF
--- a/Tools/Classic Automation Migration/Classic Automation Detect - Subscription Deployment (Prod).json
+++ b/Tools/Classic Automation Migration/Classic Automation Detect - Subscription Deployment (Prod).json
@@ -1,0 +1,308 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "workflows_classic_automation_detect_name": {
+            "defaultValue": "classic-automation-detect",
+            "type": "String"
+        },
+        "location": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Azure region where the Logic App will be deployed"
+            }
+        },
+        "resourceGroupName": {
+            "type": "String",
+            "metadata": {
+                "description": "Resource group name where the Logic App will be deployed"
+            }
+        },
+        "subscriptionId": {
+            "defaultValue": "[subscription().subscriptionId]",
+            "type": "String",
+            "metadata": {
+                "description": "Subscription ID to query workspaces from (default = current subscription)"
+            }
+        },
+        "deploymentTime": {
+            "defaultValue": "[utcNow()]",
+            "type": "String",
+            "metadata": {
+                "description": "Used to generate unique role assignment names"
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2021-04-01",
+            "name": "logicAppDeployment",
+            "resourceGroup": "[parameters('resourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "workflows_classic_automation_detect_name": {
+                            "type": "String"
+                        },
+                        "location": {
+                            "type": "String"
+                        },
+                        "subscriptionId": {
+                            "type": "String"
+                        }
+                    },
+                    "resources": [
+                        {
+                            "type": "Microsoft.Logic/workflows",
+                            "apiVersion": "2017-07-01",
+                            "name": "[parameters('workflows_classic_automation_detect_name')]",
+                            "location": "[parameters('location')]",
+                            "identity": {
+                                "type": "SystemAssigned"
+                            },
+                            "properties": {
+                                "state": "Enabled",
+                                "definition": {
+                                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                                    "contentVersion": "1.0.0.0",
+                                    "parameters": {
+                                        "$connections": {
+                                            "defaultValue": {},
+                                            "type": "Object"
+                                        },
+                                        "subscriptionId": {
+                                            "defaultValue": "",
+                                            "type": "String"
+                                        }
+                                    },
+                                    "triggers": {
+                                        "Recurrence": {
+                                            "recurrence": {
+                                                "interval": 3,
+                                                "frequency": "Week"
+                                            },
+                                            "evaluatedRecurrence": {
+                                                "interval": 3,
+                                                "frequency": "Week"
+                                            },
+                                            "type": "Recurrence"
+                                        }
+                                    },
+                                    "actions": {
+                                        "Impacted_Analytic_Rules_List_": {
+                                            "runAfter": {
+                                                "For_each_1": [
+                                                    "Succeeded",
+                                                    "Failed"
+                                                ]
+                                            },
+                                            "type": "Compose",
+                                            "inputs": "@variables('ActionList')",
+                                            "description": "Please migrate your 'Classic Automation' playbooks to automation rules.\nFor detailed, step-by-step instructions, refer to the official guide:\nhttps://learn.microsoft.com/en-us/azure/sentinel/automation/migrate-playbooks-to-automation-rules"
+                                        },
+                                        "Subscription_Id": {
+                                            "runAfter": {
+                                                "Analytic_Rules_list": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Compose",
+                                            "inputs": "@{parameters('subscriptionId')}"
+                                        },
+                                        "List_Workspaces": {
+                                            "runAfter": {
+                                                "Subscription_Id": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Http",
+                                            "inputs": {
+                                                "uri": "https://management.azure.com/subscriptions/@{outputs('Subscription_Id')}/providers/Microsoft.OperationalInsights/workspaces?api-version=2025-07-01",
+                                                "method": "GET",
+                                                "authentication": {
+                                                    "type": "ManagedServiceIdentity"
+                                                }
+                                            },
+                                            "runtimeConfiguration": {
+                                                "contentTransfer": {
+                                                    "transferMode": "Chunked"
+                                                }
+                                            }
+                                        },
+                                        "For_each_1": {
+                                            "foreach": "@body('List_Workspaces')['value']",
+                                            "actions": {
+                                                "List_Analytic_Rules": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "uri": "https://management.azure.com@{items('For_each_1')['id']}/providers/Microsoft.SecurityInsights/alertRules?api-version=2025-09-01",
+                                                        "method": "GET",
+                                                        "authentication": {
+                                                            "type": "ManagedServiceIdentity"
+                                                        }
+                                                    },
+                                                    "description": "Note: This action may fail if a workspace that is not onboarded to Microsoft Sentinel is detected. Such failures are expected and will not cause the workflow to fail.",
+                                                    "runtimeConfiguration": {
+                                                        "contentTransfer": {
+                                                            "transferMode": "Chunked"
+                                                        }
+                                                    }
+                                                },
+                                                "For_each": {
+                                                    "foreach": "@body('List_Analytic_Rules')['value']",
+                                                    "actions": {
+                                                        "Get_Analytic_Rule_Actions": {
+                                                            "type": "Http",
+                                                            "inputs": {
+                                                                "uri": "https://management.azure.com@{items('For_each_1')['id']}/providers/Microsoft.SecurityInsights/alertRules/@{items('For_each')['name']}/actions?api-version=2025-09-01",
+                                                                "method": "GET",
+                                                                "authentication": {
+                                                                    "type": "ManagedServiceIdentity"
+                                                                }
+                                                            },
+                                                            "runtimeConfiguration": {
+                                                                "contentTransfer": {
+                                                                    "transferMode": "Chunked"
+                                                                }
+                                                            }
+                                                        },
+                                                        "Condition": {
+                                                            "actions": {
+                                                                "Append_to_array_variable": {
+                                                                    "type": "AppendToArrayVariable",
+                                                                    "inputs": {
+                                                                        "name": "ActionList",
+                                                                        "value": {
+                                                                            "WorkspaceName": "@{items('For_each_1')['name']}",
+                                                                            "AnalyticRuleName": "@{items('For_each')['properties']['displayName']}",
+                                                                            "RuleId": "@{items('For_each')['name']}",
+                                                                            "Enabled": "@items('For_each')['properties']['enabled']"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            "runAfter": {
+                                                                "Get_Analytic_Rule_Actions": [
+                                                                    "Succeeded"
+                                                                ]
+                                                            },
+                                                            "else": {
+                                                                "actions": {}
+                                                            },
+                                                            "expression": {
+                                                                "and": [
+                                                                    {
+                                                                        "greater": [
+                                                                            "@length(body('Get_Analytic_Rule_Actions')['value'])",
+                                                                            0
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "type": "If"
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "List_Analytic_Rules": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Foreach"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "List_Workspaces": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach",
+                                            "description": "Note: This action may fail if a workspace that is not onboarded to Microsoft Sentinel is detected. Such failures are expected and will not cause the workflow to fail."
+                                        },
+                                        "Analytic_Rules_list": {
+                                            "runAfter": {},
+                                            "type": "InitializeVariable",
+                                            "inputs": {
+                                                "variables": [
+                                                    {
+                                                        "name": "ActionList",
+                                                        "type": "array"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "outputs": {}
+                                },
+                                "parameters": {
+                                    "$connections": {
+                                        "value": {}
+                                    },
+                                    "subscriptionId": {
+                                        "value": "[parameters('subscriptionId')]"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "outputs": {
+                        "logicAppPrincipalId": {
+                            "type": "String",
+                            "value": "[reference(resourceId('Microsoft.Logic/workflows', parameters('workflows_classic_automation_detect_name')), '2019-05-01', 'Full').identity.principalId]"
+                        }
+                    }
+                },
+                "parameters": {
+                    "workflows_classic_automation_detect_name": {
+                        "value": "[parameters('workflows_classic_automation_detect_name')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "subscriptionId": {
+                        "value": "[parameters('subscriptionId')]"
+                    }
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(subscription().id, 'SentinelReader', parameters('workflows_classic_automation_detect_name'), parameters('deploymentTime'))]",
+            "dependsOn": [
+                "logicAppDeployment"
+            ],
+            "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8d289c81-5878-46d4-8554-54e1e3d8b5cb')]",
+                "principalId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'logicAppDeployment'), '2021-04-01').outputs.logicAppPrincipalId.value]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(subscription().id, 'Reader', parameters('workflows_classic_automation_detect_name'), parameters('deploymentTime'))]",
+            "dependsOn": [
+                "logicAppDeployment"
+            ],
+            "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                "principalId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'logicAppDeployment'), '2021-04-01').outputs.logicAppPrincipalId.value]",
+                "principalType": "ServicePrincipal"
+            }
+        }
+    ],
+    "outputs": {
+        "logicAppPrincipalId": {
+            "type": "String",
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'logicAppDeployment'), '2021-04-01').outputs.logicAppPrincipalId.value]"
+        }
+    }
+}

--- a/Tools/Classic Automation Migration/Classic Automation Detect - Workspace level (Prod).json
+++ b/Tools/Classic Automation Migration/Classic Automation Detect - Workspace level (Prod).json
@@ -1,0 +1,259 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "workflows_classic_automation_detect_name": {
+            "defaultValue": "classic-automation-detect-workspace",
+            "type": "String"
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "String"
+        },
+        "subscriptionId": {
+            "defaultValue": "[subscription().subscriptionId]",
+            "type": "String",
+            "metadata": {
+                "description": "Subscription ID where the workspace is located (default = current subscription)"
+            }
+        },
+        "workspaceName": {
+            "type": "String",
+            "metadata": {
+                "description": "Log Analytics workspace name hosting Microsoft Sentinel"
+            }
+        },
+        "workspaceResourceGroup": {
+            "defaultValue": "[resourceGroup().name]",
+            "type": "String",
+            "metadata": {
+                "description": "Resource group name of the Sentinel workspace (default = current RG)"
+            }
+        }
+    },
+    "variables": {
+        "logicAppResourceId": "[resourceId('Microsoft.Logic/workflows', parameters('workflows_classic_automation_detect_name'))]",
+        "workspaceScopeId": "[resourceId(parameters('workspaceResourceGroup'), 'Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('workflows_classic_automation_detect_name')]",
+            "location": "[parameters('location')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "state": "Enabled",
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "subscriptionId": {
+                            "defaultValue": "",
+                            "type": "String"
+                        },
+                        "workspaceName": {
+                            "defaultValue": "",
+                            "type": "String"
+                        },
+                        "resourceGroup": {
+                            "defaultValue": "",
+                            "type": "String"
+                        },
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        }
+                    },
+                    "triggers": {
+                        "Recurrence": {
+                            "recurrence": {
+                                "interval": 3,
+                                "frequency": "Week"
+                            },
+                            "evaluatedRecurrence": {
+                                "interval": 3,
+                                "frequency": "Week"
+                            },
+                            "type": "Recurrence"
+                        }
+                    },
+                    "actions": {
+                        "Subscription_Id": {
+                            "runAfter": {
+                                "Analytic_Rules_list": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Compose",
+                            "inputs": "@{parameters('subscriptionId')}"
+                        },
+                        "Analytic_Rules_list": {
+                            "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "ActionList",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Workspace_Name": {
+                            "runAfter": {
+                                "Subscription_Id": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Compose",
+                            "inputs": "@{parameters('workspaceName')}"
+                        },
+                        "Resource_Group": {
+                            "runAfter": {
+                                "Workspace_Name": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Compose",
+                            "inputs": "@{parameters('resourceGroup')}"
+                        },
+                        "List_Analytic_Rules": {
+                            "runAfter": {
+                                "Resource_Group": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "uri": "https://management.azure.com/subscriptions/@{outputs('Subscription_Id')}/resourceGroups/@{outputs('Resource_Group')}/providers/Microsoft.OperationalInsights/workspaces/@{outputs('Workspace_Name')}/providers/Microsoft.SecurityInsights/alertRules?api-version=2025-09-01",
+                                "method": "GET",
+                                "authentication": {
+                                    "type": "ManagedServiceIdentity"
+                                }
+                            },
+                            "description": "",
+                            "runtimeConfiguration": {
+                                "contentTransfer": {
+                                    "transferMode": "Chunked"
+                                }
+                            }
+                        },
+                        "For_each": {
+                            "foreach": "@body('List_Analytic_Rules')['value']",
+                            "actions": {
+                                "Get_Analytic_Rule_Actions": {
+                                    "type": "Http",
+                                    "inputs": {
+                                        "uri": "https://management.azure.com/subscriptions/@{outputs('Subscription_Id')}/resourceGroups/@{outputs('Resource_Group')}/providers/Microsoft.OperationalInsights/workspaces/@{outputs('Workspace_Name')}/providers/Microsoft.SecurityInsights/alertRules/@{items('For_each')['name']}/actions?api-version=2025-09-01",
+                                        "method": "GET",
+                                        "authentication": {
+                                            "type": "ManagedServiceIdentity"
+                                        }
+                                    },
+                                    "runtimeConfiguration": {
+                                        "contentTransfer": {
+                                            "transferMode": "Chunked"
+                                        }
+                                    }
+                                },
+                                "Condition": {
+                                    "actions": {
+                                        "Append_to_array_variable": {
+                                            "type": "AppendToArrayVariable",
+                                            "inputs": {
+                                                "name": "ActionList",
+                                                "value": {
+                                                    "WorkspaceName": "@{outputs('Workspace_Name')}",
+                                                    "AnalyticRuleName": "@{items('For_each')['properties']['displayName']}",
+                                                    "RuleId": "@{items('For_each')['name']}",
+                                                    "Enabled": "@items('For_each')['properties']['enabled']"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Get_Analytic_Rule_Actions": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "else": {
+                                        "actions": {}
+                                    },
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "greater": [
+                                                    "@length(body('Get_Analytic_Rule_Actions')['value'])",
+                                                    0
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "If"
+                                }
+                            },
+                            "runAfter": {
+                                "List_Analytic_Rules": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Foreach"
+                        },
+                        "Impacted_Analytic_Rules_List_": {
+                            "runAfter": {
+                                "For_each": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Compose",
+                            "inputs": "@variables('ActionList')",
+                            "description": "Please migrate your 'Classic Automation' playbooks to automation rules.\nFor detailed, step-by-step instructions, refer to the official guide:\nhttps://learn.microsoft.com/en-us/azure/sentinel/automation/migrate-playbooks-to-automation-rules"
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "subscriptionId": {
+                        "value": "[parameters('subscriptionId')]"
+                    },
+                    "workspaceName": {
+                        "value": "[parameters('workspaceName')]"
+                    },
+                    "resourceGroup": {
+                        "value": "[parameters('workspaceResourceGroup')]"
+                    },
+                    "$connections": {
+                        "value": {}
+                    }
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(variables('workspaceScopeId'), 'SentinelReader', parameters('workflows_classic_automation_detect_name'))]",
+            "dependsOn": [
+                "[variables('logicAppResourceId')]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8d289c81-5878-46d4-8554-54e1e3d8b5cb')]",
+                "principalId": "[reference(variables('logicAppResourceId'), '2019-05-01', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+            },
+            "scope": "[variables('workspaceScopeId')]"
+        }
+    ],
+    "outputs": {
+        "logicAppPrincipalId": {
+            "type": "String",
+            "value": "[reference(variables('logicAppResourceId'), '2019-05-01', 'Full').identity.principalId]"
+        },
+        "workspaceScopeId": {
+            "type": "String",
+            "value": "[variables('workspaceScopeId')]"
+        }
+    }
+}

--- a/Tools/Classic Automation Migration/README.md
+++ b/Tools/Classic Automation Migration/README.md
@@ -1,0 +1,105 @@
+# Classic Automation Detection Tool
+
+**Author:** Sagi Yagen
+
+## Overview
+
+As Microsoft Sentinel approaches the deprecation of classic automation, this tool helps you quickly identify analytic rules that still use classic alert-trigger playbooks and need to be migrated to automation rules.
+
+This tool contains two ARM template-based Logic Apps that scan your environment and provide a complete list of impacted analytic rules requiring migration.
+
+> **Learn more:** [Migrate your Microsoft Sentinel alert-trigger playbooks to automation rules](https://learn.microsoft.com/en-us/azure/sentinel/automation/migrate-playbooks-to-automation-rules)
+
+---
+
+## Available Solutions
+
+### 1. Subscription-Level Detection (Recommended)
+
+**Permissions granted to the Logic App:**
+- `Reader` (subscription scope)
+- `Sentinel Reader` (subscription scope)
+
+**Deployment requirement:** User must have `Owner` role on the subscription
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FTools%2FClassic%20Automation%20Migration%2FClassic%20Automation%20Detect%20-%20Subscription%20Deployment%20(Prod).json)
+
+---
+
+### 2. Workspace-Level Detection
+
+**Permissions granted to the Logic App:**
+- `Sentinel Reader` (workspace scope)
+
+**Deployment requirement:** User must have `Owner` role on the workspace
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FTools%2FClassic%20Automation%20Migration%2FClassic%20Automation%20Detect%20-%20Workspace%20level%20(Prod).json)
+
+---
+
+## When to Use Each Version
+
+| Scenario | Recommended Version |
+|----------|---------------------|
+| Multiple workspaces across a subscription | **Subscription-Level** |
+| Enterprise-wide scan | **Subscription-Level** |
+| Single workspace environment | **Workspace-Level** |
+| No subscription Owner permissions | **Workspace-Level** |
+| Want minimal permission scope | **Workspace-Level** |
+| Need to scan multiple workspaces without subscription permissions | **Workspace-Level** (deploy per workspace) |
+
+---
+
+## Understanding the Output
+
+After running the Logic App, navigate to the run history and locate the final action: **"Impacted_Analytic_Rules_List_"**
+
+This action returns a list of analytic rules that still use classic automation:
+
+```json
+[
+  {
+    "WorkspaceName": "YourSentinelWorkspace",
+    "AnalyticRuleName": "Suspicious Login Activity",
+    "RuleId": "12345678-1234-1234-1234-123456789abc",
+    "Enabled": true
+  }
+]
+```
+
+### 🚨 If you have results, you need to take action!
+
+Each rule listed requires migration from classic automation to automation rules. Follow this simple step-by-step guide to perform the migration:
+
+👉 **[Migration Guide: Classic Automation to Automation Rules](https://learn.microsoft.com/en-us/azure/sentinel/automation/migrate-playbooks-to-automation-rules)**
+
+The migration typically takes 2-3 steps per rule and ensures your automations continue working after classic automation is deprecated.
+
+---
+
+## FAQ
+
+### Can I run this multiple times?
+Yes! The Logic App is non-destructive and only reads configuration data. You can run it as many times as needed.
+
+### Will this modify my analytic rules?
+No. This tool only **detects** and **reports** on analytic rules. It does not make any changes to your environment.
+
+### What if I have hundreds of analytic rules?
+The Logic App is designed to handle large environments. It processes workspaces and rules iteratively and returns all results in a single output.
+
+### Can I customize the recurrence schedule?
+Yes. After deployment, you can modify the Logic App trigger to run on any schedule you prefer, or disable the recurrence entirely and run it manually only.
+
+### Do I need to keep the Logic App after migration?
+Once you've completed all migrations, you can safely delete the Logic App. However, you may want to keep it to periodically verify that no new classic automations are added.
+
+---
+
+**Last Updated:** December 2025  
+**Version:** 1.0  
+**Type:** Community Solution
+
+---
+
+> **⚠️ Disclaimer:** This is a community-contributed tool designed to assist with the migration from classic automation to automation rules. While created to help Microsoft Sentinel customers, this is not an official Microsoft product. Use at your own discretion and test in a non-production environment first.


### PR DESCRIPTION
## Change(s):
- Added new Classic Automation Migration detection tool to Tools folder
- Includes two ARM templates:
  - Subscription-level detection (scans all workspaces in a subscription)
  - Workspace-level detection (scans a specific workspace)
- Added comprehensive README with deployment instructions, FAQ, and usage guidance

## Reason for Change(s):
- Microsoft Sentinel is deprecating classic automation (alert-trigger playbooks)
- Customers need an easy way to identify which analytic rules still use classic automation
- This tool automates the detection process across single or multiple workspaces
- Helps customers prepare for the migration deadline by providing a complete list of impacted rules

## Version Updated:
- N/A (New tool submission, not an analytic rule update)

## Testing Completed:
- Yes
- Both ARM templates deploy successfully to Azure
- Logic Apps execute correctly with managed identity authentication
- Tested on environments with:
  - Multiple workspaces (subscription-level deployment)
  - Single workspace (workspace-level deployment)
  - Verified proper RBAC permissions (Reader + Sentinel Reader)
- Deploy to Azure buttons validated and functional
- Output format tested and displays impacted analytic rules correctly

## Checked that the validations are passing and have addressed any issues that are present:
- Yes
- ARM templates follow standard Azure Resource Manager schema
- No KQL queries in this submission (Logic Apps use Azure Management API calls)
- README follows Tools folder conventions
- No custom parsers, functions, or tables required

## Additional Context:
- Related Microsoft Learn documentation: https://learn.microsoft.com/en-us/azure/sentinel/automation/migrate-playbooks-to-automation-rules
- Community solution designed to assist with official migration guidance
- Non-destructive read-only operations (no modifications to analytic rules)