### PR TITLE
fix(versioning-tools) Fixing issue where versioning is not working as expected

### DIFF
--- a/.script/package-automation/catalogAPI.ps1
+++ b/.script/package-automation/catalogAPI.ps1
@@ -151,7 +151,7 @@ function GetPackageVersion($defaultPackageVersion, $offerId, $offerDetails, $pac
     {
         $userInputMajor,$userInputMinor,$userInputBuild,$userInputRevision = $userInputPackageVersion.split(".")
         $defaultMajor,$defaultMinor,$defaultBuild,$defaultRevision = $defaultPackageVersion.split(".")
-
+    
         # Convert to integers for proper numeric comparison
         [int]$userInputMajor = $userInputMajor
         [int]$userInputMinor = $userInputMinor
@@ -162,12 +162,12 @@ function GetPackageVersion($defaultPackageVersion, $offerId, $offerDetails, $pac
 
         if ($userInputMajor -ge 3) {
             # Version 3.x.x or higher: use user input if minor and build are greater than default
-            if ($userInputMinor -ge $defaultMinor -and $userInputBuild -gt $defaultBuild) {
+            if ($userInputMinor -gt $defaultMinor -or ($userInputMinor -ge $defaultMinor -and $userInputBuild -gt $defaultBuild)) {
                 $setPackageVersion = $userInputPackageVersion
-                if ($null -eq $offerDetails) {
-                    Write-Host "Package version set to $setPackageVersion"
-                    return $setPackageVersion
-                }
+                
+                Write-Host "Package version set to $setPackageVersion"
+                return $setPackageVersion
+                
             } elseif ($null -eq $offerDetails) {
                 Write-Host "Package version set to $userInputPackageVersion"
                 return $userInputPackageVersion


### PR DESCRIPTION
#  Change(s):
-----------------------
Found an issue in the API catalog where when the user's minor version is greater than or equal to the default minor version, however the builds are equal, the user's version is not being accepted.

#  Reason for Change(s):
-----------------------
This is currently preventing builds using the correct version to be published.

# HOW TO REPRODUCE
-----------------------
1. Download the repo
1. Navigate to .Solutions/Tanium
1. Set the version for the solution to 3.3.0 _(Note the currently published version is 3.2.0)_
1. Build the solution by executing Tools/Create-Azure-Sentinel-Solution/V3/createSolutionV3.ps1

You will see that the version is incremented as a patch to 3.2.1 instead of 3.3.0 as expected.

# TESTING
-----------------------
The following image shows that in my testing it produced the correct version.
<img width="1259" height="807" alt="Screenshot 2026-03-05 at 12 01 14 PM" src="https://github.com/user-attachments/assets/88e6f973-1252-42a8-bac9-b2ca6b87de4c" />
