### PR TITLE
Add Entra ID attack chain correlation hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/FreshRoleGrantedActorSpCredentialAdded.yaml
+++ b/Hunting Queries/AuditLogs/FreshRoleGrantedActorSpCredentialAdded.yaml
@@ -1,0 +1,87 @@
+id: 661d71d1-98a4-464f-bb6b-fc3c39499b3f
+name: Service principal credential added by user granted privileged role in last 24 hours
+description: Identifies service principal credential additions by users who received Application Administrator or Global Administrator roles within the preceding 24 hours, consistent with immediate post-compromise privilege abuse.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1098.001
+query: |
+  let timeframe = 1d;
+  let roleWindow = 24h;
+  let lookback = 7d;
+  let PrivilegedRoles = dynamic([
+      "Application Administrator",
+      "Cloud Application Administrator",
+      "Global Administrator",
+      "Privileged Role Administrator"
+  ]);
+  let RecentRoleGrants =
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(0h)
+      | where OperationName =~ "Add member to role."
+      | where Result =~ "success"
+      | extend NewRoleUser = tostring(TargetResources[0].userPrincipalName)
+      | extend RoleName    = tostring(TargetResources[1].displayName)
+      | where RoleName in~ (PrivilegedRoles)
+      | where isnotempty(NewRoleUser)
+      | project NewRoleUser, RoleName, RoleGrantedTime = TimeGenerated;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName in~ (
+        "Add service principal credentials",
+        "Update application - Certificates and secrets management"
+    )
+  | where Result =~ "success"
+  | extend ActorUpn     = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp     = tostring(InitiatedBy.app.displayName)
+  | extend Actor        = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp      = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend TargetSpName = tostring(TargetResources[0].displayName)
+  | extend TargetSpId   = tostring(TargetResources[0].id)
+  | where isnotempty(ActorUpn)
+  | join kind=inner RecentRoleGrants on $left.ActorUpn == $right.NewRoleUser
+  | where TimeGenerated >= RoleGrantedTime and TimeGenerated <= RoleGrantedTime + roleWindow
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), ActorUpn)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      ActorUpn,
+      AccountName,
+      AccountUPNSuffix,
+      RoleName,
+      RoleGrantedTime,
+      TargetSpName,
+      TargetSpId,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ActorUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/FreshRoleGrantedActorSpCredentialAdded.yaml
+++ b/Hunting Queries/AuditLogs/FreshRoleGrantedActorSpCredentialAdded.yaml
@@ -22,9 +22,9 @@ query: |
   let RecentRoleGrants =
       AuditLogs
       | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(0h)
-      | where OperationName =~ "Add member to role."
+      | where OperationName in~ ("Add member to role.", "Add member to role")
       | where Result =~ "success"
-      | extend NewRoleUser = tostring(TargetResources[0].userPrincipalName)
+      | extend NewRoleUser = tolower(tostring(TargetResources[0].userPrincipalName))
       | extend RoleName    = tostring(TargetResources[1].displayName)
       | where RoleName in~ (PrivilegedRoles)
       | where isnotempty(NewRoleUser)
@@ -36,7 +36,7 @@ query: |
         "Update application - Certificates and secrets management"
     )
   | where Result =~ "success"
-  | extend ActorUpn     = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorUpn     = tolower(tostring(InitiatedBy.user.userPrincipalName))
   | extend ActorApp     = tostring(InitiatedBy.app.displayName)
   | extend Actor        = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
   | extend ActorIp      = iff(

--- a/Hunting Queries/AuditLogs/ServicePrincipalFederatedIdentityCredentialAdded.yaml
+++ b/Hunting Queries/AuditLogs/ServicePrincipalFederatedIdentityCredentialAdded.yaml
@@ -1,0 +1,69 @@
+id: 2a7c50a9-5172-4ea3-8a59-b89e8117fc2c
+name: Federated identity credential added to Entra ID service principal
+description: Identifies federated identity credential additions to Entra ID service principals. Workload identity federation allows external OIDC workloads to authenticate as the SP without secrets, which if abused enables supply chain or CI/CD pipeline compromise.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1098.001
+query: |
+  let timeframe = 1d;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName =~ "Update service principal"
+  | where Result =~ "success"
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | where tostring(ModProp.displayName) =~ "FederatedIdentityCredentials"
+  | extend OldCreds     = tostring(ModProp.oldValue)
+  | extend NewCreds     = tostring(ModProp.newValue)
+  | extend TargetSpName = tostring(TargetResources[0].displayName)
+  | extend TargetSpId   = tostring(TargetResources[0].id)
+  | extend ActorUpn     = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp     = tostring(InitiatedBy.app.displayName)
+  | extend Actor        = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp      = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend AccountName      = iff(ActorUpn has "@",
+        tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@",
+        tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      TargetSpName,
+      TargetSpId,
+      OldCreds,
+      NewCreds,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/ServicePrincipalFederatedIdentityCredentialAdded.yaml
+++ b/Hunting Queries/AuditLogs/ServicePrincipalFederatedIdentityCredentialAdded.yaml
@@ -13,7 +13,7 @@ query: |
   let timeframe = 1d;
   AuditLogs
   | where TimeGenerated >= ago(timeframe)
-  | where OperationName =~ "Update service principal"
+  | where OperationName in~ ("Update service principal")
   | where Result =~ "success"
   | mv-expand ModProp = TargetResources[0].modifiedProperties
   | where tostring(ModProp.displayName) =~ "FederatedIdentityCredentials"

--- a/Hunting Queries/MultipleDataSources/MFADisabledThenSignInFromUnseenIP.yaml
+++ b/Hunting Queries/MultipleDataSources/MFADisabledThenSignInFromUnseenIP.yaml
@@ -1,5 +1,5 @@
 id: 3140d3e9-f87c-48aa-8d81-1b78b6c5d7bf
-name: Successful sign-in from unseen IP within 60 minutes of MFA disabled for account
+name: Sign-in from unseen IP within 60 minutes of MFA disabled for account
 description: Identifies successful sign-ins from IP addresses not seen in the prior 30 days occurring within 60 minutes of MFA being disabled for the same account, consistent with post-compromise credential use after weakening authentication.
 requiredDataConnectors:
   - connectorId: AzureActiveDirectory
@@ -31,8 +31,9 @@ query: |
       SigninLogs
       | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
       | where ResultType == 0
-      | summarize KnownIPSet = make_set(IPAddress)
-          by UserPrincipalName = tolower(UserPrincipalName);
+      | project UserPrincipalName = tolower(UserPrincipalName), IPAddress
+      | summarize KnownIPSet = make_set(IPAddress, 1000)
+          by UserPrincipalName;
   SigninLogs
   | where TimeGenerated >= ago(timeframe)
   | where ResultType == 0
@@ -40,7 +41,7 @@ query: |
   | join kind=inner DisabledMFA on $left.UserUpn == $right.AffectedUser
   | where TimeGenerated >= MFADisabledTime and TimeGenerated <= MFADisabledTime + correlationWindow
   | join kind=leftouter KnownIPs on $left.UserUpn == $right.UserPrincipalName
-  | where not(set_has_element(KnownIPSet, IPAddress))
+  | where isnull(KnownIPSet) or not(set_has_element(KnownIPSet, IPAddress))
   | extend AccountName      = tostring(split(UserUpn, "@")[0])
   | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
   | project

--- a/Hunting Queries/MultipleDataSources/MFADisabledThenSignInFromUnseenIP.yaml
+++ b/Hunting Queries/MultipleDataSources/MFADisabledThenSignInFromUnseenIP.yaml
@@ -1,0 +1,80 @@
+id: 3140d3e9-f87c-48aa-8d81-1b78b6c5d7bf
+name: Successful sign-in from unseen IP within 60 minutes of MFA disabled for account
+description: Identifies successful sign-ins from IP addresses not seen in the prior 30 days occurring within 60 minutes of MFA being disabled for the same account, consistent with post-compromise credential use after weakening authentication.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+      - SigninLogs
+tactics:
+  - CredentialAccess
+  - Persistence
+relevantTechniques:
+  - T1556.006
+  - T1078.004
+query: |
+  let timeframe = 1d;
+  let correlationWindow = 60m;
+  let lookback = 30d;
+  let DisabledMFA =
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe)
+      | where OperationName in~ (
+            "Disable Strong Authentication",
+            "User deleted security info"
+        )
+      | where Result =~ "success"
+      | extend AffectedUser = tolower(tostring(TargetResources[0].userPrincipalName))
+      | where isnotempty(AffectedUser)
+      | project AffectedUser, MFADisabledTime = TimeGenerated;
+  let KnownIPs =
+      SigninLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
+      | where ResultType == 0
+      | summarize KnownIPSet = make_set(IPAddress)
+          by UserPrincipalName = tolower(UserPrincipalName);
+  SigninLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where ResultType == 0
+  | extend UserUpn = tolower(UserPrincipalName)
+  | join kind=inner DisabledMFA on $left.UserUpn == $right.AffectedUser
+  | where TimeGenerated >= MFADisabledTime and TimeGenerated <= MFADisabledTime + correlationWindow
+  | join kind=leftouter KnownIPs on $left.UserUpn == $right.UserPrincipalName
+  | where not(set_has_element(KnownIPSet, IPAddress))
+  | extend AccountName      = tostring(split(UserUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
+  | project
+      TimeGenerated,
+      UserUpn,
+      AccountName,
+      AccountUPNSuffix,
+      MFADisabledTime,
+      IPAddress,
+      AppDisplayName,
+      Location,
+      AutonomousSystemNumber,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPAddress
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]


### PR DESCRIPTION
## Summary

Three hunting queries covering attack chain correlation patterns in Entra ID — scenarios where the signal comes from sequencing two events rather than either event alone.

### Queries

**`FreshRoleGrantedActorSpCredentialAdded.yaml`** (`Hunting Queries/AuditLogs/`)
Detects service principal credential additions by users who received a privileged role (Application Administrator, Cloud Application Administrator, Global Administrator, Privileged Role Administrator) within the preceding 24 hours. The role grant and the credential addition are individually low-signal; the combination within a tight window is not. Covers T1098.001.

**`ServicePrincipalFederatedIdentityCredentialAdded.yaml`** (`Hunting Queries/AuditLogs/`)
Detects federated identity credential additions to Entra ID service principals via `Update service principal` where `modifiedProperties` contains `FederatedIdentityCredentials`. Workload identity federation lets external OIDC workloads authenticate as the SP without a secret — abused in CI/CD supply chain attacks to establish persistent access without leaving a credential artifact. Covers T1098.001.

**`MFADisabledThenSignInFromUnseenIP.yaml`** (`Hunting Queries/MultipleDataSources/`)
Correlates AuditLogs and SigninLogs: flags successful sign-ins from IP addresses not seen in the prior 30 days that occur within 60 minutes of MFA being disabled for the same account. Cross-source join covering `Disable Strong Authentication` and `User deleted security info` operations. Covers T1556.006 and T1078.004.

## MITRE ATT&CK

| Technique | Name |
|-----------|------|
| T1098.001 | Additional Cloud Credentials |
| T1556.006 | Modify Authentication Process: Multi-Factor Authentication |
| T1078.004 | Valid Accounts: Cloud Accounts |

## Data connectors

- `AzureActiveDirectory` → `AuditLogs`
- `AzureActiveDirectory` → `SigninLogs`

## Testing

All three queries validated for:
- Description ≤ 255 characters, sentence starts with "Identifies"
- No non-ASCII characters
- `in~` used for all `OperationName` comparisons
- Direct dot notation for `InitiatedBy` field access
- Entity mappings for Account and IP on all three queries