### PR TITLE
Fix typo in ASimSourceType.json description

### DIFF
--- a/ASIM/deploy/Watchlists/ASimSourceType.json
+++ b/ASIM/deploy/Watchlists/ASimSourceType.json
@@ -17,7 +17,7 @@
           "properties": {
               "displayName": "Sources_by_SourceType",
               "source": "Sources_by_SourceType.csv",
-              "description": "The watchlist is used by ASim Prarsers / regular parsers to specify Sources and their types.",
+              "description": "The watchlist is used by ASim Parsers / regular parsers to specify Sources and their types.",
               "provider": "Custom",
               "isDeleted": false,
               "labels": [


### PR DESCRIPTION
**Change(s):**
Fixed typo in ASimSourceType.json description field ("prarsers" → "parsers")

**Reason for Change(s):**
Correct spelling mistake to improve clarity and professionalism of template documentation

**Version Updated:**
N/A (not a Detection/Analytic Rule template)

**Testing Completed:**
Yes (validated JSON syntax and template deploys without errors)

**Checked that the validations are passing and have addressed any issues that are present:**
Yes