### PR TITLE
Add hunting queries: Entra ID token abuse and OAuth consent hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml
+++ b/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml
@@ -1,11 +1,9 @@
 id: 4519bc3b-1849-4f37-b98b-6e8d67b34c71
-name: Service Principal Credential Addition by Non-Historical Actor
+name: Service principal credential addition by non-historical actor
 description: |
-  Identifies service principal credential additions or updates performed by actors
-  with no history of this operation in the preceding 90 days. A new actor performing
-  this operation outside the established baseline may indicate credential abuse by a
-  compromised account. Differs from DormantServicePrincipalUpdateCredsandLogsIn by
-  baselining the initiating actor rather than the target service principal.
+  Identifies service principal credential additions or updates by actors with no history
+  of this operation in the preceding 90 days. A new actor outside the established
+  baseline may indicate credential abuse by a compromised account.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -17,7 +15,7 @@ relevantTechniques:
 query: |
   let timeframe = 1d;
   let lookback   = 90d;
-  let KnownActorSet = toscalar(
+  let KnownActors =
       AuditLogs
       | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
       | where OperationName in~ (
@@ -30,8 +28,7 @@ query: |
             tostring(InitiatedBy.user.userPrincipalName),
             tostring(InitiatedBy.app.displayName))
       | where isnotempty(Actor)
-      | summarize make_set(Actor)
-  );
+      | distinct Actor;
   AuditLogs
   | where TimeGenerated >= ago(timeframe)
   | where OperationName in~ (
@@ -49,7 +46,7 @@ query: |
   | extend TargetSP   = tostring(TargetResources[0].displayName)
   | extend TargetSpId = tostring(TargetResources[0].id)
   | where isnotempty(Actor)
-  | where not(set_has_element(KnownActorSet, Actor))
+  | join kind=leftanti KnownActors on Actor
   | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
   | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
   | project TimeGenerated, TargetSP, TargetSpId, Actor, AccountName,

--- a/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml
+++ b/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml
@@ -1,0 +1,80 @@
+id: 4519bc3b-1849-4f37-b98b-6e8d67b34c71
+name: Service Principal Credential Addition by Non-Historical Actor
+description: |
+  Identifies service principal credential additions or updates performed by actors
+  with no history of this operation in the preceding 90 days. A new actor performing
+  this operation outside the established baseline may indicate credential abuse by a
+  compromised account. Differs from DormantServicePrincipalUpdateCredsandLogsIn by
+  baselining the initiating actor rather than the target service principal.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1098.001
+query: |
+  let timeframe = 1d;
+  let lookback   = 90d;
+  let KnownActorSet = toscalar(
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
+      | where OperationName in~ (
+            "Add service principal credentials",
+            "Update application - Certificates and secrets management"
+        )
+      | where Result =~ "success"
+      | extend Actor = iff(
+            isnotempty(tostring(InitiatedBy.user.userPrincipalName)),
+            tostring(InitiatedBy.user.userPrincipalName),
+            tostring(InitiatedBy.app.displayName))
+      | where isnotempty(Actor)
+      | summarize make_set(Actor)
+  );
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName in~ (
+        "Add service principal credentials",
+        "Update application - Certificates and secrets management"
+    )
+  | where Result =~ "success"
+  | extend ActorUpn  = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp  = tostring(InitiatedBy.app.displayName)
+  | extend Actor     = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp   = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend TargetSP   = tostring(TargetResources[0].displayName)
+  | extend TargetSpId = tostring(TargetResources[0].id)
+  | where isnotempty(Actor)
+  | where not(set_has_element(KnownActorSet, Actor))
+  | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
+  | project TimeGenerated, TargetSP, TargetSpId, Actor, AccountName,
+            AccountUPNSuffix, ActorIp, OperationName, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
+++ b/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
@@ -1,11 +1,9 @@
 id: 2a2c676e-885f-43d9-90cb-2c035772e31c
-name: Anomalous Non-Interactive Token Issuance After Interactive Sign-In (AiTM Pattern)
+name: Anomalous non-interactive token issuance after interactive sign-in (AiTM pattern)
 description: |
-  Identifies non-interactive sign-ins from a different IP address and autonomous system
-  than the preceding interactive sign-in for the same user within a 10-minute window.
-  This pattern is consistent with AiTM phishing token replay, where a stolen session
-  token is used from the attacker's infrastructure shortly after the victim authenticates.
-  Complements PossibleAiTMPhishingAttemptAgainstAAD without requiring a proxy connector.
+  Identifies non-interactive sign-ins from a different IP and autonomous system than
+  the preceding interactive sign-in for the same user within a 10-minute window,
+  consistent with AiTM phishing token replay.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -25,9 +23,11 @@ query: |
       | where TimeGenerated >= ago(timeframe)
       | where ResultType == 0
       | where isnotempty(UserPrincipalName)
+      | summarize arg_max(TimeGenerated, IPAddress, AutonomousSystemNumber, CorrelationId)
+          by UserUpn = tolower(UserPrincipalName)
       | project
+          UserUpn,
           InteractiveTime = TimeGenerated,
-          UserUpn         = tolower(UserPrincipalName),
           InteractiveIp   = IPAddress,
           InteractiveAsn  = AutonomousSystemNumber,
           SessionId       = CorrelationId;

--- a/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
+++ b/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
@@ -30,7 +30,7 @@ query: |
           UserUpn           = tolower(UserPrincipalName),
           InteractiveIp     = IPAddress,
           InteractiveAsn    = AutonomousSystemNumber,
-          InteractiveDevice = tostring(DeviceDetail.deviceId),
+          InteractiveDevice = tostring(DeviceDetail["deviceId"]),
           SessionId         = CorrelationId;
   AADNonInteractiveUserSignInLogs
   | where TimeGenerated >= ago(timeframe)
@@ -41,8 +41,8 @@ query: |
   | where TimeGenerated between (InteractiveTime .. (InteractiveTime + correlationWindow))
   | where IPAddress != InteractiveIp
   | where AutonomousSystemNumber != InteractiveAsn
-  | where isempty(tostring(DeviceDetail.deviceId))
-        or tostring(DeviceDetail.deviceId) != InteractiveDevice
+  | where isempty(tostring(DeviceDetail["deviceId"]))
+        or tostring(DeviceDetail["deviceId"]) != InteractiveDevice
   | extend AccountName      = tostring(split(UserUpn, "@")[0])
   | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
   | project

--- a/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
+++ b/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
@@ -26,12 +26,11 @@ query: |
       | where ResultType == 0
       | where isnotempty(UserPrincipalName)
       | project
-          InteractiveTime   = TimeGenerated,
-          UserUpn           = tolower(UserPrincipalName),
-          InteractiveIp     = IPAddress,
-          InteractiveAsn    = AutonomousSystemNumber,
-          InteractiveDevice = tostring(DeviceDetail["deviceId"]),
-          SessionId         = CorrelationId;
+          InteractiveTime = TimeGenerated,
+          UserUpn         = tolower(UserPrincipalName),
+          InteractiveIp   = IPAddress,
+          InteractiveAsn  = AutonomousSystemNumber,
+          SessionId       = CorrelationId;
   AADNonInteractiveUserSignInLogs
   | where TimeGenerated >= ago(timeframe)
   | where ResultType == 0
@@ -41,8 +40,6 @@ query: |
   | where TimeGenerated between (InteractiveTime .. (InteractiveTime + correlationWindow))
   | where IPAddress != InteractiveIp
   | where AutonomousSystemNumber != InteractiveAsn
-  | where isempty(tostring(DeviceDetail["deviceId"]))
-        or tostring(DeviceDetail["deviceId"]) != InteractiveDevice
   | extend AccountName      = tostring(split(UserUpn, "@")[0])
   | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
   | project

--- a/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
+++ b/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
@@ -1,0 +1,84 @@
+id: 2a2c676e-885f-43d9-90cb-2c035772e31c
+name: Anomalous Non-Interactive Token Issuance After Interactive Sign-In (AiTM Pattern)
+description: |
+  Identifies non-interactive sign-ins from a different IP address and autonomous system
+  than the preceding interactive sign-in for the same user within a 10-minute window.
+  This pattern is consistent with AiTM phishing token replay, where a stolen session
+  token is used from the attacker's infrastructure shortly after the victim authenticates.
+  Complements PossibleAiTMPhishingAttemptAgainstAAD without requiring a proxy connector.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+      - AADNonInteractiveUserSignInLogs
+tactics:
+  - InitialAccess
+  - CredentialAccess
+relevantTechniques:
+  - T1539
+  - T1550
+query: |
+  let timeframe = 1d;
+  let correlationWindow = 10m;
+  let InteractiveSessions =
+      SigninLogs
+      | where TimeGenerated >= ago(timeframe)
+      | where ResultType == 0
+      | where isnotempty(UserPrincipalName)
+      | project
+          InteractiveTime   = TimeGenerated,
+          UserUpn           = tolower(UserPrincipalName),
+          InteractiveIp     = IPAddress,
+          InteractiveAsn    = AutonomousSystemNumber,
+          InteractiveDevice = tostring(DeviceDetail.deviceId),
+          SessionId         = CorrelationId;
+  AADNonInteractiveUserSignInLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where ResultType == 0
+  | where isnotempty(UserPrincipalName)
+  | extend UserUpn = tolower(UserPrincipalName)
+  | join kind=inner InteractiveSessions on UserUpn
+  | where TimeGenerated between (InteractiveTime .. (InteractiveTime + correlationWindow))
+  | where IPAddress != InteractiveIp
+  | where AutonomousSystemNumber != InteractiveAsn
+  | where isempty(tostring(DeviceDetail.deviceId))
+        or tostring(DeviceDetail.deviceId) != InteractiveDevice
+  | extend AccountName      = tostring(split(UserUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
+  | project
+      TimeGenerated,
+      UserUpn,
+      AccountName,
+      AccountUPNSuffix,
+      AppDisplayName,
+      NonInteractiveIp  = IPAddress,
+      NonInteractiveAsn = AutonomousSystemNumber,
+      InteractiveIp,
+      InteractiveAsn,
+      InteractiveTime,
+      SessionId,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: NonInteractiveIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/OAuthConsentToHighRiskPermissionScope.yaml
+++ b/Hunting Queries/MultipleDataSources/OAuthConsentToHighRiskPermissionScope.yaml
@@ -1,0 +1,84 @@
+id: 2a166359-a104-4d72-93ae-643ae69bf801
+name: OAuth Application Consent to High-Risk Permission Scope
+description: |
+  Identifies OAuth application consent events where high-risk permissions were granted,
+  including application-level permissions such as Directory.ReadWrite.All or
+  RoleManagement.ReadWrite.Directory. Flags apps with no consent history in the tenant
+  over the past 90 days. Complements SuspiciousOAuthApp_OfflineAccess by covering
+  application permissions and admin consent grants not included in that detection.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - CredentialAccess
+relevantTechniques:
+  - T1528
+query: |
+  let timeframe = 1d;
+  let lookback = 90d;
+  let HighRiskScopes = dynamic([
+      "RoleManagement.ReadWrite.Directory",
+      "Application.ReadWrite.All",
+      "AppRoleAssignment.ReadWrite.All",
+      "Directory.ReadWrite.All",
+      "User.ReadWrite.All",
+      "Mail.ReadWrite",
+      "Mail.Send",
+      "Files.ReadWrite.All",
+      "full_access_as_app"
+  ]);
+  let KnownAppSet = toscalar(
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
+      | where OperationName =~ "Consent to application"
+      | extend AppId = tostring(TargetResources[0].id)
+      | summarize make_set(AppId)
+  );
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName =~ "Consent to application"
+  | where Result =~ "success"
+  | extend AppId    = tostring(TargetResources[0].id)
+  | extend AppName  = tostring(TargetResources[0].displayName)
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | where tostring(ModProp.displayName) =~ "ConsentContext.Permissions"
+  | extend GrantedPermissions = tostring(ModProp.newValue)
+  | where GrantedPermissions has_any (HighRiskScopes)
+  | extend IsNewApp = not(set_has_element(KnownAppSet, AppId))
+  | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
+  | project TimeGenerated, AppName, AppId, GrantedPermissions, Actor,
+            AccountName, AccountUPNSuffix, ActorIp, IsNewApp, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/OAuthConsentToHighRiskPermissionScope.yaml
+++ b/Hunting Queries/MultipleDataSources/OAuthConsentToHighRiskPermissionScope.yaml
@@ -1,11 +1,9 @@
 id: 2a166359-a104-4d72-93ae-643ae69bf801
-name: OAuth Application Consent to High-Risk Permission Scope
+name: OAuth application consent to high-risk permission scope
 description: |
-  Identifies OAuth application consent events where high-risk permissions were granted,
-  including application-level permissions such as Directory.ReadWrite.All or
-  RoleManagement.ReadWrite.Directory. Flags apps with no consent history in the tenant
-  over the past 90 days. Complements SuspiciousOAuthApp_OfflineAccess by covering
-  application permissions and admin consent grants not included in that detection.
+  Identifies OAuth application consent events where high-risk permissions such as
+  Directory.ReadWrite.All or RoleManagement.ReadWrite.Directory were granted to apps
+  with no prior tenant consent history in the preceding 90 days.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -29,13 +27,12 @@ query: |
       "Files.ReadWrite.All",
       "full_access_as_app"
   ]);
-  let KnownAppSet = toscalar(
+  let KnownApps =
       AuditLogs
       | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
       | where OperationName =~ "Consent to application"
       | extend AppId = tostring(TargetResources[0].id)
-      | summarize make_set(AppId)
-  );
+      | distinct AppId;
   AuditLogs
   | where TimeGenerated >= ago(timeframe)
   | where OperationName =~ "Consent to application"
@@ -53,11 +50,11 @@ query: |
   | where tostring(ModProp.displayName) =~ "ConsentContext.Permissions"
   | extend GrantedPermissions = tostring(ModProp.newValue)
   | where GrantedPermissions has_any (HighRiskScopes)
-  | extend IsNewApp = not(set_has_element(KnownAppSet, AppId))
+  | join kind=leftanti KnownApps on AppId
   | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
   | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
   | project TimeGenerated, AppName, AppId, GrantedPermissions, Actor,
-            AccountName, AccountUPNSuffix, ActorIp, IsNewApp, CorrelationId
+            AccountName, AccountUPNSuffix, ActorIp, CorrelationId
   | sort by TimeGenerated desc
 entityMappings:
   - entityType: Account


### PR DESCRIPTION
## Summary

Three new hunting queries covering Entra ID token theft and OAuth abuse techniques active in recent campaigns (Storm-0558, Midnight Blizzard, AiTM phishing waves 2024-2025). Each query targets a detection gap not covered by existing content in the repo.

### Queries added

**`Hunting Queries/MultipleDataSources/OAuthConsentToHighRiskPermissionScope.yaml`**

Detects OAuth application consent events where high-risk permissions were granted (RoleManagement.ReadWrite.Directory, Application.ReadWrite.All, AppRoleAssignment.ReadWrite.All, Directory.ReadWrite.All, full_access_as_app, and others). Uses a 90-day tenant baseline to flag apps with no prior consent history. Covers application-level permissions and admin consent grants not included in SuspiciousOAuthApp_OfflineAccess.

Tables: `AuditLogs`
MITRE: T1528 (Steal Application Access Token) — Persistence, CredentialAccess

**`Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml`**

Identifies non-interactive sign-ins from a different IP address and autonomous system than the preceding interactive sign-in for the same user within a 10-minute window. This pattern is consistent with AiTM phishing token replay, where a stolen session token is used from attacker infrastructure shortly after the victim authenticates. Does not require a proxy connector — complements PossibleAiTMPhishingAttemptAgainstAAD.

Tables: `SigninLogs`, `AADNonInteractiveUserSignInLogs`
MITRE: T1539 (Steal Web Session Cookie), T1550 (Use Alternate Authentication Material) — InitialAccess, CredentialAccess

**`Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml`**

Flags credential additions to Service Principals (password or key) by actors with no history of performing this action in the past 90 days. Baselines the initiating identity rather than the Service Principal object, catching compromised privileged accounts and newly granted App Admin roles used for persistence. Differentiator from DormantServicePrincipalUpdateCredsandLogsIn, which baselines the SP object.

Tables: `AuditLogs`
MITRE: T1098.001 (Additional Cloud Credentials) — Persistence

## Test notes

All three queries were validated against the KQL syntax checklist used in prior PRs from this author (#14173, #14207, #14208, #14213, #14239):

- `in~` used for all OperationName comparisons (not `has_any`)
- `InitiatedBy.user.*` / `InitiatedBy.app.*` accessed directly without `parse_json(tostring(...))`
- Timeframe variables declared at the top of each query
- Descriptions under 500 characters, each starting with "Identifies"
- Entity mappings include Account and IP where applicable
- Non-ASCII scan passed on all three files

## Related

These queries complement but do not duplicate:
- `SuspiciousOAuthApp_OfflineAccess.yaml` — covers offline_access delegated scope; our query covers application permissions and admin consent
- `DormantServicePrincipalUpdateCredsandLogsIn.yaml` — baselines SP object; our query baselines the actor
- `PossibleAiTMPhishingAttemptAgainstAAD.yaml` — requires MDCA proxy connector; our query uses native AAD sign-in logs only