### PR TITLE
[ASIM] Fix naming in vimAuthenticationCiscoISEAdministrator

### DIFF
--- a/Parsers/ASimAuthentication/Parsers/vimAuthenticationCiscoISEAdministrator.yaml
+++ b/Parsers/ASimAuthentication/Parsers/vimAuthenticationCiscoISEAdministrator.yaml
@@ -17,7 +17,7 @@ References:
 Description: |
   This ASIM parser supports normalizing Cisco ISE administrator login events ingested into Microsoft Sentinel by the AMA agent to the ASIM Authentication schema.
 ParserName: vimAuthenticationCiscoISEAdministrator
-EquivalentBuiltInParser: _vim_Authentication_CiscoISEAdministrator
+EquivalentBuiltInParser: _Im_Authentication_CiscoISEAdministrator
 ParserParams:
   - Name: starttime
     Type: datetime


### PR DESCRIPTION
Fix the naming in yaml variable: EquivalentBuiltInParser