### PR TITLE
Add hunting queries: Entra ID cross-source correlation hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/MultipleDataSources/BulkRoleAssignmentsInShortWindow.yaml
+++ b/Hunting Queries/MultipleDataSources/BulkRoleAssignmentsInShortWindow.yaml
@@ -1,25 +1,10 @@
 id: 8d2cc40f-f0e0-49bf-8983-164f7be3975d
 name: Bulk role assignments performed by the same actor in a short window
 description: |
-  Hunting query that identifies actors who perform three or more Entra ID directory
-  role assignments within a ten-minute window. Legitimate role administration
-  typically involves individual, deliberate assignments. A high volume of role
-  assignments in a short period is consistent with automated post-compromise
-  persistence, where an attacker with privileged access rapidly grants directory
-  roles to multiple accounts under their control before the intrusion is detected
-  and remediated.
-  The query groups role assignment events by actor and ten-minute time bucket,
-  then flags actors who exceed the threshold. Results are enriched with the
-  actor's most recent sign-in country from SigninLogs to provide geographic
-  context for analyst triage. A bulk assignment performed from a country that
-  is unusual for the actor increases the severity of the finding.
-  The threshold of three assignments is intentionally low to avoid missing early
-  stages of an attack. Analysts should adjust the threshold variable to reduce
-  noise in environments where bulk role assignments are part of routine operations
-  such as provisioning workflows or automated onboarding pipelines.
-  Analysts must validate every result. Benign matches include automated provisioning
-  systems, helpdesk tools performing bulk user setup, and authorized mass role
-  migrations performed during tenant restructuring.
+  Identifies actors who perform three or more Entra ID directory role assignments
+  within a ten-minute window, consistent with automated post-compromise persistence.
+  Results are enriched with the actor's most recent sign-in country for analyst triage.
+  Adjust the threshold variable for environments with routine bulk provisioning workflows.
   References:
   - https://learn.microsoft.com/azure/active-directory/roles/permissions-reference
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities

--- a/Hunting Queries/MultipleDataSources/BulkRoleAssignmentsInShortWindow.yaml
+++ b/Hunting Queries/MultipleDataSources/BulkRoleAssignmentsInShortWindow.yaml
@@ -1,0 +1,118 @@
+id: 8d2cc40f-f0e0-49bf-8983-164f7be3975d
+name: Bulk role assignments performed by the same actor in a short window
+description: |
+  Hunting query that identifies actors who perform three or more Entra ID directory
+  role assignments within a ten-minute window. Legitimate role administration
+  typically involves individual, deliberate assignments. A high volume of role
+  assignments in a short period is consistent with automated post-compromise
+  persistence, where an attacker with privileged access rapidly grants directory
+  roles to multiple accounts under their control before the intrusion is detected
+  and remediated.
+  The query groups role assignment events by actor and ten-minute time bucket,
+  then flags actors who exceed the threshold. Results are enriched with the
+  actor's most recent sign-in country from SigninLogs to provide geographic
+  context for analyst triage. A bulk assignment performed from a country that
+  is unusual for the actor increases the severity of the finding.
+  The threshold of three assignments is intentionally low to avoid missing early
+  stages of an attack. Analysts should adjust the threshold variable to reduce
+  noise in environments where bulk role assignments are part of routine operations
+  such as provisioning workflows or automated onboarding pipelines.
+  Analysts must validate every result. Benign matches include automated provisioning
+  systems, helpdesk tools performing bulk user setup, and authorized mass role
+  migrations performed during tenant restructuring.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/roles/permissions-reference
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1098/003/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+      - SigninLogs
+tactics:
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1098.003
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let window = 10m;
+  let threshold = 3;
+  // Role assignment events expanded to extract the target user per event
+  let RoleAssignments =
+      AuditLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where OperationName =~ "Add member to role."
+      | where Result =~ "success"
+      | extend ActorUpn = tolower(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
+      | extend ActorApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+      | extend ActorIp  = iff(
+            isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+            tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
+            tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+      | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+      | mv-expand TargetResource = TargetResources
+      | where tostring(TargetResource.type) =~ "User"
+      | extend TargetUpn = tostring(TargetResource.userPrincipalName)
+      | where isnotempty(TargetUpn);
+  // Aggregate by actor and fixed ten-minute bucket, flag where count reaches threshold
+  let BulkActors =
+      RoleAssignments
+      | summarize
+          FirstAssignment = min(TimeGenerated),
+          LastAssignment  = max(TimeGenerated),
+          AssignedUsers   = make_set(TargetUpn),
+          AssignmentCount = count(),
+          ActorIp         = any(ActorIp)
+          by Actor, bin(TimeGenerated, window)
+      | where AssignmentCount >= threshold
+      | extend WindowDurationSeconds = datetime_diff('second', LastAssignment, FirstAssignment);
+  // Enrich with actor most recent sign-in country for geographic context
+  let ActorSignIns =
+      SigninLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where ResultType == 0
+      | extend ActorUpn = tolower(UserPrincipalName)
+      | summarize LastSignInTime = max(TimeGenerated) by ActorUpn, Location
+      | summarize arg_max(LastSignInTime, Location) by ActorUpn
+      | project ActorUpn, LastSignInCountry = Location;
+  BulkActors
+  | join kind=leftouter ActorSignIns on $left.Actor == $right.ActorUpn
+  | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
+  | project
+      FirstAssignment,
+      LastAssignment,
+      WindowDurationSeconds,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      AssignmentCount,
+      AssignedUsers,
+      LastSignInCountry
+  | sort by FirstAssignment desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/BulkRoleAssignmentsInShortWindow.yaml
+++ b/Hunting Queries/MultipleDataSources/BulkRoleAssignmentsInShortWindow.yaml
@@ -20,28 +20,29 @@ tactics:
 relevantTechniques:
   - T1098.003
 query: |
-  let starttime = todatetime('{{StartTimeISO}}');
-  let endtime = todatetime('{{EndTimeISO}}');
+  let timeframe = 1d;
   let window = 10m;
   let threshold = 3;
   // Role assignment events expanded to extract the target user per event
   let RoleAssignments =
       AuditLogs
-      | where TimeGenerated between (starttime .. endtime)
+      | where TimeGenerated >= ago(timeframe)
       | where OperationName =~ "Add member to role."
       | where Result =~ "success"
-      | extend ActorUpn = tolower(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
-      | extend ActorApp = tostring(parse_json(tostring(InitiatedBy.app)).displayName)
+      | extend ActorUpn = tolower(tostring(InitiatedBy.user.userPrincipalName))
+      | extend ActorApp = tostring(InitiatedBy.app.displayName)
       | extend ActorIp  = iff(
-            isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
-            tostring(parse_json(tostring(InitiatedBy.user)).ipAddress),
-            tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+            isnotempty(tostring(InitiatedBy.user.ipAddress)),
+            tostring(InitiatedBy.user.ipAddress),
+            tostring(InitiatedBy.app.ipAddress))
       | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
       | mv-expand TargetResource = TargetResources
       | where tostring(TargetResource.type) =~ "User"
       | extend TargetUpn = tostring(TargetResource.userPrincipalName)
       | where isnotempty(TargetUpn);
   // Aggregate by actor and fixed ten-minute bucket, flag where count reaches threshold
+  // Note: bin() uses fixed time buckets; assignments at bucket boundaries may be undercounted.
+  // For sliding-window accuracy, consider using a range join approach.
   let BulkActors =
       RoleAssignments
       | summarize
@@ -56,7 +57,7 @@ query: |
   // Enrich with actor most recent sign-in country for geographic context
   let ActorSignIns =
       SigninLogs
-      | where TimeGenerated between (starttime .. endtime)
+      | where TimeGenerated >= ago(timeframe)
       | where ResultType == 0
       | extend ActorUpn = tolower(UserPrincipalName)
       | summarize LastSignInTime = max(TimeGenerated) by ActorUpn, Location

--- a/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
+++ b/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
@@ -40,8 +40,10 @@ query: |
   | extend MethodType = tostring(TargetResources[0].displayName)
   | extend RegIp      = tostring(InitiatedBy.user.ipAddress)
   | where isnotempty(RegIp) and isnotempty(UserUpn)
-  // Join with IP baseline
-  | join kind=leftouter BaselineIPs on $left.UserUpn == $right.UserUpn
+  // Join with IP baseline; hint.strategy=broadcast pushes the smaller AuditLogs
+  // stream to all nodes holding BaselineIPs, avoiding an expensive shuffle join
+  // when the 30-day baseline is large relative to the 1-day event stream.
+  | join kind=leftouter hint.strategy=broadcast BaselineIPs on $left.UserUpn == $right.UserUpn
   // Flag registrations from IPs not present in the baseline, or users with no baseline at all
   | where isnull(KnownIPs) or not(set_has_element(KnownIPs, RegIp))
   | extend AccountName      = tostring(split(UserUpn, "@")[0])

--- a/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
+++ b/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
@@ -1,0 +1,98 @@
+id: 3d36b19f-cd62-4522-8869-23cdd9cc0c9f
+name: MFA method registered from an IP address not seen in user sign-in history
+description: |
+  Hunting query that identifies MFA method registration events where the source IP
+  address has not been observed in the registering user's successful sign-in history
+  during the previous 30 days. An attacker who has obtained a user's credentials may
+  register a new MFA method (authenticator app, phone number, FIDO key) from an
+  attacker-controlled IP to establish persistent authentication access that survives
+  a password reset. The IP-baseline approach surfaces registrations from network
+  origins that are genuinely new for that specific user, rather than flagging all
+  MFA registrations indiscriminately.
+  This query requires both AuditLogs and SigninLogs. The baseline uses successful
+  interactive sign-ins over 30 days to build a per-user set of known IP addresses.
+  Any MFA registration from an IP outside that set, or from a user with no sign-in
+  history in the baseline window, is surfaced for analyst review.
+  Analysts must validate every result. Benign matches include users registering MFA
+  from a new home network, hotel or travel Wi-Fi, a new corporate office, or a VPN
+  exit node not previously used for sign-in.
+  This query is complementary to HighRiskSignInAroundAuthMethodOrDeviceRegistration,
+  which correlates MFA registration with high-risk sign-in events and requires
+  Entra ID P2 licensing. This query does not require P2 and uses IP novelty as the
+  anomaly signal instead of identity protection risk scores.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/authentication/concept-mfa-howitworks
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1556/006/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+      - SigninLogs
+tactics:
+  - Persistence
+  - DefenseEvasion
+relevantTechniques:
+  - T1556.006
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let ipLookback = starttime - 30d;
+  // Build per-user baseline of IPs from successful sign-ins over the past 30 days
+  let BaselineIPs =
+      SigninLogs
+      | where TimeGenerated between (ipLookback .. starttime)
+      | where ResultType == 0
+      | where isnotempty(IPAddress)
+      | extend UserUpn = tolower(UserPrincipalName)
+      | summarize KnownIPs = make_set(IPAddress) by UserUpn;
+  // MFA registration events in the query window
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName =~ "User registered security info"
+  | where Result =~ "success"
+  | extend UserUpn    = tolower(tostring(TargetResources[0].userPrincipalName))
+  | extend UserId     = tostring(TargetResources[0].id)
+  | extend MethodType = tostring(TargetResources[0].displayName)
+  | extend RegIp      = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | where isnotempty(RegIp) and isnotempty(UserUpn)
+  // Join with IP baseline
+  | join kind=leftouter BaselineIPs on $left.UserUpn == $right.UserUpn
+  // Flag registrations from IPs not present in the baseline, or users with no baseline at all
+  | where isnull(KnownIPs) or not(set_has_element(KnownIPs, RegIp))
+  | extend AccountName      = tostring(split(UserUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
+  | project
+      TimeGenerated,
+      UserUpn,
+      AccountName,
+      AccountUPNSuffix,
+      UserId,
+      MethodType,
+      RegIp,
+      KnownIPCount = array_length(KnownIPs),
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: RegIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
+++ b/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
@@ -20,26 +20,25 @@ tactics:
 relevantTechniques:
   - T1556.006
 query: |
-  let starttime = todatetime('{{StartTimeISO}}');
-  let endtime = todatetime('{{EndTimeISO}}');
-  let ipLookback = starttime - 30d;
+  let timeframe = 1d;
+  let lookback = 30d;
   // Build per-user baseline of IPs from successful sign-ins over the past 30 days
   let BaselineIPs =
       SigninLogs
-      | where TimeGenerated between (ipLookback .. starttime)
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
       | where ResultType == 0
       | where isnotempty(IPAddress)
       | extend UserUpn = tolower(UserPrincipalName)
       | summarize KnownIPs = make_set(IPAddress) by UserUpn;
   // MFA registration events in the query window
   AuditLogs
-  | where TimeGenerated between (starttime .. endtime)
+  | where TimeGenerated >= ago(timeframe)
   | where OperationName =~ "User registered security info"
   | where Result =~ "success"
   | extend UserUpn    = tolower(tostring(TargetResources[0].userPrincipalName))
   | extend UserId     = tostring(TargetResources[0].id)
   | extend MethodType = tostring(TargetResources[0].displayName)
-  | extend RegIp      = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend RegIp      = tostring(InitiatedBy.user.ipAddress)
   | where isnotempty(RegIp) and isnotempty(UserUpn)
   // Join with IP baseline
   | join kind=leftouter BaselineIPs on $left.UserUpn == $right.UserUpn

--- a/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
+++ b/Hunting Queries/MultipleDataSources/MFARegistrationFromUnseenIP.yaml
@@ -1,25 +1,10 @@
 id: 3d36b19f-cd62-4522-8869-23cdd9cc0c9f
 name: MFA method registered from an IP address not seen in user sign-in history
 description: |
-  Hunting query that identifies MFA method registration events where the source IP
-  address has not been observed in the registering user's successful sign-in history
-  during the previous 30 days. An attacker who has obtained a user's credentials may
-  register a new MFA method (authenticator app, phone number, FIDO key) from an
-  attacker-controlled IP to establish persistent authentication access that survives
-  a password reset. The IP-baseline approach surfaces registrations from network
-  origins that are genuinely new for that specific user, rather than flagging all
-  MFA registrations indiscriminately.
-  This query requires both AuditLogs and SigninLogs. The baseline uses successful
-  interactive sign-ins over 30 days to build a per-user set of known IP addresses.
-  Any MFA registration from an IP outside that set, or from a user with no sign-in
-  history in the baseline window, is surfaced for analyst review.
-  Analysts must validate every result. Benign matches include users registering MFA
-  from a new home network, hotel or travel Wi-Fi, a new corporate office, or a VPN
-  exit node not previously used for sign-in.
-  This query is complementary to HighRiskSignInAroundAuthMethodOrDeviceRegistration,
-  which correlates MFA registration with high-risk sign-in events and requires
-  Entra ID P2 licensing. This query does not require P2 and uses IP novelty as the
-  anomaly signal instead of identity protection risk scores.
+  Identifies MFA method registration events where the source IP address has not
+  appeared in the registering user's 30-day sign-in history. An attacker who obtains
+  credentials may register a new MFA method from an attacker-controlled IP to maintain
+  access after a password reset. Does not require Entra ID P2 licensing.
   References:
   - https://learn.microsoft.com/azure/active-directory/authentication/concept-mfa-howitworks
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities

--- a/Hunting Queries/MultipleDataSources/SignInFromNewCountryWithSensitiveOperation.yaml
+++ b/Hunting Queries/MultipleDataSources/SignInFromNewCountryWithSensitiveOperation.yaml
@@ -23,9 +23,8 @@ relevantTechniques:
   - T1078.004
   - T1098
 query: |
-  let starttime = todatetime('{{StartTimeISO}}');
-  let endtime = todatetime('{{EndTimeISO}}');
-  let lookback = starttime - 30d;
+  let timeframe = 14d;
+  let lookback = 30d;
   let correlationWindow = 1h;
   let sensitiveOps = dynamic([
       "Add member to role.",
@@ -41,7 +40,7 @@ query: |
   // Build per-user baseline of countries from successful sign-ins over 30 days
   let BaselineCountries =
       SigninLogs
-      | where TimeGenerated between (lookback .. starttime)
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
       | where ResultType == 0
       | where isnotempty(Location)
       | extend UserUpn = tolower(UserPrincipalName)
@@ -49,7 +48,7 @@ query: |
   // Sign-ins from countries not in the user baseline
   let NewCountrySignIns =
       SigninLogs
-      | where TimeGenerated between (starttime .. endtime)
+      | where TimeGenerated >= ago(timeframe)
       | where ResultType == 0
       | where isnotempty(Location)
       | extend UserUpn = tolower(UserPrincipalName)
@@ -63,11 +62,11 @@ query: |
           AppDisplayName;
   // Sensitive AuditLogs operations correlated within the window
   AuditLogs
-  | where TimeGenerated between (starttime .. endtime)
-  | where OperationName has_any (sensitiveOps)
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName in~ (sensitiveOps)
   | where Result =~ "success"
-  | extend UserUpn    = tolower(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
-  | extend AuditIp    = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend UserUpn    = tolower(tostring(InitiatedBy.user.userPrincipalName))
+  | extend AuditIp    = tostring(InitiatedBy.user.ipAddress)
   | extend TargetName = tostring(TargetResources[0].displayName)
   | where isnotempty(UserUpn)
   | join kind=inner NewCountrySignIns on UserUpn

--- a/Hunting Queries/MultipleDataSources/SignInFromNewCountryWithSensitiveOperation.yaml
+++ b/Hunting Queries/MultipleDataSources/SignInFromNewCountryWithSensitiveOperation.yaml
@@ -1,0 +1,128 @@
+id: 271f4bf9-e387-48ef-a537-654bd53ca8e8
+name: Sign-in from new country followed by sensitive operation within one hour
+description: |
+  Hunting query that correlates a successful sign-in from a country not observed in
+  the user's 30-day sign-in history with a sensitive AuditLogs operation performed
+  by the same user within one hour of that sign-in. The combination of a geographically
+  novel access origin and an immediate high-value action is a strong indicator of
+  post-compromise activity where an attacker uses stolen credentials to sign in from
+  their own location and then immediately performs privilege escalation, persistence,
+  or data access operations.
+  Sensitive operations monitored include role member additions, application consent
+  grants, service principal credential additions, application registrations and
+  updates, Conditional Access policy changes, and domain authentication changes.
+  The 30-day country baseline is built from successful interactive sign-ins in
+  SigninLogs. Any sign-in from a country not present in that baseline is treated
+  as geographically novel for that user. The one-hour correlation window is
+  intentionally narrow to reduce false positives from users who travel and perform
+  legitimate administrative work.
+  Analysts must validate every result. Benign matches include administrators working
+  while traveling, global teams with members in different countries, and VPN or
+  proxy usage that changes the apparent country of sign-in.
+  References:
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
+  - https://learn.microsoft.com/azure/active-directory/reports-monitoring/concept-sign-ins
+  - https://attack.mitre.org/techniques/T1078/004/
+  - https://attack.mitre.org/techniques/T1098/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+      - AuditLogs
+tactics:
+  - InitialAccess
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1078.004
+  - T1098
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let lookback = starttime - 30d;
+  let correlationWindow = 1h;
+  let sensitiveOps = dynamic([
+      "Add member to role.",
+      "Consent to application",
+      "Add service principal credentials",
+      "Update application - Certificates and secrets management",
+      "Add application",
+      "Delete conditional access policy",
+      "Update conditional access policy",
+      "Set domain authentication",
+      "Add member to role (PIM activation)"
+  ]);
+  // Build per-user baseline of countries from successful sign-ins over 30 days
+  let BaselineCountries =
+      SigninLogs
+      | where TimeGenerated between (lookback .. starttime)
+      | where ResultType == 0
+      | where isnotempty(Location)
+      | extend UserUpn = tolower(UserPrincipalName)
+      | summarize KnownCountries = make_set(Location) by UserUpn;
+  // Sign-ins from countries not in the user baseline
+  let NewCountrySignIns =
+      SigninLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where ResultType == 0
+      | where isnotempty(Location)
+      | extend UserUpn = tolower(UserPrincipalName)
+      | join kind=leftouter BaselineCountries on $left.UserUpn == $right.UserUpn
+      | where isnull(KnownCountries) or not(set_has_element(KnownCountries, Location))
+      | project
+          SignInTime   = TimeGenerated,
+          UserUpn,
+          SignInIP     = IPAddress,
+          NewCountry   = Location,
+          AppDisplayName;
+  // Sensitive AuditLogs operations correlated within the window
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where OperationName has_any (sensitiveOps)
+  | where Result =~ "success"
+  | extend UserUpn    = tolower(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName))
+  | extend AuditIp    = tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)
+  | extend TargetName = tostring(TargetResources[0].displayName)
+  | where isnotempty(UserUpn)
+  | join kind=inner NewCountrySignIns on UserUpn
+  | where TimeGenerated between (SignInTime .. (SignInTime + correlationWindow))
+  | extend TimeDeltaMinutes = datetime_diff('minute', TimeGenerated, SignInTime)
+  | extend AccountName      = tostring(split(UserUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
+  | project
+      SignInTime,
+      OperationTime     = TimeGenerated,
+      TimeDeltaMinutes,
+      UserUpn,
+      AccountName,
+      AccountUPNSuffix,
+      NewCountry,
+      SignInIP,
+      AuditIp,
+      OperationName,
+      TargetName,
+      AppDisplayName
+  | sort by SignInTime desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SignInIP
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/SignInFromNewCountryWithSensitiveOperation.yaml
+++ b/Hunting Queries/MultipleDataSources/SignInFromNewCountryWithSensitiveOperation.yaml
@@ -1,24 +1,10 @@
 id: 271f4bf9-e387-48ef-a537-654bd53ca8e8
 name: Sign-in from new country followed by sensitive operation within one hour
 description: |
-  Hunting query that correlates a successful sign-in from a country not observed in
-  the user's 30-day sign-in history with a sensitive AuditLogs operation performed
-  by the same user within one hour of that sign-in. The combination of a geographically
-  novel access origin and an immediate high-value action is a strong indicator of
-  post-compromise activity where an attacker uses stolen credentials to sign in from
-  their own location and then immediately performs privilege escalation, persistence,
-  or data access operations.
-  Sensitive operations monitored include role member additions, application consent
-  grants, service principal credential additions, application registrations and
-  updates, Conditional Access policy changes, and domain authentication changes.
-  The 30-day country baseline is built from successful interactive sign-ins in
-  SigninLogs. Any sign-in from a country not present in that baseline is treated
-  as geographically novel for that user. The one-hour correlation window is
-  intentionally narrow to reduce false positives from users who travel and perform
-  legitimate administrative work.
-  Analysts must validate every result. Benign matches include administrators working
-  while traveling, global teams with members in different countries, and VPN or
-  proxy usage that changes the apparent country of sign-in.
+  Identifies successful sign-ins from a country absent in the user's 30-day history,
+  followed within one hour by a sensitive AuditLogs operation (role assignment, consent
+  grant, credential addition, CA policy change) by the same user. Correlates geographic
+  novelty with immediate high-value administrative action as a post-compromise signal.
   References:
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities
   - https://learn.microsoft.com/azure/active-directory/reports-monitoring/concept-sign-ins


### PR DESCRIPTION
## Summary

This PR adds three hunting queries that correlate data across multiple Entra ID log sources to surface post-compromise patterns that are not visible from a single table. All three queries use baseline periods to reduce noise and focus on genuinely anomalous activity rather than broad event collection.

This bundle follows PR #14239 (merged) and PR #14240 (open), continuing the same thematic focus on Entra ID identity threat detection.

## Queries included

### 1. `MFARegistrationFromUnseenIP.yaml`
Correlates AuditLogs MFA registration events (User registered security info) with a 30-day per-user IP baseline from SigninLogs. Flags any MFA method enrollment from an IP address not previously observed in that user's successful sign-in history. An attacker who obtains credentials may register an attacker-controlled authenticator before the victim notices, establishing persistent MFA-backed access that survives a password reset. This query does not require Entra ID P2 licensing and complements HighRiskSignInAroundAuthMethodOrDeviceRegistration, which requires risk scores.
- Tables: AuditLogs + SigninLogs
- MITRE: T1556.006 - Persistence, DefenseEvasion

### 2. `SignInFromNewCountryWithSensitiveOperation.yaml`
Correlates a successful sign-in from a country not observed in the user's 30-day baseline with a sensitive AuditLogs operation performed by the same user within one hour. Sensitive operations monitored include role member additions, application consent grants, service principal credential additions, application registrations, Conditional Access policy changes, domain authentication changes, and PIM activations. The narrow one-hour correlation window and country novelty baseline together produce a high-signal pattern consistent with stolen-credential access followed by immediate privilege abuse.
- Tables: SigninLogs + AuditLogs
- MITRE: T1078.004, T1098 - InitialAccess, Persistence, PrivilegeEscalation

### 3. `BulkRoleAssignmentsInShortWindow.yaml`
Flags actors who assign directory roles to three or more users within a ten-minute window, enriched with the actor's most recent sign-in country from SigninLogs. Legitimate role administration is deliberate and individual. A high volume of rapid role assignments is consistent with automated post-compromise persistence where an attacker grants directory roles to multiple controlled accounts before remediation occurs. The threshold is parameterised and can be adjusted per environment.
- Tables: AuditLogs + SigninLogs
- MITRE: T1098.003 - Persistence, PrivilegeEscalation

## Relationship to existing queries

- `DormantUserUpdateMFAandLogsIn.yaml` - existing query targets dormant accounts with no recent sign-in. Query 1 here targets any active user registering MFA from a new IP, which is a different and complementary signal.
- `HighRiskSignInAroundAuthMethodOrDeviceRegistration.yaml` - requires Entra ID P2 risk scores. Query 1 here uses IP novelty and requires no P2 licensing.
- No existing query in the repository correlates country-novel sign-ins with immediate sensitive operations, or detects bulk role assignment velocity.

## Testing

Queries were authored against the AuditLogs and SigninLogs schemas. KQL patterns and YAML structure follow the conventions of the existing MultipleDataSources hunting queries in this repository. All files were validated for non-ASCII characters before commit.