### PR TITLE
Bugfix: include sqs permissions in CloudFormation template

### DIFF
--- a/Solutions/AWS CloudFront/Data Connectors/CloudFormationTempkates/AWS CloudFornt Configuration.json
+++ b/Solutions/AWS CloudFront/Data Connectors/CloudFormationTempkates/AWS CloudFornt Configuration.json
@@ -95,6 +95,24 @@
                                         }
                                     ],
                                     "Effect": "Allow"
+                                },
+                                {
+                                    "Sid": "WebACLSQSConsumer",
+                                    "Action": [
+                                        "sqs:ReceiveMessage",
+                                        "sqs:DeleteMessage",
+                                        "sqs:GetQueueAttributes",
+                                        "sqs:ChangeMessageVisibility"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "SentinelSQSQueue",
+                                                "Arn"
+                                            ]
+                                        }
+                                    ],
+                                    "Effect": "Allow"
                                 }
                             ]
                         }


### PR DESCRIPTION
Change(s):
- Adds required permissions to role so that it can consume from the SQS queue

Reason for Change(s):
- Previously generated template was not working out of the box

Version Updated:
- N/A

Testing Completed:
- Yes