### PR TITLE
Set fetch-depth to 2 in workflow checkouts

### DIFF
--- a/.github/workflows/content-validations.yaml
+++ b/.github/workflows/content-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/data-connector-validations.yaml
+++ b/.github/workflows/data-connector-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/detection-template-schema-validations.yaml
+++ b/.github/workflows/detection-template-schema-validations.yaml
@@ -15,6 +15,8 @@ jobs:
         PRNUM: ${{ github.event.pull_request.number }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need HEAD and parent for git diff
       - name: Use .NET Core SDK ${{ env.dotnetSdkVersion }}
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/detection-validations.yaml
+++ b/.github/workflows/detection-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/documents-link-validation.yaml
+++ b/.github/workflows/documents-link-validation.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/json-syntax-validation.yaml
+++ b/.github/workflows/json-syntax-validation.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/kql-validations.yaml
+++ b/.github/workflows/kql-validations.yaml
@@ -15,6 +15,8 @@ jobs:
         PRNUM: ${{ github.event.pull_request.number }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need HEAD and parent for git diff
       - name: Use .NET Core SDK ${{ env.dotnetSdkVersion }}
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/logo-validation.yaml
+++ b/.github/workflows/logo-validation.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/non-ascii-validations.yaml
+++ b/.github/workflows/non-ascii-validations.yaml
@@ -15,6 +15,8 @@ jobs:
         dotnetSdkVersion: 3.1.401
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need HEAD and parent for git diff
       - name: Use .NET Core SDK ${{ env.dotnetSdkVersion }}
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/playbook-validations.yaml
+++ b/.github/workflows/playbook-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/sample-data-validation.yaml
+++ b/.github/workflows/sample-data-validation.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/solution-validations.yaml
+++ b/.github/workflows/solution-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/workbook-metadata-validations.yaml
+++ b/.github/workflows/workbook-metadata-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/workbook-template-validations.yaml
+++ b/.github/workflows/workbook-template-validations.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install

--- a/.github/workflows/yaml-syntax-validation.yaml
+++ b/.github/workflows/yaml-syntax-validation.yaml
@@ -19,6 +19,8 @@ jobs:
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v
       - name: npm install
         run: npm install


### PR DESCRIPTION
   Change(s):
   - Updated all GitHub Actions workflows to use 'fetch-depth: 2' when checking out code. This ensures both HEAD and its parent commit are available for git diff operations, improving validation accuracy in pull request workflows and avoiding storage issues.

   Reason for Change(s):
   - To avoid storage exhaustion issue

   Version Updated:
   - NA

   Testing Completed:
   - Yes
   
  Checked that the validations are passing and have addressed any issues that are present:
   - Yes