### PR TITLE
Update 'requiredTechniques' to 'relevantTechniques' in some Analytic Rules/Hunting Queries

### DIFF
--- a/Solutions/BitSight/Analytic Rules/BitSightCompromisedSystemsDetected.yaml
+++ b/Solutions/BitSight/Analytic Rules/BitSightCompromisedSystemsDetected.yaml
@@ -42,5 +42,5 @@ entityMappings:
         columnName: RiskVector
       - identifier: Category
         columnName: RiskCategory
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/BitSight/Analytic Rules/BitSightDiligenceRiskCategoryDetected.yaml
+++ b/Solutions/BitSight/Analytic Rules/BitSightDiligenceRiskCategoryDetected.yaml
@@ -44,5 +44,5 @@ entityMappings:
         columnName: RiskVector
       - identifier: Category
         columnName: RiskCategory
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/BitSight/Analytic Rules/BitSightDropInCompanyRatings.yaml
+++ b/Solutions/BitSight/Analytic Rules/BitSightDropInCompanyRatings.yaml
@@ -35,5 +35,5 @@ alertDetailsOverride:
 customDetails:
   CompanyName: CompanyName
   CompanyRating: Rating
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/BitSight/Analytic Rules/BitSightDropInHeadlineRating.yaml
+++ b/Solutions/BitSight/Analytic Rules/BitSightDropInHeadlineRating.yaml
@@ -34,5 +34,5 @@ alertDetailsOverride:
 customDetails:
   CompanyName: CompanyName
   CompanyRating: Rating
-version: 1.0.1
+version: 1.0.2
 kind: Scheduled

--- a/Solutions/Dynatrace/Analytic Rules/DynatraceApplicationSecurity_CodeLevelVulnerabilityDetection.yaml
+++ b/Solutions/Dynatrace/Analytic Rules/DynatraceApplicationSecurity_CodeLevelVulnerabilityDetection.yaml
@@ -66,5 +66,5 @@ incidentConfiguration:
     reopenClosedIncident: false
     lookbackDuration: PT5H
     matchingMethod: AllEntities
-version: 1.0.3
+version: 1.0.4
 kind: Scheduled

--- a/Solutions/Dynatrace/Analytic Rules/DynatraceApplicationSecurity_NonCriticalVulnerabilityDetection.yaml
+++ b/Solutions/Dynatrace/Analytic Rules/DynatraceApplicationSecurity_NonCriticalVulnerabilityDetection.yaml
@@ -61,5 +61,5 @@ incidentConfiguration:
     reopenClosedIncident: false
     lookbackDuration: PT5H
     matchingMethod: AllEntities
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Dynatrace/Analytic Rules/DynatraceApplicationSecurity_ThirdPartyVulnerabilityDetection.yaml
+++ b/Solutions/Dynatrace/Analytic Rules/DynatraceApplicationSecurity_ThirdPartyVulnerabilityDetection.yaml
@@ -67,5 +67,5 @@ incidentConfiguration:
     reopenClosedIncident: false
     lookbackDuration: PT5H
     matchingMethod: AllEntities
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/Dynatrace/Analytic Rules/Dynatrace_ProblemDetection.yaml
+++ b/Solutions/Dynatrace/Analytic Rules/Dynatrace_ProblemDetection.yaml
@@ -50,5 +50,5 @@ incidentConfiguration:
     reopenClosedIncident: false
     lookbackDuration: PT5H
     matchingMethod: AllEntities
-version: 1.0.2
+version: 1.0.3
 kind: Scheduled

--- a/Solutions/MicrosoftDefenderForEndpoint/Hunting Queries/MDE_Process-IOCs.yaml
+++ b/Solutions/MicrosoftDefenderForEndpoint/Hunting Queries/MDE_Process-IOCs.yaml
@@ -52,4 +52,4 @@ entityMappings:
         columnName: AlgorithmCustomEntity
       - identifier: Value
         columnName: FileHashCustomEntity
-version: 1.0.2
+version: 1.0.3


### PR DESCRIPTION
     Change(s):
   - Updated analytic rule YAML files to replace the 'requiredTechniques' field with 'relevantTechniques'

   Reason for Change(s):
   - relevantTechniques is correct property

   Version Updated:
   - Yes
   
   Testing Completed:
   - Yes
   
   Checked that the validations are passing and have addressed any issues that are present:
   - Yes