### PR TITLE
docs: fix three 'Microsoft' typos across playbook READMEs

### DIFF
--- a/Playbooks/Sync-Sentinel-Incident-Comments-To-M365Defender/readme.md
+++ b/Playbooks/Sync-Sentinel-Incident-Comments-To-M365Defender/readme.md
@@ -20,7 +20,7 @@ Here's how these permissions can be provided.
 
 On the application that was created in the above step, click on API Permissions on the left blade, then click Add a  Permission.
 
-From the options that open on the right, select APIs mu organization uses and search for and then click Microsft Threat Protection. 
+From the options that open on the right, select APIs mu organization uses and search for and then click Microsoft Threat Protection. 
 
 Next, click Application permissions. Select Incident.ReadWrite.All and then click on Add permissions.
 

--- a/Playbooks/Sync-Sentinel-Incident-Comments-To-M365Defender/readme.md
+++ b/Playbooks/Sync-Sentinel-Incident-Comments-To-M365Defender/readme.md
@@ -20,7 +20,7 @@ Here's how these permissions can be provided.
 
 On the application that was created in the above step, click on API Permissions on the left blade, then click Add a  Permission.
 
-From the options that open on the right, select APIs mu organization uses and search for and then click Microsoft Threat Protection. 
+From the options that open on the right, select APIs my organization uses and search for and then click Microsoft Threat Protection. 
 
 Next, click Application permissions. Select Incident.ReadWrite.All and then click on Add permissions.
 

--- a/Playbooks/Update-VIPUsers-Watchlist-from-AzureAD-Group/readme.md
+++ b/Playbooks/Update-VIPUsers-Watchlist-from-AzureAD-Group/readme.md
@@ -37,7 +37,7 @@ Now you need either to assign User Administrator role in Azure AD or to grant fo
 |
 
 <br>
-To assign Microsft Graph API permissions, first you will have to connect to Azure AD PowerShell module - https://docs.microsoft.com/powershell/module/azuread/?view=azureadps-2.0#connect-to-your-directory
+To assign Microsoft Graph API permissions, first you will have to connect to Azure AD PowerShell module - https://docs.microsoft.com/powershell/module/azuread/?view=azureadps-2.0#connect-to-your-directory
 <br>
 After login, run the following code replacing the managed identity object ID. You can find the managed identity object ID on the Identity blade under Settings for the Logic App.<br><br>
 

--- a/Playbooks/Update-VIPUsers-Watchlist-from-AzureAD-Group/readme.md
+++ b/Playbooks/Update-VIPUsers-Watchlist-from-AzureAD-Group/readme.md
@@ -37,7 +37,7 @@ Now you need either to assign User Administrator role in Azure AD or to grant fo
 |
 
 <br>
-To assign Microsoft Graph API permissions, first you will have to connect to Azure AD PowerShell module - https://docs.microsoft.com/powershell/module/azuread/?view=azureadps-2.0#connect-to-your-directory
+To assign Microsoft Graph API permissions, first you will have to connect to Azure AD PowerShell module - https://learn.microsoft.com/powershell/module/azuread/?view=azureadps-2.0#connect-to-your-directory
 <br>
 After login, run the following code replacing the managed identity object ID. You can find the managed identity object ID on the Identity blade under Settings for the Logic App.<br><br>
 

--- a/Solutions/Recorded Future/Playbooks/readme.md
+++ b/Solutions/Recorded Future/Playbooks/readme.md
@@ -137,7 +137,7 @@ After a logic app has been installed, the **Recorded Future Connector V2** needs
 
 The **azuresentinel** connector needs to be authorized for the solution to write to Microsoft Sentinel. There are multiple ways to do this, but our recommendation is using <a href="https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview" target="_blank">**system assigned managed identity**</a>, this requires that the user performing the installation needs to have the role of **Owner (with highest permissions)** or **Role Based Access Control Administrator** on resource group level.
 
-For more detailed information check out this Micrsoft <a href="https://learn.microsoft.com/en-us/azure/logic-apps/authenticate-with-managed-identity?tabs=consumption" target="_blank">guide</a>
+For more detailed information check out this Microsoft <a href="https://learn.microsoft.com/en-us/azure/logic-apps/authenticate-with-managed-identity?tabs=consumption" target="_blank">guide</a>
 
 These steps will be needed for each logic app that uses the **azuresentinel** / **RecordedFuture-MicrosoftSentinelConnection**
 1. Go to the specific logic app,  in the left menu click on the section _**Settings**_


### PR DESCRIPTION
Fixes #14109. Three 'Microsft'/'Micrsoft' typos in README files:

```diff
- Playbooks/Sync-Sentinel-Incident-Comments-To-M365Defender/readme.md
- Microsft Threat Protection
+ Microsoft Threat Protection

- Playbooks/Update-VIPUsers-Watchlist-from-AzureAD-Group/readme.md
- Microsft Graph API permissions
+ Microsoft Graph API permissions

- Solutions/Recorded Future/Playbooks/readme.md
- Micrsoft guide
+ Microsoft guide
```

Docs-only, three single-character fixes.