### PR TITLE
Logstash Plugin - Set retransmission delay as parameter

### DIFF
--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/CHANGELOG.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+- Adds configurable `retransmission_delay` parameter to control the delay in seconds between retry attempts (default: 2 seconds). This helps reduce request rate during throttling (HTTP 429) scenarios.
+
 ## 1.2.0
 - Adds managed identity authentication support for Azure VMs/VMSS (system-assigned and user-assigned via IMDS).
 - Adds AKS workload identity support via OIDC token exchange.

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
@@ -3,8 +3,8 @@
 Microsoft Sentinel provides a new output plugin for Logstash. Use this output plugin to send any log via Logstash to the Microsoft Sentinel/Log Analytics workspace. This is done with the Log Analytics DCR-based API.
 You may send logs to custom or standard tables.
 
-Plugin version: v1.2.0
-Released on: 2026-02-05
+Plugin version: v1.2.1
+Released on: 2026-03-06
 
 This plugin is currently in development and is free to use. We welcome contributions from the open source community on this project, and we request and appreciate feedback from users.
 
@@ -175,6 +175,7 @@ output {
 - **key_names** – Array of strings, if you wish to send a subset of the columns to Log Analytics.
 - **plugin_flush_interval** – Number, 5 by default. Defines the maximal time difference (in seconds) between sending two messages to Log Analytics.
 - **retransmission_time** - Number, 10 by default. This will set the amount of time in seconds given for retransmitting messages once sending has failed.
+- **retransmission_delay** - Number, 2 by default. The delay in seconds between each retry attempt when sending log data fails. Increase this value to reduce request rate during throttling (HTTP 429) scenarios.
 - **compress_data** - Boolean, false by default. When this field is true, the event data is compressed before using the API. Recommended for high throughput pipelines
 - **proxy** - String, Empty by default. Specify which proxy URL to use for API calls for all of the communications with Azure.
 - **proxy_aad** - String, Empty by default. Specify which proxy URL to use for API calls for the Microsoft Entra ID service. Overrides the proxy setting.

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/lib/logstash/outputs/microsoft-sentinel-log-analytics-logstash-output-plugin.rb
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/lib/logstash/outputs/microsoft-sentinel-log-analytics-logstash-output-plugin.rb
@@ -65,6 +65,9 @@ class LogStash::Outputs::MicrosoftSentinelOutput < LogStash::Outputs::Base
   # This will set the amount of time given for retransmitting messages once sending is failed
   config :retransmission_time, :validate => :number, :default => 10
 
+  # Delay in seconds between each retry attempt when sending fails
+  config :retransmission_delay, :validate => :number, :default => 2
+
   # Compress the message body before sending to LA
   config :compress_data, :validate => :boolean, :default => false
 
@@ -114,6 +117,7 @@ class LogStash::Outputs::MicrosoftSentinelOutput < LogStash::Outputs::Base
     logstash_configuration.proxy_aad = @proxy_aad || @proxy || ENV['http_proxy']
     logstash_configuration.proxy_endpoint = @proxy_endpoint || @proxy || ENV['http_proxy']
     logstash_configuration.retransmission_time = @retransmission_time
+    logstash_configuration.retransmission_delay = @retransmission_delay
     logstash_configuration.azure_cloud = @azure_cloud || "AzureCloud"
 
     return logstash_configuration

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/lib/logstash/sentinel_la/logstashLoganalyticsConfiguration.rb
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/lib/logstash/sentinel_la/logstashLoganalyticsConfiguration.rb
@@ -15,8 +15,6 @@ class LogstashLoganalyticsOutputConfiguration
         @managed_identity = managed_identity
         @managed_identity_object_id = managed_identity_object_id
 
-	# Delay between each resending of a message
-        @RETRANSMISSION_DELAY = 2
         @MIN_MESSAGE_AMOUNT = 100
         # Maximum of 1 MB per post to Log Analytics Data Collector API V2.
         # This is a size limit for a single post.
@@ -75,6 +73,9 @@ class LogstashLoganalyticsOutputConfiguration
 
         if @retransmission_time < 0
             raise ArgumentError, "retransmission_time must be a positive integer."
+        end
+        if @RETRANSMISSION_DELAY < 0
+            raise ArgumentError, "retransmission_delay must be a positive integer."
         end
         if @max_items < @MIN_MESSAGE_AMOUNT
             raise ArgumentError, "Setting max_items to value must be greater then #{@MIN_MESSAGE_AMOUNT}."
@@ -214,6 +215,10 @@ class LogstashLoganalyticsOutputConfiguration
 
     def retransmission_time=(new_retransmission_time)
         @retransmission_time = new_retransmission_time
+    end
+
+    def retransmission_delay=(new_retransmission_delay)
+        @RETRANSMISSION_DELAY = new_retransmission_delay
     end
 
     def compress_data

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/lib/logstash/sentinel_la/version.rb
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/lib/logstash/sentinel_la/version.rb
@@ -1,6 +1,6 @@
 module LogStash; module Outputs;
 class MicrosoftSentinelOutputInternal
-  VERSION_INFO = [1, 2, 0].freeze
+  VERSION_INFO = [1, 2, 1].freeze
   VERSION = VERSION_INFO.map(&:to_s).join('.').freeze
 
   def self.version


### PR DESCRIPTION
   Change(s):
   - @RETRANSMISSION_DELAY is now taken from plugin parameters instead of being hardcoded
   - Documentation and release note updated

   Reason for Change(s):
   - We want to increase the retry delay during throttling to prevent further throttling. 

   Version Updated:
   - Yes minor update to 1.2.1 to be published to rubygems

   Testing Completed:
   - Yes on our own logstash instances

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes


