### PR TITLE
GAL-27: halcyon alerts to sentinel incidents (new table, connector rules, analytics rule, and automation rule)

### DIFF
--- a/Solutions/Halcyon/Analytics Rules/HalcyonTriggersRule.json
+++ b/Solutions/Halcyon/Analytics Rules/HalcyonTriggersRule.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "workspace": {
+            "type": "String"
+        }
+    },
+    "resources": [
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/3855767f-ac67-4979-9db7-da6f70144ae9')]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/3855767f-ac67-4979-9db7-da6f70144ae9')]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "kind": "NRT",
+            "apiVersion": "2023-12-01-preview",
+            "properties": {
+                "displayName": "Halcyon - New Alert Detected",
+                "description": "Creates one Sentinel incident per new Halcyon alert. Deduplicates using a self-join on Halcyon_Commands_CL and an anti-join on SecurityAlert to skip already-processed alerts.",
+                "severity": "High",
+                "enabled": true,
+                "query": "Halcyon_Commands_CL\n| where TimeGenerated > ago(1m)\n| summarize arg_max(TimeGenerated, *) by HalcyonAlertId\n| join kind=leftanti (\n    Halcyon_Commands_CL\n    | where TimeGenerated between (ago(20m) .. ago(1m))\n    | summarize by HalcyonAlertId\n) on HalcyonAlertId\n| join kind=leftanti (\n    SecurityAlert\n    | where TimeGenerated > ago(14d)\n    | where AlertName has \"Halcyon\"\n    | extend HalcyonAlertId = tostring(ExtendedProperties[\"HalcyonAlertId\"])\n    | where isnotempty(HalcyonAlertId)\n    | project HalcyonAlertId\n) on HalcyonAlertId\n| extend DeviceName = tostring(device.hostname)\n| extend AlertKind = tostring(finding_info.title)",
+                "suppressionDuration": "PT1H",
+                "suppressionEnabled": false,
+                "startTimeUtc": null,
+                "tactics": [
+                    "Execution",
+                    "Impact"
+                ],
+                "techniques": [
+                    "T1486"
+                ],
+                "subTechniques": [],
+                "alertRuleTemplateName": null,
+                "requiredDataConnectors": [
+                    {
+                        "dataTypes": [
+                            "Halcyon_Commands_CL"
+                        ],
+                        "connectorId": "HalcyonPush"
+                    }
+                ],
+                "incidentConfiguration": {
+                    "createIncident": true,
+                    "groupingConfiguration": {
+                        "enabled": true,
+                        "reopenClosedIncident": false,
+                        "lookbackDuration": "PT1H",
+                        "matchingMethod": "Selected",
+                        "groupByEntities": [],
+                        "groupByAlertDetails": [],
+                        "groupByCustomDetails": ["HalcyonAlertId"]
+                    }
+                },
+                "eventGroupingSettings": {
+                    "aggregationKind": "SingleAlert"
+                },
+                "customDetails": {
+                    "HalcyonAlertId": "HalcyonAlertId",
+                    "AlertKind": "AlertKind"
+                },
+                "alertDetailsOverride": {
+                    "alertDisplayNameFormat": "Halcyon Alert: {{HalcyonAlertId}}",
+                    "alertDynamicProperties": []
+                },
+                "entityMappings": [
+                    {
+                        "entityType": "Host",
+                        "fieldMappings": [
+                            {
+                                "columnName": "DeviceName",
+                                "identifier": "HostName"
+                            }
+                        ]
+                    }
+                ],
+                "sentinelEntitiesMappings": null,
+                "templateVersion": "1.0.0"
+            }
+        }
+    ]
+}

--- a/Solutions/Halcyon/Analytics Rules/HalcyonTriggersRule.json
+++ b/Solutions/Halcyon/Analytics Rules/HalcyonTriggersRule.json
@@ -6,10 +6,14 @@
             "type": "String"
         }
     },
+    "variables": {
+        "analyticsRuleId": "3855767f-ac67-4979-9db7-da6f70144ae9",
+        "automationRuleId": "a78f9a1e-7c47-4ce4-8214-c3fdace2fc62"
+    },
     "resources": [
         {
-            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/3855767f-ac67-4979-9db7-da6f70144ae9')]",
-            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/3855767f-ac67-4979-9db7-da6f70144ae9')]",
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/', variables('analyticsRuleId'))]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('analyticsRuleId'))]",
             "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
             "kind": "NRT",
             "apiVersion": "2023-12-01-preview",
@@ -75,6 +79,49 @@
                 ],
                 "sentinelEntitiesMappings": null,
                 "templateVersion": "1.0.0"
+            }
+        },
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/automationRules/', variables('automationRuleId'))]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/', variables('automationRuleId'))]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/automationRules",
+            "apiVersion": "2023-12-01-preview",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces/providers/alertRules', parameters('workspace'), 'Microsoft.SecurityInsights', variables('analyticsRuleId'))]"
+            ],
+            "properties": {
+                "displayName": "Halcyon - Tag Incidents",
+                "order": 1,
+                "triggeringLogic": {
+                    "isEnabled": true,
+                    "triggersOn": "Incidents",
+                    "triggersWhen": "Created",
+                    "conditions": [
+                        {
+                            "conditionType": "Property",
+                            "conditionProperties": {
+                                "propertyName": "IncidentRelatedAnalyticRuleIds",
+                                "operator": "Contains",
+                                "propertyValues": [
+                                    "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/', variables('analyticsRuleId'))]"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "order": 1,
+                        "actionType": "AddLabels",
+                        "actionConfiguration": {
+                            "labels": [
+                                {
+                                    "labelName": "Halcyon"
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/Solutions/Halcyon/Analytics Rules/HalcyonTriggersRule.json
+++ b/Solutions/Halcyon/Analytics Rules/HalcyonTriggersRule.json
@@ -22,7 +22,7 @@
                 "description": "Creates one Sentinel incident per new Halcyon alert. Deduplicates using a self-join on Halcyon_Commands_CL and an anti-join on SecurityAlert to skip already-processed alerts.",
                 "severity": "High",
                 "enabled": true,
-                "query": "Halcyon_Commands_CL\n| where TimeGenerated > ago(1m)\n| summarize arg_max(TimeGenerated, *) by HalcyonAlertId\n| join kind=leftanti (\n    Halcyon_Commands_CL\n    | where TimeGenerated between (ago(20m) .. ago(1m))\n    | summarize by HalcyonAlertId\n) on HalcyonAlertId\n| join kind=leftanti (\n    SecurityAlert\n    | where TimeGenerated > ago(14d)\n    | where AlertName has \"Halcyon\"\n    | extend HalcyonAlertId = tostring(ExtendedProperties[\"HalcyonAlertId\"])\n    | where isnotempty(HalcyonAlertId)\n    | project HalcyonAlertId\n) on HalcyonAlertId\n| extend DeviceName = tostring(device.hostname)\n| extend AlertKind = tostring(finding_info.title)",
+                "query": "Halcyon_Commands_CL\n| where TimeGenerated > ago(1m)\n| summarize arg_max(TimeGenerated, *) by HalcyonAlertId\n| join kind=leftanti (\n    Halcyon_Commands_CL\n    | where TimeGenerated between (ago(20m) .. ago(1m))\n    | summarize by HalcyonAlertId\n) on HalcyonAlertId\n| join kind=leftanti (\n    SecurityAlert\n    | where TimeGenerated > ago(14d)\n    | where AlertName has \"Halcyon\"\n    | extend HalcyonAlertId = tostring(parse_json(tostring(ExtendedProperties))[\"HalcyonAlertId\"])\n    | where isnotempty(HalcyonAlertId)\n    | project HalcyonAlertId\n) on HalcyonAlertId\n| extend DeviceName = tostring(device[\"hostname\"])\n| extend AlertKind = tostring(finding_info[\"title\"])",
                 "suppressionDuration": "PT1H",
                 "suppressionEnabled": false,
                 "startTimeUtc": null,
@@ -77,8 +77,7 @@
                         ]
                     }
                 ],
-                "sentinelEntitiesMappings": null,
-                "templateVersion": "1.0.0"
+                "sentinelEntitiesMappings": null
             }
         },
         {
@@ -112,7 +111,7 @@
                 "actions": [
                     {
                         "order": 1,
-                        "actionType": "AddLabels",
+                        "actionType": "ModifyProperties",
                         "actionConfiguration": {
                             "labels": [
                                 {

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
@@ -13,6 +13,10 @@
             "type": "datetime"
           },
           {
+            "name": "time",
+            "type": "long"
+          },
+          {
             "name": "activity_id",
             "type": "int"
           },
@@ -43,10 +47,6 @@
           {
             "name": "severity",
             "type": "string"
-          },
-          {
-            "name": "time",
-            "type": "long"
           },
           {
             "name": "type_uid",
@@ -94,6 +94,10 @@
           },
           {
             "name": "rcode_id",
+            "type": "int"
+          },
+          {
+            "name": "count",
             "type": "int"
           },
           {
@@ -151,6 +155,22 @@
           {
             "name": "app",
             "type": "dynamic"
+          },
+          {
+            "name": "finding_info",
+            "type": "dynamic"
+          },
+          {
+            "name": "resources",
+            "type": "dynamic"
+          },
+          {
+            "name": "observables",
+            "type": "dynamic"
+          },
+          {
+            "name": "comment",
+            "type": "string"
           }
         ]
       }
@@ -171,8 +191,18 @@
         "destinations": [
           "clv2ws1"
         ],
-        "transformKql": "source | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms) | project-away ['time']",
+        "transformKql": "source | where class_uid != 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms) | project-away ['time'], count, finding_info, resources, observables, comment",
         "outputStream": "Custom-HalcyonEvents_CL"
+      },
+      {
+        "streams": [
+          "Custom-Halcyon"
+        ],
+        "destinations": [
+          "clv2ws1"
+        ],
+        "transformKql": "source | where class_uid == 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid) | project-away ['time'], rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
+        "outputStream": "Custom-Halcyon_Commands_CL"
       }
     ]
   }

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
@@ -61,10 +61,6 @@
             "type": "string"
           },
           {
-            "name": "raw_data",
-            "type": "string"
-          },
-          {
             "name": "status_id",
             "type": "int"
           },
@@ -191,7 +187,7 @@
         "destinations": [
           "clv2ws1"
         ],
-        "transformKql": "source | where class_uid != 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms) | project-away finding_info, resources, observables, comment",
+        "transformKql": "source | where class_uid != 2004 | extend HalcyonSourceTime = datetime(1970-01-01) + (['time'] * 1ms) | project-away finding_info, resources, observables, comment",
         "outputStream": "Custom-HalcyonEvents_CL"
       },
       {
@@ -201,7 +197,7 @@
         "destinations": [
           "clv2ws1"
         ],
-        "transformKql": "source | where class_uid == 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid), HalcyonDisplayStatus = tostring(parse_json(unmapped).halcyon_display_status), HalcyonTriageStatus = tostring(parse_json(unmapped).halcyon_triage_status) | project-away rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
+        "transformKql": "source | where class_uid == 2004 | extend HalcyonSourceTime = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid), HalcyonDisplayStatus = tostring(parse_json(unmapped).halcyon_display_status), HalcyonTriageStatus = tostring(parse_json(unmapped).halcyon_triage_status) | project-away rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
         "outputStream": "Custom-Halcyon_Commands_CL"
       }
     ]

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
@@ -201,7 +201,7 @@
         "destinations": [
           "clv2ws1"
         ],
-        "transformKql": "source | where class_uid == 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid) | project-away ['time'], rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
+        "transformKql": "source | where class_uid == 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid), HalcyonDisplayStatus = tostring(parse_json(unmapped).halcyon_display_status), HalcyonTriageStatus = tostring(parse_json(unmapped).halcyon_triage_status) | project-away ['time'], rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
         "outputStream": "Custom-Halcyon_Commands_CL"
       }
     ]

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_DCR.json
@@ -191,7 +191,7 @@
         "destinations": [
           "clv2ws1"
         ],
-        "transformKql": "source | where class_uid != 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms) | project-away ['time'], count, finding_info, resources, observables, comment",
+        "transformKql": "source | where class_uid != 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms) | project-away finding_info, resources, observables, comment",
         "outputStream": "Custom-HalcyonEvents_CL"
       },
       {
@@ -201,7 +201,7 @@
         "destinations": [
           "clv2ws1"
         ],
-        "transformKql": "source | where class_uid == 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid), HalcyonDisplayStatus = tostring(parse_json(unmapped).halcyon_display_status), HalcyonTriageStatus = tostring(parse_json(unmapped).halcyon_triage_status) | project-away ['time'], rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
+        "transformKql": "source | where class_uid == 2004 | extend TimeGenerated = datetime(1970-01-01) + (['time'] * 1ms), HalcyonAlertId = tostring(finding_info.uid), HalcyonDisplayStatus = tostring(parse_json(unmapped).halcyon_display_status), HalcyonTriageStatus = tostring(parse_json(unmapped).halcyon_triage_status) | project-away rcode, rcode_id, file, process, user, dst_endpoint, src_endpoint, query, answers, driver, module, app",
         "outputStream": "Custom-Halcyon_Commands_CL"
       }
     ]

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_connectorDefinition.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_connectorDefinition.json
@@ -22,12 +22,21 @@
             "metricName": "Events",
             "legend": "HalcyonEvents_CL",
             "baseQuery": "HalcyonEvents_CL"
+          },
+          {
+            "metricName": "Commands",
+            "legend": "Halcyon_Commands_CL",
+            "baseQuery": "Halcyon_Commands_CL"
           }
         ],
         "dataTypes": [
           {
             "name": "Halcyon Events",
             "lastDataReceivedQuery": "HalcyonEvents_CL\n | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
+          },
+          {
+            "name": "Halcyon Commands",
+            "lastDataReceivedQuery": "Halcyon_Commands_CL\n | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
           }
         ],
         "connectivityCriteria": [

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_commands.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_commands.json
@@ -86,10 +86,6 @@
                     "type": "string"
                 },
                 {
-                    "name": "raw_data",
-                    "type": "string"
-                },
-                {
                     "name": "finding_info",
                     "type": "dynamic"
                 },
@@ -132,6 +128,10 @@
                 {
                     "name": "HalcyonTriageStatus",
                     "type": "string"
+                },
+                {
+                    "name": "HalcyonSourceTime",
+                    "type": "datetime"
                 }
             ]
         }

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_commands.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_commands.json
@@ -124,6 +124,14 @@
                 {
                     "name": "comment",
                     "type": "string"
+                },
+                {
+                    "name": "HalcyonDisplayStatus",
+                    "type": "string"
+                },
+                {
+                    "name": "HalcyonTriageStatus",
+                    "type": "string"
                 }
             ]
         }

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_commands.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_commands.json
@@ -1,0 +1,131 @@
+{
+    "type": "Microsoft.OperationalInsights/workspaces/tables",
+    "apiVersion": "2025-07-01",
+    "name": "Halcyon_Commands_CL",
+    "location": "{{location}}",
+    "tags": {},
+    "properties": {
+        "plan": "Analytics",
+        "schema": {
+            "name": "Halcyon_Commands_CL",
+            "columns": [
+                {
+                    "name": "TimeGenerated",
+                    "type": "datetime"
+                },
+                {
+                    "name": "activity_id",
+                    "type": "int"
+                },
+                {
+                    "name": "activity_name",
+                    "type": "string"
+                },
+                {
+                    "name": "category_uid",
+                    "type": "int"
+                },
+                {
+                    "name": "category_name",
+                    "type": "string"
+                },
+                {
+                    "name": "class_uid",
+                    "type": "int"
+                },
+                {
+                    "name": "class_name",
+                    "type": "string"
+                },
+                {
+                    "name": "type_uid",
+                    "type": "long"
+                },
+                {
+                    "name": "type_name",
+                    "type": "string"
+                },
+                {
+                    "name": "count",
+                    "type": "int"
+                },
+                {
+                    "name": "severity_id",
+                    "type": "int"
+                },
+                {
+                    "name": "severity",
+                    "type": "string"
+                },
+                {
+                    "name": "status_id",
+                    "type": "int"
+                },
+                {
+                    "name": "status",
+                    "type": "string"
+                },
+                {
+                    "name": "message",
+                    "type": "string"
+                },
+                {
+                    "name": "action_id",
+                    "type": "int"
+                },
+                {
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "name": "disposition_id",
+                    "type": "int"
+                },
+                {
+                    "name": "disposition",
+                    "type": "string"
+                },
+                {
+                    "name": "raw_data",
+                    "type": "string"
+                },
+                {
+                    "name": "finding_info",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "metadata",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "device",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "resources",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "actor",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "observables",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "unmapped",
+                    "type": "dynamic"
+                },
+                {
+                    "name": "HalcyonAlertId",
+                    "type": "string"
+                },
+                {
+                    "name": "comment",
+                    "type": "string"
+                }
+            ]
+        }
+    }
+}

--- a/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_events.json
+++ b/Solutions/Halcyon/Data Connectors/Halcyon_ccp/Halcyon_table_events.json
@@ -58,10 +58,6 @@
                     "type": "string"
                 },
                 {
-                    "name": "raw_data",
-                    "type": "string"
-                },
-                {
                     "name": "status_id",
                     "type": "int"
                 },
@@ -148,6 +144,10 @@
                 {
                     "name": "app",
                     "type": "dynamic"
+                },
+                {
+                    "name": "HalcyonSourceTime",
+                    "type": "datetime"
                 }
             ]
         }

--- a/Solutions/Halcyon/Data/Solution_Halcyon.json
+++ b/Solutions/Halcyon/Data/Solution_Halcyon.json
@@ -8,7 +8,9 @@
   ],
   "Parsers": [],
   "Workbooks": [],
-  "Analytic Rules": [],
+  "Analytic Rules": [
+    "Analytics Rules/HalcyonTriggersRule.json"
+  ],
   "Hunting Queries": [],
   "Playbooks": [],
   "BasePath": "C:\\GitHub\\Azure-Sentinel\\Solutions\\Halcyon",


### PR DESCRIPTION
Change(s):
- Added `Halcyon_Commands_CL` custom Log Analytics table to store Halcyon alert events (OCSF class_uid 2004)
- Updated Halcyon DCR to add a second DCR stream that routes class_uid == 2004 events to `Halcyon_Commands_CL`
- Updated the Halcyon connector to expose `Halcyon_Commands_CL` as a data type in the connector UI
- Added NRT analytic rule "Halcyon - New Alert Detected" that creates one Sentinel incident per new Halcyon alert with de-duplication from updated alerts
- Added automation rule to tag newly created incidents with a Halcyon label
- Registered the new analytic rule in Solution_Halcyon.json

Reason for Change(s):
- Enables Halcyon alert ingestion to Sentinel incident creation for the Halcyon solution
- Separates Halcyon alert events into a dedicated table to support focused querying and incident generation

Version Updated:
- <TBD> - will update this before merging the playbook into this branch+pr

Testing Completed:
- Yes — validated in a Halcyon-connected Sentinel environment; DCR stream routing, table ingestion, and NRT rule incident creation confirmed

Checked that the validations are passing and have addressed any issues that are present:
- Yes