### PR TITLE
Adjust CI concurrency for forked PRs

### DIFF
--- a/.github/workflows/runAsimSchemaAndDataTesters.yaml
+++ b/.github/workflows/runAsimSchemaAndDataTesters.yaml
@@ -27,8 +27,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: asim-tests-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  # group: asim-tests-${{ github.event.pull_request.number || github.sha }}
+  # cancel-in-progress: true
+  group: >-
+    asim-tests-${{ github.event.pull_request.head.repo.fork
+      && format('pr-{0}', github.event.pull_request.number)
+      || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event.pull_request.head.repo.fork }}
 
 jobs: 
   # Security gate: Fork PRs require manual approval via "SafeToRun" label


### PR DESCRIPTION
Update the GitHub Actions concurrency settings to distinguish forked PRs from internal runs. Forked PRs are now grouped as "pr-<number>" and will cancel in-progress runs, while internal runs use a unique "run-<run_id>" group so they don't cancel other runs. The previous static concurrency lines were commented out.