### PR TITLE
Add Raw IP Address Used as URL Domain hunting query

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/IP-as-URL-Domain-Detection.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/IP-as-URL-Domain-Detection.yaml
@@ -1,0 +1,47 @@
+id: 6492c4ea-5e56-4ceb-9974-3c0c39cb4d71
+name: Raw IP Address Used as URL Domain
+description: |
+  Detects delivered inbound emails containing URLs where the domain is a raw IPv4 address.
+  Real services use domain names; attackers occasionally use raw IPs to bypass takedown of
+  malicious domains or to evade reputation-based filters. This pattern is a strong indicator
+  of commodity phishing or malware delivery.
+description-detailed: |
+  This query identifies delivered inbound emails containing URLs where the domain field is a
+  raw IPv4 address (four dotted-quad octets). It joins EmailEvents with EmailUrlInfo on
+  NetworkMessageId to enrich the URL with sender, subject, delivery action, and threat verdict.
+  
+  Attack patterns detected:
+  - Phishing links pointing to compromised IP addresses with no domain registration trail
+  - Commodity malware delivery URLs that avoid DNS-based takedown
+  - Generic spam campaigns bypassing reputation filters via raw IP rotation
+  
+  Tuning notes:
+  - Filter on EmailDirection == "Inbound" to exclude outbound security correspondence that
+    may legitimately reference raw IPs in vulnerability disclosures
+  - Maintain an allowlist of trusted security workflow mailboxes if outbound security
+    correspondence is a common false-positive source
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+  - T1566.002
+query: |
+  EmailUrlInfo
+  | where Timestamp > ago(30d)
+  | where UrlDomain matches regex @"^\d+\.\d+\.\d+\.\d+$"
+  | join kind=inner (
+      EmailEvents
+      | project NetworkMessageId, SenderFromDomain, Subject, DeliveryAction,
+                RecipientEmailAddress, EmailDirection, ThreatTypes
+    ) on NetworkMessageId
+  | where EmailDirection == "Inbound"
+  | where DeliveryAction == "Delivered"
+  | project Timestamp, SenderFromDomain, UrlDomain, Url, DeliveryAction,
+            EmailDirection, ThreatTypes, Subject, RecipientEmailAddress
+  | order by Timestamp desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/IP-as-URL-Domain-Detection.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/IP-as-URL-Domain-Detection.yaml
@@ -1,20 +1,17 @@
 id: 6492c4ea-5e56-4ceb-9974-3c0c39cb4d71
 name: Raw IP Address Used as URL Domain
 description: |
-  Detects delivered inbound emails containing URLs where the domain is a raw IPv4 address.
-  Real services use domain names; attackers occasionally use raw IPs to bypass takedown of
-  malicious domains or to evade reputation-based filters. This pattern is a strong indicator
-  of commodity phishing or malware delivery.
+  Detects delivered inbound emails with URLs that use a raw IPv4 address as the domain. This pattern often indicates phishing or malware delivery designed to evade domain-based reputation checks.
 description-detailed: |
   This query identifies delivered inbound emails containing URLs where the domain field is a
   raw IPv4 address (four dotted-quad octets). It joins EmailEvents with EmailUrlInfo on
   NetworkMessageId to enrich the URL with sender, subject, delivery action, and threat verdict.
-  
+
   Attack patterns detected:
   - Phishing links pointing to compromised IP addresses with no domain registration trail
   - Commodity malware delivery URLs that avoid DNS-based takedown
   - Generic spam campaigns bypassing reputation filters via raw IP rotation
-  
+
   Tuning notes:
   - Filter on EmailDirection == "Inbound" to exclude outbound security correspondence that
     may legitimately reference raw IPs in vulnerability disclosures
@@ -33,15 +30,38 @@ relevantTechniques:
 query: |
   EmailUrlInfo
   | where Timestamp > ago(30d)
-  | where UrlDomain matches regex @"^\d+\.\d+\.\d+\.\d+$"
+  | where UrlDomain matches regex @"^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)$"
   | join kind=inner (
       EmailEvents
+      | where Timestamp > ago(30d)
+      | where EmailDirection == "Inbound"
+      | where DeliveryAction == "Delivered"
       | project NetworkMessageId, SenderFromDomain, Subject, DeliveryAction,
                 RecipientEmailAddress, EmailDirection, ThreatTypes
     ) on NetworkMessageId
-  | where EmailDirection == "Inbound"
-  | where DeliveryAction == "Delivered"
   | project Timestamp, SenderFromDomain, UrlDomain, Url, DeliveryAction,
             EmailDirection, ThreatTypes, Subject, RecipientEmailAddress
   | order by Timestamp desc
-version: 1.0.0
+entityMappings:
+- entityType: IP
+  fieldMappings:
+    - identifier: Address
+      columnName: UrlDomain
+- entityType: URL
+  fieldMappings:
+    - identifier: Url
+      columnName: Url
+- entityType: Account
+  fieldMappings:
+    - identifier: FullName
+      columnName: RecipientEmailAddress
+version: 1.0.1
+metadata:
+    source:
+        kind: Community
+    author:
+        name: Ievgen Bondarenko
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection" ]


### PR DESCRIPTION
## What

Adding a new hunting query: **Raw IP Address Used as URL Domain** under `Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Phish/`.

## Why this is novel for this list

I checked existing queries in both the `Phish` and `URL` subfolders. The URL folder covers click metrics (Top Users, SafeLinks, blocked clicks, by-workload, etc.) and the Phish folder covers Detection Technology reporting + appspot/punycode/device-code patterns. **No existing query specifically detects URLs where the domain is a raw IPv4 address.**

This pattern is a strong indicator of:
- Commodity phishing avoiding DNS-takedown
- Generic spam campaigns rotating raw IPs
- Compromised hosts used as throwaway payload servers

The query is straightforward (regex match on `UrlDomain` plus inner join to `EmailEvents` for enrichment) and complements existing detection technology coverage by surfacing infrastructure that may not yet be classified by reputation systems.

## What it detects

```kql
EmailUrlInfo
| where Timestamp > ago(30d)
| where UrlDomain matches regex @"^\d+\.\d+\.\d+\.\d+$"
| join kind=inner (EmailEvents ...) on NetworkMessageId
| where EmailDirection == "Inbound"
| where DeliveryAction == "Delivered"
```

MITRE: T1566 Phishing, T1566.002 Spearphishing Link.

## Source

This query is contributed from [m365-security-operations](https://github.com/ibondarenko1/m365-security-operations), an open-source M365 + Cloudflare audit-and-remediate toolkit. It is drill 06 (`01-sentinel-detection-engineering/kql/06-ip-as-url-detection.kql`) in the toolkit's published KQL hunting drill set, hand-authored for small-org Microsoft 365 tenants and published under MIT.

## Tuning notes (also in `description-detailed`)

- Filter on `EmailDirection == "Inbound"` to exclude outbound security correspondence that may legitimately reference raw IPs (vulnerability disclosures, security workflow).
- Maintain an allowlist of trusted security workflow mailboxes if outbound security correspondence is a common false-positive source.

## License

The query content follows the existing Azure-Sentinel community contribution model; happy to adjust attribution or remove any portion of the description that would be better placed elsewhere.