### PR TITLE
Salesforce: Connector Update - BugFix / Multi Salesforce tenant support

### DIFF
--- a/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/SalesforceServiceCloud_DataConnectorDefinition.json
+++ b/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/SalesforceServiceCloud_DataConnectorDefinition.json
@@ -15,19 +15,19 @@
         {
           "metricName": "Total data received",
           "legend": "Salesforce Service Cloud EventLogFile Events",
-          "baseQuery": "{{graphQueriesTableName}}"
+          "baseQuery": "SalesforceServiceCloudV2_CL"
         }
       ],
       "sampleQueries": [
         {
           "description": "Get a sample of Salesforce Service Cloud Event Log File Events",
-          "query": "{{graphQueriesTableName}}\n| take 10"
+          "query": "SalesforceServiceCloudV2_CL\n| take 10"
         }
       ],
       "dataTypes": [
         {
-          "name": "{{graphQueriesTableName}}",
-          "lastDataReceivedQuery": "{{graphQueriesTableName}}\n | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
+          "name": "SalesforceServiceCloudV2_CL",
+          "lastDataReceivedQuery": "SalesforceServiceCloudV2_CL\n | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
         }
       ],
       "connectivityCriteria": [
@@ -73,12 +73,16 @@
                   {
                     "columnName": "Data Type",
                     "columnValue": "properties.dataType"
+                  },
+                  {
+                    "columnName": "Api Endpoint",
+                    "columnValue": "properties.request.apiEndpoint"
                   }
                 ],
                 "menuItems": [
                     "DeleteConnector"
                 ]
-            }
+              }
             },
             {
               "type": "ContextPane",

--- a/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/SalesforceServiceCloud_DataConnectorDefinition.json
+++ b/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/SalesforceServiceCloud_DataConnectorDefinition.json
@@ -1,6 +1,6 @@
 {
   "name": "SalesforceServiceCloudCCPDefinition",
-  "apiVersion": "2022-09-01-preview",
+  "apiVersion": "2024-09-01",
   "type": "Microsoft.SecurityInsights/dataConnectorDefinitions",
   "location": "{{location}}",
   "kind": "Customizable",
@@ -67,51 +67,95 @@
           "description": "Be advised you must have an active [Salesforce Shield Event Monitoring](https://help.salesforce.com/s/articleView?id=sf.salesforce_shield) license in order to successfully connect this data connector. If you have this license, proceed.\n\nFollow [Create a Connected App in Salesforce for OAuth](https://help.salesforce.com/s/articleView?id=platform.ev_relay_create_connected_app.htm&type=5) and [Configure a Connected App for the OAuth 2.0 Client Credentials Flow](https://help.salesforce.com/s/articleView?id=xcloud.connected_app_client_credentials_setup.htm&type=5) to create a Connected App with access to the Salesforce Service Cloud API. Through those instructions, you should get the Consumer Key and Consumer Secret.\n For Salesforce Domain name, Go to Setup, type My Domain in the Quick Find box, and select My Domain to view your domain details. Make sure to enter the domain name without a trailing slash (e.g., https://your-domain.my.salesforce.com). Fill the form below with that information.",
           "instructions": [
             {
-              "type": "Textbox",
+              "type": "DataConnectorsGrid",
               "parameters": {
-                "label": "Salesforce Domain Name",
-                "placeholder": "Salesforce Domain Name",
-                "type": "text",
-                "name": "salesforceDomainName",
-                "validations": {
-                  "required": true
-                }
-              }
-            },
-            {
-              "type": "Dropdown",
-              "parameters": {
-                "label": "Log Collection Interval",
-                "name": "queryType",
-                "options": [
+                "mapping": [
                   {
-                    "key": "SELECT Id,EventType,LogDate,Interval,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE Interval='Hourly' and CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
-                    "text": "Hourly"
-                  },
-                  {
-                    "key": "SELECT Id,EventType,LogDate,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
-                    "text": "Daily"
+                    "columnName": "Data Type",
+                    "columnValue": "properties.dataType"
                   }
                 ],
-                "placeholder": "Select an interval type",
-                "isMultiSelect": false,
-                "required": true
-              }
+                "menuItems": [
+                    "DeleteConnector"
+                ]
+            }
             },
             {
-              "type": "OAuthForm",
+              "type": "ContextPane",
               "parameters": {
-                "clientIdLabel": "Consumer Key",
-                "clientSecretLabel": "Consumer Secret",
-                "clientIdPlaceholder": "Enter Connected App Consumer Key",
-                "clientSecretPlaceholder": "Enter Connected App Consumer Secret",
-                "connectButtonLabel": "Connect",
-                "disconnectButtonLabel": "Disconnect"
+                "isPrimary": true,
+                "label": "Add Connection",
+                "title": "Configure Salesforce API Connection",
+                "subtitle": "Connect to Salesforce Service Cloud to ingest event logs",
+                "contextPaneType": "DataConnectorsContextPane",
+                "instructionSteps": [
+                  {
+                    "instructions": [
+                      {
+                        "type": "Textbox",
+                        "parameters": {
+                          "label": "Salesforce Domain Name",
+                          "placeholder": "https://your-domain.my.salesforce.com",
+                          "type": "text",
+                          "name": "salesforceDomainName",
+                          "validations": {
+                            "required": true
+                          }
+                        }
+                      },
+                      {
+                        "type": "Dropdown",
+                        "parameters": {
+                          "label": "Log Collection Interval",
+                          "name": "queryType",
+                          "options": [
+                            {
+                              "key": "SELECT Id,EventType,LogDate,Interval,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE Interval='Hourly' and CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
+                              "text": "Hourly"
+                            },
+                            {
+                              "key": "SELECT Id,EventType,LogDate,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
+                              "text": "Daily"
+                            }
+                          ],
+                          "placeholder": "Select an interval type",
+                          "isMultiSelect": false,
+                          "required": true
+                        }
+                      },
+                      {
+                        "type": "Textbox",
+                        "parameters": {
+                          "label": "Client ID",
+                          "placeholder": "Your Client ID",
+                          "type": "text",
+                          "name": "clientId",
+                          "validations": {
+                            "required": true
+                          }
+                        }
+                      },
+                      {
+                        "type": "Textbox",
+                        "parameters": {
+                          "label": "Client Secret",
+                          "placeholder": "Your Client Secret",
+                          "type": "password",
+                          "name": "clientSecret",
+                          "validations": {
+                            "required": true
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             }
           ]
         }
-      ]
+      ],
+      "isConnectivityCriteriasMatchSome": false
     }
   }
 }

--- a/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/azuredeploy_SalesforceServiceCloud_poller_connector.json
+++ b/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/azuredeploy_SalesforceServiceCloud_poller_connector.json
@@ -2549,7 +2549,7 @@
                             }
                         },
                         {
-                            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', 'SalesforceServiceCloudPolling')]",
+                            "name": "[concat('[concat(''', parameters('workspace'), ''',''/Microsoft.SecurityInsights/'', concat(''SalesforceServiceCloudPolling-'', uniqueString(parameters(''salesforceDomainName''))))]')]",
                             "apiVersion": "2022-12-01-preview",
                             "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
                             "location": "[parameters('workspace-location')]",

--- a/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/azuredeploy_SalesforceServiceCloud_poller_connector.json
+++ b/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/azuredeploy_SalesforceServiceCloud_poller_connector.json
@@ -114,19 +114,19 @@
                                         {
                                             "metricName": "Total data received",
                                             "legend": "Salesforce Service Cloud EventLogFile Events",
-                                            "baseQuery": "{{graphQueriesTableName}}"
+                                            "baseQuery": "SalesforceServiceCloudV2_CL"
                                         }
                                     ],
                                     "sampleQueries": [
                                         {
                                             "description": "Get a sample of Salesforce Service Cloud Event Log File Events",
-                                            "query": "{{graphQueriesTableName}}\n| take 10"
+                                            "query": "SalesforceServiceCloudV2_CL\n| take 10"
                                         }
                                     ],
                                     "dataTypes": [
                                         {
-                                            "name": "{{graphQueriesTableName}}",
-                                            "lastDataReceivedQuery": "{{graphQueriesTableName}}\n | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
+                                            "name": "SalesforceServiceCloudV2_CL",
+                                            "lastDataReceivedQuery": "SalesforceServiceCloudV2_CL\n | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
                                         }
                                     ],
                                     "connectivityCriteria": [
@@ -172,6 +172,10 @@
                                                             {
                                                                 "columnName": "Data Type",
                                                                 "columnValue": "properties.dataType"
+                                                            },
+                                                            {
+                                                                "columnName": "Api Endpoint",
+                                                                "columnValue": "properties.request.apiEndpoint"
                                                             }
                                                         ],
                                                         "menuItems": [
@@ -2287,19 +2291,19 @@
                         {
                             "metricName": "Total data received",
                             "legend": "Salesforce Service Cloud EventLogFile Events",
-                            "baseQuery": "{{graphQueriesTableName}}"
+                            "baseQuery": "SalesforceServiceCloudV2_CL"
                         }
                     ],
                     "sampleQueries": [
                         {
                             "description": "Get a sample of Salesforce Service Cloud Event Log File Events",
-                            "query": "{{graphQueriesTableName}}\n| take 10"
+                            "query": "SalesforceServiceCloudV2_CL\n| take 10"
                         }
                     ],
                     "dataTypes": [
                         {
-                            "name": "{{graphQueriesTableName}}",
-                            "lastDataReceivedQuery": "{{graphQueriesTableName}}\n | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
+                            "name": "SalesforceServiceCloudV2_CL",
+                            "lastDataReceivedQuery": "SalesforceServiceCloudV2_CL\n | where TimeGenerated > ago(12h) | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
                         }
                     ],
                     "connectivityCriteria": [
@@ -2341,6 +2345,10 @@
                                     {
                                         "columnName": "Data Type",
                                         "columnValue": "properties.dataType"
+                                    },
+                                    {
+                                        "columnName": "Api Endpoint",
+                                        "columnValue": "properties.request.apiEndpoint"
                                     }
                                 ],
                                 "menuItems": [

--- a/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/azuredeploy_SalesforceServiceCloud_poller_connector.json
+++ b/Solutions/Salesforce Service Cloud/Data Connectors/SalesforceSentinelConnector_CCP/azuredeploy_SalesforceServiceCloud_poller_connector.json
@@ -99,7 +99,7 @@
                         },
                         {
                             "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentIdConnectorDefinition'))]",
-                            "apiVersion": "2022-09-01-preview",
+                            "apiVersion": "2024-09-01",
                             "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectorDefinitions",
                             "location": "[parameters('workspace-location')]",
                             "kind": "Customizable",
@@ -166,51 +166,95 @@
                                             "description": "Follow [Create a Connected App in Salesforce for OAuth](https://help.salesforce.com/s/articleView?id=platform.ev_relay_create_connected_app.htm&type=5) and [Configure a Connected App for the OAuth 2.0 Client Credentials Flow](https://help.salesforce.com/s/articleView?id=xcloud.connected_app_client_credentials_setup.htm&type=5) to create a Connected App with access to the Salesforce Service Cloud API. Through those instructions, you should get the Consumer Key and Consumer Secret.\n For Salesforce Domain name, Go to Setup, type My Domain in the Quick Find box, and select My Domain to view your domain details. Make sure to enter the domain name without a trailing slash (e.g., https://your-domain.my.salesforce.com). Fill the form below with that information.",
                                             "instructions": [
                                                 {
-                                                    "type": "Textbox",
+                                                    "type": "DataConnectorsGrid",
                                                     "parameters": {
-                                                        "label": "Salesforce Domain Name",
-                                                        "placeholder": "Salesforce Domain Name",
-                                                        "type": "text",
-                                                        "name": "salesforceDomainName",
-                                                        "validations": {
-                                                            "required": true
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "type": "Dropdown",
-                                                    "parameters": {
-                                                        "label": "Log Collection Interval",
-                                                        "name": "queryType",
-                                                        "options": [
+                                                        "mapping": [
                                                             {
-                                                                "key": "SELECT Id,EventType,LogDate,Interval,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE Interval='Hourly' and CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
-                                                                "text": "Hourly"
-                                                            },
-                                                            {
-                                                                "key": "SELECT Id,EventType,LogDate,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
-                                                                "text": "Daily"
+                                                                "columnName": "Data Type",
+                                                                "columnValue": "properties.dataType"
                                                             }
                                                         ],
-                                                        "placeholder": "Select an interval type",
-                                                        "isMultiSelect": false,
-                                                        "required": true
+                                                        "menuItems": [
+                                                            "DeleteConnector"
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "OAuthForm",
+                                                    "type": "ContextPane",
                                                     "parameters": {
-                                                        "clientIdLabel": "Consumer Key",
-                                                        "clientSecretLabel": "Consumer Secret",
-                                                        "clientIdPlaceholder": "Enter Connected App Consumer Key",
-                                                        "clientSecretPlaceholder": "Enter Connected App Consumer Secret",
-                                                        "connectButtonLabel": "Connect",
-                                                        "disconnectButtonLabel": "Disconnect"
+                                                        "isPrimary": true,
+                                                        "label": "Add Connection",
+                                                        "title": "Configure Salesforce API Connection",
+                                                        "subtitle": "Connect to Salesforce Service Cloud to ingest event logs",
+                                                        "contextPaneType": "DataConnectorsContextPane",
+                                                        "instructionSteps": [
+                                                            {
+                                                                "instructions": [
+                                                                    {
+                                                                        "type": "Textbox",
+                                                                        "parameters": {
+                                                                            "label": "Salesforce Domain Name",
+                                                                            "placeholder": "https://your-domain.my.salesforce.com",
+                                                                            "type": "text",
+                                                                            "name": "salesforceDomainName",
+                                                                            "validations": {
+                                                                                "required": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "Dropdown",
+                                                                        "parameters": {
+                                                                            "label": "Log Collection Interval",
+                                                                            "name": "queryType",
+                                                                            "options": [
+                                                                                {
+                                                                                    "key": "SELECT Id,EventType,LogDate,Interval,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE Interval='Hourly' and CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
+                                                                                    "text": "Hourly"
+                                                                                },
+                                                                                {
+                                                                                    "key": "SELECT Id,EventType,LogDate,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
+                                                                                    "text": "Daily"
+                                                                                }
+                                                                            ],
+                                                                            "placeholder": "Select an interval type",
+                                                                            "isMultiSelect": false,
+                                                                            "required": true
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "Textbox",
+                                                                        "parameters": {
+                                                                            "label": "Client ID",
+                                                                            "placeholder": "Your Client ID",
+                                                                            "type": "text",
+                                                                            "name": "clientId",
+                                                                            "validations": {
+                                                                                "required": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "Textbox",
+                                                                        "parameters": {
+                                                                            "label": "Client Secret",
+                                                                            "placeholder": "Your Client Secret",
+                                                                            "type": "password",
+                                                                            "name": "clientSecret",
+                                                                            "validations": {
+                                                                                "required": true
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
-                                    ]
+                                    ],
+                                    "isConnectivityCriteriasMatchSome": false
                                 }
                             }
                         },
@@ -2228,7 +2272,7 @@
         },
         {
             "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/',variables('_dataConnectorContentIdConnectorDefinition'))]",
-            "apiVersion": "2022-09-01-preview",
+            "apiVersion": "2024-09-01",
             "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectorDefinitions",
             "location": "[parameters('workspace-location')]",
             "kind": "Customizable",
@@ -2291,55 +2335,93 @@
                     },
                     "instructionSteps": [
                         {
-                            "title": "Connect to Salesforce Service Cloud API to start collecting event logs in Microsoft Sentinel",
-                            "description": "Follow [Create a Connected App in Salesforce for OAuth](https://help.salesforce.com/s/articleView?id=platform.ev_relay_create_connected_app.htm&type=5) and [Configure a Connected App for the OAuth 2.0 Client Credentials Flow](https://help.salesforce.com/s/articleView?id=xcloud.connected_app_client_credentials_setup.htm&type=5) to create a Connected App with access to the Salesforce Service Cloud API. Through those instructions, you should get the Consumer Key and Consumer Secret.\n For Salesforce Domain name, Go to Setup, type My Domain in the Quick Find box, and select My Domain to view your domain details. Make sure to enter the domain name without a trailing slash (e.g., https://your-domain.my.salesforce.com). Fill the form below with that information.",
-                            "instructions": [
-                                {
-                                    "type": "Textbox",
-                                    "parameters": {
-                                        "label": "Salesforce Domain Name",
-                                        "placeholder": "Salesforce Domain Name",
-                                        "type": "text",
-                                        "name": "salesforceDomainName",
-                                        "validations": {
-                                            "required": true
-                                        }
+                            "type": "DataConnectorsGrid",
+                            "parameters": {
+                                "mapping": [
+                                    {
+                                        "columnName": "Data Type",
+                                        "columnValue": "properties.dataType"
                                     }
-                                },
-                                {
-                                    "type": "Dropdown",
-                                    "parameters": {
-                                        "label": "Log Collection Interval",
-                                        "name": "queryType",
-                                        "options": [
+                                ],
+                                "menuItems": [
+                                    "DeleteConnector"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ContextPane",
+                            "parameters": {
+                                "isPrimary": true,
+                                "label": "Add Connection",
+                                "title": "Configure Salesforce API Connection",
+                                "subtitle": "Connect to Salesforce Service Cloud to ingest event logs",
+                                "contextPaneType": "DataConnectorsContextPane",
+                                "instructionSteps": [
+                                    {
+                                        "instructions": [
                                             {
-                                                "key": "SELECT Id,EventType,LogDate,Interval,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE Interval='Hourly' and CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
-                                                "text": "Hourly"
+                                                "type": "Textbox",
+                                                "parameters": {
+                                                    "label": "Salesforce Domain Name",
+                                                    "placeholder": "https://your-domain.my.salesforce.com",
+                                                    "type": "text",
+                                                    "name": "salesforceDomainName",
+                                                    "validations": {
+                                                        "required": true
+                                                    }
+                                                }
                                             },
                                             {
-                                                "key": "SELECT Id,EventType,LogDate,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
-                                                "text": "Daily"
+                                                "type": "Dropdown",
+                                                "parameters": {
+                                                    "label": "Log Collection Interval",
+                                                    "name": "queryType",
+                                                    "options": [
+                                                        {
+                                                            "key": "SELECT Id,EventType,LogDate,Interval,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE Interval='Hourly' and CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
+                                                            "text": "Hourly"
+                                                        },
+                                                        {
+                                                            "key": "SELECT Id,EventType,LogDate,CreatedDate,LogFile,LogFileLength FROM EventLogFile WHERE CreatedDate>{_QueryWindowStartTime} and CreatedDate<{_QueryWindowEndTime}",
+                                                            "text": "Daily"
+                                                        }
+                                                    ],
+                                                    "placeholder": "Select an interval type",
+                                                    "isMultiSelect": false,
+                                                    "required": true
+                                                }
+                                            },
+                                            {
+                                                "type": "Textbox",
+                                                "parameters": {
+                                                    "label": "Client ID",
+                                                    "placeholder": "Your Client ID",
+                                                    "type": "text",
+                                                    "name": "clientId",
+                                                    "validations": {
+                                                        "required": true
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "type": "Textbox",
+                                                "parameters": {
+                                                    "label": "Client Secret",
+                                                    "placeholder": "Your Client Secret",
+                                                    "type": "password",
+                                                    "name": "clientSecret",
+                                                    "validations": {
+                                                        "required": true
+                                                    }
+                                                }
                                             }
-                                        ],
-                                        "placeholder": "Select an interval type",
-                                        "isMultiSelect": false,
-                                        "required": true
+                                        ]
                                     }
-                                },
-                                {
-                                    "type": "OAuthForm",
-                                    "parameters": {
-                                        "clientIdLabel": "Consumer Key",
-                                        "clientSecretLabel": "Consumer Secret",
-                                        "clientIdPlaceholder": "Enter Connected App Consumer Key",
-                                        "clientSecretPlaceholder": "Enter Connected App Consumer Secret",
-                                        "connectButtonLabel": "Connect",
-                                        "disconnectButtonLabel": "Disconnect"
-                                    }
-                                }
-                            ]
+                                ]
+                            }
                         }
-                    ]
+                    ],
+                    "isConnectivityCriteriasMatchSome": false
                 }
             }
         },


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated OAuth authentication for the connector definition to use 2024-09-01 and the blade configuration panel.
   - Added a connector table for multiple Salesforce tenants.
   - Added a UUID based on the Salesforce domain to allow multiple tenants to be connected.
   - Updarted Files:
     - SalesforceServiceCloud_DataConnectorDefinition.json
     - azuredeploy_SalesforceServiceCloud_poller_connector.json

   Reason for Change(s):
   - Data Connector was broken. It would cause an error when a connection / deployment was attempted.
   - The Connector also didn't support multiple Salesforce tenants, so support was added to maintain multiple Connectors.
   - Resolves ISSUE #13669

   Version Updated:
   - No

   Testing Completed:
   - Yes
   - Changes have been validated and deployed to multiple Sentinel instances.
   - Tested multi-Salesforce tenant deployment on one Sentinel instance.

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes