### PR TITLE
Add hunting queries: Entra ID identity and application threat hunting pack (5 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/AdminConsentGrantedToApplication.yaml
+++ b/Hunting Queries/AuditLogs/AdminConsentGrantedToApplication.yaml
@@ -60,12 +60,14 @@ query: |
   | where NewValue has "AllPrincipals"
   | extend ScopeRaw = extract(@'Scope:\s*([^,\]]*)', 1, NewValue)
   | extend Scopes   = split(trim(" ", ScopeRaw), " ")
+  | mv-expand Scope = Scopes to typeof(string)
+  | extend Scope    = trim(" ", Scope)
   | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
   | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
   | summarize
       FirstSeen     = min(TimeGenerated),
       LastSeen      = max(TimeGenerated),
-      GrantedScopes = make_set(Scopes),
+      GrantedScopes = make_set(Scope),
       EventCount    = count()
       by AppName, AppId, Actor, AccountName, AccountUPNSuffix, ActorIp, CorrelationId
   | sort by FirstSeen desc

--- a/Hunting Queries/AuditLogs/AdminConsentGrantedToApplication.yaml
+++ b/Hunting Queries/AuditLogs/AdminConsentGrantedToApplication.yaml
@@ -1,0 +1,98 @@
+id: 0364b6b6-65cf-4ba2-ad0d-9ce80e0ae71e
+name: Admin consent granted to application
+description: |
+  Hunting query that identifies admin consent grants to Entra ID applications. Admin
+  consent (also referred to as tenant-wide consent) allows an administrator to authorize
+  an application to access resources on behalf of all users in the tenant, without
+  requiring individual user consent. This is identified in AuditLogs by the presence of
+  the AllPrincipals principal type in the ConsentAction.Permissions modified property.
+  Admin consent grants are a high-value persistence mechanism. Once granted, the
+  application retains access even if the user who performed the grant changes their
+  password or has their account disabled, because the permission is attached to the
+  service principal and not to the user session. This technique was used in the
+  Midnight Blizzard and Storm-0558 campaigns to maintain persistent access to
+  Microsoft 365 environments via OAuth applications after initial access was established.
+  This query is complementary to OAuthConsentToHighRiskPermission.yaml, which focuses
+  on user-level consents to newly observed applications with high-risk scopes. This
+  query focuses exclusively on the tenant-wide admin consent signal regardless of the
+  application age or specific scope, because AllPrincipals grants carry elevated risk
+  by nature.
+  Analysts must validate every result. Benign matches include authorized enterprise
+  application deployments, ISV integrations performed by IT administrators, and
+  Microsoft-published first-party applications onboarded by a global administrator.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/manage-apps/grant-admin-consent
+  - https://learn.microsoft.com/azure/active-directory/manage-apps/protect-against-consent-phishing
+  - https://attack.mitre.org/techniques/T1528/
+  - https://attack.mitre.org/techniques/T1098/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - CredentialAccess
+  - Persistence
+relevantTechniques:
+  - T1528
+  - T1098
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName =~ "Consent to application"
+  | where Result =~ "success"
+  | extend AppName  = tolower(tostring(TargetResources[0].displayName))
+  | extend AppId    = tostring(TargetResources[0].id)
+  | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | extend PropName = tostring(ModProp.displayName)
+  | extend NewValue = replace_string(tostring(ModProp.newValue), '"', "")
+  | where PropName =~ "ConsentAction.Permissions"
+  // Admin consent sets the principal type to AllPrincipals (tenant-wide grant)
+  // User consent uses the individual user's object ID as the principal
+  | where NewValue has "AllPrincipals"
+  | extend ScopeRaw = extract(@'Scope:\s*([^,\]]*)', 1, NewValue)
+  | extend Scopes   = split(trim(" ", ScopeRaw), " ")
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | summarize
+      FirstSeen     = min(TimeGenerated),
+      LastSeen      = max(TimeGenerated),
+      GrantedScopes = make_set(Scopes),
+      EventCount    = count()
+      by AppName, AppId, Actor, AccountName, AccountUPNSuffix, ActorIp, CorrelationId
+  | sort by FirstSeen desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: Name
+        columnName: AppName
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/AppRegistrationWithExternalRedirectUri.yaml
+++ b/Hunting Queries/AuditLogs/AppRegistrationWithExternalRedirectUri.yaml
@@ -1,0 +1,110 @@
+id: c4e0baf0-283b-49d7-8b40-a1c72e92a4b2
+name: Application registration or update with external redirect URI
+description: |
+  Hunting query that identifies Entra ID application registrations and updates where one
+  or more redirect URIs (reply URLs) point to an external domain that is not a trusted
+  Microsoft endpoint, localhost, or a standard OAuth out-of-band value. An attacker who
+  can register or modify an application may add an attacker-controlled redirect URI to
+  intercept OAuth authorization codes and exchange them for access tokens without user
+  interaction after consent is granted.
+  Trusted prefixes excluded by this query include login.microsoftonline.com,
+  login.microsoft.com, login.windows.net, portal.azure.com, localhost, 127.0.0.1,
+  urn:ietf:wg, ms-appx-web, and msal. Any redirect URI not matching these prefixes
+  is surfaced for analyst review.
+  Analysts must validate every result. Benign matches include newly registered
+  third-party SaaS integrations, legitimate ISV applications, and authorized partner
+  applications that use their own domains as redirect targets.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/develop/reply-url
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1528/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1528
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let trustedPrefixes = dynamic([
+      "https://login.microsoftonline.com",
+      "https://login.microsoft.com",
+      "https://login.windows.net",
+      "https://portal.azure.com",
+      "http://localhost",
+      "https://localhost",
+      "http://127.0.0.1",
+      "https://127.0.0.1",
+      "urn:ietf:wg",
+      "ms-appx-web://",
+      "msal"
+  ]);
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName in~ ("Add application", "Update application")
+  | where Result =~ "success"
+  | extend ModProps  = TargetResources[0].modifiedProperties
+  | extend AppName   = tostring(TargetResources[0].displayName)
+  | extend AppId     = tostring(TargetResources[0].id)
+  | extend ActorUpn  = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp  = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp   = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | mv-expand ModProp = ModProps
+  | where tostring(ModProp.displayName) =~ "ReplyUrls"
+  // newValue is a JSON array of redirect URIs
+  | extend RawUrls = tostring(ModProp.newValue)
+  | extend UrlArray = todynamic(RawUrls)
+  | mv-expand RedirectUri = UrlArray to typeof(string)
+  | extend RedirectUri = trim('"', trim(' ', RedirectUri))
+  | where isnotempty(RedirectUri)
+  // Exclude trusted prefixes
+  | where not(RedirectUri has_any (trustedPrefixes))
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      OperationName,
+      AppName,
+      AppId,
+      RedirectUri,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId,
+      Result
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: Name
+        columnName: AppName
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/ConditionalAccessPolicyDisabledOrDeleted.yaml
+++ b/Hunting Queries/AuditLogs/ConditionalAccessPolicyDisabledOrDeleted.yaml
@@ -35,7 +35,7 @@ relevantTechniques:
 query: |
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
-  // Deleted policies — always surface regardless of modifiedProperties content
+  // Deleted policies - always surface regardless of modifiedProperties content
   let Deletions =
       AuditLogs
       | where TimeGenerated between (starttime .. endtime)

--- a/Hunting Queries/AuditLogs/ConditionalAccessPolicyDisabledOrDeleted.yaml
+++ b/Hunting Queries/AuditLogs/ConditionalAccessPolicyDisabledOrDeleted.yaml
@@ -1,0 +1,120 @@
+id: 0456a783-2fd9-4e07-aa05-4aa0afdab0a6
+name: Conditional Access policy disabled or deleted
+description: |
+  Hunting query that identifies Conditional Access policies that have been disabled or
+  deleted. An attacker who obtains privileged access to an Entra ID tenant will commonly
+  disable or delete CA policies to remove multi-factor authentication requirements,
+  trusted location restrictions, or compliant-device conditions before proceeding with
+  lateral movement or data exfiltration. Disabling a CA policy is a silent, low-noise
+  action that does not interrupt active sessions and may go unnoticed without dedicated
+  monitoring.
+  This query surfaces two event types: policy state changes from enabled to disabled
+  (OperationName: Update conditional access policy) and outright policy deletions
+  (OperationName: Delete conditional access policy). Both are extracted from the Policy
+  category of AuditLogs and include the actor identity and source IP for analyst
+  correlation.
+  Analysts must validate every result. Benign matches include authorized policy
+  lifecycle management, scheduled policy reviews, tenant restructuring activities,
+  and break-glass account testing. The signal value is highest when the actor is not
+  a known CA administrator or when the action occurs outside of change-window hours.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/conditional-access/overview
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1562/001/
+  - https://attack.mitre.org/techniques/T1556/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - DefenseEvasion
+  - Persistence
+relevantTechniques:
+  - T1562.001
+  - T1556
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  // Deleted policies — always surface regardless of modifiedProperties content
+  let Deletions =
+      AuditLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where Category =~ "Policy"
+      | where OperationName =~ "Delete conditional access policy"
+      | where Result =~ "success"
+      | extend PolicyName  = tostring(TargetResources[0].displayName)
+      | extend PolicyId    = tostring(TargetResources[0].id)
+      | extend ActorUpn    = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+      | extend ActorApp    = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+      | extend ActorIp     = iff(
+            isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+            tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+            tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+      | extend Actor       = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+      | extend StateChange = "Deleted"
+      | extend OldValue    = ""
+      | extend NewValue    = "";
+  // Updated policies where the state transitioned from enabled to disabled
+  let Disablements =
+      AuditLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where Category =~ "Policy"
+      | where OperationName =~ "Update conditional access policy"
+      | where Result =~ "success"
+      | extend PolicyName = tostring(TargetResources[0].displayName)
+      | extend PolicyId   = tostring(TargetResources[0].id)
+      | extend ActorUpn   = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+      | extend ActorApp   = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+      | extend ActorIp    = iff(
+            isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+            tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+            tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+      | extend Actor      = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+      | mv-expand ModProp = TargetResources[0].modifiedProperties
+      | extend PropName   = tostring(ModProp.displayName)
+      | extend OldValue   = tostring(ModProp.oldValue)
+      | extend NewValue   = tostring(ModProp.newValue)
+      | where PropName =~ "State"
+            and OldValue has "enabled"
+            and NewValue has "disabled"
+      | extend StateChange = "Disabled";
+  union Deletions, Disablements
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      OperationName,
+      PolicyName,
+      PolicyId,
+      StateChange,
+      OldValue,
+      NewValue,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/GuestAccountAddedToPrivilegedRole.yaml
+++ b/Hunting Queries/AuditLogs/GuestAccountAddedToPrivilegedRole.yaml
@@ -74,7 +74,7 @@ query: |
       | mv-expand TargetResource = TargetResources
       | where tostring(TargetResource.type) =~ "Role"
       | extend RoleName = tostring(TargetResource.displayName)
-      | project CorrelationId, RoleName
+      | summarize RoleName = any(RoleName) by CorrelationId
   ) on CorrelationId
   // Keep only privileged roles
   | where RoleName in~ (privilegedRoles)

--- a/Hunting Queries/AuditLogs/GuestAccountAddedToPrivilegedRole.yaml
+++ b/Hunting Queries/AuditLogs/GuestAccountAddedToPrivilegedRole.yaml
@@ -1,0 +1,120 @@
+id: abed6064-9406-4171-a961-5fd38de5f79a
+name: Guest or external account added to a privileged Entra ID role
+description: |
+  Hunting query that identifies guest or external accounts being added to privileged
+  Entra ID directory roles. External accounts are identified by the presence of #EXT#
+  in the UserPrincipalName, which is the standard suffix assigned by Entra ID to all
+  guest and B2B invited users. Privileged roles covered include Global Administrator,
+  Privileged Role Administrator, Security Administrator, Exchange Administrator,
+  SharePoint Administrator, Application Administrator, Cloud Application Administrator,
+  Authentication Administrator, Conditional Access Administrator, Helpdesk Administrator,
+  and User Administrator.
+  Adding an external identity to a privileged role is an unusual operation in most
+  tenants and can indicate account compromise, insider threat, or a misconfigured
+  administrative workflow. Analysts must validate every result. Benign matches include
+  authorized partner or consultant access with documented approval.
+  This query uses AuditLogs only and does not require Microsoft Defender XDR or
+  Entra ID P2 licensing.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/roles/permissions-reference
+  - https://learn.microsoft.com/azure/active-directory/external-identities/user-properties
+  - https://attack.mitre.org/techniques/T1098/003/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1098.003
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let privilegedRoles = dynamic([
+      "Global Administrator",
+      "Privileged Role Administrator",
+      "Security Administrator",
+      "Exchange Administrator",
+      "SharePoint Administrator",
+      "Application Administrator",
+      "Cloud Application Administrator",
+      "Authentication Administrator",
+      "Conditional Access Administrator",
+      "Helpdesk Administrator",
+      "User Administrator"
+  ]);
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName =~ "Add member to role."
+  | where Result =~ "success"
+  // Extract actor
+  | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  // Expand target resources to find both the user and the role entries
+  | mv-expand TargetResource = TargetResources
+  | extend ResourceType = tostring(TargetResource.type)
+  | extend ResourceUPN  = tostring(TargetResource.userPrincipalName)
+  | extend ResourceName = tostring(TargetResource.displayName)
+  // Identify the target user (guest/external) by #EXT# marker
+  | where ResourceType =~ "User" and ResourceUPN has "#EXT#"
+  | extend GuestUPN = ResourceUPN
+  | extend GuestId  = tostring(TargetResource.id)
+  // Join back to find the role name in the same event
+  | join kind=inner (
+      AuditLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where OperationName =~ "Add member to role."
+      | where Result =~ "success"
+      | mv-expand TargetResource = TargetResources
+      | where tostring(TargetResource.type) =~ "Role"
+      | extend RoleName = tostring(TargetResource.displayName)
+      | project CorrelationId, RoleName
+  ) on CorrelationId
+  // Keep only privileged roles
+  | where RoleName in~ (privilegedRoles)
+  | extend AccountName      = tostring(split(GuestUPN, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(GuestUPN, "@")[1])
+  | extend ActorName        = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend ActorUPNSuffix   = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      GuestUPN,
+      AccountName,
+      AccountUPNSuffix,
+      GuestId,
+      RoleName,
+      Actor,
+      ActorName,
+      ActorUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: GuestUPN
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/OAuthConsentToHighRiskPermission.yaml
+++ b/Hunting Queries/AuditLogs/OAuthConsentToHighRiskPermission.yaml
@@ -1,0 +1,102 @@
+id: c449826b-d6d0-4ac8-8dad-19acc3fc75a7
+name: OAuth consent to high-risk permission by a new or rarely seen application
+description: |
+  Hunting query that identifies OAuth consent events where the granted permission scope
+  includes high-risk delegated or application permissions, and where the target application
+  has not been observed in the tenant during the previous 30 days. The combination of a
+  newly observed application and a high-privilege scope can indicate a consent phishing
+  attempt, an illicit OAuth grant, or an insider threat granting excessive permissions
+  to an external application.
+  High-risk scopes covered include Mail.ReadWrite, Mail.Send, Files.ReadWrite.All,
+  full_access_as_app, Directory.ReadWrite.All, EWS.AccessAsUser.All, and
+  Exchange.ManageAsApp. Analysts must validate every result. Benign matches include
+  newly deployed enterprise applications with legitimate mail or directory integration,
+  freshly registered automation accounts, and authorized ISV integrations.
+  This query is complementary to ConsentToApplicationDiscovery.yaml, which covers all
+  consent events regardless of scope or application age.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/manage-apps/protect-against-consent-phishing
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1528/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1528
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let appLookback = starttime - 30d;
+  let highRiskScopes = dynamic([
+      "Mail.ReadWrite", "Mail.Send", "Files.ReadWrite.All",
+      "full_access_as_app", "Directory.ReadWrite.All",
+      "EWS.AccessAsUser.All", "Exchange.ManageAsApp"
+  ]);
+  // Applications seen in the tenant during the 30-day baseline period
+  let KnownApps =
+      AuditLogs
+      | where TimeGenerated between (appLookback .. starttime)
+      | where OperationName =~ "Consent to application"
+      | extend AppName = tolower(tostring(TargetResources[0].displayName))
+      | where isnotempty(AppName)
+      | summarize by AppName;
+  // Consent events in the current window
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName =~ "Consent to application"
+  | extend ModProps   = TargetResources[0].modifiedProperties
+  | extend AppName    = tolower(tostring(TargetResources[0].displayName))
+  | extend ActorUpn   = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp   = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp    = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | mv-expand ModProps
+  | extend PropertyName = tostring(ModProps.displayName)
+  | extend NewValue     = replace_string(tostring(ModProps.newValue), '"', "")
+  | where PropertyName =~ "ConsentAction.Permissions"
+  // Extract individual scope tokens from the permission string
+  | extend ScopeRaw = extract(@'Scope:\s*([^,\]]*)', 1, NewValue)
+  | extend Scopes = split(trim(" ", ScopeRaw), " ")
+  | mv-expand Scope = Scopes to typeof(string)
+  | extend Scope = trim(" ", Scope)
+  | where Scope in~ (highRiskScopes)
+  // Keep only applications not seen in the 30-day baseline
+  | join kind=leftanti KnownApps on AppName
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | summarize
+      FirstSeen     = min(TimeGenerated),
+      LastSeen      = max(TimeGenerated),
+      GrantedScopes = make_set(Scope),
+      EventCount    = count()
+      by AppName, Actor, AccountName, AccountUPNSuffix, ActorIp, CorrelationId, Result
+  | sort by FirstSeen desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]


### PR DESCRIPTION
## Summary

This PR adds five hunting queries targeting the Entra ID application layer and identity persistence attack surface. The queries are grouped because they map to a single adversary workflow: an attacker who obtains privileged access to an Entra ID tenant will typically perform some combination of these five actions to establish persistence, escalate privilege, and remove defenses before proceeding with their objectives.

All queries use `AuditLogs` exclusively, require only the Azure Active Directory data connector, and include entity mappings for Account and IP. No Entra ID P2 or Defender XDR licensing is required.

## Queries included

### 1. `OAuthConsentToHighRiskPermission.yaml`
Identifies consent events where the granted scope includes high-risk delegated or application permissions (Mail.ReadWrite, Mail.Send, Files.ReadWrite.All, full_access_as_app, Directory.ReadWrite.All, EWS.AccessAsUser.All, Exchange.ManageAsApp) **and** the target application has not been observed in the tenant during the previous 30 days. The combination of a newly seen application and a high-privilege scope is the canonical consent phishing pattern.
- MITRE: T1528 — CredentialAccess

### 2. `AdminConsentGrantedToApplication.yaml`
Surfaces tenant-wide OAuth consent grants identified by the AllPrincipals principal type in the ConsentAction.Permissions audit property. Admin consent persists beyond user password resets and account disablements because the permission is bound to the service principal, not the user session. This technique was used in the Midnight Blizzard and Storm-0558 campaigns. Complements query 1, which targets user-level consents.
- MITRE: T1528, T1098 — CredentialAccess, Persistence

### 3. `AppRegistrationWithExternalRedirectUri.yaml`
Identifies Add application and Update application audit events where one or more ReplyUrls point to a domain that is not a trusted Microsoft endpoint, localhost, or a standard OAuth out-of-band value. An attacker with application registration rights can add an attacker-controlled redirect URI to intercept authorization codes after consent is granted.
- MITRE: T1528 — CredentialAccess

### 4. `GuestAccountAddedToPrivilegedRole.yaml`
Identifies Add member to role audit events where the target user UPN contains `#EXT#`, which is the standard suffix Entra ID assigns to all guest and B2B invited accounts. Privileged roles monitored include Global Administrator, Privileged Role Administrator, Security Administrator, Exchange Administrator, SharePoint Administrator, Application Administrator, Cloud Application Administrator, Authentication Administrator, Conditional Access Administrator, Helpdesk Administrator, and User Administrator.
- MITRE: T1098.003 — Persistence, PrivilegeEscalation

### 5. `ConditionalAccessPolicyDisabledOrDeleted.yaml`
Surfaces CA policy deletions and state transitions from enabled to disabled. Attackers with admin access commonly silence CA policies to remove MFA requirements, trusted location restrictions, or compliant-device conditions before lateral movement or data exfiltration. The query handles deletions (where modifiedProperties is empty) and disablements (where the State property transitions) as two separate branches unified before output.
- MITRE: T1562.001, T1556 — DefenseEvasion, Persistence

## Relationship to existing queries

- `ConsentToApplicationDiscovery.yaml` — existing query captures all consent events broadly. Queries 1 and 2 here are additive: query 1 filters on scope risk and application novelty, query 2 filters on the AllPrincipals tenant-wide grant type.
- `AccountAddedtoPrivilegedPIMGroup.yaml` — existing query covers PIM group additions. Query 4 here covers direct directory role assignments, which is a different code path.
- `AccountMFAModifications.yaml` — existing query logs MFA events without baseline comparison. No overlap with this bundle.

## Testing

Queries were authored against the `AuditLogs` schema documented at learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities and validated against live tenant data. KQL patterns follow the same conventions used in the existing AuditLogs hunting queries in this repository.