### PR TITLE
Add support for UseRandomGuid poller property

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -574,18 +574,10 @@ function createCCPConnectorResources($contentResourceDetails, $dataFileMetadata,
                 }
             
                 if ($global:commaSeparatedTextFieldName -eq "") {
-                    if ($useRandomGuid) {
-                        $outputString += ")]"
-                    } else {
-                        $outputString += ")]"
-                    }
+                    $outputString += ")]"
                 }
                 else {
-                    if ($useRandomGuid) {
-                        $outputString += ", copyIndex())]"
-                    } else {
-                        $outputString += ", copyIndex())]"
-                    }
+                    $outputString += ", copyIndex())]"
                 }
 
                 return $outputString


### PR DESCRIPTION
  
   **Change(s):**
This change modifies the behavior of the createCCPConnector.ps1 script to add support for a new property inside the poller definition.   If the user adds the property `UseRandomGuid=false ` , the packaging script will not append a random GUID to the data connector name (dataConneectorId).

This change allows the user to override the existing behavior which is to append a random GUID using `guidValue `in the mainTemplate.json.

It is suitable for solutions that already use a unique identifier as the dataconnector ID (name) and encounter issues with having the random GUID appended by the default behavior.

   **Reason for Change(s):**
   - Limitations with the existing packaging tool behavior caused by addition of a random GUID to the connector name.

   **Version Updated:**
   - N/A

   **Testing Completed:**
   - Yes, validated the property results in the desired changes  in behavior while retaining existing behavior for existing solutions.

