### PR TITLE
Update minimum tls version from 1.0 to 1.2 for Azure storage account

### DIFF
--- a/Solutions/Trend Micro Vision One/Data Connectors/azuredeploy_TrendMicroVisionOne_API_FunctionApp.json
+++ b/Solutions/Trend Micro Vision One/Data Connectors/azuredeploy_TrendMicroVisionOne_API_FunctionApp.json
@@ -71,6 +71,7 @@
             },
             "kind": "StorageV2",
             "properties": {
+                "minimumTlsVersion": "TLS1_2",
                 "networkAcls": {
                     "bypass": "AzureServices",
                     "virtualNetworkRules": [],


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - added minimum tls version 1.2

   Reason for Change(s):
   - update minimum tls version from 1.0 to 1.2 for Azure storage account

   Version Updated:
   - No Detections/Analytic Rule templates updated.
   
   Testing Completed:
   - yes
   
   Checked that the validations are passing and have addressed any issues that are present:
   - yes