### PR TITLE
[AWS ELB] - Update Sentinel table names to use the alias in README.md

### DIFF
--- a/Solutions/AWS ELB/Data Connectors/CloudFormationTemplates/README.md
+++ b/Solutions/AWS ELB/Data Connectors/CloudFormationTemplates/README.md
@@ -69,12 +69,12 @@ To ingest AWS Elastic Load Balancing logs into Microsoft Sentinel, you need to c
 
 | Log Type | S3 Folder | Sentinel Table |
 |---|---|---|
-| ALB access logs | `ALBLogs/` | `AWSALBAccessLogs` |
-| NLB access logs | `NLBAccessLogs/` | `AWSNLBAccessLogs` |
-| NLB flow logs | `NLBFlowLogs/` | `AWSELBFlowLogs` |
-| GLB flow logs | `GLBFlowLogs/` | `AWSELBFlowLogs` |
+| ALB access logs | `ALBLogs/` | `AWSALBAccessLogsData` |
+| NLB access logs | `NLBAccessLogs/` | `AWSNLBAccessLogsData` |
+| NLB flow logs | `NLBFlowLogs/` | `AWSELBFlowLogsData` |
+| GLB flow logs | `GLBFlowLogs/` | `AWSELBFlowLogsData` |
 
-> **Note:** In the `AWSELBFlowLogs` table, a column named `LogType` indicates whether a row is from NLB flow logs or GLB flow logs.
+> **Note:** In the `AWSELBFlowLogsData` table, a column named `LogType` indicates whether a row is from NLB flow logs or GLB flow logs.
 
 ## Additional Information
 


### PR DESCRIPTION
   Change(s):
   - Use table alias and not real table name.

   Reason for Change(s):
   - Encourage use of the alias which unions both the custom and standard tables' data

   Version Updated: N/A

   Testing Completed: N/A

   Checked that the validations are passing and have addressed any issues that are present: 👍 

