### PR TITLE
[ASIM] Add missing schemas to ParsersDatabase

### DIFF
--- a/.script/tests/KqlvalidationsTests/FunctionSchemasLoaders/ParsersDatabase.cs
+++ b/.script/tests/KqlvalidationsTests/FunctionSchemasLoaders/ParsersDatabase.cs
@@ -16,13 +16,38 @@ namespace Kqlvalidations.Tests.FunctionSchemasLoaders
             {
                 new ParserConfiguration()
                 {
+                    Schema= "ASimAlertEvent",
+                    SampleFunctionName= "_Im_AlertEvent",
+                },
+                new ParserConfiguration()
+                {
+                    Schema= "ASimAssetEntity",
+                    SampleFunctionName= "_Im_AssetEntity",
+                },
+                new ParserConfiguration()
+                {
+                    Schema= "ASimAuditEvent",
+                    SampleFunctionName= "_Im_AuditEvent",
+                },
+                new ParserConfiguration()
+                {
+                    Schema= "ASimAuthentication",
+                    SampleFunctionName= "_Im_Authentication",
+                },
+                new ParserConfiguration()
+                {
+                    Schema= "ASimDhcpEvent",
+                    SampleFunctionName= "_Im_DhcpEvent",
+                },
+                new ParserConfiguration()
+                {
                     Schema= "ASimDns",
                     SampleFunctionName= "_Im_Dns",
                 },
                 new ParserConfiguration()
                 {
-                    Schema= "ASimWebSession",
-                    SampleFunctionName= "_Im_WebSession",
+                    Schema= "ASimFileEvent",
+                    SampleFunctionName= "_Im_FileEvent",
                 },
                 new ParserConfiguration()
                 {
@@ -36,24 +61,19 @@ namespace Kqlvalidations.Tests.FunctionSchemasLoaders
                 },
                 new ParserConfiguration()
                 {
-                    Schema= "ASimAuditEvent",
-                    SampleFunctionName= "_Im_AuditEvent",
-                },
-                new ParserConfiguration()
-                {
                     Schema= "ASimRegistryEvent",
                     SampleFunctionName= "_Im_RegistryEvent",
                 },
                 new ParserConfiguration()
                 {
-                    Schema= "ASimFileEvent",
-                    SampleFunctionName= "_Im_FileEvent",
+                    Schema= "ASimUserManagement",
+                    SampleFunctionName= "_Im_UserManagement",
                 },
                 new ParserConfiguration()
                 {
-                    Schema= "ASimAuthentication",
-                    SampleFunctionName= "_Im_Authentication",
-                },
+                    Schema= "ASimWebSession",
+                    SampleFunctionName= "_Im_WebSession",
+                }
             };
     }
 


### PR DESCRIPTION
AlertEvent, AssetEntity, DhcpEvent, UserManagement were missing in ParsersDatabase in kql validation.

Adding this will have parsers have their KQL validated when a PR is pushed.