### PR TITLE
Snowflake CCP: fix under-ingestion by streaming events per-row 

### DIFF
--- a/Solutions/Snowflake/Data Connectors/SnowflakeLogs_ccp/SnowflakeLogs_DCR.json
+++ b/Solutions/Snowflake/Data Connectors/SnowflakeLogs_ccp/SnowflakeLogs_DCR.json
@@ -104,7 +104,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeLoad_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -114,7 +114,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeLogin_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -124,7 +124,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeMaterializedView_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -134,7 +134,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeQuery_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -144,7 +144,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeRoleGrant_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -154,7 +154,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeRoles_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -164,7 +164,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeTables_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -174,7 +174,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeTableStorageMetrics_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -184,7 +184,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeUserGrant_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       },
       {
         "streams": [
@@ -194,7 +194,7 @@
           "clv2ws1"
         ],
         "outputStream": "Custom-SnowflakeUsers_CL",
-        "transformKql": "source \r\n| extend Data = tostring(data), TimeGenerated = now() \r\n| where Data !contains \"[]\"\r\n| project TimeGenerated, Data"
+        "transformKql": "source\r\n| extend rawRow = todynamic(data)\r\n| extend evt = todynamic(tostring(rawRow[0]))\r\n| extend Data = tostring(pack_array(evt))\r\n| extend TimeGenerated = now()\r\n| where isnotempty(Data)\r\n| project TimeGenerated, Data"
       }
     ]
   }

--- a/Solutions/Snowflake/Data Connectors/SnowflakeLogs_ccp/SnowflakeLogs_PollingConfig.json
+++ b/Solutions/Snowflake/Data Connectors/SnowflakeLogs_ccp/SnowflakeLogs_PollingConfig.json
@@ -33,7 +33,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -62,7 +62,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -87,7 +87,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -116,7 +116,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -141,7 +141,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -170,7 +170,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -195,7 +195,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -224,7 +224,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -249,7 +249,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -278,7 +278,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -303,7 +303,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -332,7 +332,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -357,7 +357,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -386,7 +386,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -411,7 +411,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -440,7 +440,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -465,7 +465,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },
@@ -494,7 +494,7 @@
     "properties": {
       "auth": {
         "type": "APIKey",
-        "ApiKey": "{{apiKey}}",
+        "ApiKey": "{{apikey}}",
         "ApiKeyName": "Authorization",
         "ApiKeyIdentifier": "Bearer"
       },
@@ -519,7 +519,7 @@
       },
       "response": {
         "eventsJsonPaths": [
-          "$"
+          "$.data[*]"
         ],
         "format": "json"
       },


### PR DESCRIPTION
The Snowflake CCP connector was silently dropping rows whenever a response page's serialized JSON contained the literal substring '[]' anywhere - including in metadata blocks like "partitionInfo":[] or "parameters":[].

The old transform 'where Data !contains "[]"' inspected the entire serialized page, so a single empty metadata array caused every event in that page to be discarded.

Customer impact (documented case): 4,652 LOGIN_HISTORY events for a 2-hour window appeared in Sentinel as only ~1,209 (~26%). Surviving rows happened to live in partitions whose page-JSON did not contain '[]'.

Fix :

1. Change response JSONPath from "$" to "$.data[*]" so the Poller streams events per-row and page-level metadata never reaches the DCR transform.

2. Remove the page-killing 'where Data !contains "[]"' filter.

3. Use pack_array(evt) in the new transform so the existing Snowflake() ASIM parser (mv-expand OuterArray = todynamic(Data)) continues to work unchanged - fully backward compatible.

4. Keep TimeGenerated = now() (event-time conversion deferred to a follow-up PR).

Source-of-truth files only:

- Solutions/Snowflake/Data Connectors/SnowflakeLogs_ccp/SnowflakeLogs_DCR.json

- Solutions/Snowflake/Data Connectors/SnowflakeLogs_ccp/SnowflakeLogs_PollingConfig.json

Solutions/Snowflake/Package/mainTemplate.json will be regenerated by the standard solution-build pipeline in a follow-up version-bump PR; not touched here to keep the diff minimal and focused.

Generator-side commit in the internal ca-3p-connectors repo: users/krishnachi/snowflake-fix @ 7bd1f6cf

   Required items, please complete
   
   Change(s):
   - See guidance below

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


# Guidance <- remove section before submitting
-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for XYZ.yaml

   Reason for Change(s):
   - New schema used for XYZ.yaml
   - Resolves ISSUE #1234

   Version updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

_Note: If updating a detection, you must update the version field._

> Before the submission has been made, please look at running the KQL and Yaml Validation Checks locally.
> https://github.com/Azure/Azure-Sentinel#run-kql-validation-locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
