### PR TITLE
Add hunting query: service principal credential addition by rarely observed actor

### DIFF
--- a/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByRareActor.yaml
+++ b/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByRareActor.yaml
@@ -1,0 +1,99 @@
+id: 138381e3-95d5-4d21-ab0b-13f941b82acc
+name: Service principal or application credential addition by a rarely observed actor
+description: |
+  Hunting query that looks for credential additions or updates on service principals and
+  applications performed by actors (users or apps) that have not been observed initiating
+  the same operations in the previous 90 days. Covered operations are
+  "Add service principal credentials" and "Update application - Certificates and secrets
+  management", which correspond to adding passwordCredentials or keyCredentials to an
+  existing registration. A rarely observed actor performing these operations can indicate
+  persistence activity, such as a compromised account adding a backdoor credential to a
+  high-privilege application.
+  This query is hypothesis-driven and requires analyst validation. Benign matches include
+  newly onboarded administrators, infrastructure-as-code pipelines running for the first
+  time, and certificate rotation performed by a different operator than usual.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1098/001/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1098.001
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let baselineLookback = starttime - 90d;
+  let credOps = dynamic([
+      "Add service principal credentials",
+      "Update application - Certificates and secrets management"
+  ]);
+  // Build 90-day baseline of actors who have previously performed credential operations
+  let KnownActors =
+      AuditLogs
+      | where TimeGenerated between (baselineLookback .. starttime)
+      | where OperationName in~ (credOps)
+      | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+      | extend ActorApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+      | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+      | where isnotempty(Actor)
+      | summarize by Actor;
+  // Credential operations in the current window
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName in~ (credOps)
+  | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | where isnotempty(Actor)
+  // Keep only actors not seen in the 90-day baseline
+  | join kind=leftanti KnownActors on Actor
+  | extend TargetDisplayName = tostring(TargetResources[0].displayName)
+  | extend TargetId = tostring(TargetResources[0].id)
+  | extend TargetType = tostring(TargetResources[0].type)
+  | extend AccountName = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      OperationName,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorApp,
+      ActorIp,
+      TargetDisplayName,
+      TargetId,
+      TargetType,
+      CorrelationId,
+      Result
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]


### PR DESCRIPTION
## Summary

Adds one new community hunting query under `Hunting Queries/AuditLogs/`:

- `ServicePrincipalCredentialAdditionByRareActor.yaml` — identifies credential
  additions or updates on service principals and applications performed by actors
  (users or apps) not observed initiating the same operations in the previous 90 days.

## Coverage angle

Existing credential-related hunting queries in the repository are either:
- Tagged `[Nobelium]` and scoped to a specific threat actor via `CloudAppEvents` (requires Microsoft Defender XDR)
- Focused on dormant service principals (`DormantServicePrincipalUpdateCredsandLogsIn.yaml`)
- Generic rare-audit queries across all `OperationName` values (`RareAuditActivityByUser.yaml`, `RareAuditActivityByApp.yaml`)

This query is the only one that:
1. Uses `AuditLogs` only (no Microsoft Defender XDR required)
2. Scopes specifically to `"Add service principal credentials"` and `"Update application - Certificates and secrets management"`
3. Builds a 90-day actor baseline and surfaces initiators outside that baseline

## MITRE

- T1098.001 — Account Manipulation: Additional Cloud Credentials

Tactic: `Persistence`.

## Validation

Structural validation performed against existing `Hunting Queries/AuditLogs/` examples.
Query logic verified synthetically: 90-day baseline excludes known actors, current-window
events from new actors are surfaced. Benign matches include newly onboarded administrators,
IaC pipelines running for the first time, and certificate rotation by a different operator.

## Test plan

- [ ] CI schema validation passes
- [ ] KQL parses against `AuditLogs` schema