### PR TITLE
Update catalogAPI

### DIFF
--- a/.script/package-automation/catalogAPI.ps1
+++ b/.script/package-automation/catalogAPI.ps1
@@ -159,7 +159,7 @@ function GetPackageVersion($defaultPackageVersion, $offerId, $offerDetails, $pac
         [int]$defaultMajor = $defaultMajor
         [int]$defaultMinor = $defaultMinor
         [int]$defaultBuild = $defaultBuild
-
+        
         if ($userInputMajor -ge 3) {
             # Version 3.x.x or higher: use user input if minor and build are greater than default
             if ($userInputMinor -ge $defaultMinor -and $userInputBuild -gt $defaultBuild) {
@@ -218,9 +218,14 @@ function GetPackageVersion($defaultPackageVersion, $offerId, $offerDetails, $pac
                 {
                     $identifiedOfferVersion = $offerMetadataVersion
                     $catalogMajor,$catalogminor,$catalogbuild,$catalogrevision = $identifiedOfferVersion.split(".")
-                    $defaultMajor,$defaultminor,$defaultbuild,$defaultrevision = $setPackageVersion.split(".")
-
-                    if ($defaultMajor -gt $catalogMajor -and $defaultminor -gt $catalogminor -and $defaultbuild -ge $catalogbuild)
+                    $defaultMajor,$defaultMinor,$defaultBuild,$defaultrevision = $setPackageVersion.split(".")
+                    
+                    if($catalogMajor -le 3)
+                    {
+                        Write-Host "Package version $setPackageVersion greater then the CatalogAPI version so $defaultVersionMessage"
+                        return $setPackageVersion
+                    }
+                    elseif ($defaultMajor -gt $catalogMajor -and $defaultMinor -gt $catalogminor -and $defaultBuild -ge $catalogbuild)
                     {
                         # eg: 3.0.0 > 2.0.1 ==> 3.0.0 or 3.1.2 > 3.1.1 ==> 3.1.2
                         Write-Host "Package version $setPackageVersion greater then the CatalogAPI version so $defaultVersionMessage"


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Modify the CatalogAPI file so that package generation defaults to version 3.0.0. If the package version specified while using the v3 tool is less than 3.0.0, generate the package with version 3.0.0 instead.
