### PR TITLE
Sentinel Training Lab: simplify auth to UAMI-only, fix deployment UX

### DIFF
--- a/Tools/Microsoft-Sentinel-Training-Lab/Artifacts/LinkedTemplates/deployDetectionRules.json
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Artifacts/LinkedTemplates/deployDetectionRules.json
@@ -5,48 +5,23 @@
         "scheduleStartTime": {
             "type": "string",
             "metadata": {
-                "description": "UTC start time for the one-time detection-rules schedule (should run before data ingestion)"
+                "description": "UTC start time for the one-time detection-rules schedule"
             }
         },
         "userAssignedIdentityResourceId": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
-                "description": "Full resource ID of a pre-created User-Assigned Managed Identity that has been granted the Microsoft Graph CustomDetection.ReadWrite.All application permission. Required when using Managed Identity auth (leave SPN params empty)."
-            }
-        },
-        "spnTenantId": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Microsoft Entra tenant ID for service principal authentication. Provide together with spnClientId and spnClientSecret to use SPN auth instead of Managed Identity."
-            }
-        },
-        "spnClientId": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Application (client) ID of the service principal with CustomDetection.ReadWrite.All permission."
-            }
-        },
-        "spnClientSecret": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Client secret of the service principal."
+                "description": "Full resource ID of a pre-created User-Assigned Managed Identity with Microsoft Graph CustomDetection.ReadWrite.All permission."
             }
         }
     },
     "variables": {
         "automationAccountName": "[concat('sentineldetections', uniqueString(resourceGroup().id))]",
         "runbookName": "DeployDetectionRules",
-        "scheduleName": "[concat('DeployDetectionRulesOnce-', uniqueString(resourceGroup().id, parameters('scheduleStartTime')))]",
-        "useSpn": "[and(not(empty(parameters('spnTenantId'))), not(empty(parameters('spnClientId'))), not(empty(parameters('spnClientSecret'))))]",
-        "useManagedIdentity": "[and(not(variables('useSpn')), not(empty(parameters('userAssignedIdentityResourceId'))))]"
+        "scheduleName": "[concat('DeployDetectionRulesOnce-', uniqueString(resourceGroup().id, parameters('scheduleStartTime')))]"
     },
     "resources": [
         {
-            "condition": "[variables('useManagedIdentity')]",
             "type": "Microsoft.Automation/automationAccounts",
             "apiVersion": "2023-11-01",
             "name": "[variables('automationAccountName')]",
@@ -54,21 +29,9 @@
             "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
-                    "[if(variables('useManagedIdentity'), parameters('userAssignedIdentityResourceId'), 'placeholder')]": {}
+                    "[parameters('userAssignedIdentityResourceId')]": {}
                 }
             },
-            "properties": {
-                "sku": {
-                    "name": "Basic"
-                }
-            }
-        },
-        {
-            "condition": "[variables('useSpn')]",
-            "type": "Microsoft.Automation/automationAccounts",
-            "apiVersion": "2023-11-01",
-            "name": "[variables('automationAccountName')]",
-            "location": "[resourceGroup().location]",
             "properties": {
                 "sku": {
                     "name": "Basic"
@@ -106,7 +69,6 @@
             }
         },
         {
-            "condition": "[variables('useManagedIdentity')]",
             "type": "Microsoft.Automation/automationAccounts/variables",
             "apiVersion": "2023-11-01",
             "name": "[concat(variables('automationAccountName'), '/DetectionRulesManagedIdentityClientId')]",
@@ -115,46 +77,7 @@
             ],
             "properties": {
                 "isEncrypted": false,
-                "value": "[if(variables('useManagedIdentity'), concat('\"', reference(parameters('userAssignedIdentityResourceId'), '2023-01-31').clientId, '\"'), '\"\"')]"
-            }
-        },
-        {
-            "condition": "[variables('useSpn')]",
-            "type": "Microsoft.Automation/automationAccounts/variables",
-            "apiVersion": "2023-11-01",
-            "name": "[concat(variables('automationAccountName'), '/DetectionRulesTenantId')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Automation/automationAccounts', variables('automationAccountName'))]"
-            ],
-            "properties": {
-                "isEncrypted": false,
-                "value": "[concat('\"', parameters('spnTenantId'), '\"')]"
-            }
-        },
-        {
-            "condition": "[variables('useSpn')]",
-            "type": "Microsoft.Automation/automationAccounts/variables",
-            "apiVersion": "2023-11-01",
-            "name": "[concat(variables('automationAccountName'), '/DetectionRulesClientId')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Automation/automationAccounts', variables('automationAccountName'))]"
-            ],
-            "properties": {
-                "isEncrypted": false,
-                "value": "[concat('\"', parameters('spnClientId'), '\"')]"
-            }
-        },
-        {
-            "condition": "[variables('useSpn')]",
-            "type": "Microsoft.Automation/automationAccounts/variables",
-            "apiVersion": "2023-11-01",
-            "name": "[concat(variables('automationAccountName'), '/DetectionRulesClientSecret')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Automation/automationAccounts', variables('automationAccountName'))]"
-            ],
-            "properties": {
-                "isEncrypted": true,
-                "value": "[concat('\"', parameters('spnClientSecret'), '\"')]"
+                "value": "[concat('\"', reference(parameters('userAssignedIdentityResourceId'), '2023-01-31').clientId, '\"')]"
             }
         },
         {
@@ -174,6 +97,5 @@
                 }
             }
         }
-    ],
-    "outputs": {}
+    ]
 }

--- a/Tools/Microsoft-Sentinel-Training-Lab/Exercises/E03_mitre_attack_coverage.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Exercises/E03_mitre_attack_coverage.md
@@ -14,7 +14,7 @@ Use the **MITRE ATT&CK** page in Microsoft Sentinel to visualise which tactics a
 
 The MITRE ATT&CK framework is the industry standard for classifying adversary behaviour. Microsoft Sentinel maps every analytics rule to MITRE tactics and techniques, giving you a heat-map view of your detection posture.
 
-The lab solution deploys **17 detection rules** covering a multi-stage attack that spans:
+The lab solution deploys **22 detection rules** covering a multi-stage attack that spans:
 
 | Tactic | Techniques | Rule examples |
 | --- | --- | --- |

--- a/Tools/Microsoft-Sentinel-Training-Lab/Exercises/Onboarding.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Exercises/Onboarding.md
@@ -52,15 +52,12 @@ If you already have a workspace, skip to [Step 2](#step-2-add-microsoft-sentinel
 
 This deploys pre-recorded telemetry (~20 MB) and creates analytics rules, workbooks, watchlists, and playbooks used in the subsequent exercises.
 
-Make sure you have completed the **Custom Detection Rules Setup** from the [README](../README.md) (either Option A — UAMI or Option B — Service Principal). You will need the credentials during deployment.
+Make sure you have completed the **Custom Detection Rules Setup** from the [README](../README.md) (creating the User-Assigned Managed Identity). You will need the UAMI resource ID during deployment.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FTools%2FMicrosoft-Sentinel-Training-Lab%2FPackage%2FmainTemplate.json)
 
 1. Select the **Subscription**, **Resource Group**, and **Workspace** from the previous steps.
-2. Under **Detection Rules Auth Method**, choose your preferred option:
-   - **User-Assigned Managed Identity** — paste the UAMI's full resource ID.
-   - **Service Principal (App Registration)** — enter the Tenant ID, Client ID, and Client Secret.
-   - **None** — skip custom detection rules deployment.
+2. Under **Detection Rules Identity Resource Id**, paste the full resource ID of your UAMI (or leave empty to skip detection rules deployment).
 3. Select **Review + create**, then **Create**.
 
 > **Note:** The deployment takes approximately **15 minutes**.

--- a/Tools/Microsoft-Sentinel-Training-Lab/Package/mainTemplate.json
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Package/mainTemplate.json
@@ -52,46 +52,13 @@
                                                                                 "description":  "UTC start time for the detection-rules runbook (runs after ingestion)"
                                                                             }
                                                            },
-                       "detectionRulesAuthMethod":  {
-                                                        "type":  "string",
-                                                        "defaultValue":  "none",
-                                                        "allowedValues":  [
-                                                                              "none",
-                                                                              "uami",
-                                                                              "spn"
-                                                                          ],
-                                                        "metadata":  {
-                                                                         "description":  "Authentication method for detection rules deployment."
-                                                                     }
-                                                    },
                        "detectionRulesIdentityResourceId":  {
                                                                 "type":  "string",
                                                                 "defaultValue":  "",
                                                                 "metadata":  {
-                                                                                 "description":  "Full resource ID of a pre-created User-Assigned Managed Identity with Microsoft Graph CustomDetection.ReadWrite.All permission. Required when using Managed Identity auth (leave SPN params empty)."
+                                                                                 "description":  "Full resource ID of a pre-created User-Assigned Managed Identity with Microsoft Graph CustomDetection.ReadWrite.All permission. Leave empty to skip detection rules deployment."
                                                                              }
                                                             },
-                       "detectionRulesSpnTenantId":  {
-                                                         "type":  "string",
-                                                         "defaultValue":  "",
-                                                         "metadata":  {
-                                                                          "description":  "Microsoft Entra tenant ID for service principal authentication. Provide together with SpnClientId and SpnClientSecret to use SPN auth instead of Managed Identity."
-                                                                      }
-                                                     },
-                       "detectionRulesSpnClientId":  {
-                                                         "type":  "string",
-                                                         "defaultValue":  "",
-                                                         "metadata":  {
-                                                                          "description":  "Application (client) ID of the service principal with CustomDetection.ReadWrite.All permission."
-                                                                      }
-                                                     },
-                       "detectionRulesSpnClientSecret":  {
-                                                             "type":  "securestring",
-                                                             "defaultValue":  "",
-                                                             "metadata":  {
-                                                                              "description":  "Client secret of the service principal."
-                                                                          }
-                                                         },
                        "enableIngestion":  {
                                                "type":  "bool",
                                                "defaultValue":  true,
@@ -151,7 +118,7 @@
                           "name":  "deployDetectionRules",
                           "type":  "Microsoft.Resources/deployments",
                           "apiVersion":  "2024-07-01",
-                          "condition":  "[not(equals(parameters('detectionRulesAuthMethod'), 'none'))]",
+                          "condition":  "[not(empty(parameters('detectionRulesIdentityResourceId')))]",
                           "dependsOn":  [
                                             "[resourceId('Microsoft.Resources/deployments', 'workspaceCreation')]"
                                         ],
@@ -167,16 +134,7 @@
                                                                                       },
                                                                 "userAssignedIdentityResourceId":  {
                                                                                                        "value":  "[parameters('detectionRulesIdentityResourceId')]"
-                                                                                                   },
-                                                                "spnTenantId":  {
-                                                                                    "value":  "[parameters('detectionRulesSpnTenantId')]"
-                                                                                },
-                                                                "spnClientId":  {
-                                                                                    "value":  "[parameters('detectionRulesSpnClientId')]"
-                                                                                },
-                                                                "spnClientSecret":  {
-                                                                                        "value":  "[parameters('detectionRulesSpnClientSecret')]"
-                                                                                    }
+                                                                                                   }
                                                             }
                                          }
                       },

--- a/Tools/Microsoft-Sentinel-Training-Lab/README.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/README.md
@@ -34,7 +34,7 @@ This lab deploys **custom detection rules** to Microsoft Defender XDR via the Mi
 
 #### 1. Create the UAMI
 
-Replace `<your-resource-group>` with your resource group name, then run:
+Open the [Azure portal](https://portal.azure.com/) and click the **Cloud Shell** button (>_) in the top navigation bar. Select **PowerShell** if prompted. Then replace `<your-resource-group>` with your resource group name and run:
 
 ```powershell
 az identity create --resource-group <your-resource-group> --name SentinelDetectionRulesIdentity
@@ -42,7 +42,7 @@ az identity create --resource-group <your-resource-group> --name SentinelDetecti
 
 #### 2. Grant the Microsoft Graph permission
 
-Replace `<your-resource-group>` and run each line:
+In the same Cloud Shell session, replace `<your-resource-group>` and run each command:
 
 ```powershell
 $miObjectId = (az identity show --resource-group <your-resource-group> --name SentinelDetectionRulesIdentity --query principalId -o tsv)

--- a/Tools/Microsoft-Sentinel-Training-Lab/README.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/README.md
@@ -20,119 +20,53 @@ Before you begin, make sure you have:
 
 ## Custom Detection Rules Setup
 
-This lab deploys **custom detection rules** to Microsoft Defender XDR via the Microsoft Graph Security API. The Automation runbook that creates the rules needs an identity with the `CustomDetection.ReadWrite.All` Microsoft Graph application permission. You can use **either** a User-Assigned Managed Identity (UAMI) **or** a Service Principal (App Registration) — pick the option that suits your environment.
+This lab deploys **custom detection rules** to Microsoft Defender XDR via the Microsoft Graph Security API. The Automation runbook that creates the rules needs a **User-Assigned Managed Identity (UAMI)** with the `CustomDetection.ReadWrite.All` Microsoft Graph application permission.
 
-> **Tip:** Leave all identity fields empty during deployment if you want to skip custom detection rules entirely.
-
-Complete **one** of the two options below before deployment.
+> **Tip:** Leave the identity field empty during deployment if you want to skip custom detection rules entirely.
 
 ---
 
-### Option A — User-Assigned Managed Identity (UAMI)
+### Create a User-Assigned Managed Identity (UAMI)
 
-> **Tip — Use GitHub Copilot:** You can complete this entire setup by pasting the following prompt into GitHub Copilot Chat (in VS Code or the Defender portal):
+> **Tip — Use GitHub Copilot:** You can complete this entire setup by pasting the following prompt into GitHub Copilot Chat in VS Code:
 >
 > *"Create a User-Assigned Managed Identity called SentinelDetectionRulesIdentity in my resource group, grant it the Microsoft Graph CustomDetection.ReadWrite.All application permission, and give me the full resource ID to use during deployment."*
->
-> Copilot will generate the exact CLI commands for your environment.
 
-#### A1. Create the UAMI
+#### 1. Create the UAMI
 
-```powershell
-# Create the UAMI (adjust resource group and name as needed)
-az identity create `
-  --resource-group <your-resource-group> `
-  --name SentinelDetectionRulesIdentity
-```
-
-#### A2. Grant the Microsoft Graph permission
+Replace `<your-resource-group>` with your resource group name, then run:
 
 ```powershell
-# Variables
-$miObjectId   = (az identity show --resource-group <your-resource-group> --name SentinelDetectionRulesIdentity --query principalId -o tsv)
-$graphAppId   = "00000003-0000-0000-c000-000000000000"   # Microsoft Graph
-$appRoleId    = "e0fd9c8d-a12e-4cc9-9827-20c8c3cd6fb8"   # CustomDetection.ReadWrite.All
-
-# Get the Microsoft Graph service principal
-$graphSpId = (az ad sp show --id $graphAppId --query id -o tsv)
-
-# Assign the app role to the managed identity
-az rest --method POST `
-  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$graphSpId/appRoleAssignedTo" `
-  --headers "Content-Type=application/json" `
-  --body "{\"principalId\":\"$miObjectId\",\"resourceId\":\"$graphSpId\",\"appRoleId\":\"$appRoleId\"}"
+az identity create --resource-group <your-resource-group> --name SentinelDetectionRulesIdentity
 ```
 
-#### A3. Deploy
+#### 2. Grant the Microsoft Graph permission
+
+Replace `<your-resource-group>` and run each line:
+
+```powershell
+$miObjectId = (az identity show --resource-group <your-resource-group> --name SentinelDetectionRulesIdentity --query principalId -o tsv)
+```
+
+```powershell
+$graphSpId = (az ad sp show --id "00000003-0000-0000-c000-000000000000" --query id -o tsv)
+```
+
+```powershell
+$body = @{principalId=$miObjectId; resourceId=$graphSpId; appRoleId="e0fd9c8d-a12e-4cc9-9827-20c8c3cd6fb8"} | ConvertTo-Json -Compress
+```
+
+```powershell
+az rest --method POST --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$graphSpId/appRoleAssignedTo" --headers "Content-Type=application/json" --body $body
+```
+
+#### 3. Deploy
 
 Pass the UAMI's **full resource ID** as the `detectionRulesIdentityResourceId` parameter when deploying (in [Onboarding Step 4](./Exercises/Onboarding.md#step-4-deploy-the-microsoft-sentinel-training-lab-solution)):
 
 ```
 /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/SentinelDetectionRulesIdentity
 ```
-
----
-
-### Option B — Service Principal (App Registration)
-
-Use this option when you cannot create or use a Managed Identity (e.g., cross-tenant deployments or restricted RBAC environments).
-
-> **Tip — Use GitHub Copilot:** You can complete this setup by pasting the following prompt into GitHub Copilot Chat:
->
-> *"Create an App Registration called SentinelDetectionRulesSPN, grant it the Microsoft Graph CustomDetection.ReadWrite.All application permission, create a client secret, and give me the Tenant ID, Client ID, and Client Secret to use during deployment."*
-
-**Prefer the portal?** You can complete steps B1–B3 entirely from the Azure portal by following [Create a Microsoft Entra app and service principal in the portal](https://learn.microsoft.com/entra/identity-platform/howto-create-service-principal-portal). That guide covers app registration, API permission assignment (use **Microsoft Graph → Application permissions → CustomDetection.ReadWrite.All**), and client secret creation. Once done, skip ahead to **B4** below.
-
-<p align="center">
-<img src="./Images/OnboardingImage8.png?raw=true">
-</p>
-
-#### B1. Create an App Registration
-
-```powershell
-# Create the app registration
-az ad app create --display-name SentinelDetectionRulesSPN
-
-# Note the appId (client ID) from the output
-$appId = (az ad app list --display-name SentinelDetectionRulesSPN --query "[0].appId" -o tsv)
-
-# Create a service principal for the app
-az ad sp create --id $appId
-```
-
-#### B2. Grant the Microsoft Graph permission
-
-```powershell
-$spObjectId   = (az ad sp show --id $appId --query id -o tsv)
-$graphAppId   = "00000003-0000-0000-c000-000000000000"   # Microsoft Graph
-$appRoleId    = "e0fd9c8d-a12e-4cc9-9827-20c8c3cd6fb8"   # CustomDetection.ReadWrite.All
-
-$graphSpId = (az ad sp show --id $graphAppId --query id -o tsv)
-
-az rest --method POST `
-  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$graphSpId/appRoleAssignedTo" `
-  --headers "Content-Type=application/json" `
-  --body "{\"principalId\":\"$spObjectId\",\"resourceId\":\"$graphSpId\",\"appRoleId\":\"$appRoleId\"}"
-```
-
-> **Note:** Granting application permissions requires **Global Administrator** or **Privileged Role Administrator** in Microsoft Entra ID, or admin consent must be granted afterwards.
-
-#### B3. Create a client secret
-
-```powershell
-az ad app credential reset --id $appId --append
-# Save the "password" value — it will not be shown again.
-```
-
-#### B4. Deploy
-
-During deployment, provide the following three parameters (leave the UAMI field empty):
-
-| Parameter | Value |
-|---|---|
-| `detectionRulesSpnTenantId` | Your Microsoft Entra **Tenant ID** |
-| `detectionRulesSpnClientId` | The **Application (client) ID** from step B1 |
-| `detectionRulesSpnClientSecret` | The **client secret** from step B3 |
 
 ## Getting started
 


### PR DESCRIPTION
Simplifies detection rules auth from dual-option (UAMI/SPN) to UAMI-only. Fixes copy-paste CLI commands. Updates rule count to 22.