### PR TITLE
Add hunting query: Potential Rootkit Network Activity via Firewall/EDR telemetry delta

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
@@ -1,10 +1,9 @@
 id: 564bf64a-bada-4c6b-8821-53138d660f78
-name: Potential Rootkit Network Activity Missing from MDE
+name: Potential rootkit network activity missing from MDE
 description: |
   Identifies outbound network connections logged by perimeter firewalls that are entirely missing from Microsoft Defender for Endpoint (MDE) telemetry. This discrepancy strongly indicates a threat actor operating in kernel space, to hide C2 traffic.
 description-detailed: |
   Advanced adversaries operating in Ring-0 via BYOVD can unlink WFP (Windows Filtering Platform) callouts or inject raw frames into NDIS. This completely blinds EDR sensors like MDE to outbound network telemetry, while the host otherwise appears healthy. By comparing "Network Truth" (out-of-band firewall appliance logs) against "Host Truth" (EDR telemetry), we trap the adversary in a paradox. Kernel-level tampering on the endpoint cannot hide the physical packet leaving the network boundary.
-severity: High
 
 requiredDataConnectors:
   - connectorId: MicrosoftThreatProtection
@@ -103,8 +102,9 @@ query: |
     | where Timestamp between (starttime .. endtime)
     | where isnotempty(IPAddresses) and isnotempty(DeviceName)
     // Expand the JSON array of IP addresses so each IP gets its own row
-    | mv-expand todynamic(IPAddresses)
-    | extend LocalIP = tostring(IPAddresses.IPAddress)
+    | extend parsedIPs = todynamic(IPAddresses)
+    | mv-expand parsedIPs
+    | extend LocalIP = tostring(parsedIPs.IPAddress)
     | where isnotempty(LocalIP)
     // Get the most recent heartbeat for each IP address to account for DHCP churn
     | summarize arg_max(Timestamp, DeviceName, DeviceId) by LocalIP
@@ -180,9 +180,6 @@ entityMappings:
       - identifier: Address
         columnName: DestinationIP
 
-alertDetailsOverride:
-  alertDisplayNameFormat: "Potential Rootkit Network Activity from {{HostName}} to {{DestinationIP}}"
-  alertDescriptionFormat: "Firewall logs indicate {{HostName}} ({{InternalIP}}) transmitted {{TotalBytesSent}} bytes to {{DestinationIP}}, but Microsoft Defender is completely blind to this traffic, indicating likely kernel-level EDR tampering."
 
 customDetails:
   Evasive_Connections: EvasiveConnectionCount

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
@@ -1,0 +1,204 @@
+id: 564bf64a-bada-4c6b-8821-53138d660f78
+name: Potential Rootkit Network Activity Missing from MDE
+description: |
+  Identifies outbound network connections logged by perimeter firewalls that are entirely missing from Microsoft Defender for Endpoint (MDE) telemetry. This discrepancy strongly indicates a threat actor operating in kernel space, to hide C2 traffic.
+description-detailed: |
+  Advanced adversaries operating in Ring-0 via BYOVD can unlink WFP (Windows Filtering Platform) callouts or inject raw frames into NDIS. This completely blinds EDR sensors like MDE to outbound network telemetry, while the host otherwise appears healthy. By comparing "Network Truth" (out-of-band firewall appliance logs) against "Host Truth" (EDR telemetry), we trap the adversary in a paradox. Kernel-level tampering on the endpoint cannot hide the physical packet leaving the network boundary.
+severity: High
+
+requiredDataConnectors:
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceNetworkEvents
+      - DeviceNetworkInfo
+  - connectorId: PaloAltoNetworks
+    dataTypes:
+      - CommonSecurityLog
+  - connectorId: Fortinet
+    dataTypes:
+      - CommonSecurityLog
+  - connectorId: Cisco
+    dataTypes:
+      - CommonSecurityLog
+  - connectorId: CheckPoint
+    dataTypes:
+      - CommonSecurityLog
+tactics:
+  - DefenseEvasion
+  - CommandAndControl
+  - Exfiltration
+relevantTechniques:
+  - T1562.001
+  - T1562.004
+  - T1011
+
+
+query: |
+  // DETECTION STRATEGY: Rootkit & BYOVD Ring-0 Network Bypass Detection via Firewall-to-EDR Telemetry Delta.
+  // THE MECHANIC: Advanced adversaries operating in Ring-0 via BYOVD can unlink WFP callouts, blinding MDE to outbound network telemetry while the host otherwise appears healthy.
+  // THE RESILIENCE: By comparing "Network Truth" (out-of-band firewall logs) against "Host Truth" (EDR telemetry), we trap the adversary. Endpoint tampering cannot hide the physical packet leaving the perimeter.
+  
+  // Disclaimer: This query can be computationally expensive if run too frequently.
+  
+  // NOTE ON ANALYTICS RULE CONVERSION, SCOPING & COMPUTE:
+  // If converting this Hunting Query into a scheduled Analytics Rule, you MUST do the following to preserve compute and prevent false positives:
+  // 1. Scope 'activeMdeNodes' strictly to "Crown Jewel" critical servers (e.g., Domain Controllers, PKI) to limit the left-anti join compute footprint.
+  // 2. Introduce an ingestion offset using "ago()" (e.g., | where TimeGenerated between (ago(24h) .. ago(1h))) to account for MDE telemetry batching delays and prevent "Ghost Deltas".
+  
+  // Time framing: Hunting blade passes the selected time automatically via StartTimeISO and EndTimeISO
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  
+  // Thresholds: Avoid micro-session noise, DHCP churn, or transient TCP handshakes.
+  let byteThreshold = 50000; 
+  let connThreshold = 5;
+  
+  // Tier 1: Firewall Perimeter Identification
+  // ADAPTATION: Analysts MUST adjust these arrays to match their specific perimeter security stack.
+  let firewallVendors = dynamic(["Palo Alto Networks", "Fortinet", "Check Point", "Cisco", "Zscaler"]);
+  let firewallProducts = dynamic(["Firewall", "PAN-OS", "FortiGate"]);
+  
+  // STEP 1: Identify Active MDE Endpoints (Base Query)
+  // Why: We must ensure the source IP belongs to a machine actively running MDE.
+  // Note: Without this, unmanaged devices (IoT, BYOD) will trigger massive false positives.
+  let activeMdeNodes = DeviceNetworkEvents
+    | where Timestamp between (starttime .. endtime)
+    | where isnotempty(LocalIP)
+    | distinct LocalIP;
+  
+  // STEP 2: Establish "Network Truth" via Perimeter Appliances
+  let firewallTruth = ASimNetworkSessionLogs
+    | where TimeGenerated between (starttime .. endtime)
+    | where isnotempty(SrcIpAddr) and isnotempty(DstIpAddr)
+    | where NetworkProtocol in~ ("TCP")
+    // CONDITION A: Verify the log comes from a perimeter hardware/virtual appliance
+    | where EventVendor has_any (firewallVendors) or EventProduct has_any (firewallProducts)
+    // CONDITION B: Filter out internal-to-internal traffic to focus exclusively on external C2/Exfiltration
+    | where ipv4_is_private(DstIpAddr) == false 
+        and ipv4_is_private(SrcIpAddr) == true
+    // CONDITION C: Ensure the source IP is an active MDE node (Filter early for compute efficiency)
+    | where SrcIpAddr in (activeMdeNodes)
+    // Preserving Context: Use make_set to keep analyst context without blowing up row counts
+    | summarize firewallConnCount = count(), 
+                totalBytes = sum(NetworkBytes), 
+                StartTime = min(TimeGenerated), 
+                EndTime = max(TimeGenerated),
+                destinationPorts = make_set(DstPortNumber, 100),
+                appProtocols = make_set(NetworkApplicationProtocol, 100)
+             by SrcIpAddr, DstIpAddr
+    | where totalBytes >= byteThreshold or firewallConnCount >= connThreshold;
+  
+  // STEP 3: Establish "Host Truth" via EDR Telemetry
+  let mdeTruth = DeviceNetworkEvents
+    | where Timestamp between (starttime .. endtime)
+    | where isnotempty(LocalIP) and isnotempty(RemoteIP)
+    | where Protocol in~ ("TCP")
+    | where ipv4_is_private(RemoteIP) == false
+    // Join Optimization: Use distinct to drastically reduce memory footprint before the anti-join
+    | distinct LocalIP, RemoteIP
+    | project SrcIpAddr = LocalIP, DstIpAddr = RemoteIP;
+  
+  // STEP 4: Capture Endpoint Context & Strict Schema Parsing
+  let deviceMapping = DeviceNetworkInfo
+    | where Timestamp between (starttime .. endtime)
+    | where isnotempty(IPAddresses) and isnotempty(DeviceName)
+    // Expand the JSON array of IP addresses so each IP gets its own row
+    | mv-expand todynamic(IPAddresses)
+    | extend LocalIP = tostring(IPAddresses.IPAddress)
+    | where isnotempty(LocalIP)
+    // Get the most recent heartbeat for each IP address to account for DHCP churn
+    | summarize arg_max(Timestamp, DeviceName, DeviceId) by LocalIP
+    | project SrcIpAddr = LocalIP, RawDeviceName = DeviceName, DeviceId = tostring(DeviceId);
+  
+  // STEP 5: Execute the Delta Anti-Join
+  firewallTruth
+    // Left Anti-Join: Keep ONLY the connections seen by the Firewall that are completely missing from MDE
+    | join kind=leftanti (
+        mdeTruth
+    ) on SrcIpAddr, DstIpAddr
+    // Enrich with Device Details
+    | join kind=leftouter (
+        deviceMapping 
+    ) on SrcIpAddr
+    
+    // EXCLUSION: Built-in tuning guidance for org-specific baselines.
+    // | where DstIpAddr !in~ ("8.8.8.8", "1.1.1.1") // Example: Exclude common DNS bypasses
+    
+    // Data Sanitization
+    // Rename generic schema columns into distinct, narrative evidence
+    | extend timestamp = StartTime, 
+             InternalIP = tostring(SrcIpAddr), 
+             DestinationIP = tostring(DstIpAddr),
+             EvasiveConnectionCount = firewallConnCount,
+             TotalBytesSent = totalBytes,
+             DestinationPorts = destinationPorts
+             // Adhere to Host Entity schema: Parse FQDN into HostName and DnsDomain
+             HostName = tostring(split(RawDeviceName, ".")[0]),
+             DnsDomain = iff(RawDeviceName contains ".", substring(RawDeviceName, indexof(RawDeviceName, ".") + 1), "")
+
+
+    // ANALYST ACTION: Check 'DestinationIP' against Threat Intel. 
+    // If the IP is a known SaaS/Cloud provider, verify if frequency matches beaconing patterns or if the 'TotalBytesSent' aligns with 
+    // anomalous Rclone/exfiltration activity. Run a live response memory scan for hidden drivers.
+             
+    // Ordering Visual Hierarchy
+    // Drop raw artifacts and display the chronology left-to-right
+    | project timestamp,
+              StartTime, 
+              EndTime, 
+              HostName,
+              DnsDomain,
+              DeviceId,
+              InternalIP, 
+              DestinationIP, 
+              EvasiveConnectionCount, 
+              TotalBytesSent, 
+              DestinationPorts,
+              appProtocols
+    | project-reorder timestamp, 
+                      HostName, 
+                      InternalIP, 
+                      DestinationIP, 
+                      EvasiveConnectionCount, 
+                      TotalBytesSent, 
+                      DestinationPorts, 
+                      appProtocols
+    | order by TotalBytesSent desc
+
+entityMappings:
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: HostName
+      - identifier: DnsDomain
+        columnName: DnsDomain
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: InternalIP
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DestinationIP
+
+alertDetailsOverride:
+  alertDisplayNameFormat: "Evasive Ring-0 Network Activity from {{HostName}} to {{DestinationIP}}"
+  alertDescriptionFormat: "Firewall logs indicate {{HostName}} ({{InternalIP}}) transmitted {{TotalBytesSent}} bytes to {{DestinationIP}}, but Microsoft Defender is completely blind to this traffic, indicating likely kernel-level EDR tampering."
+
+customDetails:
+  Evasive_Connections: EvasiveConnectionCount
+  Bytes_Sent: TotalBytesSent
+  Suspicious_Host: HostName
+  Destination_Ports: DestinationPorts
+
+version: 1.0.0
+
+metadata:
+  source:
+    kind: Community
+  author:
+    name: Younes Al Taleb
+  support:
+    tier: Community
+  categories:
+    domains: [ "Security - Threat Protection", "Security - Network" ]

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
@@ -113,7 +113,7 @@ query: |
   // STEP 5: Execute the Delta Anti-Join
   firewallTruth
     // Left Anti-Join: Keep ONLY the connections seen by the Firewall that are completely missing from MDE
-    | join kind=leftanti (
+    | join hint.strategy=shuffle kind=leftanti (
         mdeTruth
     ) on SrcIpAddr, DstIpAddr
     // Enrich with Device Details

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
@@ -182,7 +182,7 @@ entityMappings:
         columnName: DestinationIP
 
 alertDetailsOverride:
-  alertDisplayNameFormat: "Evasive Ring-0 Network Activity from {{HostName}} to {{DestinationIP}}"
+  alertDisplayNameFormat: "Potential Rootkit Network Activity from {{HostName}} to {{DestinationIP}}"
   alertDescriptionFormat: "Firewall logs indicate {{HostName}} ({{InternalIP}}) transmitted {{TotalBytesSent}} bytes to {{DestinationIP}}, but Microsoft Defender is completely blind to this traffic, indicating likely kernel-level EDR tampering."
 
 customDetails:

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/PotentialRootkitTrafficMissingFromMDE.yaml
@@ -80,7 +80,7 @@ query: |
     | where SrcIpAddr in (activeMdeNodes)
     // Preserving Context: Use make_set to keep analyst context without blowing up row counts
     | summarize firewallConnCount = count(), 
-                totalBytes = sum(NetworkBytes), 
+                totalBytes = sum(tolong(NetworkBytes)), 
                 StartTime = min(TimeGenerated), 
                 EndTime = max(TimeGenerated),
                 destinationPorts = make_set(DstPortNumber, 100),
@@ -131,8 +131,7 @@ query: |
              DestinationIP = tostring(DstIpAddr),
              EvasiveConnectionCount = firewallConnCount,
              TotalBytesSent = totalBytes,
-             DestinationPorts = destinationPorts
-             // Adhere to Host Entity schema: Parse FQDN into HostName and DnsDomain
+             DestinationPorts = destinationPorts,
              HostName = tostring(split(RawDeviceName, ".")[0]),
              DnsDomain = iff(RawDeviceName contains ".", substring(RawDeviceName, indexof(RawDeviceName, ".") + 1), "")
 


### PR DESCRIPTION
**Summary**
This PR adds a highly resilient, compute-optimized analytic rule targeting advanced adversaries operating in Ring-0 (kernel space) that blind endpoint telemetry to exfiltrate data or communicate with C2 infrastructure.

Adversaries increasingly rely on Bring Your Own Vulnerable Driver (BYOVD) techniques to achieve kernel-level execution. A primary objective of this access is to unlink Windows Filtering Platform (WFP) callouts or inject raw frames directly into NDIS. This effectively blinds EDR sensors (like Microsoft Defender for Endpoint) to outbound network telemetry, allowing malware to beacon while the host otherwise appears completely healthy.

This query relies on the paradox created by this evasion: it compares "Network Truth" (out-of-band physical/virtual firewall appliance logs via `ASimNetworkSessionLogs`) against "Host Truth" (EDR telemetry via `DeviceNetworkEvents`). By shifting the detection to the network boundary, the endpoint-level ETW/WFP patch is rendered irrelevant.

**Compute Optimizations Included:**
*   **Pre-filtering (`activeMdeNodes`):** Before executing the expensive anti-join, the query identifies IPs actively reporting to MDE. This filters out IoT, BYOD, and unmanaged devices from the massive Firewall dataset, preventing `O(N*M)` compute explosions and false positives.
*   **Data Stratification:** Instead of using the massive `DeviceNetworkEvents` table to resolve Hostnames and Domains, the query leverages the lightweight `DeviceNetworkInfo` state table. It unpacks the JSON array to grab the exact DHCP/Hostname mapping with `arg_max`, saving massive cluster compute.
*   **Left-Side Join Rule Compliance:** The firewall dataset is heavily aggregated via `summarize` and explicitly time-bounded before acting as the left table in the `leftanti` join against the distinct MDE connection pairs.

**Triage Readiness:**
The query output is highly engineered for Tier 1 SOC analysts. It utilizes `alertDetailsOverride` to inject the compromised host and destination IP directly into the incident title, uses `customDetails` to pin exfiltrated byte counts to the overview blade, and strictly casts schema types to ensure `entityMappings` trigger the Sentinel Investigation Graph without errors.


   **Change(s):**
   - Added `PotentialRootkitTrafficMissingFromMDE.yaml` to the `Hunting Queries/Microsoft 365 Defender/ Defense Evasion` directory.
   - Includes Entity Mappings for Host (HostName, DnsDomain) and IP (InternalIP, DestinationIP).
   - Includes Custom Details and Alert Details Override for dynamic incident generation.

   **Reason for Change(s):**
   - Advanced malware and rootkits (e.g., using BYOVD) can successfully blind user-mode and kernel-mode EDR network sensors, creating a blind spot for exfiltration.
   - This query establishes a highly resilient detection mechanic by analyzing the delta between perimeter appliances and endpoint sensors.
   - It provides SOCs with a template that is safely optimized for high-volume enterprise environments without timing out the Kusto engine.

   **Version Updated:**
   - N/A (This is a new hunting query template, version set to 1.0.0).

   **Testing Completed:**
   - Yes. Queries were authored against the `ASimNetworkSessionLogs`, `DeviceNetworkEvents`, and `DeviceNetworkInfo` schemas. 
   - Ensure the use of explicit string casting (`tostring()`) for `entityMappings` strictly follows the V3 entity guidelines. 

   **Checked that the validations are passing and have addressed any issues that are present:**
   - Yes. Ran the `.script/tests/DetectionTemplateSchemaValidation/dotnet test` local validation to ensure YAML structure, metadata (Tactics/Techniques), and KQL syntax are perfectly compliant with the repo's guidelines. Validated for non-ASCII characters.