### PR TITLE
Increase stale branch cleanup throughput (operations-per-run: 10 → 50)

### DIFF
--- a/.github/workflows/cleanup-stale-branch.yaml
+++ b/.github/workflows/cleanup-stale-branch.yaml
@@ -26,7 +26,7 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           days-before-branch-stale: 90
           days-before-branch-delete: 30
-          operations-per-run: 10
+          operations-per-run: 50
           dry-run: false
           ignore-branches-with-open-prs: true
           stale-branch-message: |


### PR DESCRIPTION
   Change(s):
   - Increased `operations-per-run` from *10 → 50* in the stale branch cleanup workflow.

   Reason for Change(s):
   - To process a larger number of stale branches per workflow run, improving cleanup efficiency.
   - Helps reduce backlog in repositories with many stale branches, ensuring quicker maintenance.
   - Minimizes the number of scheduled runs needed to fully clean up stale branches.

   Version Updated:
   - Not required

   Testing Completed:
   - Change is configuration-only (increase in operations-per-run).

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes