### PR TITLE
Add hunting queries: Entra ID workload identity and privileged role hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/ApplicationAppRoleAssignedHighPrivilege.yaml
+++ b/Hunting Queries/AuditLogs/ApplicationAppRoleAssignedHighPrivilege.yaml
@@ -1,0 +1,71 @@
+id: 840c673e-a712-49eb-a6a9-6759d5259c4b
+name: High-privilege application role assigned to service principal
+description: Identifies application role assignments to service principals where the granted role includes permissions such as Mail.ReadWrite, Directory.ReadWrite.All, or RoleManagement.ReadWrite.Directory. Application-level permissions grant tenant-wide access without user context and are not bound by MFA or Conditional Access policies.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - CredentialAccess
+relevantTechniques:
+  - T1098.003
+  - T1528
+query: |
+  let timeframe = 1d;
+  let HighRiskRoles = dynamic([
+      "Mail.ReadWrite",
+      "Mail.Send",
+      "Files.ReadWrite.All",
+      "Directory.ReadWrite.All",
+      "RoleManagement.ReadWrite.Directory",
+      "Application.ReadWrite.All",
+      "AppRoleAssignment.ReadWrite.All",
+      "User.ReadWrite.All",
+      "full_access_as_app"
+  ]);
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName =~ "Add app role assignment to service principal"
+  | where Result =~ "success"
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend TargetSpName = tostring(TargetResources[0].displayName)
+  | extend TargetSpId   = tostring(TargetResources[0].id)
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | where tostring(ModProp.displayName) =~ "AppRole.Value"
+  | extend AppRoleName = trim('"', tostring(ModProp.newValue))
+  | where AppRoleName in~ (HighRiskRoles)
+  | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
+  | project TimeGenerated, Actor, AccountName, AccountUPNSuffix, ActorIp,
+            TargetSpName, TargetSpId, AppRoleName, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/ApplicationAppRoleAssignedHighPrivilege.yaml
+++ b/Hunting Queries/AuditLogs/ApplicationAppRoleAssignedHighPrivilege.yaml
@@ -1,6 +1,10 @@
 id: 840c673e-a712-49eb-a6a9-6759d5259c4b
 name: High-privilege application role assigned to service principal
-description: Identifies application role assignments to service principals where the granted role includes permissions such as Mail.ReadWrite, Directory.ReadWrite.All, or RoleManagement.ReadWrite.Directory. Application-level permissions grant tenant-wide access without user context and are not bound by MFA or Conditional Access policies.
+description: |
+  Identifies application role assignments to service principals granting high-risk
+  permissions such as Mail.ReadWrite, Directory.ReadWrite.All, or
+  RoleManagement.ReadWrite.Directory, which provide tenant-wide API access
+  without user context.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:

--- a/Hunting Queries/AuditLogs/DirectoryRoleAssignedOutsidePIM.yaml
+++ b/Hunting Queries/AuditLogs/DirectoryRoleAssignedOutsidePIM.yaml
@@ -1,6 +1,9 @@
 id: 2df6ff4f-f90f-4158-ac4a-98c1b23d9e18
 name: Privileged directory role assigned outside PIM workflow
-description: Identifies permanent directory role assignments to privileged roles made outside the Privileged Identity Management activation workflow. Direct assignments bypass PIM approval and justification requirements. Complements PIMRoleActivationOutsideBusinessHours by covering the non-PIM assignment path used in post-compromise persistence.
+description: |
+  Identifies permanent directory role assignments to privileged roles made outside
+  the Privileged Identity Management activation workflow. Direct assignments bypass
+  PIM approval and justification requirements.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -43,10 +46,12 @@ query: |
   | where tostring(ModProp.displayName) =~ "Role.DisplayName"
   | extend RoleName = trim('"', tostring(ModProp.newValue))
   | where RoleName in~ (PrivilegedRoles)
+  | extend ActorName        = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend ActorUPNSuffix   = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
   | extend AccountName      = iff(TargetUpn has "@", tostring(split(TargetUpn, "@")[0]), TargetUpn)
   | extend AccountUPNSuffix = iff(TargetUpn has "@", tostring(split(TargetUpn, "@")[1]), "")
-  | project TimeGenerated, Actor, ActorIp, TargetUpn, AccountName, AccountUPNSuffix,
-            TargetId, RoleName, CorrelationId
+  | project TimeGenerated, Actor, ActorName, ActorUPNSuffix, ActorIp,
+            TargetUpn, AccountName, AccountUPNSuffix, TargetId, RoleName, CorrelationId
   | sort by TimeGenerated desc
 entityMappings:
   - entityType: Account
@@ -54,13 +59,17 @@ entityMappings:
       - identifier: FullName
         columnName: Actor
       - identifier: Name
-        columnName: AccountName
+        columnName: ActorName
       - identifier: UPNSuffix
-        columnName: AccountUPNSuffix
+        columnName: ActorUPNSuffix
   - entityType: Account
     fieldMappings:
       - identifier: FullName
         columnName: TargetUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
   - entityType: IP
     fieldMappings:
       - identifier: Address

--- a/Hunting Queries/AuditLogs/DirectoryRoleAssignedOutsidePIM.yaml
+++ b/Hunting Queries/AuditLogs/DirectoryRoleAssignedOutsidePIM.yaml
@@ -1,0 +1,77 @@
+id: 2df6ff4f-f90f-4158-ac4a-98c1b23d9e18
+name: Privileged directory role assigned outside PIM workflow
+description: Identifies permanent directory role assignments to privileged roles made outside the Privileged Identity Management activation workflow. Direct assignments bypass PIM approval and justification requirements. Complements PIMRoleActivationOutsideBusinessHours by covering the non-PIM assignment path used in post-compromise persistence.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1098.003
+query: |
+  let timeframe = 14d;
+  let PrivilegedRoles = dynamic([
+      "Global Administrator",
+      "Privileged Role Administrator",
+      "Application Administrator",
+      "Cloud Application Administrator",
+      "Exchange Administrator",
+      "SharePoint Administrator",
+      "User Account Administrator",
+      "Authentication Administrator",
+      "Privileged Authentication Administrator",
+      "Security Administrator",
+      "Hybrid Identity Administrator"
+  ]);
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where Category =~ "RoleManagement"
+  | where OperationName =~ "Add member to role."
+  | where Result =~ "success"
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend TargetUpn = tostring(TargetResources[0].userPrincipalName)
+  | extend TargetId  = tostring(TargetResources[0].id)
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | where tostring(ModProp.displayName) =~ "Role.DisplayName"
+  | extend RoleName = trim('"', tostring(ModProp.newValue))
+  | where RoleName in~ (PrivilegedRoles)
+  | extend AccountName      = iff(TargetUpn has "@", tostring(split(TargetUpn, "@")[0]), TargetUpn)
+  | extend AccountUPNSuffix = iff(TargetUpn has "@", tostring(split(TargetUpn, "@")[1]), "")
+  | project TimeGenerated, Actor, ActorIp, TargetUpn, AccountName, AccountUPNSuffix,
+            TargetId, RoleName, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: TargetUpn
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/WorkloadIdentitySignInFromNewCountry.yaml
+++ b/Hunting Queries/MultipleDataSources/WorkloadIdentitySignInFromNewCountry.yaml
@@ -1,0 +1,50 @@
+id: e366bd25-400c-433f-b984-c5b8aece15f2
+name: Workload identity sign-in from a country not in 30-day baseline
+description: Identifies service principal sign-ins from a country not present in the SP's 30-day sign-in history. Workload identities with stable infrastructure rarely authenticate from new geographies. A new-country sign-in may indicate stolen client credentials or a compromised CI/CD pipeline replaying credentials from attacker infrastructure.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AADServicePrincipalSignInLogs
+tactics:
+  - InitialAccess
+  - CredentialAccess
+relevantTechniques:
+  - T1078.004
+query: |
+  let timeframe = 1d;
+  let lookback = 30d;
+  let BaselineCountries =
+      AADServicePrincipalSignInLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
+      | where ResultType == 0
+      | where isnotempty(Location)
+      | summarize KnownCountries = make_set(Location) by ServicePrincipalId;
+  AADServicePrincipalSignInLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where ResultType == 0
+  | where isnotempty(Location)
+  | join kind=leftouter hint.strategy=broadcast BaselineCountries on ServicePrincipalId
+  | where isnull(KnownCountries) or not(set_has_element(KnownCountries, Location))
+  | extend AccountName = ServicePrincipalName
+  | project TimeGenerated, ServicePrincipalId, ServicePrincipalName, AccountName,
+            AppId, Location, IPAddress, ResourceDisplayName, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: ServicePrincipalName
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPAddress
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/WorkloadIdentitySignInFromNewCountry.yaml
+++ b/Hunting Queries/MultipleDataSources/WorkloadIdentitySignInFromNewCountry.yaml
@@ -1,6 +1,9 @@
 id: e366bd25-400c-433f-b984-c5b8aece15f2
-name: Workload identity sign-in from a country not in 30-day baseline
-description: Identifies service principal sign-ins from a country not present in the SP's 30-day sign-in history. Workload identities with stable infrastructure rarely authenticate from new geographies. A new-country sign-in may indicate stolen client credentials or a compromised CI/CD pipeline replaying credentials from attacker infrastructure.
+name: Workload identity sign-in from a country not in 14-day baseline
+description: |
+  Identifies service principal sign-ins from a country not present in the SP's
+  sign-in history over the preceding 14 days. A new-country sign-in for a workload
+  identity may indicate stolen client credentials or a compromised pipeline.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
     dataTypes:
@@ -12,7 +15,7 @@ relevantTechniques:
   - T1078.004
 query: |
   let timeframe = 1d;
-  let lookback = 30d;
+  let lookback = 14d;
   let BaselineCountries =
       AADServicePrincipalSignInLogs
       | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)


### PR DESCRIPTION
## Summary

Three hunting queries targeting workload identity abuse and privileged role assignment anomalies — a detection area with limited existing coverage in the repo and high relevance to active threat actor techniques (Storm-0558, Midnight Blizzard, post-compromise persistence patterns documented in 2024-2025 Microsoft incident response guidance).

### Queries added

**`Hunting Queries/AuditLogs/DirectoryRoleAssignedOutsidePIM.yaml`**

Detects permanent directory role assignments to privileged roles (Global Administrator, Privileged Role Administrator, Application Administrator, and others) made via the direct assignment path, bypassing Privileged Identity Management approval and justification requirements. Complements `PIMRoleActivationOutsideBusinessHours` by covering the non-PIM assignment path. Differentiator: `OperationName =~ "Add member to role."` (exact match) excludes all PIM activation variants which carry the `(PIM activation)` suffix.

Tables: `AuditLogs`
MITRE: T1098.003 — Persistence, PrivilegeEscalation

**`Hunting Queries/MultipleDataSources/WorkloadIdentitySignInFromNewCountry.yaml`**

Identifies service principal sign-ins from a country not present in the SP's 30-day geographic baseline. Workload identities with stable infrastructure — CI/CD pipelines, automation accounts, managed integrations — sign in from consistent cloud regions. A new-country sign-in for an SP may indicate stolen client credentials replayed from attacker infrastructure. Uses `AADServicePrincipalSignInLogs` with `hint.strategy=broadcast` on the baseline join.

Tables: `AADServicePrincipalSignInLogs`
MITRE: T1078.004 — InitialAccess, CredentialAccess

**`Hunting Queries/AuditLogs/ApplicationAppRoleAssignedHighPrivilege.yaml`**

Flags application role assignments to service principals where the granted role is in a high-risk set (Mail.ReadWrite, Directory.ReadWrite.All, RoleManagement.ReadWrite.Directory, Application.ReadWrite.All, and others). Application-level permissions grant tenant-wide access without user context, are not scoped by Conditional Access, and are not visible in standard delegated permission reviews. This is the application-permission equivalent of consent grants and covers the mechanism used by Midnight Blizzard to maintain persistent Exchange access.

Tables: `AuditLogs`
MITRE: T1098.003, T1528 — Persistence, CredentialAccess

## Test notes

All three queries validated against the KQL checklist from prior merged PRs (#14173, #14207, #14208, #14213, #14239):

- `in~` for all list membership checks; `=~` for exact OperationName matching
- `InitiatedBy.*` accessed directly without `parse_json(tostring(...))`
- `hint.strategy=broadcast` on baseline joins where the event stream is smaller than the baseline
- `trim('"', ...)` applied to `modifiedProperties.newValue` before `in~` comparison to handle JSON-quoted strings
- Descriptions under 400 characters, each starting with "Identifies"
- Non-ASCII scan passed on all three files

## Related

- `PIMRoleActivationOutsideBusinessHours` (#14240) — covers PIM activations; this PR covers direct non-PIM assignments
- `BulkRoleAssignmentsInShortWindow` (#14262) — covers volume anomalies in role assignment; this PR covers privileged role assignment outside PIM regardless of volume
- No existing query covers `AADServicePrincipalSignInLogs` geographic baseline in this repo