### PR TITLE
Update queries from 'Firepower' to 'FTD'

### DIFF
--- a/Workbooks/CiscoFirepower.json
+++ b/Workbooks/CiscoFirepower.json
@@ -138,7 +138,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize count() by bin(TimeGenerated, {TimeRange:grain})",
+        "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize count() by bin(TimeGenerated, {TimeRange:grain})",
         "size": 1,
         "title": "📊 Data flow over Time - TimeBrush enabled.  You can click within this chart and select a subset of the data.  TimeRange selected: {TimeRange:label} with Automatic Time Grain of: {TimeRange:grain}",
         "color": "pink",
@@ -215,7 +215,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize count() by DeviceAction\r\n| order by count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize count() by DeviceAction\r\n| order by count_ desc",
               "size": 3,
               "title": "Count by Actions ",
               "timeContextFromParameter": "TimeRange",
@@ -274,7 +274,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize count() by Protocol\r\n| order by Protocol asc, count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize count() by Protocol\r\n| order by Protocol asc, count_ desc",
               "size": 3,
               "title": "Count by Protocols",
               "timeContextFromParameter": "TimeRange",
@@ -345,7 +345,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize count() by DeviceName\r\n| order by count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize count() by DeviceName\r\n| order by count_ desc",
               "size": 3,
               "title": "Count by DeviceName",
               "timeContextFromParameter": "TimeRange",
@@ -404,7 +404,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where isnotempty(DeviceEventClassID)  \r\n| extend ThreatId = coalesce(\r\n                            column_ifexists(\"DeviceEventCategory\", \"\"),\r\n                            extract('cat=([^;]+)',1,AdditionalExtensions),\r\n                            \"\"\r\n                        )\r\n| where isnotempty(ThreatId)\r\n| summarize Amount=count() by ThreatId, LogSeverity\r\n| order by LogSeverity desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where isnotempty(DeviceEventClassID)  \r\n| extend ThreatId = coalesce(\r\n                            column_ifexists(\"DeviceEventCategory\", \"\"),\r\n                            extract('cat=([^;]+)',1,AdditionalExtensions),\r\n                            \"\"\r\n                        )\r\n| where isnotempty(ThreatId)\r\n| summarize Amount=count() by ThreatId, LogSeverity\r\n| order by LogSeverity desc",
               "size": 3,
               "title": "Count by Threats",
               "timeContextFromParameter": "TimeRange",
@@ -477,7 +477,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize count() by ApplicationProtocol\r\n| order by count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize count() by ApplicationProtocol\r\n| order by count_ desc",
               "size": 0,
               "title": "Count by Application Protocol ",
               "timeContextFromParameter": "TimeRange",
@@ -550,7 +550,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize count() by  DeviceEventClassID\r\n| order by count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize count() by  DeviceEventClassID\r\n| order by count_ desc",
               "size": 1,
               "title": "Count by EventClass",
               "timeContextFromParameter": "TimeRange",
@@ -710,7 +710,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction has \"Block\"\r\n| summarize arg_max(TimeGenerated,*) by DeviceName, SourceIP",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction has \"Block\"\r\n| summarize arg_max(TimeGenerated,*) by DeviceName, SourceIP",
               "size": 0,
               "title": "Blocks by Device, {$rowCount} - Click to check IOC status",
               "timeContextFromParameter": "TimeRange",
@@ -790,7 +790,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "  let starttime = 14d;\r\n  let endtime = 1d;\r\n  let timeframe = 1h;\r\n  let scorethreshold = 5;\r\n  let percentotalthreshold = 50;\r\n  let TimeSeriesData = CommonSecurityLog\r\n  | where DeviceVendor =~ \"Cisco\"\r\n  | where DeviceProduct =~ 'Firepower'\r\n  | where isnotempty(DestinationIP) and isnotempty(SourceIP)\r\n  | where TimeGenerated between (startofday(ago(starttime))..startofday(ago(endtime)))\r\n  | project TimeGenerated,SourceIP, DestinationIP, DeviceVendor\r\n  | make-series Total=count() on TimeGenerated from startofday(ago(starttime)) to startofday(ago(endtime)) step timeframe by DeviceVendor;\r\n  // Filtering specific records associated with spikes as outliers\r\n  let TimeSeriesAlerts=materialize(TimeSeriesData\r\n  | extend (anomalies, score, baseline) = series_decompose_anomalies(Total, scorethreshold, -1, 'linefit')\r\n  | mv-expand Total to typeof(double), TimeGenerated to typeof(datetime), anomalies to typeof(double),score to typeof(double), baseline to typeof(long)\r\n  | where anomalies > 0 | extend score = round(score,2), AnomalyHour = TimeGenerated\r\n  | project DeviceVendor,AnomalyHour, TimeGenerated, Total, baseline, anomalies, score);\r\n  let AnomalyHours = materialize(TimeSeriesAlerts  | where TimeGenerated > ago(2d) | project TimeGenerated);\r\n  // Join anomalies with Base Data to popalate associated records for investigation - Results sorted by score in descending order\r\n  TimeSeriesAlerts\r\n  | where TimeGenerated > ago(2d)\r\n  | join (\r\n      CommonSecurityLog\r\n  | where isnotempty(DestinationIP) and isnotempty(SourceIP)\r\n  | where TimeGenerated > ago(2d)\r\n  | extend DateHour = bin(TimeGenerated, 1h) // create a new column and round to hour\r\n  | where DateHour in ((AnomalyHours)) //filter the dataset to only selected anomaly hours\r\n  | summarize HourlyCount = count(), TimeGeneratedMax = arg_max(TimeGenerated, *), DestinationIPlist = make_set(DestinationIP, 100), DestinationPortlist = make_set(DestinationPort, 100) by DeviceVendor, SourceIP, TimeGeneratedHour= bin(TimeGenerated, 1h)\r\n  | extend AnomalyHour = TimeGeneratedHour\r\n  ) on AnomalyHour, DeviceVendor\r\n  | extend PercentTotal = round((HourlyCount / Total) * 100, 3)\r\n  | where PercentTotal > percentotalthreshold\r\n  | project DeviceVendor , AnomalyHour, TimeGeneratedMax, SourceIP, DestinationIPlist, DestinationPortlist, HourlyCount, PercentTotal, Total, baseline, score, anomalies\r\n  | summarize HourlyCount=sum(HourlyCount), StartTimeUtc=min(TimeGeneratedMax), EndTimeUtc=max(TimeGeneratedMax), SourceIPlist = make_set(SourceIP, 100), SourceIPMax= arg_max(SourceIP, *), DestinationIPlist = make_set(DestinationIPlist, 100), DestinationPortlist = make_set(DestinationPortlist, 100) by DeviceVendor , AnomalyHour, Total, baseline, score, anomalies\r\n  | project DeviceVendor , AnomalyHour, EndTimeUtc, SourceIPMax ,SourceIPlist, DestinationIPlist, DestinationPortlist, HourlyCount, Total, baseline, score, anomalies\r\n  | extend timestamp= EndTimeUtc , IPCustomEntity = SourceIPMax",
+              "query": "  let starttime = 14d;\r\n  let endtime = 1d;\r\n  let timeframe = 1h;\r\n  let scorethreshold = 5;\r\n  let percentotalthreshold = 50;\r\n  let TimeSeriesData = CommonSecurityLog\r\n  | where DeviceVendor =~ \"Cisco\"\r\n  | where DeviceProduct =~ 'FTD'\r\n  | where isnotempty(DestinationIP) and isnotempty(SourceIP)\r\n  | where TimeGenerated between (startofday(ago(starttime))..startofday(ago(endtime)))\r\n  | project TimeGenerated,SourceIP, DestinationIP, DeviceVendor\r\n  | make-series Total=count() on TimeGenerated from startofday(ago(starttime)) to startofday(ago(endtime)) step timeframe by DeviceVendor;\r\n  // Filtering specific records associated with spikes as outliers\r\n  let TimeSeriesAlerts=materialize(TimeSeriesData\r\n  | extend (anomalies, score, baseline) = series_decompose_anomalies(Total, scorethreshold, -1, 'linefit')\r\n  | mv-expand Total to typeof(double), TimeGenerated to typeof(datetime), anomalies to typeof(double),score to typeof(double), baseline to typeof(long)\r\n  | where anomalies > 0 | extend score = round(score,2), AnomalyHour = TimeGenerated\r\n  | project DeviceVendor,AnomalyHour, TimeGenerated, Total, baseline, anomalies, score);\r\n  let AnomalyHours = materialize(TimeSeriesAlerts  | where TimeGenerated > ago(2d) | project TimeGenerated);\r\n  // Join anomalies with Base Data to popalate associated records for investigation - Results sorted by score in descending order\r\n  TimeSeriesAlerts\r\n  | where TimeGenerated > ago(2d)\r\n  | join (\r\n      CommonSecurityLog\r\n  | where isnotempty(DestinationIP) and isnotempty(SourceIP)\r\n  | where TimeGenerated > ago(2d)\r\n  | extend DateHour = bin(TimeGenerated, 1h) // create a new column and round to hour\r\n  | where DateHour in ((AnomalyHours)) //filter the dataset to only selected anomaly hours\r\n  | summarize HourlyCount = count(), TimeGeneratedMax = arg_max(TimeGenerated, *), DestinationIPlist = make_set(DestinationIP, 100), DestinationPortlist = make_set(DestinationPort, 100) by DeviceVendor, SourceIP, TimeGeneratedHour= bin(TimeGenerated, 1h)\r\n  | extend AnomalyHour = TimeGeneratedHour\r\n  ) on AnomalyHour, DeviceVendor\r\n  | extend PercentTotal = round((HourlyCount / Total) * 100, 3)\r\n  | where PercentTotal > percentotalthreshold\r\n  | project DeviceVendor , AnomalyHour, TimeGeneratedMax, SourceIP, DestinationIPlist, DestinationPortlist, HourlyCount, PercentTotal, Total, baseline, score, anomalies\r\n  | summarize HourlyCount=sum(HourlyCount), StartTimeUtc=min(TimeGeneratedMax), EndTimeUtc=max(TimeGeneratedMax), SourceIPlist = make_set(SourceIP, 100), SourceIPMax= arg_max(SourceIP, *), DestinationIPlist = make_set(DestinationIPlist, 100), DestinationPortlist = make_set(DestinationPortlist, 100) by DeviceVendor , AnomalyHour, Total, baseline, score, anomalies\r\n  | project DeviceVendor , AnomalyHour, EndTimeUtc, SourceIPMax ,SourceIPlist, DestinationIPlist, DestinationPortlist, HourlyCount, Total, baseline, score, anomalies\r\n  | extend timestamp= EndTimeUtc , IPCustomEntity = SourceIPMax",
               "size": 0,
               "title": "Time series anomaly detection for total volume of traffic, {$rowCount}",
               "timeContextFromParameter": "TimeRange",
@@ -813,7 +813,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "ComputerList",
                   "type": 10,
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n//| where DeviceAction has \"Block\"\r\n| summarize  by Computer\r\n| order by Computer asc",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n//| where DeviceAction has \"Block\"\r\n| summarize  by Computer\r\n| order by Computer asc",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -839,7 +839,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"Firepower\" \r\n| where Activity == \"File Malware Event\"\r\n| where '{ComputerList}' == DeviceAction or '{ComputerList:label}' == \"<unset>\"\r\n",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"FTD\" \r\n| where Activity == \"File Malware Event\"\r\n| where '{ComputerList}' == DeviceAction or '{ComputerList:label}' == \"<unset>\"\r\n",
               "size": 0,
               "title": "File Malware Events, {$rowCount}",
               "timeContextFromParameter": "TimeRange",
@@ -861,7 +861,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "DeviceAction",
                   "type": 10,
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n//| where DeviceAction has \"Block\"\r\n| where DestinationPort == \"80\"\r\n| summarize  by DeviceAction\r\n| order by DeviceAction asc",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n//| where DeviceAction has \"Block\"\r\n| where DestinationPort == \"80\"\r\n| summarize  by DeviceAction\r\n| order by DeviceAction asc",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -887,7 +887,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"Firepower\" \r\n| where DestinationPort == \"80\"\r\n| where '{DeviceAction}' == DeviceAction or '{DeviceAction:label}' == \"<unset>\"\r\n",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"FTD\" \r\n| where DestinationPort == \"80\"\r\n| where '{DeviceAction}' == DeviceAction or '{DeviceAction:label}' == \"<unset>\"\r\n",
               "size": 0,
               "title": "Outbound Web Traffic Port 80, {$rowCount}",
               "timeContextFromParameter": "TimeRange",
@@ -900,7 +900,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"Firepower\"\r\n| extend bytesOut = extract('bytesOut=([^;]+)',1,AdditionalExtensions)\r\n| summarize by bytesOut, Computer,  RequestURL, SourceUserName , SourceIP, SourceHostName, DestinationIP, DestinationPort\r\n| top 20 by bytesOut\r\n| order by bytesOut desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"FTD\"\r\n| extend bytesOut = extract('bytesOut=([^;]+)',1,AdditionalExtensions)\r\n| summarize by bytesOut, Computer,  RequestURL, SourceUserName , SourceIP, SourceHostName, DestinationIP, DestinationPort\r\n| top 20 by bytesOut\r\n| order by bytesOut desc",
               "size": 0,
               "title": "Top 20 sending URLs (bytes Sent Out)",
               "timeContextFromParameter": "TimeRange",
@@ -945,7 +945,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"Firepower\" \r\n| summarize LastLogReceived = max(TimeGenerated)| project IsConnected = LastLogReceived > ago(30d), LastLogReceived, minsSinceLastLog = datetime_diff('minute',LastLogReceived, now())",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor == \"Cisco\"\r\n| where DeviceProduct == \"FTD\" \r\n| summarize LastLogReceived = max(TimeGenerated)| project IsConnected = LastLogReceived > ago(30d), LastLogReceived, minsSinceLastLog = datetime_diff('minute',LastLogReceived, now())",
               "size": 0,
               "title": "IsConnected",
               "timeContextFromParameter": "TimeRange",
@@ -984,7 +984,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where _IsBillable = true\r\n| make-series billedData = sum(_BilledSize) on TimeGenerated from {TimeRange:start} to now() step 1d  by Type",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where _IsBillable = true\r\n| make-series billedData = sum(_BilledSize) on TimeGenerated from {TimeRange:start} to now() step 1d  by Type",
               "size": 1,
               "title": "Data Ingested during  {TimeRange:label}",
               "timeContextFromParameter": "TimeRange",
@@ -1029,7 +1029,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where isnotempty(MaliciousIP)\r\n| summarize count() by MaliciousIP , MaliciousIPCountry, MaliciousIPLatitude, MaliciousIPLongitude,SourceIP, DestinationIP, DeviceName, IndicatorThreatType, ThreatConfidence, ReportReferenceLink\r\n| order by count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where isnotempty(MaliciousIP)\r\n| summarize count() by MaliciousIP , MaliciousIPCountry, MaliciousIPLatitude, MaliciousIPLongitude,SourceIP, DestinationIP, DeviceName, IndicatorThreatType, ThreatConfidence, ReportReferenceLink\r\n| order by count_ desc",
               "size": 0,
               "title": "Count by Malicious IP",
               "timeContextFromParameter": "TimeRange",
@@ -1089,7 +1089,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where isnotempty(MaliciousIP)\r\n| summarize count() by MaliciousIP , MaliciousIPCountry, MaliciousIPLatitude, MaliciousIPLongitude\r\n| order by count_ desc",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where isnotempty(MaliciousIP)\r\n| summarize count() by MaliciousIP , MaliciousIPCountry, MaliciousIPLatitude, MaliciousIPLongitude\r\n| order by count_ desc",
               "size": 0,
               "title": "Malicious IP by Country",
               "timeContextFromParameter": "TimeRange",
@@ -1156,7 +1156,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by SourceIP, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by SourceIP, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
               "size": 0,
               "title": "Top 10 Blocked inbound IPs",
               "timeContextFromParameter": "TimeRange",
@@ -1182,7 +1182,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by SourcePort, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by SourcePort, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
               "size": 0,
               "title": "Top 10 Blocked inbound Ports",
               "timeContextFromParameter": "TimeRange",
@@ -1208,7 +1208,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by DestinationIP, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by DestinationIP, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
               "size": 0,
               "title": "Top 10 Blocked outbound IPs",
               "timeContextFromParameter": "TimeRange",
@@ -1234,7 +1234,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by DestinationPort, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by DestinationPort, Computer\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
               "size": 0,
               "title": "Top 10 Blocked outbound Ports",
               "timeContextFromParameter": "TimeRange",
@@ -1260,7 +1260,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by Protocol\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by Protocol\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
               "size": 0,
               "title": "Top 10 Blocked Protocols",
               "timeContextFromParameter": "TimeRange",
@@ -1286,7 +1286,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by Computer, DeviceName\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where DeviceAction contains \"Block\"\r\n| summarize Total = count() by Computer, DeviceName\r\n| top 10 by Total\r\n//| summarize count() by DeviceAction",
               "size": 0,
               "title": "Top 10 Blocked Computer vs. DeviceName",
               "timeContextFromParameter": "TimeRange",
@@ -1341,7 +1341,7 @@
                   "multiSelect": true,
                   "quote": "'",
                   "delimiter": ",",
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| summarize Count = count() by DeviceAction\r\n| order by Count desc\r\n| project Value = DeviceAction, Label = strcat(DeviceAction, \" count: \", Count)",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| summarize Count = count() by DeviceAction\r\n| order by Count desc\r\n| project Value = DeviceAction, Label = strcat(DeviceAction, \" count: \", Count)",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1370,7 +1370,7 @@
                   "multiSelect": true,
                   "quote": "'",
                   "delimiter": ",",
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| where isnotempty(DestinationIP) \r\n| summarize Count = count() by SourceIP\r\n| order by Count desc\r\n| project Value = SourceIP, Label = strcat(SourceIP, \" count: \", Count)",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| where isnotempty(DestinationIP) \r\n| summarize Count = count() by SourceIP\r\n| order by Count desc\r\n| project Value = SourceIP, Label = strcat(SourceIP, \" count: \", Count)",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1401,7 +1401,7 @@
                   "multiSelect": true,
                   "quote": "'",
                   "delimiter": ",",
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| summarize Count = count() by SourcePort\r\n| order by Count desc\r\n| project Value = SourcePort, Label = strcat(SourcePort, \" count: \", Count)",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| summarize Count = count() by SourcePort\r\n| order by Count desc\r\n| project Value = SourcePort, Label = strcat(SourcePort, \" count: \", Count)",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1431,7 +1431,7 @@
                   "multiSelect": true,
                   "quote": "'",
                   "delimiter": ",",
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| where isnotempty(DestinationIP) \r\n| summarize Count = count() by DestinationIP\r\n| order by Count desc\r\n| project Value = DestinationIP, Label = strcat(DestinationIP, \" count: \", Count)",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| where isnotempty(DestinationIP) \r\n| summarize Count = count() by DestinationIP\r\n| order by Count desc\r\n| project Value = DestinationIP, Label = strcat(DestinationIP, \" count: \", Count)",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1461,7 +1461,7 @@
                   "multiSelect": true,
                   "quote": "'",
                   "delimiter": ",",
-                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| where isnotempty(DestinationPort) \r\n| summarize Count = count() by DestinationPort\r\n| order by Count desc\r\n| project Value = DestinationPort, Label = strcat(DestinationPort, \" count: \", Count)",
+                  "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")\r\n| where isnotempty(DestinationPort) \r\n| summarize Count = count() by DestinationPort\r\n| order by Count desc\r\n| project Value = DestinationPort, Label = strcat(DestinationPort, \" count: \", Count)",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1493,7 +1493,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'Firepower'\r\n| where (SourceIP in ({SourceIP}) or '{SourceIP:label}' == \"All\") \r\n    and (SourcePort in ({SourcePort}) or '{SourcePort:label}' == \"All\") \r\n    and (DestinationIP in ({DestinationIP}) or '{DestinationIP:label}' == \"All\") \r\n    and (DestinationPort in ({DestinationPort}) or '{DestinationPort:label}' == \"All\")\r\n    and (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")",
+              "query": "CommonSecurityLog\r\n| where DeviceVendor =~ \"Cisco\"\r\n| where DeviceProduct =~ 'FTD'\r\n| where (SourceIP in ({SourceIP}) or '{SourceIP:label}' == \"All\") \r\n    and (SourcePort in ({SourcePort}) or '{SourcePort:label}' == \"All\") \r\n    and (DestinationIP in ({DestinationIP}) or '{DestinationIP:label}' == \"All\") \r\n    and (DestinationPort in ({DestinationPort}) or '{DestinationPort:label}' == \"All\")\r\n    and (DeviceAction in ({DeviceAction}) or '{DeviceAction:label}' == \"All\")",
               "size": 0,
               "title": "Filtered View, count:  {$rowCount}",
               "timeContextFromParameter": "TimeRange",


### PR DESCRIPTION
The Sentinel parser does not store the "DeviceVendor" as "Firepower". It stores it as "FTD" this change reflects that and fixes the dashboard

   Required items, please complete
   
   Change(s):
   - Update queries from 'Firepower' to 'FTD'

   Reason for Change(s):
   - default dashboard did not work as Sentinel does not store the data with the DeviceVendor as Firepower. It stores it as FTD

   Version Updated:
   - Uncertain

   Testing Completed:
   - Yes. The graphs and charts were fixed

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
