### PR TITLE
Fix swapped IsBillable display labels in WorkspaceUsage workbook

### DIFF
--- a/Workbooks/WorkspaceUsage.json
+++ b/Workbooks/WorkspaceUsage.json
@@ -1256,14 +1256,14 @@
                         {
                           "operator": "==",
                           "thresholdValue": "false",
-                          "representation": "blueDark",
-                          "text": "True"
+                          "representation": "green",
+                          "text": "False"
                         },
                         {
                           "operator": "Default",
                           "thresholdValue": null,
-                          "representation": "green",
-                          "text": "False"
+                          "representation": "blueDark",
+                          "text": "True"
                         }
                       ]
                     }


### PR DESCRIPTION
## Problem
In the WorkspaceUsage workbook (query - 12, Basic depth level), the IsBillable column formatter has swapped display text labels:
- When the data value is `false`, it displays **True**
- When the data value is anything else (true), it displays **False**

This causes the IsBillable column to show the opposite of the actual billing status.

## Fix
Swapped the `text` values (and their corresponding colors) so the display matches the actual data:
- `false` -> displays **False** (green)
- Default/true -> displays **True** (blueDark)

## Changed file
- `Workbooks/WorkspaceUsage.json`