### PR TITLE
Add NuGet package source configuration for Veeam connector

### DIFF
--- a/Solutions/Veeam/Data Connectors/AzureFunctionVeeam/NuGet.Config
+++ b/Solutions/Veeam/Data Connectors/AzureFunctionVeeam/NuGet.Config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
Adds a NuGet.Config with package source mapping to pin dependencies to their expected NuGet feeds. Packages sourced from feeds other than nuget.org will need their feed added to this configuration.