### PR TITLE
Fix JSON syntax in WorkbooksMetadata.json

### DIFF
--- a/Workbooks/WorkbooksMetadata.json
+++ b/Workbooks/WorkbooksMetadata.json
@@ -10359,6 +10359,8 @@
     "templateRelativePath": "NetskopeWebTx_Workbook.json",
     "subtitle": "Web Traffic Analysis and Security Monitoring",
     "provider": "Netskope"
+  },
+  {
     "workbookKey": "MicrosoftCopilotActivityMonitoring",
     "logoFileName": "Copilot_logo.svg",
     "description": "Microsoft Copilot Activity Monitoring.",


### PR DESCRIPTION
Insert a missing object separator ("}, {") in Workbooks/WorkbooksMetadata.json to correct the JSON array structure. This fixes parsing errors and ensures the MicrosoftCopilotActivityMonitoring workbook entry is recognized correctly.

   Required items, please complete
   
   Change(s):Insert a missing object separator
   - 

   Reason for Change(s):
   - Insert a missing object separator

   Version Updated:
   - na

   Testing Completed:
   - yes

   