### PR TITLE
Checkout PR branch; block fork test infra changes

### DIFF
--- a/.github/workflows/runAsimSchemaAndDataTesters.yaml
+++ b/.github/workflows/runAsimSchemaAndDataTesters.yaml
@@ -43,6 +43,14 @@ jobs:
     outputs:
       approved: ${{ steps.check-approval.outputs.approved }}
     steps:
+      - name: Checkout pull request branch
+        if: github.event.pull_request != null
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
       - name: Check if PR needs approval
         id: check-approval
         run: |
@@ -96,7 +104,39 @@ jobs:
             echo "needs_approval=false" >> $GITHUB_OUTPUT
             echo "comment_needed=false" >> $GITHUB_OUTPUT
           fi
-      
+
+      - name: Prevent fork modifications to test infrastructure
+        if: github.event.pull_request.head.repo.fork == true
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          log_info() { echo "ℹ️  $1"; }
+          log_error() { echo "❌ $1"; }
+          log_success() { echo "✅ $1"; }
+
+          log_info "Checking for modifications to asimParsersTest folder in fork PR..."
+
+          # We are currently checked out at the fork's HEAD SHA (actions/checkout did that).
+          # Add the base repo as a remote and fetch the base branch, so we can diff reliably.
+          git remote remove upstream 2>/dev/null || true
+          git remote add upstream "https://github.com/${{ github.repository }}.git"
+
+          log_info "Fetching base branch ${{ github.event.pull_request.base.ref }} from upstream..."
+          git fetch --no-tags --prune upstream "${{ github.event.pull_request.base.ref }}"
+
+          # Diff base branch (FETCH_HEAD) -> current HEAD (fork head)
+          modified_files="$(git diff --name-only "FETCH_HEAD...HEAD")"
+
+          if echo "$modified_files" | grep -E "\.script/tests/asimParsersTest/" > /dev/null; then
+            log_error "Fork PRs cannot modify the asimParsersTest test infrastructure folder"
+            log_error "Modified test files detected:"
+            echo "$modified_files" | grep "\.script/tests/asimParsersTest/" | sed 's/^/  - /'
+            exit 1
+          fi
+          
+          log_success "No modifications to asimParsersTest folder detected"
+
       - name: Comment on fork PR for approval guidance
         if: |
           always() && 


### PR DESCRIPTION
Add a checkout step for pull request workflows (actions/checkout@v3 with PR head ref/repo and fetch-depth: 0) so the runner is at the PR commit. Add a guard for forked PRs that fetches the base branch from the upstream repo, diffs FETCH_HEAD...HEAD, and fails the job if any files under .script/tests/asimParsersTest/ are modified. The new step logs findings and provides a clear error message listing offending files to prevent untrusted forks from altering test infrastructure.