### PR TITLE
Add hunting query: short-window sign-in ASN mismatch (interactive vs non-interactive)

### DIFF
--- a/Hunting Queries/MultipleDataSources/SignInASNMismatchInteractiveVsNonInteractive.yaml
+++ b/Hunting Queries/MultipleDataSources/SignInASNMismatchInteractiveVsNonInteractive.yaml
@@ -1,7 +1,11 @@
 id: 868599d4-84f7-4c31-ba00-d2a2c87efaab
 name: Short-window sign-in mismatch between interactive and non-interactive activity
 description: |
-  Hypothesis-driven Microsoft Sentinel hunting query that surfaces short-window mismatches
+  Identify successful sign-ins where a non-interactive sign-in for the same user occurs
+  within 10 minutes from a different ASN and IP than the interactive sign-in. This pattern
+  can indicate post-compromise token misuse and requires analyst validation.
+description-detailed: |
+  This hypothesis-driven Microsoft Sentinel hunting query surfaces short-window mismatches
   between successful interactive sign-ins (SigninLogs) and successful non-interactive sign-ins
   (AADNonInteractiveUserSignInLogs) for the same user, where the originating Autonomous System
   Number (ASN) and IP address differ within a 10-minute window. This pattern can correspond to

--- a/Hunting Queries/MultipleDataSources/SignInASNMismatchInteractiveVsNonInteractive.yaml
+++ b/Hunting Queries/MultipleDataSources/SignInASNMismatchInteractiveVsNonInteractive.yaml
@@ -1,0 +1,112 @@
+id: 868599d4-84f7-4c31-ba00-d2a2c87efaab
+name: Short-window sign-in mismatch between interactive and non-interactive activity
+description: |
+  Hypothesis-driven Microsoft Sentinel hunting query that surfaces short-window mismatches
+  between successful interactive sign-ins (SigninLogs) and successful non-interactive sign-ins
+  (AADNonInteractiveUserSignInLogs) for the same user, where the originating Autonomous System
+  Number (ASN) and IP address differ within a 10-minute window. This pattern can correspond to
+  a possible post-compromise session misuse scenario in which previously issued authentication
+  material is being used from a different network origin shortly after an interactive sign-in.
+  This query does not observe credential or session theft itself, and it does not claim
+  definitive adversary-in-the-middle behavior. Analysts must validate every result.
+  Expect benign matches in scenarios such as VPN connect/disconnect, user roaming between
+  networks, mobile application background token refresh, multi-device usage, and corporate
+  proxies or egress points that change the public ASN as traffic shifts between services.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/concept-sign-ins
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/concept-all-sign-ins
+  - https://attack.mitre.org/techniques/T1550/001/
+  - https://attack.mitre.org/techniques/T1539/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+      - AADNonInteractiveUserSignInLogs
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1550.001
+  - T1539
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let window = 10m;
+  let interactive =
+      SigninLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where ResultType == 0
+      | project
+          InteractiveTime = TimeGenerated,
+          UserPrincipalName = tolower(UserPrincipalName),
+          InteractiveIP = IPAddress,
+          InteractiveASN = AutonomousSystemNumber,
+          InteractiveDeviceId = tostring(DeviceDetail.deviceId),
+          InteractiveAppDisplayName = AppDisplayName,
+          InteractiveCorrelationId = CorrelationId;
+  let nonInteractive =
+      AADNonInteractiveUserSignInLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where ResultType == 0
+      | project
+          NonInteractiveTime = TimeGenerated,
+          UserPrincipalName = tolower(UserPrincipalName),
+          NonInteractiveIP = IPAddress,
+          NonInteractiveASN = AutonomousSystemNumber,
+          NonInteractiveDeviceId = tostring(DeviceDetail.deviceId),
+          NonInteractiveAppDisplayName = AppDisplayName,
+          NonInteractiveCorrelationId = CorrelationId;
+  interactive
+  | join kind=inner nonInteractive on UserPrincipalName
+  | where NonInteractiveTime between (InteractiveTime .. (InteractiveTime + window))
+  | where isnotempty(InteractiveASN) and isnotempty(NonInteractiveASN)
+  | where InteractiveASN != NonInteractiveASN
+  | where InteractiveIP != NonInteractiveIP
+  | extend DeviceIdMismatch = iff(
+        isnotempty(InteractiveDeviceId) and isnotempty(NonInteractiveDeviceId)
+            and InteractiveDeviceId != NonInteractiveDeviceId,
+        true, false)
+  | extend TimeDeltaSeconds = datetime_diff('second', NonInteractiveTime, InteractiveTime)
+  | extend AccountName = tostring(split(UserPrincipalName, "@")[0]),
+           AccountUPNSuffix = tostring(split(UserPrincipalName, "@")[1])
+  | project
+      InteractiveTime,
+      NonInteractiveTime,
+      TimeDeltaSeconds,
+      UserPrincipalName,
+      AccountName,
+      AccountUPNSuffix,
+      InteractiveIP,
+      NonInteractiveIP,
+      InteractiveASN,
+      NonInteractiveASN,
+      InteractiveDeviceId,
+      NonInteractiveDeviceId,
+      DeviceIdMismatch,
+      InteractiveAppDisplayName,
+      NonInteractiveAppDisplayName,
+      InteractiveCorrelationId,
+      NonInteractiveCorrelationId
+  | sort by InteractiveTime desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserPrincipalName
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: NonInteractiveIP
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/SignInASNMismatchInteractiveVsNonInteractive.yaml
+++ b/Hunting Queries/MultipleDataSources/SignInASNMismatchInteractiveVsNonInteractive.yaml
@@ -44,7 +44,6 @@ query: |
           UserPrincipalName = tolower(UserPrincipalName),
           InteractiveIP = IPAddress,
           InteractiveASN = AutonomousSystemNumber,
-          InteractiveDeviceId = tostring(DeviceDetail.deviceId),
           InteractiveAppDisplayName = AppDisplayName,
           InteractiveCorrelationId = CorrelationId;
   let nonInteractive =
@@ -56,7 +55,6 @@ query: |
           UserPrincipalName = tolower(UserPrincipalName),
           NonInteractiveIP = IPAddress,
           NonInteractiveASN = AutonomousSystemNumber,
-          NonInteractiveDeviceId = tostring(DeviceDetail.deviceId),
           NonInteractiveAppDisplayName = AppDisplayName,
           NonInteractiveCorrelationId = CorrelationId;
   interactive
@@ -65,10 +63,6 @@ query: |
   | where isnotempty(InteractiveASN) and isnotempty(NonInteractiveASN)
   | where InteractiveASN != NonInteractiveASN
   | where InteractiveIP != NonInteractiveIP
-  | extend DeviceIdMismatch = iff(
-        isnotempty(InteractiveDeviceId) and isnotempty(NonInteractiveDeviceId)
-            and InteractiveDeviceId != NonInteractiveDeviceId,
-        true, false)
   | extend TimeDeltaSeconds = datetime_diff('second', NonInteractiveTime, InteractiveTime)
   | extend AccountName = tostring(split(UserPrincipalName, "@")[0]),
            AccountUPNSuffix = tostring(split(UserPrincipalName, "@")[1])
@@ -83,9 +77,6 @@ query: |
       NonInteractiveIP,
       InteractiveASN,
       NonInteractiveASN,
-      InteractiveDeviceId,
-      NonInteractiveDeviceId,
-      DeviceIdMismatch,
       InteractiveAppDisplayName,
       NonInteractiveAppDisplayName,
       InteractiveCorrelationId,


### PR DESCRIPTION
## Summary

Adds one new community hunting query under `Hunting Queries/MultipleDataSources/`:

- `SignInASNMismatchInteractiveVsNonInteractive.yaml` — surfaces short-window
  mismatches between successful interactive sign-ins (`SigninLogs`) and
  successful non-interactive sign-ins (`AADNonInteractiveUserSignInLogs`)
  for the same user, where ASN and IP differ within a 10-minute window.

This is a hypothesis-driven hunting query. It does not claim definitive
adversary-in-the-middle detection and does not observe credential or
session theft itself. Analysts must validate every result; benign matches
are expected in VPN, roaming, mobile background refresh, multi-device,
and corporate proxy scenarios.

## Coverage angle

The repository already includes `PossibleAiTMPhishingAttemptAgainstAAD`
(Solutions/SecurityThreatEssentialSolution) which correlates risky
sign-ins with web-session data via Zscaler/`_Im_WebSession`. This new
hunting query takes a complementary angle that does not require any
non-AAD connector — it cross-references AAD's own interactive vs
non-interactive sign-in tables.

## MITRE

- T1550.001 — Use Alternate Authentication Material: Application Access Token
- T1539 — Steal Web Session Cookie (referenced as a possible post-compromise
  usage pattern, not the theft itself)

Tactic: `CredentialAccess`. T1557 deliberately omitted since the query
does not observe AiTM behaviour directly.

## Validation

Synthetic-only validation using `datatable()` was performed locally.
Three test cases were used: (a) different ASN within 5 minutes → match;
(b) same ASN different IP → no match; (c) outside 10-minute window → no match.
Expected single-row result confirmed.

## Test plan

- [ ] CI schema validation passes
- [ ] KQL parses against `SigninLogs` and `AADNonInteractiveUserSignInLogs` schemas