### PR TITLE
Switch python version to 3.12 in deployment template

### DIFF
--- a/Solutions/WithSecureElementsViaFunction/Data Connectors/azuredeploy_Connector_WithSecureElements_AzureFunction.json
+++ b/Solutions/WithSecureElementsViaFunction/Data Connectors/azuredeploy_Connector_WithSecureElements_AzureFunction.json
@@ -122,7 +122,7 @@
           "alwaysOn": true,
           "httpsOnly": true,
           "siteConfig": {
-            "linuxFxVersion": "PYTHON|3.10"
+            "linuxFxVersion": "PYTHON|3.12"
           }
         },
         "resources": [


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Python version in deployment template is updated from 3.10 to 3.12

   Reason for Change(s):
   - The function code is now written in Python 3.12

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes

