### PR TITLE
Add hunting query for ETW-patching resistant .NET in-memory execution

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/AnomalousNETRuntimeFilelessInjection.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/AnomalousNETRuntimeFilelessInjection.yaml
@@ -1,7 +1,10 @@
 id: 2df3fa1f-d573-4e0a-82f2-da62d3f2973f
 name: Anomalous .NET runtime loading for fileless payload
 description: |
-  Identifies when the .NET engine is loaded by an untrusted file path or a hijacked native tool. Malware uses this technique to execute malicious code entirely in memory to remain invisible. Legitimate .NET applications usually run from secure directories like Program Files and are digitally signed by known vendors.
+  Identifies native processes or binaries in writable paths loading .NET runtimes. This suggests in-memory code injection and ETW patching used by malware to execute code while evading detection by security tools.
+
+description-detailed: |
+  Identifies native Windows binaries or processes in user-writable folders that unexpectedly load the .NET runtime engine. This activity is anomalous because these processes are not built on .NET and typically do not require these files to function. Malware uses this technique to execute malicious code entirely in memory, often while attempting to disable security logging (ETW patching) to remain invisible. Legitimate .NET applications usually run from secure directories like Program Files and are digitally signed by known vendors.
   References:
   https://www.microsoft.com/en-us/security/blog/2026/05/14/kazuar-anatomy-of-a-nation-state-botnet/
   https://r136a1.dev/2026/01/14/command-and-evade-turlas-kazuar-v3-loader/

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/AnomalousNETRuntimeFilelessInjection.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/AnomalousNETRuntimeFilelessInjection.yaml
@@ -1,0 +1,142 @@
+id: 2df3fa1f-d573-4e0a-82f2-da62d3f2973f
+name: Anomalous .NET runtime loading for fileless payload
+description: |
+  Identifies when the .NET engine is loaded by an untrusted file path or a hijacked native tool. Malware uses this technique to execute malicious code entirely in memory to remain invisible. Legitimate .NET applications usually run from secure directories like Program Files and are digitally signed by known vendors.
+  References:
+  https://www.microsoft.com/en-us/security/blog/2026/05/14/kazuar-anatomy-of-a-nation-state-botnet/
+  https://r136a1.dev/2026/01/14/command-and-evade-turlas-kazuar-v3-loader/
+
+requiredDataConnectors:
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceImageLoadEvents
+tactics:
+  - DefenseEvasion
+  - Execution
+relevantTechniques:
+  - T1562.001
+  - T1055
+query: |
+  // -----------------------------------------------------------------------------
+  // DETECTION STRATEGY: ETW-Patching Resistant .NET In-Memory Execution
+  // 
+  // THE MECHANIC: Advanced malware (like Kazuar) often executes .NET payloads 
+  // entirely in memory to avoid disk-based antivirus scans. To hide this execution 
+  // from EDRs, the malware patches Event Tracing for Windows (ETW) in user-mode 
+  // (e.g., overwriting ntdll.dll!EtwEventWrite with a return instruction). This blinds 
+  // the EDR, preventing it from seeing the standard 'ClrUnbackedModuleLoaded' 
+  // events that usually trigger memory execution alerts.
+  //
+  // THE RESILIENCE: While user-mode ETW can be easily patched by malware running 
+  // with standard privileges, the malware CANNOT hide the physical loading of the 
+  // .NET runtime engine (CLR) DLLs themselves. DLL loads trigger kernel-level 
+  // callbacks (PsSetLoadImageNotifyRoutine) which user-mode malware cannot intercept. 
+  // This query relies exclusively on DeviceImageLoadEvents (kernel-driven telemetry) 
+  // to detect when native Windows tools (LOLBins) or untrusted binaries running from 
+  // user-writable paths unexpectedly load the .NET execution engine. By shifting 
+  // detection to the kernel-level prerequisite of the attack, we render the user-mode 
+  // ETW patch irrelevant.
+  // -----------------------------------------------------------------------------
+  
+  // Define a list of native Windows binaries (LOLBins) that are written in C/C++.
+  // Under normal circumstances, these native tools have no legitimate reason to boot 
+  // up the .NET runtime. If they load 'clr.dll' or 'mscoree.dll', it is a highly reliable 
+  // indicator that they have been hijacked (e.g., via malicious COM object instantiation) 
+  // to host a fileless .NET payload.
+  
+  // Note: Binaries like powershell.exe, csc.exe, or msbuild.exe are built on or deeply integrated with
+  // .NET, so loading clr.dll is perfectly normal for them.
+  let AnomalousLOLBins = dynamic([
+    // Tier 1: Most Heavily Abused Processes
+    "rundll32.exe", "regsvr32.exe", "mshta.exe", "dllhost.exe", "svchost.exe", "spoolsv.exe", "werfault.exe", "explorer.exe",
+    // Tier 2: Scripting & Automation Hosts
+    "wscript.exe", "cscript.exe", "wmic.exe", "msiexec.exe",
+    // Tier 3: Admin & Setup Utilities
+    "odbcconf.exe", "control.exe", "cmstp.exe", "certutil.exe"
+  ]);
+  
+  // Base Query: Look for the .NET Execution Engine DLLs being loaded into memory
+  DeviceImageLoadEvents
+  // STEP 1: Identify processes loading the .NET Common Language Runtime (CLR) engines.
+  // 'mscoree.dll'   -> The traditional .NET execution engine.
+  // 'clr.dll'       -> The core .NET framework runtime.
+  // 'mscorwks.dll'  -> Legacy .NET workstation runtime.
+  // 'coreclr.dll'   -> The modern .NET Core runtime.
+  | where FileName in~ ("clr.dll", "mscoree.dll", "mscorwks.dll", "coreclr.dll")
+  
+
+  // STEP 2: Apply Behavioral Filters to isolate malicious injection/loading.
+  // We use a strict Whitelist approach for paths. We only trust strict, Admin-secured directories.
+  // By using regex anchored to the start of the string (^), we prevent attackers from 
+  // bypassing the rule by creating a fake "Program Files" folder inside a user-writable 
+  // directory (e.g., C:\Users\Public\Program Files\malware.exe).
+
+  | extend IsTrustedPath = InitiatingProcessFolderPath matches regex @"^[a-zA-Z]:\\(?:Program Files|Program Files \(x86\)|Windows)(?:\\|$)"
+
+
+  // STEP 2: Apply Behavioral Filters to isolate malicious injection/loading.
+  | where 
+    // CONDITION A: A native Windows LOLBin is suddenly loading the .NET engine.
+    (InitiatingProcessFileName in~ (AnomalousLOLBins))
+    or 
+    // CONDITION B: An executable running from ANY untrusted, user-writable directory 
+    // (AppData, Temp, PerfLogs, etc.) is loading the .NET engine.
+    (not(IsTrustedPath))
+  
+  // EXCLUSION: Filter out poorly behaved legitimate software (like user-context auto-updaters) 
+  // by ensuring the binary's internal version metadata does not belong to a trusted software vendor.
+  // Note: Schema recommends using SHA1 over SHA256 as it is more reliably populated.
+  // Insert legitimate internal tool hashes or signer here if they legitimately run .NET from Temp/AppData.
+  // | where InitiatingProcessSHA1 !in~ ("<Legit_SHA1_1>", "<Legit_SHA1_2>")
+  // | where InitiatingProcessVersionInfoCompanyName !in~ ( "Microsoft Corporation", "Google LLC", "Google Inc", "Cisco Systems, Inc.", "Intel Corporation" )
+  
+  // STEP 3: Format the output for triage.
+  // We surface the Command Line, Folder Path, and SHA1 hash for immediate context.
+  | extend timestamp = Timestamp
+  | project 
+    Timestamp,
+    timestamp,
+    DeviceName, 
+    ActionType,
+    LoadedDll = FileName, 
+    InitiatingProcessAccountName,
+    InitiatingProcessFileName, 
+    InitiatingProcessFolderPath, 
+    InitiatingProcessCommandLine, 
+    InitiatingProcessParentFileName,
+    InitiatingProcessVersionInfoCompanyName,
+    InitiatingProcessSHA1
+  | project-reorder 
+    Timestamp,
+    DeviceName,
+    InitiatingProcessAccountName,
+    InitiatingProcessFileName,
+    InitiatingProcessCommandLine,
+    LoadedDll,
+    InitiatingProcessFolderPath,
+    InitiatingProcessParentFileName
+
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: DeviceName
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: InitiatingProcessAccountName
+  - entityType: Process
+    fieldMappings:
+      - identifier: CommandLine
+        columnName: InitiatingProcessCommandLine
+version: 1.0.0
+
+metadata:
+    source:
+        kind: Community
+    author:
+        name: Younes Al Taleb
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection" ]

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/AnomalousNETRuntimeFilelessInjection.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/AnomalousNETRuntimeFilelessInjection.yaml
@@ -95,23 +95,25 @@ query: |
   
   // STEP 3: Format the output for triage.
   // We surface the Command Line, Folder Path, and SHA1 hash for immediate context.
-  | extend timestamp = Timestamp
+  | extend ProcessIdString = tostring(InitiatingProcessId)
   | project 
     Timestamp,
-    timestamp,
     DeviceName, 
     ActionType,
     LoadedDll = FileName, 
+    InitiatingProcessAccountDomain,
     InitiatingProcessAccountName,
     InitiatingProcessFileName, 
     InitiatingProcessFolderPath, 
     InitiatingProcessCommandLine, 
+    ProcessIdString,
     InitiatingProcessParentFileName,
     InitiatingProcessVersionInfoCompanyName,
     InitiatingProcessSHA1
   | project-reorder 
     Timestamp,
     DeviceName,
+    InitiatingProcessAccountDomain,
     InitiatingProcessAccountName,
     InitiatingProcessFileName,
     InitiatingProcessCommandLine,
@@ -122,16 +124,20 @@ query: |
 entityMappings:
   - entityType: Host
     fieldMappings:
-      - identifier: HostName
+      - identifier: FullName
         columnName: DeviceName
   - entityType: Account
     fieldMappings:
       - identifier: Name
         columnName: InitiatingProcessAccountName
+      - identifier: NTDomain
+        columnName: InitiatingProcessAccountDomain
   - entityType: Process
     fieldMappings:
       - identifier: CommandLine
         columnName: InitiatingProcessCommandLine
+      - identifier: ProcessId
+        columnName: ProcessIdString
 version: 1.0.0
 
 metadata:


### PR DESCRIPTION
## Summary
This PR adds a highly resilient hunting query targeting the initial staging and injection phase of fileless .NET malware. 

Adversaries increasingly rely on executing .NET assemblies directly in memory to avoid disk-based heuristics. A common defense evasion technique in these attack chains is patching ETW (e.g., overwriting `ntdll.dll!EtwEventWrite`) prior to loading the payload, which prevents security products from observing the in-memory execution. 

This query relies exclusively on `DeviceImageLoadEvents` (kernel-driven telemetry via `PsSetLoadImageNotifyRoutine`) to detect the physical loading of the .NET execution engine (`clr.dll`, `mscoree.dll`, etc.). By shifting the detection to the kernel-level prerequisite of the attack, the user-mode ETW patch is rendered irrelevant.


## Behavioral Filters Included:
1. **LOLBin Hijacking:** Alerts if native C/C++ Windows tools (like `rundll32.exe`, `wscript.exe`, `mshta.exe`) suddenly load the .NET engine. Since these native tools do not legitimately host .NET by default, this is a strong indicator of COM object hijacking or malicious injection.
2. **Suspicious Staging Paths:** Alerts if an executable running from a high-risk, user-writable directory (e.g., `\AppData\`, `\Temp\`, `\ProgramData\`) loads the .NET engine, as legitimate .NET enterprise applications are typically installed in secured directories (`C:\Program Files\`).


## Relationship to existing queries:
Existing memory execution queries heavily rely on `DeviceEvents` with `ActionType == "ClrUnbackedModuleLoaded"`. This query is additive and serves as a resilient fallback: it catches the prerequisite behavior (the loading of the CLR engine itself) ensuring detection is maintained even if the attacker successfully blinds ETW telemetry.


## Testing
The query was authored against the `DeviceImageLoadEvents` schema and validated against KQL patterns used in the existing Defense Evasion hunting queries in this repository. Explicit exclusions were built using `InitiatingProcessVersionInfoCompanyName` to handle legitimate, poorly-behaved third-party updaters operating out of `AppData` without relying on easily-spoofed file names.


## Change(s):
- Added `AnomalousNETFilelessInjection.yaml` to the Hunting Queries directory.
- Includes entity mappings for Host, Account, and Process.


## Reason for Change(s):
- Advanced malware (e.g., Kazuar/Secret Blizzard) heavily utilizes fileless .NET execution. To evade detection, adversaries patch user-mode Event Tracing for Windows (ETW), effectively blinding EDR sensors to standard `ClrUnbackedModuleLoaded` events.
- This query shifts detection to the kernel-level prerequisite of the attack (loading the .NET runtime DLLs) which user-mode malware cannot intercept or patch.
- It filters for Native Windows tools (LOLBins) or untrusted binaries operating from user-writable paths that have no legitimate reason to boot the .NET runtime.

## Version Updated:
- N/A (This is a new Hunting Query, version set to 1.0.0).

## Testing Completed:
   - Yes

Checked that the validations are passing and have addressed any issues that are present:
   - Yes