### PR TITLE
[Solutions Analyzer] Fix azuredeploy wrapper producing duplicate connector IDs

### DIFF
--- a/Tools/Solutions Analyzer/map_solutions_connectors_tables.py
+++ b/Tools/Solutions Analyzer/map_solutions_connectors_tables.py
@@ -6708,6 +6708,22 @@ def main() -> None:
         has_valid_connector = False
         has_data_connectors_dir = False
 
+        # Track connector titles seen from non-azuredeploy definition files per directory.
+        # This is used to deduplicate CCP v2 azuredeploy wrapper files that produce
+        # phantom connector IDs. In CCP v2 folders, two files typically coexist:
+        #   1. *_DataConnectorDefinition.json — the actual definition with a literal "id"
+        #   2. azuredeploy_*_poller_connector.json — an ARM deployment wrapper whose "id"
+        #      is an ARM variable reference (e.g. "[variables('...')]").
+        # Both describe the SAME connector. But because the ARM template's "id" cannot be
+        # resolved, find_connector_objects() generates a synthetic ID from the title, which
+        # differs from the definition file's literal ID. This causes one logical connector
+        # to appear as two in the output.
+        # Fix: when an azuredeploy file produces a connector with id_generated=True and the
+        # same (directory, title) was already seen from a non-azuredeploy file with a literal
+        # ID, skip the azuredeploy entry.
+        # Key: (parent_directory, connector_title) -> literal connector_id
+        definition_title_by_dir: Dict[Tuple[str, str], str] = {}
+
         for data_connectors_dir in data_connectors_dirs:
             if not data_connectors_dir.exists():
                 continue
@@ -6738,6 +6754,47 @@ def main() -> None:
                 connector_entries = find_connector_objects(data)
                 if not connector_entries:
                     continue
+
+                # --- Deduplicate CCP v2 azuredeploy wrapper connectors ---
+                # Phase 1: Register titles from non-azuredeploy files (literal IDs)
+                is_azuredeploy_file = json_path.name.lower().startswith("azuredeploy")
+                parent_dir_key = str(json_path.parent)
+                if not is_azuredeploy_file:
+                    for entry in connector_entries:
+                        if not entry.get("id_generated", False):
+                            title = entry.get("title", "")
+                            if title:
+                                definition_title_by_dir[(parent_dir_key, title)] = entry.get("id", "")
+
+                # Phase 2: Filter out azuredeploy entries that duplicate a definition file
+                if is_azuredeploy_file:
+                    filtered_entries = []
+                    for entry in connector_entries:
+                        if entry.get("id_generated", False):
+                            title = entry.get("title", "")
+                            key = (parent_dir_key, title)
+                            if key in definition_title_by_dir:
+                                real_id = definition_title_by_dir[key]
+                                synthetic_id = entry.get("id", "")
+                                add_issue(
+                                    issues,
+                                    solution_name=solution_info["solution_name"],
+                                    solution_folder=solution_info["solution_folder"],
+                                    connector_id=synthetic_id,
+                                    connector_title=title,
+                                    connector_publisher=entry.get("publisher", ""),
+                                    relevant_file=safe_relative(json_path, data_connectors_dir),
+                                    reason="azuredeploy_duplicate_skipped",
+                                    details=f"Skipped azuredeploy wrapper connector '{synthetic_id}' "
+                                            f"(synthetic ID from title); same title already registered "
+                                            f"from definition file with literal ID '{real_id}'.",
+                                )
+                                continue  # Skip this duplicate entry
+                        filtered_entries.append(entry)
+                    connector_entries = filtered_entries
+                    if not connector_entries:
+                        continue
+
                 has_valid_connector = True
                 
                 # === Table extraction with priority ordering ===


### PR DESCRIPTION
## Summary
Fixes a connector overcount bug in Solutions Analyzer for CCP v2 solutions where azuredeploy wrapper files can produce synthetic connector IDs that duplicate real definition entries.

## Root Cause
- Non-literal IDs in azuredeploy wrapper files are converted to generated IDs from title
- In CCP v2, wrapper and definition describe the same connector, producing duplicates

## Fix
- Add two-phase deduplication in map_solutions_connectors_tables.py
- Track non-azuredeploy literal IDs by (parent directory, connector title)
- Skip azuredeploy entries when ID is generated and a matching non-azuredeploy definition exists

## Validation
- Reproduced with 1Password: removes synthetic duplicate only
- connectors.csv: 593 -> 592
- solutions_with_connectors.csv: 606 -> 605
- solutions_connectors_tables_mapping.csv: 1397 -> 1396
- solutions.csv unchanged
