### PR TITLE
Add unquoted service path abuse hunting query

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
@@ -66,7 +66,7 @@ query: |
       | project NetworkMessageId, EmailTimeGenerated = TimeGenerated, ReportId, RecipientEmailAddress, SenderFromAddress, SenderMailFromAddress, SenderDisplayName, Subject, DeliveryAction, DeliveryLocation, ThreatTypes
     ) on NetworkMessageId
     | project
-        timestamp = TimeGenerated,
+        Timestamp = TimeGenerated,
         Source,
         TimeGenerated,
         ReportId,
@@ -94,7 +94,7 @@ query: |
       | project TeamsMessageId, MessageTimeGenerated = TimeGenerated, Timestamp, SenderEmailAddress, SenderDisplayName, SenderObjectId, SenderType, RecipientDetails, GroupId, GroupName, ThreadId, ThreadName, ThreadType, IsExternalThread, MessageType, MessageSubtype, Subject, ThreatTypes, DeliveryAction, DeliveryLocation, ReportId
     ) on TeamsMessageId
     | project
-        timestamp = TimeGenerated,
+        Timestamp = TimeGenerated,
         Source,
         TimeGenerated,
         ReportId,
@@ -126,4 +126,4 @@ query: |
         ;
   union isfuzzy=true EmailFindings, TeamsFindings
   | order by TimeGenerated desc
-version: l.0.0
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
@@ -1,0 +1,129 @@
+id: 9582b09c-a5cd-4da0-8244-52cc952da158
+name: Punycode lookalikes
+description: |
+  Punycode lookalike domains in Emails and Teams messages 
+description-detailed: |
+  Detects URLs containing punycode domains (xn--) where the decoded Unicode domain includes common Cyrillic/Greek/fullwidth ASCII lookalike characters.
+  This query covers a use-case which is on only detecting phishing attempts that use visually similar characters to impersonate legitimate domains.
+  The research started in october but didnt have the time to finish it until now. A diary on Sans by Xavier made me realize that I need to finish this work.
+  A diary on Sans ISC about this technique can be found here: https://isc.sans.edu/forums/diary/Detecting+Punycode+Lookalike+Domains+in+Emails/28812/
+  Contact: @MattiasBorg82 for questions or suggestions.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+  - MessageUrlInfo
+  - MessageEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let AsciiLookalikeChars = @"([\u0430\u0435\u043E\u0440\u0441\u0445\u0456\u0443\u043C\u043D\u0455\u0442\u04BB\u0501\u03B1\u03B5\u03BF\u03C1\u03C7\u03BA\u03BD\u03F2\uFF41-\uFF5A\uFF21-\uFF3A])";
+  // Function 
+  let NormalizeLookalikes = (s:string) {
+    replace(@"\u0501","d",
+    replace(@"\u04BB","h",
+    replace(@"\u0442","t",
+    replace(@"\u0455","s",
+    replace(@"\u043D","n",
+    replace(@"\u043C","m",
+    replace(@"\u0443","y",
+    replace(@"\u0456","i",
+    replace(@"\u03C7","x",
+    replace(@"\u0445","x",
+    replace(@"\u03F2","c",
+    replace(@"\u0441","c",
+    replace(@"\u03C1","p",
+    replace(@"\u0440","p",
+    replace(@"\u03BF","o",
+    replace(@"\u043E","o",
+    replace(@"\u03B5","e",
+    replace(@"\u0435","e",
+    replace(@"\u03B1","a",
+    replace(@"\u0430","a",s)
+  )))))))))))))))))))};
+  // End Function
+  // Function
+  let SuspiciousPunycodeDomains = (T:(TimeGenerated:datetime, Url:string, UrlDomain:string, ReportId:string, NetworkMessageId:string, TeamsMessageId:string, Source:string)) {
+    T
+    | where UrlDomain has "xn--"
+    | extend DomainUnicode = punycode_domain_from_string(UrlDomain)
+    | extend Lookalikes = extract_all(AsciiLookalikeChars, DomainUnicode)
+    | where array_length(Lookalikes) > 0
+    | extend Normalized = NormalizeLookalikes(DomainUnicode)
+    | where Normalized matches regex @"^[A-Za-z0-9\.\-]+$"
+    | project TimeGenerated, Url, UrlDomain, DomainUnicode, Lookalikes, Normalized, ReportId, NetworkMessageId, TeamsMessageId, Source;
+  };
+  // End Function
+  let EmailFindings =
+    EmailUrlInfo
+    | project TimeGenerated, Url, UrlDomain, ReportId, NetworkMessageId, TeamsMessageId = "", Source = "Email"
+    | invoke SuspiciousPunycodeDomains()
+    | join kind=innerunique (
+      EmailEvents
+      | project NetworkMessageId, EmailTimeGenerated = TimeGenerated, ReportId, RecipientEmailAddress, SenderFromAddress, SenderMailFromAddress, SenderDisplayName, Subject, DeliveryAction, DeliveryLocation, ThreatTypes
+    ) on NetworkMessageId
+    | project
+        timestamp = TimeGenerated,
+        Source,
+        TimeGenerated,
+        ReportId,
+        NetworkMessageId,
+        TeamsMessageId,
+        Url,
+        UrlDomain,
+        DomainUnicode,
+        Lookalikes,
+        Normalized,
+        Subject,
+        ThreatTypes,
+        DeliveryAction,
+        DeliveryLocation,
+        SenderDisplayName,
+        SenderFromAddress,
+        SenderMailFromAddress,
+        RecipientEmailAddress;
+  let TeamsFindings =
+    MessageUrlInfo
+    | project TimeGenerated, Url, UrlDomain, ReportId, NetworkMessageId = "", TeamsMessageId, Source = "Teams"
+    | invoke SuspiciousPunycodeDomains()
+    | join kind=innerunique (
+      MessageEvents
+      | project TeamsMessageId, MessageTimeGenerated = TimeGenerated, Timestamp, SenderEmailAddress, SenderDisplayName, SenderObjectId, SenderType, RecipientDetails, GroupId, GroupName, ThreadId, ThreadName, ThreadType, IsExternalThread, MessageType, MessageSubtype, Subject, ThreatTypes, DeliveryAction, DeliveryLocation, ReportId
+    ) on TeamsMessageId
+    | project
+        timestamp = TimeGenerated,
+        Source,
+        TimeGenerated,
+        ReportId,
+        NetworkMessageId,
+        TeamsMessageId,
+        Url,
+        UrlDomain,
+        DomainUnicode,
+        Lookalikes,
+        Normalized,
+        Subject,
+        ThreatTypes,
+        DeliveryAction,
+        DeliveryLocation,
+        SenderDisplayName,
+        SenderEmailAddress,
+        SenderObjectId,
+        SenderType,
+        RecipientDetails,
+        GroupId,
+        GroupName,
+        ThreadId,
+        ThreadName,
+        ThreadType,
+        IsExternalThread,
+        MessageType,
+        MessageSubtype
+        //| where IsExternalThread == true // Use filter if only external threats are in scope
+        ;
+  union isfuzzy=true EmailFindings, TeamsFindings
+  | order by TimeGenerated desc
+version: l.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Privilege escalation/unquoted-service-path-abuse.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Privilege escalation/unquoted-service-path-abuse.yaml
@@ -1,0 +1,77 @@
+id: 42dbabf8-0c47-4625-bba8-c548eb9b40e9
+name: Detect-unquoted-service-path-abuse
+description: |
+  Detects potential unquoted service path abuse by identifying vulnerable unquoted service paths
+  and correlating them with executions from possible abuse locations.
+description-detailed: |
+  This query looks for vulnerable unquoted service paths from TVM data and correlates them with 
+  process execution and file activity that matches possible abuse paths.
+requiredDataConnectors:
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceProcessEvents
+      - DeviceFileEvents
+      - DeviceTvmSecureConfigurationAssessment
+tactics:
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1574.009
+query: |
+  // DefenderBoys - Mattias
+  // @mattiasborg82
+  let Lookback = 30d;
+  let UnquotedServicePathService =
+  DeviceTvmSecureConfigurationAssessment
+  | where ConfigurationId == "scid-3001"
+  | where Timestamp >= ago(Lookback)
+  | where IsApplicable == 1 and IsCompliant == 0
+  | extend ParsedContext = parse_json(Context)
+  | mv-expand ServiceEntry = ParsedContext
+  | extend ServiceName = tostring(ServiceEntry[0]), ServicePathRaw = tostring(ServiceEntry[1])
+  | extend ServicePathRawNorm = tolower(replace_string(ServicePathRaw, "/", "\\"))
+  | where ServicePathRawNorm contains " "
+  | where not(ServicePathRawNorm startswith "\"")
+  | extend ServicePath = trim(@" """, ServicePathRawNorm)
+  | where ServicePath matches regex @"^[a-zA-Z]:\\.*\.exe$"
+  | extend CandidateIndexes = range(0, strlen(ServicePath) - 1, 1)
+  | mv-apply CandidateIndex = CandidateIndexes on (
+      extend SpaceIndex = toint(CandidateIndex)
+      | where substring(ServicePath, SpaceIndex, 1) == " "
+      | extend CandidatePrefix = substring(ServicePath, 0, SpaceIndex)
+      | extend HijackFolderPath = strcat(CandidatePrefix, ".exe")
+      | where HijackFolderPath matches regex @"^[a-zA-Z]:\\.*\.exe$"
+      | where HijackFolderPath != ServicePath
+      | project DeviceId, DeviceName, ServiceName, ServicePath, HijackFolderPath
+  )
+  | summarize by DeviceId, DeviceName, ServiceName, ServicePath, HijackFolderPath;
+  let ServiceHijackExecutions =
+  DeviceProcessEvents
+  | where Timestamp >= ago(Lookback)
+  | where InitiatingProcessFileName =~ "services.exe"
+  | extend ExecutedPath = tolower(FolderPath)
+  | project ExecutionTime = Timestamp, DeviceId, DeviceName, ExecutedPath, FileName, FolderPath, ProcessCommandLine, SHA1, SHA256, MD5, FileSize, ProcessVersionInfoCompanyName, ProcessVersionInfoProductName, ProcessVersionInfoOriginalFileName, AccountDomain, AccountName, AccountUpn, ProcessIntegrityLevel, ProcessTokenElevation, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessIntegrityLevel, InitiatingProcessTokenElevation, ReportId;
+  let FileActivityOnHijackFolderPath =
+  // Adding File activities to provide more data into an eventual incident
+  DeviceFileEvents
+  | where Timestamp >= ago(Lookback)
+  | where FolderPath matches regex @"^[a-zA-Z]:\\.*\.exe$"
+  | extend CurrentFolderPath = tolower(FolderPath)
+  | extend PreviousPath = tolower(iff(ActionType =~ "FileRenamed" and isnotempty(PreviousFolderPath) and isnotempty(PreviousFileName), strcat(PreviousFolderPath, "\\", PreviousFileName), ""))
+  | project Timestamp, DeviceId, DeviceName, FileActionType=ActionType, CurrentFolderPath, PreviousPath, FileName, SHA1, SHA256, MD5, FileSize, FileOriginUrl, FileOriginReferrerUrl, FileOriginIP, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessAccountUpn, InitiatingProcessFolderPath, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessIntegrityLevel, InitiatingProcessTokenElevation, InitiatingProcessParentFileName, RequestProtocol, RequestSourceIP, RequestSourcePort, RequestAccountName, RequestAccountDomain, ShareName, ReportId;
+  UnquotedServicePathService
+  | join kind=inner ServiceHijackExecutions on DeviceId
+  | where ExecutedPath == HijackFolderPath
+  | join kind=leftouter FileActivityOnHijackFolderPath on DeviceId // File events is just extra not mandatory
+  | where CurrentFolderPath == HijackFolderPath or isempty(CurrentFolderPath)
+  | extend FileActivityBeforeExecution = iff(isnotempty(Timestamp) and Timestamp <= ExecutionTime, true, false)
+  | extend FileActivityType = case(
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileCreated", "Hijack file created",
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileModified", "Hijack file modified",
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileDeleted", "Hijack file deleted",
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileRenamed", "Hijack file renamed into path",
+      isempty(FileActionType), "No matching file event",
+      "N/A"
+  )
+  | project ExecutionTime, DeviceName, ServiceName, VulnerableServicePath = ServicePath, ExpectedHijackFolderPath = HijackFolderPath, ExecutedPath, FileActivityTimestamp = Timestamp, FileActivityBeforeExecution, FileActivityType, CurrentFolderPath, PreviousPath, FileName, FolderPath, ProcessCommandLine, SHA1, SHA256, MD5, FileSize, ProcessVersionInfoCompanyName, ProcessVersionInfoProductName, ProcessVersionInfoOriginalFileName, AccountDomain, AccountName, AccountUpn, ProcessIntegrityLevel, ProcessTokenElevation, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessIntegrityLevel, InitiatingProcessTokenElevation, InitiatingProcessParentFileName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessAccountUpn, InitiatingProcessFolderPath, FileOriginUrl, FileOriginReferrerUrl, FileOriginIP, RequestProtocol, RequestSourceIP, RequestSourcePort, RequestAccountName, RequestAccountDomain, ShareName, ReportId
+  | order by ExecutionTime desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
@@ -66,7 +66,7 @@ query: |
       | project NetworkMessageId, EmailTimeGenerated = TimeGenerated, ReportId, RecipientEmailAddress, SenderFromAddress, SenderMailFromAddress, SenderDisplayName, Subject, DeliveryAction, DeliveryLocation, ThreatTypes
     ) on NetworkMessageId
     | project
-        timestamp = TimeGenerated,
+        Timestamp = TimeGenerated,
         Source,
         TimeGenerated,
         ReportId,
@@ -94,7 +94,7 @@ query: |
       | project TeamsMessageId, MessageTimeGenerated = TimeGenerated, Timestamp, SenderEmailAddress, SenderDisplayName, SenderObjectId, SenderType, RecipientDetails, GroupId, GroupName, ThreadId, ThreadName, ThreadType, IsExternalThread, MessageType, MessageSubtype, Subject, ThreatTypes, DeliveryAction, DeliveryLocation, ReportId
     ) on TeamsMessageId
     | project
-        timestamp = TimeGenerated,
+        Timestamp = TimeGenerated,
         Source,
         TimeGenerated,
         ReportId,
@@ -126,4 +126,4 @@ query: |
         ;
   union isfuzzy=true EmailFindings, TeamsFindings
   | order by TimeGenerated desc
-version: l.0.0
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Phish/Punycode chars lookalike domains.yaml
@@ -1,0 +1,129 @@
+id: 9582b09c-a5cd-4da0-8244-52cc952da158
+name: Punycode lookalikes
+description: |
+  Punycode lookalike domains in Emails and Teams messages 
+description-detailed: |
+  Detects URLs containing punycode domains (xn--) where the decoded Unicode domain includes common Cyrillic/Greek/fullwidth ASCII lookalike characters.
+  This query covers a use-case which is on only detecting phishing attempts that use visually similar characters to impersonate legitimate domains.
+  The research started in october but didnt have the time to finish it until now. A diary on Sans by Xavier made me realize that I need to finish this work.
+  A diary on Sans ISC about this technique can be found here: https://isc.sans.edu/forums/diary/Detecting+Punycode+Lookalike+Domains+in+Emails/28812/
+  Contact: @MattiasBorg82 for questions or suggestions.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+  - MessageUrlInfo
+  - MessageEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let AsciiLookalikeChars = @"([\u0430\u0435\u043E\u0440\u0441\u0445\u0456\u0443\u043C\u043D\u0455\u0442\u04BB\u0501\u03B1\u03B5\u03BF\u03C1\u03C7\u03BA\u03BD\u03F2\uFF41-\uFF5A\uFF21-\uFF3A])";
+  // Function 
+  let NormalizeLookalikes = (s:string) {
+    replace(@"\u0501","d",
+    replace(@"\u04BB","h",
+    replace(@"\u0442","t",
+    replace(@"\u0455","s",
+    replace(@"\u043D","n",
+    replace(@"\u043C","m",
+    replace(@"\u0443","y",
+    replace(@"\u0456","i",
+    replace(@"\u03C7","x",
+    replace(@"\u0445","x",
+    replace(@"\u03F2","c",
+    replace(@"\u0441","c",
+    replace(@"\u03C1","p",
+    replace(@"\u0440","p",
+    replace(@"\u03BF","o",
+    replace(@"\u043E","o",
+    replace(@"\u03B5","e",
+    replace(@"\u0435","e",
+    replace(@"\u03B1","a",
+    replace(@"\u0430","a",s)
+  )))))))))))))))))))};
+  // End Function
+  // Function
+  let SuspiciousPunycodeDomains = (T:(TimeGenerated:datetime, Url:string, UrlDomain:string, ReportId:string, NetworkMessageId:string, TeamsMessageId:string, Source:string)) {
+    T
+    | where UrlDomain has "xn--"
+    | extend DomainUnicode = punycode_domain_from_string(UrlDomain)
+    | extend Lookalikes = extract_all(AsciiLookalikeChars, DomainUnicode)
+    | where array_length(Lookalikes) > 0
+    | extend Normalized = NormalizeLookalikes(DomainUnicode)
+    | where Normalized matches regex @"^[A-Za-z0-9\.\-]+$"
+    | project TimeGenerated, Url, UrlDomain, DomainUnicode, Lookalikes, Normalized, ReportId, NetworkMessageId, TeamsMessageId, Source;
+  };
+  // End Function
+  let EmailFindings =
+    EmailUrlInfo
+    | project TimeGenerated, Url, UrlDomain, ReportId, NetworkMessageId, TeamsMessageId = "", Source = "Email"
+    | invoke SuspiciousPunycodeDomains()
+    | join kind=innerunique (
+      EmailEvents
+      | project NetworkMessageId, EmailTimeGenerated = TimeGenerated, ReportId, RecipientEmailAddress, SenderFromAddress, SenderMailFromAddress, SenderDisplayName, Subject, DeliveryAction, DeliveryLocation, ThreatTypes
+    ) on NetworkMessageId
+    | project
+        timestamp = TimeGenerated,
+        Source,
+        TimeGenerated,
+        ReportId,
+        NetworkMessageId,
+        TeamsMessageId,
+        Url,
+        UrlDomain,
+        DomainUnicode,
+        Lookalikes,
+        Normalized,
+        Subject,
+        ThreatTypes,
+        DeliveryAction,
+        DeliveryLocation,
+        SenderDisplayName,
+        SenderFromAddress,
+        SenderMailFromAddress,
+        RecipientEmailAddress;
+  let TeamsFindings =
+    MessageUrlInfo
+    | project TimeGenerated, Url, UrlDomain, ReportId, NetworkMessageId = "", TeamsMessageId, Source = "Teams"
+    | invoke SuspiciousPunycodeDomains()
+    | join kind=innerunique (
+      MessageEvents
+      | project TeamsMessageId, MessageTimeGenerated = TimeGenerated, Timestamp, SenderEmailAddress, SenderDisplayName, SenderObjectId, SenderType, RecipientDetails, GroupId, GroupName, ThreadId, ThreadName, ThreadType, IsExternalThread, MessageType, MessageSubtype, Subject, ThreatTypes, DeliveryAction, DeliveryLocation, ReportId
+    ) on TeamsMessageId
+    | project
+        timestamp = TimeGenerated,
+        Source,
+        TimeGenerated,
+        ReportId,
+        NetworkMessageId,
+        TeamsMessageId,
+        Url,
+        UrlDomain,
+        DomainUnicode,
+        Lookalikes,
+        Normalized,
+        Subject,
+        ThreatTypes,
+        DeliveryAction,
+        DeliveryLocation,
+        SenderDisplayName,
+        SenderEmailAddress,
+        SenderObjectId,
+        SenderType,
+        RecipientDetails,
+        GroupId,
+        GroupName,
+        ThreadId,
+        ThreadName,
+        ThreadType,
+        IsExternalThread,
+        MessageType,
+        MessageSubtype
+        //| where IsExternalThread == true // Use filter if only external threats are in scope
+        ;
+  union isfuzzy=true EmailFindings, TeamsFindings
+  | order by TimeGenerated desc
+version: l.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Privilege Escalation/unquoted-service-path-abuse.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Privilege Escalation/unquoted-service-path-abuse.yaml
@@ -1,0 +1,77 @@
+id: 42dbabf8-0c47-4625-bba8-c548eb9b40e9
+name: Detect-unquoted-service-path-abuse
+description: |
+  Detects potential unquoted service path abuse by identifying vulnerable unquoted service paths
+  and correlating them with executions from possible abuse locations.
+description-detailed: |
+  This query looks for vulnerable unquoted service paths from TVM data and correlates them with 
+  process execution and file activity that matches possible abuse paths.
+requiredDataConnectors:
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceProcessEvents
+      - DeviceFileEvents
+      - DeviceTvmSecureConfigurationAssessment
+tactics:
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1574.009
+query: |
+  // DefenderBoys - Mattias
+  // @mattiasborg82
+  let Lookback = 30d;
+  let UnquotedServicePathService =
+  DeviceTvmSecureConfigurationAssessment
+  | where ConfigurationId == "scid-3001"
+  | where Timestamp >= ago(Lookback)
+  | where IsApplicable == 1 and IsCompliant == 0
+  | extend ParsedContext = parse_json(Context)
+  | mv-expand ServiceEntry = ParsedContext
+  | extend ServiceName = tostring(ServiceEntry[0]), ServicePathRaw = tostring(ServiceEntry[1])
+  | extend ServicePathRawNorm = tolower(replace_string(ServicePathRaw, "/", "\\"))
+  | where ServicePathRawNorm contains " "
+  | where not(ServicePathRawNorm startswith "\"")
+  | extend ServicePath = trim(@" """, ServicePathRawNorm)
+  | where ServicePath matches regex @"^[a-zA-Z]:\\.*\.exe$"
+  | extend CandidateIndexes = range(0, strlen(ServicePath) - 1, 1)
+  | mv-apply CandidateIndex = CandidateIndexes on (
+      extend SpaceIndex = toint(CandidateIndex)
+      | where substring(ServicePath, SpaceIndex, 1) == " "
+      | extend CandidatePrefix = substring(ServicePath, 0, SpaceIndex)
+      | extend HijackFolderPath = strcat(CandidatePrefix, ".exe")
+      | where HijackFolderPath matches regex @"^[a-zA-Z]:\\.*\.exe$"
+      | where HijackFolderPath != ServicePath
+      | project DeviceId, DeviceName, ServiceName, ServicePath, HijackFolderPath
+  )
+  | summarize by DeviceId, DeviceName, ServiceName, ServicePath, HijackFolderPath;
+  let ServiceHijackExecutions =
+  DeviceProcessEvents
+  | where Timestamp >= ago(Lookback)
+  | where InitiatingProcessFileName =~ "services.exe"
+  | extend ExecutedPath = tolower(FolderPath)
+  | project ExecutionTime = Timestamp, DeviceId, DeviceName, ExecutedPath, FileName, FolderPath, ProcessCommandLine, SHA1, SHA256, MD5, FileSize, ProcessVersionInfoCompanyName, ProcessVersionInfoProductName, ProcessVersionInfoOriginalFileName, AccountDomain, AccountName, AccountUpn, ProcessIntegrityLevel, ProcessTokenElevation, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessIntegrityLevel, InitiatingProcessTokenElevation, ReportId;
+  let FileActivityOnHijackFolderPath =
+  // Adding File activities to provide more data into an eventual incident
+  DeviceFileEvents
+  | where Timestamp >= ago(Lookback)
+  | where FolderPath matches regex @"^[a-zA-Z]:\\.*\.exe$"
+  | extend CurrentFolderPath = tolower(FolderPath)
+  | extend PreviousPath = tolower(iff(ActionType =~ "FileRenamed" and isnotempty(PreviousFolderPath) and isnotempty(PreviousFileName), strcat(PreviousFolderPath, "\\", PreviousFileName), ""))
+  | project Timestamp, DeviceId, DeviceName, FileActionType=ActionType, CurrentFolderPath, PreviousPath, FileName, SHA1, SHA256, MD5, FileSize, FileOriginUrl, FileOriginReferrerUrl, FileOriginIP, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessAccountUpn, InitiatingProcessFolderPath, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessIntegrityLevel, InitiatingProcessTokenElevation, InitiatingProcessParentFileName, RequestProtocol, RequestSourceIP, RequestSourcePort, RequestAccountName, RequestAccountDomain, ShareName, ReportId;
+  UnquotedServicePathService
+  | join kind=inner ServiceHijackExecutions on DeviceId
+  | where ExecutedPath == HijackFolderPath
+  | join kind=leftouter FileActivityOnHijackFolderPath on DeviceId // File events is just extra not mandatory
+  | where CurrentFolderPath == HijackFolderPath or isempty(CurrentFolderPath)
+  | extend FileActivityBeforeExecution = iff(isnotempty(Timestamp) and Timestamp <= ExecutionTime, true, false)
+  | extend FileActivityType = case(
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileCreated", "Hijack file created",
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileModified", "Hijack file modified",
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileDeleted", "Hijack file deleted",
+      CurrentFolderPath == HijackFolderPath and FileActionType =~ "FileRenamed", "Hijack file renamed into path",
+      isempty(FileActionType), "No matching file event",
+      "N/A"
+  )
+  | project ExecutionTime, DeviceName, ServiceName, VulnerableServicePath = ServicePath, ExpectedHijackFolderPath = HijackFolderPath, ExecutedPath, FileActivityTimestamp = Timestamp, FileActivityBeforeExecution, FileActivityType, CurrentFolderPath, PreviousPath, FileName, FolderPath, ProcessCommandLine, SHA1, SHA256, MD5, FileSize, ProcessVersionInfoCompanyName, ProcessVersionInfoProductName, ProcessVersionInfoOriginalFileName, AccountDomain, AccountName, AccountUpn, ProcessIntegrityLevel, ProcessTokenElevation, InitiatingProcessFileName, InitiatingProcessCommandLine, InitiatingProcessIntegrityLevel, InitiatingProcessTokenElevation, InitiatingProcessParentFileName, InitiatingProcessAccountDomain, InitiatingProcessAccountName, InitiatingProcessAccountUpn, InitiatingProcessFolderPath, FileOriginUrl, FileOriginReferrerUrl, FileOriginIP, RequestProtocol, RequestSourceIP, RequestSourcePort, RequestAccountName, RequestAccountDomain, ShareName, ReportId
+  | order by ExecutionTime desc
+version: 1.0.0


### PR DESCRIPTION
Change(s):
- Added new Microsoft 365 Defender hunting query: "Detect unquoted service path abuse"
- Query identifies vulnerable unquoted service paths (scid-3001) and correlates them with process and file execution activity from potential abuse paths
- Added YAML definition in both:
  - Hunting Queries/Microsoft 365 Defender/
  - Solutions/Microsoft Defender XDR/Hunting Queries/

Reason for Change(s):
- Detects a well-known privilege escalation technique (Unquoted Service Path Abuse - T1574.009)
- Provides defenders with visibility into both misconfiguration and potential exploitation attempts
- Helps bridge the gap between configuration weaknesses and actual attacker behavior

Version Updated:
- N/A

Testing Completed:
- Yes
- Query tested in Microsoft Defender Advanced Hunting
- Verified syntax, table availability, and expected results

Checked that the validations are passing and have addressed any issues that are present:
- Yes