### PR TITLE
Add hunting queries: Entra ID defense weakening and privilege abuse hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
+++ b/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
@@ -19,12 +19,12 @@ query: |
   | where Result =~ "success"
   | extend DomainName = tostring(TargetResources[0].displayName)
   | extend DomainId   = tostring(TargetResources[0].id)
-  | extend ActorUpn   = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-  | extend ActorApp   = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorUpn   = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp   = tostring(InitiatedBy.app.displayName)
   | extend ActorIp    = iff(
-        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
-        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
-        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
   | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
   | mv-expand ModProp = TargetResources[0].modifiedProperties
   | extend PropName = tostring(ModProp.displayName)

--- a/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
+++ b/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
@@ -1,15 +1,6 @@
 id: 902e4b5a-4e6a-46e1-a897-4cdbda0693b3
 name: Federated domain added to Entra ID tenant
-description: |
-  Identifies Set domain authentication events that transition a managed domain to
-  federated authentication (Golden SAML). An attacker with Global Administrator access
-  can configure a malicious IdP to issue arbitrary SAML tokens for any user in the
-  tenant, bypassing MFA and surviving password resets.
-  References:
-  - https://learn.microsoft.com/azure/active-directory/hybrid/connect/whatis-fed
-  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
-  - https://attack.mitre.org/techniques/T1484/002/
-  - https://www.semperis.com/blog/golden-saml-newly-discovered-attack-technique-forges-authentication-to-cloud-apps/
+description: Identifies federation configuration changes to Entra ID domains, a persistence technique that allows attackers to forge authentication tokens for any user account in the tenant without knowing their password.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -21,10 +12,9 @@ tactics:
 relevantTechniques:
   - T1484.002
 query: |
-  let starttime = todatetime('{{StartTimeISO}}');
-  let endtime = todatetime('{{EndTimeISO}}');
+  let timeframe = 14d;
   AuditLogs
-  | where TimeGenerated between (starttime .. endtime)
+  | where TimeGenerated >= ago(timeframe)
   | where OperationName =~ "Set domain authentication"
   | where Result =~ "success"
   | extend DomainName = tostring(TargetResources[0].displayName)

--- a/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
+++ b/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
@@ -1,27 +1,10 @@
 id: 902e4b5a-4e6a-46e1-a897-4cdbda0693b3
 name: Federated domain added to Entra ID tenant
 description: |
-  Hunting query that identifies changes to domain authentication that convert a managed
-  domain to federated authentication. When a domain is federated, Entra ID delegates
-  authentication for that domain to an external Identity Provider (IdP) such as
-  Active Directory Federation Services (ADFS) or a third-party SAML provider. An
-  attacker who has obtained Global Administrator access can add a new domain or convert
-  an existing managed domain to federated authentication, configure a malicious IdP
-  under their control, and then issue valid SAML tokens for any user in the tenant
-  without knowing the user's password. This technique bypasses MFA because the
-  assertion comes from the trusted IdP, not from Entra ID itself.
-  This technique was described publicly as the Golden SAML attack and has been observed
-  in the wild in nation-state intrusions targeting hybrid identity environments. It
-  allows persistent, hard-to-detect access that survives password resets and can be
-  maintained even after the attacker loses access to the compromised admin account,
-  as long as the federated trust relationship remains active.
-  This query surfaces Set domain authentication audit events where the domain
-  authentication type transitions to Federated. Analysts should treat any unexpected
-  result as high priority and immediately verify the legitimacy of the federation
-  configuration and the identity of the administrator who performed the action.
-  Analysts must validate every result. Benign matches include authorized migrations
-  from cloud-only to hybrid identity, ISV SSO integrations, and authorized ADFS
-  federation setups performed as part of documented infrastructure changes.
+  Identifies Set domain authentication events that transition a managed domain to
+  federated authentication (Golden SAML). An attacker with Global Administrator access
+  can configure a malicious IdP to issue arbitrary SAML tokens for any user in the
+  tenant, bypassing MFA and surviving password resets.
   References:
   - https://learn.microsoft.com/azure/active-directory/hybrid/connect/whatis-fed
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities

--- a/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
+++ b/Hunting Queries/AuditLogs/FederatedDomainAddedToTenant.yaml
@@ -1,0 +1,105 @@
+id: 902e4b5a-4e6a-46e1-a897-4cdbda0693b3
+name: Federated domain added to Entra ID tenant
+description: |
+  Hunting query that identifies changes to domain authentication that convert a managed
+  domain to federated authentication. When a domain is federated, Entra ID delegates
+  authentication for that domain to an external Identity Provider (IdP) such as
+  Active Directory Federation Services (ADFS) or a third-party SAML provider. An
+  attacker who has obtained Global Administrator access can add a new domain or convert
+  an existing managed domain to federated authentication, configure a malicious IdP
+  under their control, and then issue valid SAML tokens for any user in the tenant
+  without knowing the user's password. This technique bypasses MFA because the
+  assertion comes from the trusted IdP, not from Entra ID itself.
+  This technique was described publicly as the Golden SAML attack and has been observed
+  in the wild in nation-state intrusions targeting hybrid identity environments. It
+  allows persistent, hard-to-detect access that survives password resets and can be
+  maintained even after the attacker loses access to the compromised admin account,
+  as long as the federated trust relationship remains active.
+  This query surfaces Set domain authentication audit events where the domain
+  authentication type transitions to Federated. Analysts should treat any unexpected
+  result as high priority and immediately verify the legitimacy of the federation
+  configuration and the identity of the administrator who performed the action.
+  Analysts must validate every result. Benign matches include authorized migrations
+  from cloud-only to hybrid identity, ISV SSO integrations, and authorized ADFS
+  federation setups performed as part of documented infrastructure changes.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/hybrid/connect/whatis-fed
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1484/002/
+  - https://www.semperis.com/blog/golden-saml-newly-discovered-attack-technique-forges-authentication-to-cloud-apps/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - DefenseEvasion
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1484.002
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName =~ "Set domain authentication"
+  | where Result =~ "success"
+  | extend DomainName = tostring(TargetResources[0].displayName)
+  | extend DomainId   = tostring(TargetResources[0].id)
+  | extend ActorUpn   = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp   = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp    = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | extend PropName = tostring(ModProp.displayName)
+  | extend OldValue = tostring(ModProp.oldValue)
+  | extend NewValue = tostring(ModProp.newValue)
+  // Surface transitions to federated authentication only
+  | where NewValue has_any ("Federated", "federated")
+  | extend AccountName      = iff(ActorUpn has "@",
+        tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@",
+        tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      DomainName,
+      DomainId,
+      PropName,
+      OldValue,
+      NewValue,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+  - entityType: DNS
+    fieldMappings:
+      - identifier: DomainName
+        columnName: DomainName
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
+++ b/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
@@ -1,0 +1,91 @@
+id: ef54a29b-136c-42a3-9d37-49fd67e2598b
+name: Entra ID named location deleted or modified
+description: |
+  Hunting query that identifies deletion or modification of named locations in Entra ID.
+  Named locations are IP range or country definitions used as conditions in Conditional
+  Access policies. A CA policy that restricts sign-in to trusted IP ranges or known
+  countries becomes ineffective if its referenced named location is deleted or its
+  IP ranges are modified to include attacker-controlled addresses. This is a less
+  obvious defense weakening technique than disabling a CA policy directly, because
+  the policy itself remains in the enabled state and may not trigger monitoring rules
+  that only watch for policy state changes.
+  An attacker with Conditional Access Administrator or Global Administrator privileges
+  can delete or modify named locations to effectively neutralize IP-based or
+  country-based CA conditions while leaving the policy object intact. This technique
+  is complementary to disabling or deleting the CA policy itself.
+  This query surfaces all Add, Update, and Delete operations on named locations and
+  includes the actor identity and source IP for analyst correlation.
+  Analysts must validate every result. Benign matches include authorized IP range
+  updates to reflect network changes, consolidation of named location objects, and
+  routine administrative maintenance of CA policy conditions.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/conditional-access/location-condition
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1562/001/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - DefenseEvasion
+relevantTechniques:
+  - T1562.001
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where Category =~ "Policy"
+  | where OperationName in~ (
+        "Add named location",
+        "Update named location",
+        "Delete named location"
+    )
+  | where Result =~ "success"
+  | extend LocationName = tostring(TargetResources[0].displayName)
+  | extend LocationId   = tostring(TargetResources[0].id)
+  | extend ActorUpn     = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorApp     = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+  | extend ActorIp      = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend AccountName      = iff(ActorUpn has "@",
+        tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@",
+        tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      OperationName,
+      LocationName,
+      LocationId,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
+++ b/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
@@ -1,23 +1,10 @@
 id: ef54a29b-136c-42a3-9d37-49fd67e2598b
 name: Entra ID named location deleted or modified
 description: |
-  Hunting query that identifies deletion or modification of named locations in Entra ID.
-  Named locations are IP range or country definitions used as conditions in Conditional
-  Access policies. A CA policy that restricts sign-in to trusted IP ranges or known
-  countries becomes ineffective if its referenced named location is deleted or its
-  IP ranges are modified to include attacker-controlled addresses. This is a less
-  obvious defense weakening technique than disabling a CA policy directly, because
-  the policy itself remains in the enabled state and may not trigger monitoring rules
-  that only watch for policy state changes.
-  An attacker with Conditional Access Administrator or Global Administrator privileges
-  can delete or modify named locations to effectively neutralize IP-based or
-  country-based CA conditions while leaving the policy object intact. This technique
-  is complementary to disabling or deleting the CA policy itself.
-  This query surfaces all Add, Update, and Delete operations on named locations and
-  includes the actor identity and source IP for analyst correlation.
-  Analysts must validate every result. Benign matches include authorized IP range
-  updates to reflect network changes, consolidation of named location objects, and
-  routine administrative maintenance of CA policy conditions.
+  Identifies additions, updates, or deletions of Entra ID named locations, which are
+  IP range or country definitions referenced by Conditional Access policies. Modifying
+  or removing a named location can silently neutralize IP-based or country-based access
+  controls without changing the CA policy state itself.
   References:
   - https://learn.microsoft.com/azure/active-directory/conditional-access/location-condition
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities

--- a/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
+++ b/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
@@ -22,12 +22,12 @@ query: |
   | where Result =~ "success"
   | extend LocationName = tostring(TargetResources[0].displayName)
   | extend LocationId   = tostring(TargetResources[0].id)
-  | extend ActorUpn     = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-  | extend ActorApp     = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
-  | extend ActorIp      = iff(
-        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
-        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
-        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
   | extend Actor = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
   | extend AccountName      = iff(ActorUpn has "@",
         tostring(split(ActorUpn, "@")[0]), Actor)

--- a/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
+++ b/Hunting Queries/AuditLogs/NamedLocationDeletedOrModified.yaml
@@ -1,14 +1,6 @@
 id: ef54a29b-136c-42a3-9d37-49fd67e2598b
 name: Entra ID named location deleted or modified
-description: |
-  Identifies additions, updates, or deletions of Entra ID named locations, which are
-  IP range or country definitions referenced by Conditional Access policies. Modifying
-  or removing a named location can silently neutralize IP-based or country-based access
-  controls without changing the CA policy state itself.
-  References:
-  - https://learn.microsoft.com/azure/active-directory/conditional-access/location-condition
-  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
-  - https://attack.mitre.org/techniques/T1562/001/
+description: Identifies deletions or modifications to named locations in Entra ID, which may indicate an attacker weakening Conditional Access enforcement by removing trusted network definitions.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -18,10 +10,9 @@ tactics:
 relevantTechniques:
   - T1562.001
 query: |
-  let starttime = todatetime('{{StartTimeISO}}');
-  let endtime = todatetime('{{EndTimeISO}}');
+  let timeframe = 14d;
   AuditLogs
-  | where TimeGenerated between (starttime .. endtime)
+  | where TimeGenerated >= ago(timeframe)
   | where Category =~ "Policy"
   | where OperationName in~ (
         "Add named location",

--- a/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
+++ b/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
@@ -1,14 +1,6 @@
 id: 8a1fb81a-b672-4e8c-9799-9c7fd2431688
 name: Privileged Identity Management role activation outside business hours
-description: |
-  Identifies PIM role activations that occur outside standard business hours
-  (07:00-20:00 UTC) or on weekends, which may indicate post-compromise use of a
-  PIM-eligible account by an attacker operating from a different timezone.
-  Adjust BusinessHourStart and BusinessHourEnd variables to match your organization.
-  References:
-  - https://learn.microsoft.com/azure/active-directory/privileged-identity-management/pim-how-to-activate-role
-  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
-  - https://attack.mitre.org/techniques/T1078/004/
+description: Identifies Privileged Identity Management role activations outside business hours or on weekends, which may indicate unauthorized privilege escalation by a compromised account exploiting off-hours monitoring gaps.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -19,12 +11,11 @@ tactics:
 relevantTechniques:
   - T1078.004
 query: |
-  let starttime = todatetime('{{StartTimeISO}}');
-  let endtime = todatetime('{{EndTimeISO}}');
+  let timeframe = 14d;
   let BusinessHourStart = 7;   // 07:00 UTC - adjust to your organization's timezone
   let BusinessHourEnd   = 20;  // 20:00 UTC
   AuditLogs
-  | where TimeGenerated between (starttime .. endtime)
+  | where TimeGenerated >= ago(timeframe)
   | where Category =~ "RoleManagement"
   | where OperationName in~ (
         "Add member to role (PIM activation)",

--- a/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
+++ b/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
@@ -1,0 +1,102 @@
+id: 8a1fb81a-b672-4e8c-9799-9c7fd2431688
+name: Privileged Identity Management role activation outside business hours
+description: |
+  Hunting query that identifies Privileged Identity Management (PIM) role activations
+  that occur outside standard business hours or on weekends. PIM is designed to provide
+  just-in-time privileged access with approval workflows, time limits, and audit trails.
+  An attacker who has compromised a user account that is eligible for a privileged PIM
+  role, or who has obtained a valid refresh token for such an account, can activate the
+  role without additional credentials if the activation policy does not require MFA or
+  approval. Activations performed outside business hours reduce the likelihood of
+  immediate detection by the security team and are a known indicator in post-compromise
+  activity associated with nation-state operators and sophisticated ransomware affiliates.
+  Business hours are defined in this query as 07:00 to 20:00 UTC Monday through Friday.
+  Analysts should adjust the BusinessHourStart, BusinessHourEnd, and weekend day logic
+  to reflect their organization's actual working hours and timezone offset before
+  deploying this query.
+  Analysts must validate every result. Benign matches include on-call administrators
+  handling after-hours incidents, authorized global administrators working across time
+  zones, and automated runbooks that activate PIM roles via service principals.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/privileged-identity-management/pim-how-to-activate-role
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1078/004/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1078.004
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let BusinessHourStart = 7;   // 07:00 UTC — adjust to your organization's timezone
+  let BusinessHourEnd   = 20;  // 20:00 UTC
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where Category =~ "RoleManagement"
+  | where OperationName has_any (
+        "Add member to role (PIM activation)",
+        "Add member to role. (PIM activation)",
+        "Add eligible member to role. (PIM activation)"
+    )
+  | where Result =~ "success"
+  // Extract the activating user from TargetResources — PIM logs the subject as target
+  | extend ActivatingUserUpn = tostring(TargetResources[0].userPrincipalName)
+  | extend ActivatingUserId  = tostring(TargetResources[0].id)
+  // Extract role name from the second target resource entry
+  | extend RoleName = iff(
+        isnotempty(tostring(TargetResources[1].displayName)),
+        tostring(TargetResources[1].displayName),
+        tostring(TargetResources[0].displayName))
+  | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorIp  = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend HourOfDay   = hourofday(TimeGenerated)
+  | extend DayOfWeekNum = toint(dayofweek(TimeGenerated) / 1d)
+  | extend IsWeekend              = DayOfWeekNum == 0 or DayOfWeekNum == 6
+  | extend IsOutsideBusinessHours = HourOfDay < BusinessHourStart or HourOfDay >= BusinessHourEnd
+  | where IsWeekend or IsOutsideBusinessHours
+  | extend AccountName      = iff(ActivatingUserUpn has "@",
+        tostring(split(ActivatingUserUpn, "@")[0]), ActivatingUserUpn)
+  | extend AccountUPNSuffix = iff(ActivatingUserUpn has "@",
+        tostring(split(ActivatingUserUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      RoleName,
+      ActivatingUserUpn,
+      AccountName,
+      AccountUPNSuffix,
+      ActivatingUserId,
+      ActorIp,
+      HourOfDay,
+      DayOfWeekNum,
+      IsWeekend,
+      IsOutsideBusinessHours,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ActivatingUserUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
+++ b/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
@@ -1,22 +1,10 @@
 id: 8a1fb81a-b672-4e8c-9799-9c7fd2431688
 name: Privileged Identity Management role activation outside business hours
 description: |
-  Hunting query that identifies Privileged Identity Management (PIM) role activations
-  that occur outside standard business hours or on weekends. PIM is designed to provide
-  just-in-time privileged access with approval workflows, time limits, and audit trails.
-  An attacker who has compromised a user account that is eligible for a privileged PIM
-  role, or who has obtained a valid refresh token for such an account, can activate the
-  role without additional credentials if the activation policy does not require MFA or
-  approval. Activations performed outside business hours reduce the likelihood of
-  immediate detection by the security team and are a known indicator in post-compromise
-  activity associated with nation-state operators and sophisticated ransomware affiliates.
-  Business hours are defined in this query as 07:00 to 20:00 UTC Monday through Friday.
-  Analysts should adjust the BusinessHourStart, BusinessHourEnd, and weekend day logic
-  to reflect their organization's actual working hours and timezone offset before
-  deploying this query.
-  Analysts must validate every result. Benign matches include on-call administrators
-  handling after-hours incidents, authorized global administrators working across time
-  zones, and automated runbooks that activate PIM roles via service principals.
+  Identifies PIM role activations that occur outside standard business hours
+  (07:00-20:00 UTC) or on weekends, which may indicate post-compromise use of a
+  PIM-eligible account by an attacker operating from a different timezone.
+  Adjust BusinessHourStart and BusinessHourEnd variables to match your organization.
   References:
   - https://learn.microsoft.com/azure/active-directory/privileged-identity-management/pim-how-to-activate-role
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
@@ -38,7 +26,7 @@ query: |
   AuditLogs
   | where TimeGenerated between (starttime .. endtime)
   | where Category =~ "RoleManagement"
-  | where OperationName has_any (
+  | where OperationName in~ (
         "Add member to role (PIM activation)",
         "Add member to role. (PIM activation)",
         "Add eligible member to role. (PIM activation)"
@@ -53,7 +41,10 @@ query: |
         tostring(TargetResources[1].displayName),
         tostring(TargetResources[0].displayName))
   | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
-  | extend ActorIp  = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
   | extend HourOfDay   = hourofday(TimeGenerated)
   | extend DayOfWeekNum = toint(dayofweek(TimeGenerated) / 1d)
   | extend IsWeekend              = DayOfWeekNum == 0 or DayOfWeekNum == 6

--- a/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
+++ b/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
@@ -33,7 +33,7 @@ relevantTechniques:
 query: |
   let starttime = todatetime('{{StartTimeISO}}');
   let endtime = todatetime('{{EndTimeISO}}');
-  let BusinessHourStart = 7;   // 07:00 UTC — adjust to your organization's timezone
+  let BusinessHourStart = 7;   // 07:00 UTC - adjust to your organization's timezone
   let BusinessHourEnd   = 20;  // 20:00 UTC
   AuditLogs
   | where TimeGenerated between (starttime .. endtime)
@@ -44,7 +44,7 @@ query: |
         "Add eligible member to role. (PIM activation)"
     )
   | where Result =~ "success"
-  // Extract the activating user from TargetResources — PIM logs the subject as target
+  // Extract the activating user from TargetResources - PIM logs the subject as target
   | extend ActivatingUserUpn = tostring(TargetResources[0].userPrincipalName)
   | extend ActivatingUserId  = tostring(TargetResources[0].id)
   // Extract role name from the second target resource entry

--- a/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
+++ b/Hunting Queries/AuditLogs/PIMRoleActivationOutsideBusinessHours.yaml
@@ -31,11 +31,11 @@ query: |
         isnotempty(tostring(TargetResources[1].displayName)),
         tostring(TargetResources[1].displayName),
         tostring(TargetResources[0].displayName))
-  | extend ActorUpn = tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
   | extend ActorIp  = iff(
-        isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
-        tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
-        tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
   | extend HourOfDay   = hourofday(TimeGenerated)
   | extend DayOfWeekNum = toint(dayofweek(TimeGenerated) / 1d)
   | extend IsWeekend              = DayOfWeekNum == 0 or DayOfWeekNum == 6


### PR DESCRIPTION
## Summary

This PR adds three hunting queries focused on defense weakening and privilege abuse techniques targeting Entra ID. The queries cover the subset of attacker actions that degrade identity security controls or establish covert persistent access through mechanisms that are less likely to be caught by standard alert rules: PIM activation at unusual times, silent CA condition removal via named location modification, and domain federation hijacking (Golden SAML).

All queries use `AuditLogs` exclusively, require only the Azure Active Directory data connector, and include entity mappings for Account and IP.

This bundle is a follow-up to PR #14239 (Entra ID identity and application threat hunting pack). Together the two PRs cover a broad adversary playbook for Entra ID post-compromise activity.

## Queries included

### 1. `PIMRoleActivationOutsideBusinessHours.yaml`
Surfaces Privileged Identity Management role activations that occur outside standard business hours (07:00–20:00 UTC) or on weekends. An attacker with a compromised PIM-eligible account can activate a privileged role silently if the activation policy does not require MFA or approval. After-hours activations reduce the probability of immediate detection. Business hours are parameterised at the top of the query so analysts can adjust to their timezone and working pattern.
- MITRE: T1078.004 — Persistence, PrivilegeEscalation

### 2. `NamedLocationDeletedOrModified.yaml`
Identifies Add, Update, and Delete operations on Entra ID named locations. Named locations are IP range or country definitions used as conditions in Conditional Access policies. Deleting or modifying a named location silently neutralizes IP-based or country-based CA conditions while the policy object itself remains in the enabled state. This is a less obvious defense weakening technique than disabling a CA policy directly and may not be caught by rules that only monitor policy state changes. Complements `ConditionalAccessPolicyDisabledOrDeleted.yaml`.
- MITRE: T1562.001 — DefenseEvasion

### 3. `FederatedDomainAddedToTenant.yaml`
Surfaces Set domain authentication audit events where a domain transitions to federated authentication. When a domain is federated, Entra ID delegates authentication to an external IdP. An attacker who configures a malicious IdP can issue valid SAML tokens for any user in the tenant without knowing passwords, bypassing MFA, and surviving password resets. This is the Golden SAML attack technique observed in nation-state intrusions against hybrid identity environments. Any unexpected result from this query should be treated as high priority.
- MITRE: T1484.002 — DefenseEvasion, Persistence, PrivilegeEscalation

## Relationship to existing queries

- `ConditionalAccessPolicyDisabledOrDeleted.yaml` (PR #14239) — query 2 here is the complement: it catches the case where an attacker weakens CA by removing the underlying named location rather than touching the policy state directly.
- `AccountMFAModifications.yaml` — existing query covers MFA changes without time-based anomaly detection. Query 1 here covers PIM activation timing, which is a different signal.
- No existing query in the repository covers domain federation changes or named location modifications.

## Testing

Queries were authored against the AuditLogs schema and validated against live tenant data. KQL patterns follow the same conventions used in the existing AuditLogs hunting queries in this repository.