### PR TITLE
Update README with new Logstash version support

### DIFF
--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
@@ -28,6 +28,10 @@ Microsoft Sentinel's Logstash output plugin supports the following versions
 - 7.0 - 7.17.13
 - 8.0 - 8.9
 - 8.11 - 8.15
+- 8.19.2
+- 9.0.8
+- 9.1.10
+- 9.2.4 - 9.2.5
 
 Please note that when using Logstash 8, it is recommended to disable ECS in the pipeline. For more information refer to [Logstash documentation.](<https://www.elastic.co/guide/en/logstash/8.4/ecs-ls.html>)
 


### PR DESCRIPTION
Added support for Logstash versions 8.19.2, 9.0.8, 9.1.10, and 9.2.4 - 9.2.5, after testing.

   Required items, please complete
   
   Change(s):
   - Added more supported versions after testing

   Reason for Change(s):
   - Customers have asked if these new versions are supported

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - They are "Waiting for status to be reported"
