### PR TITLE
Add hunting query: Short-lived ephemeral code signing certificates (MSaaS / Fox Tempest)

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
@@ -1,10 +1,14 @@
 id: e920899f-edf0-446c-bb13-effbaf61b27b
 name: Short-lived ephemeral code signing certificates
 description: |
-  Identifies files signed by certificates with a lifespan of 14 days or less. Commercial software certificates usually last over a year, while short-lived certificates are only used in DevOps pipelines. A short-lived certificate found in a non-dev environment indicates automated Malware-Signing-as-a-Service (MSaaS) used to evade reputation-based security controls.
+  Identifies files signed by certificates with a lifespan <= 14 days on non-developer endpoints. While legitimate software certs last 1+ years, ephemeral certs indicate Malware-Signing-as-a-Service (MSaaS) abuse to evade reputation-based controls.
+
+description-detailed: |
+  Commercial software is typically signed with certificates valid for 1 to 3 years. Ephemeral (short-lived) certificates are legitimately used in automated DevOps pipelines (e.g., Azure Artifact Signing). However, threat actors like Fox Tempest operate Malware-Signing-as-a-Service (MSaaS) to generate 72-hour to 14-day certificates for malicious payloads. Finding these short-lived certificates in a non-developer environment is a high-fidelity indicator of evasion, as it allows malware to bypass SmartScreen and EDR reputation filters before the certificate can be revoked.
   References:
-  https://www.microsoft.com/en-us/security/blog/2026/05/19/exposing-fox-tempest-a-malware-signing-service-operation/
-  https://learn.microsoft.com/en-us/azure/artifact-signing/overview
+  - https://www.microsoft.com/en-us/security/blog/2026/05/19/exposing-fox-tempest-a-malware-signing-service-operation/
+  - https://learn.microsoft.com/en-us/azure/artifact-signing/overview
+
 
 requiredDataConnectors:
   - connectorId: MicrosoftThreatProtection
@@ -14,12 +18,12 @@ requiredDataConnectors:
       - DeviceTvmSoftwareInventory
 tactics:
   - DefenseEvasion
-  - Resource Development
+  - ResourceDevelopment
 relevantTechniques:
   - T1553.002
   - T1588.003
 tags:
-- Fox Tempest
+- FoxTempest
 query: |
   // --- ADAPTATION GUIDE ---
   // 1. EphemeralThreshold: 14 days is the 'anomalous zone'. Values over 30d may lead to higher false positives.

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
@@ -45,9 +45,9 @@ query: |
     | union (
       DeviceInfo
       | where Timestamp >= ago(lookback)
-      | where DeviceManualTags has_any (devDeviceTags) 
-        or DeviceDynamicTags has_any (devDeviceTags) 
-        or RegistryDeviceTag has_any (devDeviceTags)
+      | where RegistryDeviceTag has_any (devDeviceTags) 
+        // Optional table if used: or DeviceDynamicTags has_any (devDeviceTags) 
+        // Optional table if used: or DeviceManualTags has_any (devDeviceTags)
       | summarize by DeviceId
     )
     | summarize by DeviceId

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
@@ -1,0 +1,109 @@
+id: e920899f-edf0-446c-bb13-effbaf61b27b
+name: Short-lived ephemeral code signing certificates
+description: |
+  Identifies files signed by certificates with a lifespan of 14 days or less. Commercial software certificates usually last over a year, while short-lived certificates are only used in DevOps pipelines. A short-lived certificate found in a non-dev environment indicates automated Malware-Signing-as-a-Service (MSaaS) used to evade reputation-based security controls.
+  References:
+  https://www.microsoft.com/en-us/security/blog/2026/05/19/exposing-fox-tempest-a-malware-signing-service-operation/
+  https://learn.microsoft.com/en-us/azure/artifact-signing/overview
+
+requiredDataConnectors:
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceFileCertificateInfo
+      - DeviceInfo
+      - DeviceTvmSoftwareInventory
+tactics:
+  - DefenseEvasion
+  - Resource Development
+relevantTechniques:
+  - T1553.002
+  - T1588.003
+tags:
+- Fox Tempest
+query: |
+  // --- ADAPTATION GUIDE ---
+  // 1. EphemeralThreshold: 14 days is the 'anomalous zone'. Values over 30d may lead to higher false positives.
+  // 2. DevSoftwareKeywords: Add internal dev tools (e.g., 'Jenkins', 'TeamCity') to reduce noise.
+  // 3. devDeviceTags: Add internal dev device group name to reduce noise.
+  // 4. ExcludedIssuers: Add your organization's internal CA name here to prevent false positives.
+
+  let ephemeralThreshold = 14d;
+  let devSoftwareKeywords = dynamic(["Visual Studio", "IntelliJ", "Jenkins", "GitHub", "Git", "Kubernetes", "Docker", "Sublime"]);
+  let devDeviceTags = dynamic(["Engineering", "Dev-Workstation", "Build-Server"]);
+  let excludedIssuers = dynamic(["Internal-CA-Example", "Local-Admin-Signer"]);
+
+  // Step 1: Create a lookup table of developer assets likely to use legitimate short-lived certificates via Software and Device Tags
+  let devAssets = (
+    DeviceTvmSoftwareInventory
+    | where SoftwareName has_any (devSoftwareKeywords)
+    | summarize by DeviceId
+    | union (
+      DeviceInfo
+      | where DeviceManualTags has_any (devDeviceTags) 
+        or DeviceDynamicTags has_any (devDeviceTags) 
+        or RegistryDeviceTag has_any (devDeviceTags)
+      | summarize by DeviceId
+    )
+    | summarize by DeviceId
+  );
+
+  // Step 2: Identify certificates within the 14-day anomalous window
+  DeviceFileCertificateInfo
+  | extend TotalLifespan = datetime_diff('day', CertificateExpirationTime, CertificateCreationTime)
+  | where TotalLifespan <= ephemeralThreshold and TotalLifespan > 0
+  | where isnotempty(Issuer) and not(Issuer has_any (excludedIssuers))
+
+  // Step 3: Remove known dev machines to surface anomalies on standard user endpoints
+  | join kind=leftanti (devAssets) on DeviceId
+
+  // Step 4: Enrich with the latest machine details
+  | join kind=inner (
+      DeviceInfo 
+      | summarize arg_max(TimeGenerated, *) by DeviceId
+    ) on DeviceId
+  | project 
+      Timestamp, 
+      DeviceName,
+      DeviceId,
+      PublicIP, 
+      LoggedOnUsers,
+      FileName,
+      SHA1,
+      Signer,
+      Issuer, 
+      IsTrusted,
+      Subject, 
+      TotalLifespan, 
+      CertificateCreationTime, 
+      CertificateExpirationTime
+
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: DeviceName
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: PublicIP
+  - entityType: File
+    fieldMappings:
+      - identifier: Name
+        columnName: FileName
+  - entityType: FileHash
+    fieldMappings:
+      - identifier: Algorithm
+        columnName: SHA1
+customDetails:
+  DefenderDeviceId: DeviceId
+  CertLifespanDays: TotalLifespan
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: Younes Al Taleb
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection" ]

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
@@ -32,6 +32,7 @@ query: |
   // 4. ExcludedIssuers: Add your organization's internal CA name here to prevent false positives.
 
   let ephemeralThreshold = 14d;
+  let lookback = 7d;
   let devSoftwareKeywords = dynamic(["Visual Studio", "IntelliJ", "Jenkins", "GitHub", "Git", "Kubernetes", "Docker", "Sublime"]);
   let devDeviceTags = dynamic(["Engineering", "Dev-Workstation", "Build-Server"]);
   let excludedIssuers = dynamic(["Internal-CA-Example", "Local-Admin-Signer"]);
@@ -43,6 +44,7 @@ query: |
     | summarize by DeviceId
     | union (
       DeviceInfo
+      | where Timestamp >= ago(lookback)
       | where DeviceManualTags has_any (devDeviceTags) 
         or DeviceDynamicTags has_any (devDeviceTags) 
         or RegistryDeviceTag has_any (devDeviceTags)
@@ -63,6 +65,7 @@ query: |
   // Step 4: Enrich with the latest machine details
   | join kind=inner (
       DeviceInfo 
+      | where Timestamp >= ago(lookback)
       | summarize arg_max(Timestamp, *) by DeviceId
     ) on DeviceId
   | project 

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
@@ -71,12 +71,10 @@ query: |
       DeviceId,
       PublicIP, 
       LoggedOnUsers,
-      FileName,
       SHA1,
       Signer,
       Issuer, 
       IsTrusted,
-      Subject, 
       TotalLifespan, 
       CertificateCreationTime, 
       CertificateExpirationTime
@@ -90,10 +88,6 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: PublicIP
-  - entityType: File
-    fieldMappings:
-      - identifier: Name
-        columnName: FileName
   - entityType: FileHash
     fieldMappings:
       - identifier: Value
@@ -101,13 +95,14 @@ entityMappings:
 customDetails:
   DefenderDeviceId: DeviceId
   CertLifespanDays: TotalLifespan
+
 version: 1.0.0
 metadata:
-    source:
-      kind: Community
-    author:
-      name: Younes Al Taleb
-    support:
-      tier: Community
-    categories:
-      domains: [ "Security - Threat Protection" ]
+  source:
+    kind: Community
+  author:
+    name: Younes Al Taleb
+  support:
+    tier: Community
+  categories:
+    domains: [ "Security - Threat Protection" ]

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/Short-livedEphemeralCodeSigningCertificates.yaml
@@ -23,7 +23,7 @@ relevantTechniques:
   - T1553.002
   - T1588.003
 tags:
-- FoxTempest
+  - FoxTempest
 query: |
   // --- ADAPTATION GUIDE ---
   // 1. EphemeralThreshold: 14 days is the 'anomalous zone'. Values over 30d may lead to higher false positives.
@@ -53,8 +53,8 @@ query: |
 
   // Step 2: Identify certificates within the 14-day anomalous window
   DeviceFileCertificateInfo
-  | extend TotalLifespan = datetime_diff('day', CertificateExpirationTime, CertificateCreationTime)
-  | where TotalLifespan <= ephemeralThreshold and TotalLifespan > 0
+  | extend TotalLifespan = CertificateExpirationTime - CertificateCreationTime
+  | where TotalLifespan <= ephemeralThreshold and TotalLifespan > 0d
   | where isnotempty(Issuer) and not(Issuer has_any (excludedIssuers))
 
   // Step 3: Remove known dev machines to surface anomalies on standard user endpoints
@@ -63,7 +63,7 @@ query: |
   // Step 4: Enrich with the latest machine details
   | join kind=inner (
       DeviceInfo 
-      | summarize arg_max(TimeGenerated, *) by DeviceId
+      | summarize arg_max(Timestamp, *) by DeviceId
     ) on DeviceId
   | project 
       Timestamp, 
@@ -96,7 +96,7 @@ entityMappings:
         columnName: FileName
   - entityType: FileHash
     fieldMappings:
-      - identifier: Algorithm
+      - identifier: Value
         columnName: SHA1
 customDetails:
   DefenderDeviceId: DeviceId
@@ -104,10 +104,10 @@ customDetails:
 version: 1.0.0
 metadata:
     source:
-        kind: Community
+      kind: Community
     author:
-        name: Younes Al Taleb
+      name: Younes Al Taleb
     support:
-        tier: Community
+      tier: Community
     categories:
-        domains: [ "Security - Threat Protection" ]
+      domains: [ "Security - Threat Protection" ]


### PR DESCRIPTION
## Summary
This PR adds a new hunting query that correlates endpoint certificate data (`DeviceFileCertificateInfo`) with software and device inventory logs to surface the anomalous use of short-lived code-signing certificates on non-developer endpoints. 

Legitimate commercial software is typically signed with certificates valid for 1+ years. However, a recent Microsoft Threat Intelligence report highlighted the Fox Tempest operation, which provides Malware-Signing-as-a-Service (MSaaS). These actors use stolen identities to abuse platforms like Microsoft Trusted Signing, generating short-lived (e.g., 72-hour) certificates. This allows malware (like Oyster, Lumma, and Rhysida ransomware) to bypass SmartScreen and EDR reputation filters before the certificate can be widely revoked. 

This query uses a 14-day lifespan threshold to catch these ephemeral certificates while applying a dual-method exclusion (Software Inventory and Device Tags) to filter out legitimate automated DevOps and build pipelines, yielding a high-signal indicator of compromise.



## Queries included
1. `Short-livedEphemeralCertificates.yaml`
Correlates the calculated total lifespan of a certificate (Expiration minus Creation) from `DeviceFileCertificateInfo` with a dynamic exclusion list of developer endpoints derived from `DeviceTvmSoftwareInventory` and `DeviceInfo`. Flags any file signed by a publicly trusted CA with a lifespan of 14 days or less on standard user endpoints.

*   **Tables:** `DeviceFileCertificateInfo` + `DeviceInfo` + `DeviceTvmSoftwareInventory`
*   **MITRE:** T1553.002, T1588.003 - DefenseEvasion, Resource Development


## Change(s):
- Added new hunting query `Short-livedEphemeralCertificates.yaml` to the "Hunting Queries/Microsoft 365 Defender/Defense evasion" folder.


## Reason for Change(s):
- Detects emerging MSaaS (Malware-Signing-as-a-Service) behavior highlighted in the recent Fox Tempest threat intelligence report.
- Provides defenders with a behavioral tripwire (lifespan anomaly) rather than relying on reactive hash or signer-based IOCs, making the rule highly resilient against future actors abusing Identity-as-a-Service platforms.
- No existing query in the repository correlates code signing certificate lifespan.


## Version Updated:
- N/A (This is a new Hunting Query. Initial version set to 1.0.0)


## Testing Completed:
Queries were authored against the DeviceFileCertificateInfo, DeviceTvmSoftwareInventory and DeviceInfo schemas. KQL patterns and YAML structure follow the conventions of the existing Microsoft 365 hunting queries in this repository. All files were validated for non-ASCII characters before commit.


## Checked that the validations are passing and have addressed any issues that are present:
 - Yes. Ran the `.script/tests/DetectionTemplateSchemaValidation/dotnet test` local validation to ensure YAML structure and KQL syntax are perfectly compliant.