### PR TITLE
fix(solutions-analyzer): discover SAP and SAPCC connectors via overrides

### DIFF
--- a/Tools/Solutions Analyzer/map_solutions_connectors_tables.py
+++ b/Tools/Solutions Analyzer/map_solutions_connectors_tables.py
@@ -2222,6 +2222,54 @@ def apply_overrides_to_data(
     return [apply_overrides_to_row(row, overrides, entity_type, key_field) for row in data]
 
 
+# Solution-info fields that must be patched at metadata-collection time, BEFORE
+# downstream consumers (marketplace lookup, dependency graph, synthetic connector
+# row construction) read them. Standard Solution-entity overrides applied later
+# via apply_overrides_to_data() only patch the OUTPUT rows; they cannot fix
+# upstream behaviors that depend on these fields being correct in solutions_info.
+SOLUTION_INIT_OVERRIDE_FIELDS: Set[str] = {
+    'solution_publisher_id',
+    'solution_offer_id',
+}
+
+
+def apply_early_solution_metadata_overrides(
+    solution_info: Dict[str, str],
+    overrides: List[Override]
+) -> Dict[str, str]:
+    """Patch solution_info with Solution-entity overrides for fields that must be
+    set BEFORE marketplace lookup and dependency graph construction.
+
+    Currently restricted to a small whitelist (SOLUTION_INIT_OVERRIDE_FIELDS) to
+    avoid double-application or accidental masking of late-stage overrides
+    (e.g., is_published, which is intentionally set from marketplace data).
+
+    Use case: solutions whose folder structure does not include a
+    SolutionMetadata.json (e.g., the agent-based SAP solution under Solutions/SAP/)
+    have empty publisher_id/offer_id by default. Without these populated,
+    marketplace lookup is skipped, dependency graph excludes the solution, and
+    the synthetic_connector mechanism produces rows with no Marketplace identity.
+    Patching these fields at metadata-collection time threads the corrected
+    identity through the entire downstream pipeline.
+
+    Pattern matching uses solution_name (same key as the late-stage Solution
+    overrides applied in apply_overrides_to_data()).
+
+    Returns the (mutated) solution_info dict for chaining.
+    """
+    name = solution_info.get('solution_name', '')
+    if not name:
+        return solution_info
+    for override in overrides:
+        if override.entity != 'solution':
+            continue
+        if override.field not in SOLUTION_INIT_OVERRIDE_FIELDS:
+            continue
+        if override.matches(name):
+            solution_info[override.field] = override.value
+    return solution_info
+
+
 def apply_plural_table_fix(name: str) -> Tuple[str, Optional[str]]:
     lowered = name.lower()
     corrected = PLURAL_TABLE_CORRECTIONS.get(lowered)
@@ -7422,7 +7470,15 @@ def main() -> None:
         if solution_idx % 50 == 0 or solution_idx == 1:
             log_print(f"  [{solution_idx}/{total_solutions}] Processing {solution_dir.name}...")
         solution_info = collect_solution_info(solution_dir.resolve())
-        
+
+        # Apply Solution-entity overrides for fields that must be patched BEFORE
+        # downstream consumers (marketplace lookup, dependency graph, synthetic
+        # connector row construction) read them. See SOLUTION_INIT_OVERRIDE_FIELDS.
+        # The cached collect_solution_info() result is left unmodified; this patch
+        # is applied per-run to the local solution_info before it enters
+        # all_solutions_info.
+        solution_info = apply_early_solution_metadata_overrides(solution_info, overrides)
+
         # Store all solution info for later processing
         all_solutions_info[solution_info["solution_name"]] = solution_info
         
@@ -8190,8 +8246,14 @@ def main() -> None:
                 details="Solution contains connectors but is missing SolutionMetadata.json.",
             )
         
-        # Track solutions that truly have no connectors (no Data Connectors dir or no valid connectors)
-        if not has_data_connectors_dir or not has_valid_connector:
+        # Track solutions that truly have no connectors. has_valid_connector is True
+        # when either (a) the Data Connectors/ directory contained at least one valid
+        # connector definition file, or (b) a synthetic_connector entry in the
+        # overrides CSV produced rows for this solution. The previous condition also
+        # required a Data Connectors/ directory to exist, which incorrectly excluded
+        # solutions whose connectors are declared exclusively via synthetic_connector
+        # overrides (e.g., the agent-based SAP solution under Solutions/SAP/).
+        if not has_valid_connector:
             solutions_without_connectors.add(solution_info["solution_name"])
 
     # Add rows for solutions without any connectors

--- a/Tools/Solutions Analyzer/solution_analyzer_overrides.csv
+++ b/Tools/Solutions Analyzer/solution_analyzer_overrides.csv
@@ -753,3 +753,15 @@ Connector,BitSight,ingestion_api,Log Ingestion API,Dead code: orphaned azure_sen
 Connector,VectraXDR,ingestion_api,Log Ingestion API,Dead code: orphaned azure_sentinel.py with HTTP Collector patterns is no longer used
 Connector,NordPass,collection_method,Azure Function,Connector JSON lacks Azure Function markers but deployment/ ARM template deploys an Azure Function with DCR-based ingestion
 Connector,NordPass,ingestion_api,Log Ingestion API,Deployment ARM template uses DCR endpoint and immutable ID (Log Ingestion API) but patterns are not in connector JSON
+Solution,SAP,solution_publisher_id,sentinel4sap,"Synthesize marketplace publisherId for the agent-based SAP solution which has no SolutionMetadata.json. Required for marketplace lookup, dependency graph, and synthetic_connector row construction. Pairs with solution_offer_id override and synthetic_connector entries for SAP and SAPCC."
+Solution,SAP,solution_offer_id,sentinel4sap,"Synthesize marketplace offerId for the agent-based SAP solution which has no SolutionMetadata.json. See companion solution_publisher_id override comment."
+synthetic_connector,SAP,connector_id,SAP,"MMA agent-based SAP applications connector (SAP NetWeaver/ABAP/HANA), shipped via the legacy Microsoft Sentinel for SAP Docker agent (now deprecated, superseded by SAPCC). Visible in the Content Hub portal as solution sentinel4sap.sentinel4sap with status Featured but auto-discovery cannot find it because the SAP folder ships connector definitions under Agentless/, Tools/, and ARM templates/ rather than the standard Data Connectors/ folder."
+synthetic_connector,SAP,title,Microsoft Sentinel for SAP - agent based (Deprecated),
+synthetic_connector,SAP,publisher,Microsoft Corporation,
+synthetic_connector,SAP,description,"Legacy MMA agent-based ingestion of SAP NetWeaver/ABAP/HANA security and audit logs into Microsoft Sentinel via the Microsoft Sentinel for SAP Docker container. Marked deprecated; new deployments should use the SAPCC (agentless CCF) connector instead.",
+synthetic_connector,SAP,tables,ABAPAuditLog;ABAPChangeDocsLog;ABAPUserDetails;ABAPAuthorizationDetails,
+synthetic_connector,SAP,connector_id,SAPCC,"Agentless SAP applications connector using the Codeless Connector Framework (CCF). Visible in Content Hub portal as solution sentinel4sap.sentinel4sap with status Featured. Defined in Solutions/SAP/Tools/IntegrationSuite/SAPCC_DCR.json which the analyzer's standard Data Connectors/ scan does not reach."
+synthetic_connector,SAP,title,Microsoft Sentinel for SAP - agentless,
+synthetic_connector,SAP,publisher,Microsoft Corporation,
+synthetic_connector,SAP,description,"Modern agentless ingestion of SAP NetWeaver/ABAP/HANA telemetry (SentinelHealth, ABAPAuditLog, ABAPChangeDocsLog, ABAPUserDetails, ABAPAuthorizationDetails) into Microsoft Sentinel via the Codeless Connector Framework (CCF). Recommended replacement for the deprecated agent-based SAP connector.",
+synthetic_connector,SAP,tables,ABAPAuditLog;ABAPChangeDocsLog;ABAPUserDetails;ABAPAuthorizationDetails;SentinelHealth,


### PR DESCRIPTION
## Summary

The Solutions Analyzer fails to discover the **SAP** and **SAPCC** connectors
shipped under `Solutions/SAP/`. As a result, downstream consumers of
`solutions_connectors_tables_mapping.csv` (community inventory tools, parity
reports, etc.) report false-negatives for two top-tier SAP connectors that
are clearly visible in the Content Hub portal as Microsoft-published,
Featured-status connectors under marketplace identity
`sentinel4sap.sentinel4sap`.

This PR fixes that by extending the `solution_analyzer_overrides.csv`
override schema (a small Python change) and adding the SAP/SAPCC override
rows.

## Architecture (mirrors the canonical TemplateContents catalog)

- **`SAP`** = MMA agent-based, shipped via the Microsoft Sentinel for SAP
  Docker agent. Marked **deprecated**; superseded by SAPCC.
- **`SAPCC`** = agentless connector using the Codeless Connector Framework
  (CCF). The recommended modern ingestion path for SAP NetWeaver/ABAP/HANA.

Both are listed under the same solution (`SAP applications`,
`sentinel4sap.sentinel4sap`).

## Root causes (3 distinct issues, all SAP-folder-specific)

1. **No `SolutionMetadata.json` for `Solutions/SAP/`.** `collect_solution_info()`
   returns empty `publisher_id`/`offer_id`. This breaks marketplace lookup,
   the dependency graph, and any `synthetic_connector` rows produced for
   that solution (the rows are emitted but with no marketplace identity).
2. **Non-standard packaging.** Neither connector is declared via standard
   `Data Connectors/*.json` files. They live under `Solutions/SAP/Agentless/`,
   `Solutions/SAP/Tools/IntegrationSuite/SAPCC_DCR.json`, and
   `Solutions/SAP/ARM templates/azuredeploy.json`.
3. **`has_connectors=false` for synthetic-only solutions.** The
   `solutions_without_connectors` check additionally required a
   `Data Connectors/` directory to exist. Even after synthetic injection
   produced rows for SAP/SAPCC, the SAP solution still reported
   `has_connectors=false` in `solutions.csv`.

## Changes

### `Tools/Solutions Analyzer/map_solutions_connectors_tables.py`

Three small, scoped additions:

1. **New `SOLUTION_INIT_OVERRIDE_FIELDS` constant + `apply_early_solution_metadata_overrides()` helper** (~50 lines, near `apply_overrides_to_data`).
   Whitelisted to `{solution_publisher_id, solution_offer_id}` only — applied
   right after `collect_solution_info()` and before `all_solutions_info` is
   populated, so the corrected marketplace identity threads through every
   downstream consumer.
2. **Call site for the helper** in the main solution-processing loop.
3. **Tightened `solutions_without_connectors` check**: removed the
   `not has_data_connectors_dir or` clause so synthetic_connector-only
   solutions correctly report `has_connectors=true`.

### `Tools/Solutions Analyzer/solution_analyzer_overrides.csv`

12 new rows appended (existing `MicrosoftSentinelSAP` entry left untouched):

| Type | Rows | Purpose |
|---|---|---|
| `Solution,SAP,*` | 2 | Synthesize `publisher_id`/`offer_id = sentinel4sap` (matches marketplace identity `sentinel4sap.sentinel4sap`) |
| `synthetic_connector,SAP,connector_id=SAP,*` | 5 | MMA agent-based, **deprecated** — title `Microsoft Sentinel for SAP - agent based (Deprecated)`, 4 ABAP tables |
| `synthetic_connector,SAP,connector_id=SAPCC,*` | 5 | Agentless CCF — title `Microsoft Sentinel for SAP - agentless`, same 4 ABAP tables + SentinelHealth |

## Verification

Analyzer re-run with the patched code + CSV produces an additive, isolated diff:

| File | Before | After | Δ | Notes |
|---|---:|---:|---:|---|
| `solutions_connectors_tables_mapping.csv` | 1389 | 1397 | **+8 rows** | Each row = one (connector, table) pair. SAP+SAPCC together produce 9 new rows (4 ABAP for SAP, 4 ABAP + 1 SentinelHealth for SAPCC), minus 1 dropped placeholder "no connectors" row = +8 net. Diff fully scoped to SAP rows; row-signature diff against pre-fix snapshot confirms zero collateral changes to other solutions. |
| `connectors.csv` | 613 | 615 | **+2 rows** | SAP + SAPCC |
| `solutions.csv` | 525 | 525 | unchanged | But SAP row gains populated `solution_publisher_id`, `solution_offer_id`, `has_connectors=true`, `is_published=true`, `mp_url` |

### Before/after for the SAP row in `solutions.csv`

```
BEFORE: solution_name=SAP  solution_publisher_id=  solution_offer_id=  has_connectors=false  is_published=  mp_url=
AFTER:  solution_name=SAP  solution_publisher_id=sentinel4sap  solution_offer_id=sentinel4sap  has_connectors=true  is_published=true  mp_url=https://azuremarketplace.microsoft.com/en-us/marketplace/apps/sentinel4sap.sentinel4sap
```

### Cross-validated against Content Hub portal data

Pulled live Content Hub catalog via `contentProductPackages`. Found SAP and
SAPCC at rows 333 and 335:

```
| 333 | sentinel4sap.sentinel4sap | SAP    | SAP             | 1.0.0 | SAP applications | Microsoft Corporation | Featured | true |
| 335 | sentinel4sap.sentinel4sap | SAPCC  | SAPCCConnections| 1.0.0 | SAP applications | Microsoft Corporation | Featured | true |
```

Marketplace identity, solution display name, publisher all match.

### Cross-validated against the canonical TemplateContents catalog

```
| 366 | sentinel4sap.sentinel4sap | SAP applications | Microsoft Corporation | ... | SAP    | ... | Microsoft Sentinel for SAP - agent based (Deprecated) | MMA | false |
| 367 | sentinel4sap.sentinel4sap | SAP applications | Microsoft Corporation | ... | SAPCC  | ... | Microsoft Sentinel for SAP - agentless                 | CCF | false |
```

Connector titles, collection methods, and is_deprecated all align with the
synthetic_connector entries this PR adds.

## Scope explicitly excluded

- **`Dynamics365FinanceOperations`**: ships exclusively through internal
  TemplateContents pipeline; zero references anywhere in the public
  Azure-Sentinel repo (verified via recursive grep). Cannot be fixed in the
  public analyzer.
- **`ZeroFox_Alert_Polling`**: legacy connector embedded inline in
  `Solutions/ZeroFox/Package/mainTemplate.json` under a marketplace identity
  that does not match the modern ZeroFox solution package. Needs separate
  marketplace reconciliation, not an analyzer fix.

## Backward compatibility

- Existing `MicrosoftSentinelSAP` synthetic_connector rows are left untouched.
- New `SOLUTION_INIT_OVERRIDE_FIELDS` whitelist deliberately restricted to 2
  fields. Other Solution-entity overrides (`is_published`,
  `solution_support_tier`, `additional_information`, `dependency_override`)
  continue to flow through the existing late-stage `apply_overrides_to_data()`
  path.
- No new files added; no schema-breaking changes to either CSV.
- Public Solutions Analyzer outputs (`*.csv`, `*.md`) are not committed in
  this PR; they will regenerate on next analyzer run.
