### PR TITLE
Correct contentHub solution version by fetching solution version in m…

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V3/README.md
+++ b/Tools/Create-Azure-Sentinel-Solution/V3/README.md
@@ -102,6 +102,7 @@ eg: C:\Github\Azure-Sentinel\Solutions\Agari\Data
   "dependentDomainSolutionIds": [],
   "BasePath": "{Path to Solution Content}",
   "Version": "3.0.0", // Default version of 3.0.0. If you want create templateSpec package then change variable 'defaultPackageVersion' value in createSolutionV3.ps1 file 
+  "DataConnectorCCFVersion": "3.0.1", // Optional. The version of the ccf data connector, it will show up as the version of the connector in the portal. If not specified, the value of "Version" will be used.
   "Metadata": "{Name of Solution Metadata file}",
   "TemplateSpec": true, // Default should be true
   "StaticDataConnectorIds": [] // Optional array property. Specify Static Data Connector Ids only. If Generic Data connector than no need to specify. 
@@ -172,7 +173,8 @@ eg: C:\Github\Azure-Sentinel\Solutions\Agari\Data
     "Playbooks/Playbooks/CiscoUmbrella-GetDomainInfo/azuredeploy.json"
   ],
   "BasePath": "C:\\GitHub\\Azure-Sentinel",
-  "Version": "3.0.0", // Default version of 3.0.0. If you want create templateSpec package then change variable 'defaultPackageVersion' value in createSolutionV3.ps1 file 
+  "Version": "3.0.0", // Default version of 3.0.0. If you want create templateSpec package then change variable 'defaultPackageVersion' value in createSolutionV3.ps1 file
+  "DataConnectorCCFVersion": "3.0.1", // Optional. The version of the ccf data connector, it will show up as the version of the connector in the portal. If not specified, the value of "Version" will be used.
   "Metadata": "SolutionMetadata.json",
   "TemplateSpec": true, // Default should be true
   "StaticDataConnectorIds": [] // Optional array property. Specify Static Data Connector Ids only. If Generic Data connector than no need to specify.

--- a/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/createCCPConnector.ps1
@@ -410,7 +410,7 @@ function createCCPConnectorResources($contentResourceDetails, $dataFileMetadata,
     }
 
     if (!$global:baseMainTemplate.variables.dataConnectorCCPVersion) {
-        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorCCPVersion" -NotePropertyValue $dataFileMetadata.Version
+        $global:baseMainTemplate.variables | Add-Member -NotePropertyName "dataConnectorCCPVersion" -NotePropertyValue ($dataFileMetadata.DataConnectorCCFVersion ?? $dataFileMetadata.Version)
     }
 
     try {


### PR DESCRIPTION
   Change(s):
   - Correct contentHub solution version by fetching solution version in metadata to replace default 1.0.0

   Reason for Change(s):
   - All Content Hub data connectors show the version as `1.0.0`

   Version Updated:
   - Not applicable

   Testing Completed:
   - Yes