### PR TITLE
Add CodeQL suppression comments for SHA1 and compatibility

### DIFF
--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/azure/identity/_credentials/certificate.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/azure/identity/_credentials/certificate.py
@@ -120,7 +120,7 @@ def load_pkcs12_certificate(certificate_data: bytes, password: Optional[bytes] =
     pem_sections = [key_bytes] + [c.public_bytes(Encoding.PEM) for c in [cert] + additional_certs]
     pem_bytes = b"".join(pem_sections)
 
-    fingerprint = cert.fingerprint(hashes.SHA1())  # nosec
+    fingerprint = cert.fingerprint(hashes.SHA1())  # nosec        # CodeQL [SM02167] This is for backward compatibility.
 
     return _Cert(pem_bytes, private_key, fingerprint)
 

--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/hazmat/_oid.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/hazmat/_oid.py
@@ -140,7 +140,7 @@ _SIG_OIDS_TO_HASH: dict[ObjectIdentifier, hashes.HashAlgorithm | None] = {
     SignatureAlgorithmOID.ECDSA_WITH_SHA384: hashes.SHA384(),
     SignatureAlgorithmOID.ECDSA_WITH_SHA512: hashes.SHA512(),
     SignatureAlgorithmOID.ECDSA_WITH_SHA3_224: hashes.SHA3_224(),
-    SignatureAlgorithmOID.ECDSA_WITH_SHA3_256: hashes.SHA3_256(),
+    SignatureAlgorithmOID.ECDSA_WITH_SHA3_256: hashes.SHA3_256(),       # CodeQL [SM02167] This is for compatibility.
     SignatureAlgorithmOID.ECDSA_WITH_SHA3_384: hashes.SHA3_384(),
     SignatureAlgorithmOID.ECDSA_WITH_SHA3_512: hashes.SHA3_512(),       # CodeQL [SM02167] This is for compatibility.
     SignatureAlgorithmOID.DSA_WITH_SHA1: hashes.SHA1(),

--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/hazmat/backends/openssl/backend.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/hazmat/backends/openssl/backend.py
@@ -209,7 +209,7 @@ class Backend:
 
     def hmac_supported(self, algorithm: hashes.HashAlgorithm) -> bool:
         # FIPS mode still allows SHA1 for HMAC
-        if self._fips_enabled and isinstance(algorithm, hashes.SHA1):
+        if self._fips_enabled and isinstance(algorithm, hashes.SHA1):       # CodeQL [SM02167] This is for backwards compatibility.
             return True
 
         return self.hash_supported(algorithm)

--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -80,7 +80,7 @@ class PKCS7SignatureBuilder:
         if not isinstance(
             hash_algorithm,
             (
-                hashes.SHA224,
+                hashes.SHA224,          # CodeQL [SM02167] This is for compatibility.
                 hashes.SHA256,
                 hashes.SHA384,
                 hashes.SHA512,

--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/x509/base.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/x509/base.py
@@ -49,7 +49,7 @@ _AllowedHashTypes = typing.Union[
     hashes.SHA3_224,
     hashes.SHA3_256,
     hashes.SHA3_384,            # CodeQL [SM02167] This is for comtatibility.
-    hashes.SHA3_512,
+    hashes.SHA3_512,            # CodeQL [SM02167] This is for comtatibility.
 ]
 
 

--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/x509/ocsp.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/cryptography/x509/ocsp.py
@@ -37,7 +37,7 @@ class OCSPResponseStatus(utils.Enum):
 
 _ALLOWED_HASHES = (
     hashes.SHA1,            # CodeQL [SM02167] This is for backwards compatibility.
-    hashes.SHA224,
+    hashes.SHA224,          # CodeQL [SM02167] This is for backwards compatibility.
     hashes.SHA256,
     hashes.SHA384,
     hashes.SHA512,

--- a/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/requests/auth.py
+++ b/Solutions/CyberArkAudit/Data Connectors/.python_packages/lib/site-packages/requests/auth.py
@@ -202,7 +202,7 @@ class HTTPDigestAuth(AuthBase):
         s += time.ctime().encode("utf-8")
         s += os.urandom(8)
 
-        cnonce = hashlib.sha1(s).hexdigest()[:16]
+        cnonce = hashlib.sha1(s).hexdigest()[:16]          # CodeQL [SM02167] This is for compatibility.
         if _algorithm == "MD5-SESS":
             HA1 = hash_utf8(f"{HA1}:{nonce}:{cnonce}")
 

--- a/Solutions/CyeraDSPM/Data Connectors/CyeraDSPM_Functions/AzureFunction/CyeraConnector/__init__.py
+++ b/Solutions/CyeraDSPM/Data Connectors/CyeraDSPM_Functions/AzureFunction/CyeraConnector/__init__.py
@@ -120,7 +120,7 @@ DRY_RUN = _env_bool("DRY_RUN", False)
 
 # -------------------- Azure clients --------------------
 
-_default_cred = DefaultAzureCredential(exclude_interactive_browser_credential=True)
+_default_cred = DefaultAzureCredential(exclude_interactive_browser_credential=True)       # CodeQL [SM05139] Commecting to supress alert. Partner have been asked to udate the code to address the alert.
 _blob_client: Optional[BlobServiceClient] = None
 
 def _init_blob_client() -> BlobServiceClient:

--- a/Solutions/MimecastAudit/Data Connectors/Helpers/request_helper.py
+++ b/Solutions/MimecastAudit/Data Connectors/Helpers/request_helper.py
@@ -3,7 +3,7 @@ from Models.Enum.mimecast_response_codes import MimecastResponseCodes
 from Models.Error.errors import MimecastRequestError
 from Models.Request.refresh_access_key import RefreshAccessKeyRequest
 import base64
-from hashlib import sha1 as EncryptionAlgo
+from hashlib import sha1 as EncryptionAlgo      # CodeQL [SM02167] CCF based data connector is in development. This will be deprecated once CCF based connector is available.
 import hmac
 import uuid
 import datetime

--- a/Solutions/MimecastSEG/Data Connectors/Helpers/request_helper.py
+++ b/Solutions/MimecastSEG/Data Connectors/Helpers/request_helper.py
@@ -3,7 +3,7 @@ from ..Models.Enum.mimecast_response_codes import MimecastResponseCodes
 from ..Models.Error.errors import MimecastRequestError
 from ..Models.Request.refresh_access_key import RefreshAccessKeyRequest
 import base64
-from hashlib import sha1 as EncryptionAlgo
+from hashlib import sha1 as EncryptionAlgo       # CodeQL [SM02167] CCF based data connector is in development. This will be deprecated once CCF based connector is available.
 import hmac
 import uuid
 import datetime

--- a/Solutions/MimecastTIRegional/Data Connectors/Helpers/threat_intel_feed_request_helper.py
+++ b/Solutions/MimecastTIRegional/Data Connectors/Helpers/threat_intel_feed_request_helper.py
@@ -9,7 +9,7 @@ from ..Models.Enum.mimecast_endpoints import MimecastEndpoints
 from ..Models.Enum.mimecast_response_codes import MimecastResponseCodes
 from ..Models.Error.errors import MimecastRequestError
 import base64
-from hashlib import sha1 as EncryptionAlgo
+from hashlib import sha1 as EncryptionAlgo       # CodeQL [SM02167] CCF based data connector is in development. This will be deprecated once CCF based connector is available.
 import hmac
 import uuid
 import datetime

--- a/Solutions/MimecastTTP/Data Connectors/Helpers/request_helper.py
+++ b/Solutions/MimecastTTP/Data Connectors/Helpers/request_helper.py
@@ -3,7 +3,7 @@ from ..Models.Enum.mimecast_response_codes import MimecastResponseCodes
 from ..Models.Error.errors import MimecastRequestError
 from ..Models.Request.refresh_access_key import RefreshAccessKeyRequest
 import base64
-from hashlib import sha1 as EncryptionAlgo
+from hashlib import sha1 as EncryptionAlgo         # CodeQL [SM02167] CCF based data connector is in development. This will be deprecated once CCF based connector is available.
 import hmac
 import uuid
 import datetime

--- a/Solutions/Workplace from Facebook/Data Connectors/WorkplaceFacebook/WorkplaceWebhooksTrigger/__init__.py
+++ b/Solutions/Workplace from Facebook/Data Connectors/WorkplaceFacebook/WorkplaceWebhooksTrigger/__init__.py
@@ -28,7 +28,7 @@ if(not match):
 def hmac_sha1(message, secret):
     message = bytes(message, 'utf-8')
     secret = bytes(secret, 'utf-8')
-    hash = hmac.new(secret, message, hashlib.sha1)
+    hash = hmac.new(secret, message, hashlib.sha1)       # CodeQL [SM02167] SHA1 is used here for HMAC verification.
     return hash.hexdigest()
 
 


### PR DESCRIPTION
   Change(s):
   - Added comments to suppress CodeQL alerts related to SHA1 and other hash algorithms for backward compatibility and ongoing development.

   Reason for Change(s):
   - To supress CodeQL alerts

   Version Updated:
   - NA

   Testing Completed:
   - NA

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes