### PR TITLE
Remove PII sample values from UEBABehaviorsAnalysisWorkbook

### DIFF
--- a/Solutions/UEBA Essentials/Workbooks/UEBABehaviorsAnalysisWorkbook.json
+++ b/Solutions/UEBA Essentials/Workbooks/UEBABehaviorsAnalysisWorkbook.json
@@ -288,7 +288,7 @@
                                     "type": 1,
                                     "description": "Comma-separated list of entity values from the selected incident",
                                     "isRequired": false,
-                                    "value": "\"arn:aws:iam::648887187133:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS\"",
+                                    "value": "",
                                     "key": "incident-entities-param"
                                 },
                                 {
@@ -299,7 +299,7 @@
                                     "type": 1,
                                     "description": "DateTime of the incident (e.g., 2026-01-08T12:00:00Z)",
                                     "isRequired": false,
-                                    "value": "2026-01-11T12:00:00Z",
+                                    "value": "",
                                     "key": "incident-time-param"
                                 },
                                 {
@@ -309,7 +309,7 @@
                                     "label": "Hours Before",
                                     "type": 1,
                                     "isRequired": true,
-                                    "value": "24h",
+                                    "value": "",
                                     "key": "window-before-param"
                                 },
                                 {
@@ -319,7 +319,7 @@
                                     "label": "Hours After",
                                     "type": 1,
                                     "isRequired": true,
-                                    "value": "12h",
+                                    "value": "",
                                     "key": "window-after-param"
                                 }
                             ],


### PR DESCRIPTION
## Summary
This PR removes hardcoded sample PII values from the UEBA Behaviors Analysis Workbook by replacing them with empty strings.

## Changes
The following parameter default values have been cleared in `Solutions/UEBA Essentials/Workbooks/UEBABehaviorsAnalysisWorkbook.json`:
- **IncidentEntities**: Removed AWS IAM role ARN sample value
- **IncidentTime**: Removed sample timestamp value
- **WindowBefore**: Removed default time window value (24h)
- **WindowAfter**: Removed default time window value (12h)

## Rationale
This ensures the workbook template does not contain potentially sensitive sample data that could be considered PII.

## Testing
- ✅ JSON syntax validation passed
- ✅ File structure preserved
- ✅ Only target values modified