### PR TITLE
Microsoft Defender XDR connector: add 'Microsoft Defender XDR' to Pro…

### DIFF
--- a/Solutions/Microsoft Defender XDR/Data Connectors/MicrosoftThreatProtection.JSON
+++ b/Solutions/Microsoft Defender XDR/Data Connectors/MicrosoftThreatProtection.JSON
@@ -16,7 +16,7 @@
         {
             "metricName": "Total data received",
             "legend": "Alerts",
-            "baseQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")"
+            "baseQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")"
         },
         {
             "metricName": "Total data received",
@@ -47,7 +47,7 @@
     "sampleQueries": [
         {
             "description": "All Microsoft Defender XDR alerts",
-            "query": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")\n            | sort by TimeGenerated"
+            "query": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")\n            | sort by TimeGenerated"
         },
         {
             "description": "Find possible clear text passwords in Windows registry.",
@@ -135,7 +135,7 @@
         },
         {
             "name": "SecurityAlert",
-            "lastDataReceivedQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+            "lastDataReceivedQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
         },
         {
             "name": "DeviceEvents",

--- a/Solutions/Microsoft Defender XDR/Package/mainTemplate.json
+++ b/Solutions/Microsoft Defender XDR/Package/mainTemplate.json
@@ -2043,7 +2043,7 @@
                     {
                       "metricName": "Total data received",
                       "legend": "Alerts",
-                      "baseQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")"
+                      "baseQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")"
                     },
                     {
                       "metricName": "Total data received",
@@ -2143,7 +2143,7 @@
                     },
                     {
                       "name": "SecurityAlert",
-                      "lastDataReceivedQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+                      "lastDataReceivedQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
                     },
                     {
                       "name": "DeviceEvents",
@@ -2320,7 +2320,7 @@
             {
               "metricName": "Total data received",
               "legend": "Alerts",
-              "baseQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")"
+              "baseQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")"
             },
             {
               "metricName": "Total data received",
@@ -2355,7 +2355,7 @@
             },
             {
               "name": "SecurityAlert",
-              "lastDataReceivedQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\")\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+              "lastDataReceivedQuery": "SecurityAlert \n| where ProductName in(\"Microsoft Defender Advanced Threat Protection\",\"Office 365 Advanced Threat Protection\",\"Azure Advanced Threat Protection\",\"Microsoft Cloud App Security\",\"Microsoft 365 Defender\",\"Microsoft Defender XDR\")\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
             },
             {
               "name": "DeviceEvents",


### PR DESCRIPTION
Fixes ICM 21000000998563.

Post-rebrand, Microsoft Defender XDR alerts arrive in SecurityAlert with ProductName = "Microsoft Defender XDR", but the MicrosoftThreatProtection connector definition only filters on the legacy product names (MDATP, O365 ATP, Azure ATP, MCAS, Microsoft 365 Defender). As a result:

 - The connector status icon renders grey/disconnected for SecurityAlert because lastDataReceivedQuery returns 0 rows, even though data is flowing.
 - The "Total data received" graph (graphQueries.baseQuery) and the "All Microsoft Defender XDR alerts" sample query (sampleQueries.query) miss the rebranded alerts.

Other data types (DeviceEvents, etc.) are unaffected because their queries don't filter on ProductName.

   Change(s):

 - Added "Microsoft Defender XDR" to the ProductName in (...) list in 3 places in Solutions/Microsoft Defender XDR/Data Connectors/MicrosoftThreatProtection.JSON: - graphQueries[].baseQuery (Alerts metric)
 - sampleQueries[].query ("All Microsoft Defender XDR alerts")
 - dataTypes[].lastDataReceivedQuery for SecurityAlert
 - Mirrored the same 4 changes in the generated Solutions/Microsoft Defender XDR/Package/mainTemplate.json so the packaged solution stays consistent.

   Reason for Change(s):

 - Resolves connector status displaying grey/disconnected for the Microsoft Defender XDR connector after the product rebrand.
 - Resolves ICM 21000000998563.

   Version Updated:

 - N/A — this change does not modify any Detections/Analytic Rule templates.

   Testing Completed:

 - Yes — validated the modified JSON files parse correctly. Confirmed via Kusto that SecurityAlert | where ProductName == "Microsoft Defender XDR" returns current rows that the existing query misses; the updated lastDataReceivedQuery returns a non-empty Time.

   Checked that the validations are passing and have addressed any issues that are present:

 - Yes
