### PR TITLE
Handle multiple offers in GetCatalogDetails

### DIFF
--- a/.script/package-automation/catalogAPI.ps1
+++ b/.script/package-automation/catalogAPI.ps1
@@ -25,6 +25,25 @@ function GetCatalogDetails($offerId)
                 return $null;
             }
             else {
+                # Handle case where multiple offers are returned with same name
+                if ($offerDetails -is [System.Object[]])
+                {
+                    Write-Host "Multiple offers found for offerId $offerId. Selecting the latest one."
+                    # If multiple results, sort by displayRank (higher is newer/better) or by modifiedDate if available
+                    if ($offerDetails[0].PSObject.Properties.Name -contains 'displayRank')
+                    {
+                        $offerDetails = $offerDetails | Sort-Object -Property displayRank -Descending | Select-Object -First 1
+                    }
+                    elseif ($offerDetails[0].PSObject.Properties.Name -contains 'modifiedDate')
+                    {
+                        $offerDetails = $offerDetails | Sort-Object -Property modifiedDate -Descending | Select-Object -First 1
+                    }
+                    else
+                    {
+                        # If no rank or date property, just pick the first one
+                        $offerDetails = $offerDetails[0]
+                    }
+                }
                 Write-Host "CatalogAPI Details found for offerId $offerId"
                 return $offerDetails;
             }

--- a/.script/package-automation/catalogAPI.ps1
+++ b/.script/package-automation/catalogAPI.ps1
@@ -26,19 +26,24 @@ function GetCatalogDetails($offerId)
             }
             else {
                 # Handle case where multiple offers are returned with same OfferId
-                if ($offerDetails -is [System.Object[]])
+                if ($offerDetails -is [System.Object[]] -and $offerDetails.Count -gt 1)
                 {
-                    Write-Host "Multiple offers found for offerId $offerId. Selecting the latest one."
-                    if ($offerDetails[0].PSObject.Properties.Name -contains 'displayRank')
+                    Write-Host "Multiple offers found for offerId $offerId. Matching by publisherId from baseMetadata."
+                    $matched = $offerDetails | Where-Object { $_.publisherId -eq $baseMetadata.publisherId }
+                    if ($null -ne $matched)
                     {
-                        $offerDetails = $offerDetails | Sort-Object -Property displayRank -Descending | Select-Object -First 1
-                    }
-                    elseif ($offerDetails[0].PSObject.Properties.Name -contains 'modifiedDate')
-                    {
-                        $offerDetails = $offerDetails | Sort-Object -Property modifiedDate -Descending | Select-Object -First 1
+                        if ($matched -is [System.Object[]])
+                        {
+                            $offerDetails = $matched[0]
+                        }
+                        else
+                        {
+                            $offerDetails = $matched
+                        }
                     }
                     else
                     {
+                        Write-Host "No offer matched publisherId '$($baseMetadata.publisherId)'. Defaulting to first offer."
                         $offerDetails = $offerDetails[0]
                     }
                 }

--- a/.script/package-automation/catalogAPI.ps1
+++ b/.script/package-automation/catalogAPI.ps1
@@ -25,11 +25,10 @@ function GetCatalogDetails($offerId)
                 return $null;
             }
             else {
-                # Handle case where multiple offers are returned with same name
+                # Handle case where multiple offers are returned with same OfferId
                 if ($offerDetails -is [System.Object[]])
                 {
                     Write-Host "Multiple offers found for offerId $offerId. Selecting the latest one."
-                    # If multiple results, sort by displayRank (higher is newer/better) or by modifiedDate if available
                     if ($offerDetails[0].PSObject.Properties.Name -contains 'displayRank')
                     {
                         $offerDetails = $offerDetails | Sort-Object -Property displayRank -Descending | Select-Object -First 1
@@ -40,7 +39,6 @@ function GetCatalogDetails($offerId)
                     }
                     else
                     {
-                        # If no rank or date property, just pick the first one
                         $offerDetails = $offerDetails[0]
                     }
                 }


### PR DESCRIPTION
Update GetCatalogDetails to handle cases where the Catalog API returns multiple offers for the same offerId. If an array of offers is returned, the script now selects the best candidate by displayRank (descending) or by modifiedDate (descending), falling back to the first item if neither property exists. Adds a diagnostic Write-Host message when multiple offers are found.

   Required items, please complete
   
   Change(s):
   - See guidance below

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


# Guidance <- remove section before submitting
-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for XYZ.yaml

   Reason for Change(s):
   - New schema used for XYZ.yaml
   - Resolves ISSUE #1234

   Version updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

_Note: If updating a detection, you must update the version field._

> Before the submission has been made, please look at running the KQL and Yaml Validation Checks locally.
> https://github.com/Azure/Azure-Sentinel#run-kql-validation-locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
