### PR TITLE
Training Lab: E02 add note about empty TI join results

### DIFF
--- a/Tools/Microsoft-Sentinel-Training-Lab/Exercises/E02_threat_intelligence_mdti.md
+++ b/Tools/Microsoft-Sentinel-Training-Lab/Exercises/E02_threat_intelligence_mdti.md
@@ -145,6 +145,10 @@ AWSCloudTrail
 | sort by TimeGenerated desc
 ```
 
+> **Note:** These queries may return **empty results** in the lab environment — this is expected. The lab's pre-ingested telemetry uses synthetic IP addresses that are unlikely to appear in Microsoft's real-world threat intelligence feed. In a production environment with live traffic, these joins are how you detect connections to known-malicious infrastructure.
+>
+> **What to take away:** The query *pattern* is what matters — `join kind=inner` between a TI indicator table and your telemetry. You can apply this same pattern to any data source (firewall logs, cloud trails, identity events) in your production workspace where real traffic will match real indicators.
+
 #### Step 5 — Explore Indicator Statistics
 
 Get an overview of your threat intelligence coverage:


### PR DESCRIPTION
## Summary
Adds an explanatory note to Exercise 2 (Threat Intelligence) after the TI-to-telemetry join queries.

## Problem
The join queries in Step 4 match MDTI threat intelligence indicators against the lab's firewall and CloudTrail logs. Since the lab uses synthetic IP addresses, these joins will almost always return empty results — which can confuse users who expect matches.

## Fix
Added a callout note after both join queries explaining:
- Empty results are **expected** in the lab environment (synthetic IPs vs real-world TI)
- The **query pattern** (join kind=inner between TI and telemetry) is what matters
- In production with real traffic, these joins detect connections to known-malicious infrastructure

## Files Changed
- `Tools/Microsoft-Sentinel-Training-Lab/Exercises/E02_threat_intelligence_mdti.md`