### PR TITLE
Introduced vSys (deviceCustomString3) and DeviceName into the summary rules for Palo Alto Networks.

### DIFF
--- a/Summary rules/Network/PaloAltoPANOSNetworkSessionIPSummary.yaml
+++ b/Summary rules/Network/PaloAltoPANOSNetworkSessionIPSummary.yaml
@@ -11,7 +11,7 @@ query: |
   CommonSecurityLog
   | where DeviceVendor == "Palo Alto Networks" and DeviceProduct == "PAN-OS" and Activity == "TRAFFIC"
   // You can customize the summary table by adding or removing fields based on your requirement.
-  | summarize Count = count(), SentBytes=sum(SentBytes), ReceivedBytes=sum(ReceivedBytes) by deviceCustomString3, DeviceName, SourceIP, DestinationIP, DestinationPort, DeviceAction, bin(TimeGenerated,1h)
+  | summarize Count = count(), SentBytes=sum(SentBytes), ReceivedBytes=sum(ReceivedBytes) by vSys=deviceCustomString3, DeviceName, SourceIP, DestinationIP, DestinationPort, DeviceAction, bin(TimeGenerated,1h)
 binSize: 60
 version: 1.0.0
 metadata:

--- a/Summary rules/Network/PaloAltoPANOSNetworkSessionIPSummary.yaml
+++ b/Summary rules/Network/PaloAltoPANOSNetworkSessionIPSummary.yaml
@@ -11,7 +11,7 @@ query: |
   CommonSecurityLog
   | where DeviceVendor == "Palo Alto Networks" and DeviceProduct == "PAN-OS" and Activity == "TRAFFIC"
   // You can customize the summary table by adding or removing fields based on your requirement.
-  | summarize Count = count(), SentBytes=sum(SentBytes), ReceivedBytes=sum(ReceivedBytes) by SourceIP, DestinationIP, DestinationPort, DeviceAction, bin(TimeGenerated,1h)
+  | summarize Count = count(), SentBytes=sum(SentBytes), ReceivedBytes=sum(ReceivedBytes) by deviceCustomString3, DeviceName, SourceIP, DestinationIP, DestinationPort, DeviceAction, bin(TimeGenerated,1h)
 binSize: 60
 version: 1.0.0
 metadata:

--- a/Summary rules/WebSession/PaloAltoPANOSWebSessionIPSummary.yaml
+++ b/Summary rules/WebSession/PaloAltoPANOSWebSessionIPSummary.yaml
@@ -14,7 +14,8 @@ query: |
             and Activity == "THREAT"
             and DeviceEventClassID == "url"
   // You can customize the summary table by adding or removing fields based on your requirement.
-  | summarize Count = count(), SentBytes = sum(SentBytes), ReceivedBytes = sum(ReceivedBytes) by SourceIP, SourceUserName, DestinationIP, DestinationHostName, DeviceAction, bin(TimeGenerated,1h)
+  // added deviceCustomString3 (vsys) and DeviceName.
+  | summarize Count = count(), SentBytes = sum(SentBytes), ReceivedBytes = sum(ReceivedBytes) by deviceCustomString3, DeviceName, SourceIP, SourceUserName, DestinationIP, DestinationHostName, DeviceAction, bin(TimeGenerated,1h)
 binSize: 60
 version: 1.0.0
 metadata:

--- a/Summary rules/WebSession/PaloAltoPANOSWebSessionIPSummary.yaml
+++ b/Summary rules/WebSession/PaloAltoPANOSWebSessionIPSummary.yaml
@@ -15,7 +15,7 @@ query: |
             and DeviceEventClassID == "url"
   // You can customize the summary table by adding or removing fields based on your requirement.
   // added deviceCustomString3 (vsys) and DeviceName.
-  | summarize Count = count(), SentBytes = sum(SentBytes), ReceivedBytes = sum(ReceivedBytes) by deviceCustomString3, DeviceName, SourceIP, SourceUserName, DestinationIP, DestinationHostName, DeviceAction, bin(TimeGenerated,1h)
+  | summarize Count = count(), SentBytes = sum(SentBytes), ReceivedBytes = sum(ReceivedBytes) by vSys=deviceCustomString3, DeviceName, SourceIP, SourceUserName, DestinationIP, DestinationHostName, DeviceAction, bin(TimeGenerated,1h)
 binSize: 60
 version: 1.0.0
 metadata:


### PR DESCRIPTION
Change(s):

Updated the summary rule to include vSys (deviceCustomString3) and DeviceName in the aggregation logic to ensure proper device-level distinction.

Reason for Change(s):

Addresses false positives caused by overlapping subnets and network ranges, where multiple devices were previously summarized incorrectly.
Using DeviceCustomString3 and DeviceName resolves incorrect correlations and improves detection accuracy.

Version Updated:

Yes
Required for Detections/Analytic Rule templates.

Testing Completed:

Yes

Checked that the validations are passing and have addressed any issues that are present:

Yes