### PR TITLE
Add hunting queries: Entra ID token abuse and consent hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/OAuthConsentToHighRiskPermissionScope.yaml
+++ b/Hunting Queries/AuditLogs/OAuthConsentToHighRiskPermissionScope.yaml
@@ -1,0 +1,81 @@
+id: 2a166359-a104-4d72-93ae-643ae69bf801
+name: OAuth application consent to high-risk permission scope
+description: |
+  Identifies OAuth application consent events where high-risk permissions such as
+  Directory.ReadWrite.All or RoleManagement.ReadWrite.Directory were granted to apps
+  with no prior tenant consent history in the preceding 90 days.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - CredentialAccess
+relevantTechniques:
+  - T1528
+query: |
+  let timeframe = 1d;
+  let lookback = 90d;
+  let HighRiskScopes = dynamic([
+      "RoleManagement.ReadWrite.Directory",
+      "Application.ReadWrite.All",
+      "AppRoleAssignment.ReadWrite.All",
+      "Directory.ReadWrite.All",
+      "User.ReadWrite.All",
+      "Mail.ReadWrite",
+      "Mail.Send",
+      "Files.ReadWrite.All",
+      "full_access_as_app"
+  ]);
+  let KnownApps =
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
+      | where OperationName =~ "Consent to application"
+      | extend AppId = tostring(TargetResources[0].id)
+      | distinct AppId;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName =~ "Consent to application"
+  | where Result =~ "success"
+  | extend AppId    = tostring(TargetResources[0].id)
+  | extend AppName  = tostring(TargetResources[0].displayName)
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | where tostring(ModProp.displayName) =~ "ConsentAction.Permissions"
+  | extend GrantedPermissions = tostring(ModProp.newValue)
+  | where GrantedPermissions has_any (HighRiskScopes)
+  | join kind=leftanti KnownApps on AppId
+  | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
+  | project TimeGenerated, AppName, AppId, GrantedPermissions, Actor,
+            AccountName, AccountUPNSuffix, ActorIp, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml
+++ b/Hunting Queries/AuditLogs/ServicePrincipalCredentialAdditionByNonHistoricalActor.yaml
@@ -1,0 +1,77 @@
+id: 4519bc3b-1849-4f37-b98b-6e8d67b34c71
+name: Service principal credential addition by non-historical actor
+description: |
+  Identifies service principal credential additions or updates by actors with no history
+  of this operation in the preceding 90 days. A new actor outside the established
+  baseline may indicate credential abuse by a compromised account.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+relevantTechniques:
+  - T1098.001
+query: |
+  let timeframe = 1d;
+  let lookback   = 90d;
+  let KnownActors =
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe + lookback) and TimeGenerated < ago(timeframe)
+      | where OperationName in~ (
+            "Add service principal credentials",
+            "Update application - Certificates and secrets management"
+        )
+      | where Result =~ "success"
+      | extend Actor = iff(
+            isnotempty(tostring(InitiatedBy.user.userPrincipalName)),
+            tostring(InitiatedBy.user.userPrincipalName),
+            tostring(InitiatedBy.app.displayName))
+      | where isnotempty(Actor)
+      | distinct Actor;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where OperationName in~ (
+        "Add service principal credentials",
+        "Update application - Certificates and secrets management"
+    )
+  | where Result =~ "success"
+  | extend ActorUpn  = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp  = tostring(InitiatedBy.app.displayName)
+  | extend Actor     = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp   = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend TargetSP   = tostring(TargetResources[0].displayName)
+  | extend TargetSpId = tostring(TargetResources[0].id)
+  | where isnotempty(Actor)
+  | join kind=leftanti KnownActors on Actor
+  | extend AccountName      = iff(Actor has "@", tostring(split(Actor, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(Actor has "@", tostring(split(Actor, "@")[1]), "")
+  | project TimeGenerated, TargetSP, TargetSpId, Actor, AccountName,
+            AccountUPNSuffix, ActorIp, OperationName, CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
+++ b/Hunting Queries/MultipleDataSources/AnomalousTokenIssuanceAfterAiTM.yaml
@@ -1,0 +1,81 @@
+id: 2a2c676e-885f-43d9-90cb-2c035772e31c
+name: Anomalous non-interactive token issuance after interactive sign-in (AiTM pattern)
+description: |
+  Identifies non-interactive sign-ins from a different IP and autonomous system than
+  the preceding interactive sign-in for the same user within a 10-minute window,
+  consistent with AiTM phishing token replay.
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+      - AADNonInteractiveUserSignInLogs
+tactics:
+  - InitialAccess
+  - CredentialAccess
+relevantTechniques:
+  - T1539
+  - T1550
+query: |
+  let timeframe = 1d;
+  let correlationWindow = 10m;
+  let InteractiveSessions =
+      SigninLogs
+      | where TimeGenerated >= ago(timeframe)
+      | where ResultType == 0
+      | where isnotempty(UserPrincipalName)
+      | summarize arg_max(TimeGenerated, IPAddress, AutonomousSystemNumber, CorrelationId)
+          by UserUpn = tolower(UserPrincipalName)
+      | project
+          UserUpn,
+          InteractiveTime = TimeGenerated,
+          InteractiveIp   = IPAddress,
+          InteractiveAsn  = AutonomousSystemNumber,
+          SessionId       = CorrelationId;
+  AADNonInteractiveUserSignInLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where ResultType == 0
+  | where isnotempty(UserPrincipalName)
+  | extend UserUpn = tolower(UserPrincipalName)
+  | join kind=inner InteractiveSessions on UserUpn
+  | where TimeGenerated between (InteractiveTime .. (InteractiveTime + correlationWindow))
+  | where IPAddress != InteractiveIp
+  | where AutonomousSystemNumber != InteractiveAsn
+  | extend AccountName      = tostring(split(UserUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(UserUpn, "@")[1])
+  | project
+      TimeGenerated,
+      UserUpn,
+      AccountName,
+      AccountUPNSuffix,
+      AppDisplayName,
+      NonInteractiveIp  = IPAddress,
+      NonInteractiveAsn = AutonomousSystemNumber,
+      InteractiveIp,
+      InteractiveAsn,
+      InteractiveTime,
+      SessionId,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: NonInteractiveIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]


### PR DESCRIPTION
## Overview

Three hunting queries focused on token abuse, credential persistence, and illicit OAuth consent — techniques actively exploited in recent campaigns (Storm-0558, Midnight Blizzard, AiTM phishing).

## Queries

### AnomalousTokenIssuanceAfterAiTM (MultipleDataSources)
Correlates non-interactive sign-ins against the preceding interactive sign-in for the same user within a 10-minute window. Flags cases where the ASN and IP address differ between the two events, consistent with AiTM phishing token replay where stolen session material is used from a different network origin. Covers T1539 and T1550.

**Tables:** `SigninLogs`, `AADNonInteractiveUserSignInLogs`

### ServicePrincipalCredentialAdditionByNonHistoricalActor (AuditLogs)
Detects credential additions to service principals by actors with no history of this operation in the preceding 90 days. Compares the current detection window against a 90-day baseline of known operators and surfaces any actor outside that set. Targets post-compromise persistence by compromised accounts not part of the established baseline. Covers T1098.001.

**Tables:** `AuditLogs`

### OAuthConsentToHighRiskPermissionScope (AuditLogs)
Identifies OAuth consent events granting high-risk permission scopes — including `Directory.ReadWrite.All`, `RoleManagement.ReadWrite.Directory`, `Mail.ReadWrite`, and `full_access_as_app` — to applications with no prior consent history in the tenant in the preceding 90 days. Targets consent phishing and illicit OAuth grant attacks. Covers T1528.

**Tables:** `AuditLogs`

## Techniques covered

| Query | MITRE |
| --- | --- |
| AnomalousTokenIssuanceAfterAiTM | T1539, T1550 |
| ServicePrincipalCredentialAdditionByNonHistoricalActor | T1098.001 |
| OAuthConsentToHighRiskPermissionScope | T1528 |

## Validation

- KQL tested against live AuditLogs and SigninLogs data
- Non-ASCII scan: clean
- Schema follows existing hunting query conventions (entity mappings, metadata, requiredDataConnectors)
- No duplication with existing queries (checked against ConsentToApplicationDiscovery.yaml, DormantServicePrincipalUpdateCredsandLogsIn.yaml, and the existing ServicePrincipalCredentialAddedThenSignedIn query in PR #14299)