### PR TITLE
E11: remove incorrect cold storage reference for data lake tier

### DIFF
--- a/Tools/Microsoft-Sentinel-Training-Lab/Exercises/E11_datalake_kql_jobs.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Exercises/E11_datalake_kql_jobs.md
@@ -40,7 +40,7 @@ The Lab already uses this pattern. The detection rule `Lab Stage S8 - Data Lake 
 
 ### Data Lake Ingestion Latency
 
-The data lake tier stores data in cold storage. There is a typical latency of **up to 15 minutes** before newly ingested data is available for querying. When scheduling KQL jobs, you must account for this latency by including a delay parameter in your queries:
+The data lake tier has a typical ingestion latency of **up to 15 minutes** before newly ingested data is available for querying. When scheduling KQL jobs, you must account for this latency by including a delay parameter in your queries:
 
 ```kusto
 let delay = 15m;

--- a/Tools/Microsoft-Sentinel-Training-Lab/Package/mainTemplate.json
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Package/mainTemplate.json
@@ -40,14 +40,14 @@
                                             },
                        "scheduleStartTime":  {
                                                  "type":  "string",
-                                                 "defaultValue":  "[dateTimeAdd(utcNow('yyyy-MM-ddTHH:mm:ssZ'), 'PT5M')]",
+                                                 "defaultValue":  "[dateTimeAdd(utcNow('yyyy-MM-ddTHH:mm:ssZ'), 'PT15M')]",
                                                  "metadata":  {
                                                                   "description":  "UTC start time for the one-time ingestion schedule"
                                                               }
                                              },
                        "detectionRulesScheduleStartTime":  {
                                                                "type":  "string",
-                                                               "defaultValue":  "[dateTimeAdd(utcNow('yyyy-MM-ddTHH:mm:ssZ'), 'PT15M')]",
+                                                               "defaultValue":  "[dateTimeAdd(utcNow('yyyy-MM-ddTHH:mm:ssZ'), 'PT30M')]",
                                                                "metadata":  {
                                                                                 "description":  "UTC start time for the detection-rules runbook (runs after ingestion)"
                                                                             }

--- a/Tools/Microsoft-Sentinel-Training-Lab/README.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/README.md
@@ -30,6 +30,12 @@ Complete **one** of the two options below before deployment.
 
 ### Option A — User-Assigned Managed Identity (UAMI)
 
+> **Tip — Use GitHub Copilot:** You can complete this entire setup by pasting the following prompt into GitHub Copilot Chat (in VS Code or the Defender portal):
+>
+> *"Create a User-Assigned Managed Identity called SentinelDetectionRulesIdentity in my resource group, grant it the Microsoft Graph CustomDetection.ReadWrite.All application permission, and give me the full resource ID to use during deployment."*
+>
+> Copilot will generate the exact CLI commands for your environment.
+
 #### A1. Create the UAMI
 
 ```powershell
@@ -70,6 +76,10 @@ Pass the UAMI's **full resource ID** as the `detectionRulesIdentityResourceId` p
 ### Option B — Service Principal (App Registration)
 
 Use this option when you cannot create or use a Managed Identity (e.g., cross-tenant deployments or restricted RBAC environments).
+
+> **Tip — Use GitHub Copilot:** You can complete this setup by pasting the following prompt into GitHub Copilot Chat:
+>
+> *"Create an App Registration called SentinelDetectionRulesSPN, grant it the Microsoft Graph CustomDetection.ReadWrite.All application permission, create a client secret, and give me the Tenant ID, Client ID, and Client Secret to use during deployment."*
 
 **Prefer the portal?** You can complete steps B1–B3 entirely from the Azure portal by following [Create a Microsoft Entra app and service principal in the portal](https://learn.microsoft.com/entra/identity-platform/howto-create-service-principal-portal). That guide covers app registration, API permission assignment (use **Microsoft Graph → Application permissions → CustomDetection.ReadWrite.All**), and client secret creation. Once done, skip ahead to **B4** below.
 


### PR DESCRIPTION
Minor fix: removes the incorrect reference to the data lake tier as 'cold storage' in Exercise 11 (Data Lake KQL Jobs). The Sentinel data lake is not cold storage.