### PR TITLE
RecordedFutureIdentity: fix invalid playbook

### DIFF
--- a/Solutions/Recorded Future Identity/Playbooks/v3.0/RFI-confirm-EntraID-risky-user/azuredeploy.json
+++ b/Solutions/Recorded Future Identity/Playbooks/v3.0/RFI-confirm-EntraID-risky-user/azuredeploy.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.2.0.0",
+    "contentVersion": "1.2.1.0",
     "metadata": {
         "title": "RFI-confirm-EntraID-risky-user",
         "description": "This playbook confirms compromise of users deemed 'high risk' by EntraID.",
-        "lastUpdateTime": "2025-04-29T14:25:00.000Z",
+        "lastUpdateTime": "2026-05-04T00:00:00.000Z",
         "entities": [],
         "tags": ["Identity protection"],
         "support": {
@@ -28,6 +28,11 @@
                 "version": "1.2",
                 "title": "Improved stability",
                 "notes": [ "Removed Get Risky User action due to instability" ]
+            },
+            {
+                "version": "1.2.1",
+                "title": "Bug fix",
+                "notes": [ "Removed stale references to deleted 'Check_if_AD_Identity_Protection_risky_users_list_contains_the_user' action that caused ARM template deploy failure" ]
             }
         ]
     },
@@ -48,7 +53,7 @@
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "tags": {
-                "hidden-SentinelTemplateVersion": "1.2"
+                "hidden-SentinelTemplateVersion": "1.2.1"
             },
             "dependsOn": [
 				"[resourceId('Microsoft.Web/connections', variables('EntraIDConnectionName'))]",
@@ -200,7 +205,6 @@
                             "inputs": {
                                 "body": {
                                     "data": {
-                                        "active_directory_identity_protection_results_for_risky_user": "@body('Check_if_AD_Identity_Protection_risky_users_list_contains_the_user')",
                                         "parameters_passed": {
                                             "active_directory_domain": "@triggerBody()?['active_directory_domain']",
                                             "risky_user_email": "@triggerBody()?['risky_user_email']"
@@ -218,10 +222,6 @@
                                     "properties": {
                                         "data": {
                                             "properties": {
-                                                "active_directory_identity_protection_results_for_risky_user": {
-                                                    "properties": {},
-                                                    "type": "object"
-                                                },
                                                 "parameters_passed": {
                                                     "properties": {
                                                         "active_directory_domain": {
@@ -321,7 +321,6 @@
                             "inputs": {
                                 "body": {
                                     "data": {
-                                        "active_directory_identity_protection_results_for_risky_user": "@body('Check_if_AD_Identity_Protection_risky_users_list_contains_the_user')",
                                         "parameters_passed": {
                                             "active_directory_domain": "@triggerBody()?['active_directory_domain']",
                                             "risky_user_email": "@triggerBody()?['risky_user_email']"
@@ -338,10 +337,6 @@
                                     "properties": {
                                         "data": {
                                             "properties": {
-                                                "active_directory_identity_protection_results_for_risky_user": {
-                                                    "properties": {},
-                                                    "type": "object"
-                                                },
                                                 "parameters_passed": {
                                                     "properties": {
                                                         "active_directory_domain": {


### PR DESCRIPTION
   Change(s):
   - remove stale references in `RFI-confirm-EntraID-risky-user` ARM template

   Reason for Change(s):
   - The action `Check_if_AD_Identity_Protection_risky_users_list_contains_the_user` was deleted in v1.2 but its `@body()` references were left in both response actions, causing `InvalidTemplate` validation failure at deploy time.

   Version Updated:
   - This playbook is NOT part of the main solution, it is only installable from Github. Therefore we have not re-packaged `mainTemplate.json` or bumped the solution version.

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below