### PR TITLE
Feature/amirsasson/fix dataconnector name logic

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -626,6 +626,14 @@ function createCCPConnectorResources($contentResourceDetails, $dataFileMetadata,
                     $armResource.type = "Microsoft.OperationalInsights/workspaces/providers/dataConnectors"
                     $armResource.kind = $ccpItem.PollerKind;
 
+                    if ($null -ne $fileContent.condition) {
+                        $armResource | Add-Member -MemberType NoteProperty -Name "condition" -Value $fileContent.condition                       
+                    }
+
+                    if ($null -ne $fileContent.copy) {
+                        $armResource | Add-Member -MemberType NoteProperty -Name "copy" -Value $fileContent.copy
+                    }
+
                     if ($global:commaSeparatedTextFieldName -ne "") {
                         $copyObject = [ordered]@{
                             name  = "copyObject"


### PR DESCRIPTION
Fix packaging script to respect when the Poller config already specifies the full name of the resource.
in addition respect [Condition ](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-tutorial-use-conditions) and Arm [Copy](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/copy-resources) 