### PR TITLE
Add AWS Config CCF data connector

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/AWSConfig_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/AWSConfig_CL.json
@@ -1,0 +1,85 @@
+{
+  "Name": "AWSConfig_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "CaptureTime",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "AwsAccountId",
+      "Type": "String"
+    },
+    {
+      "Name": "AwsRegion",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceType",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceId",
+      "Type": "String"
+    },
+    {
+      "Name": "Arn",
+      "Type": "String"
+    },
+    {
+      "Name": "AvailabilityZone",
+      "Type": "String"
+    },
+    {
+      "Name": "ConfigItemStatus",
+      "Type": "String"
+    },
+    {
+      "Name": "ConfigItemVersion",
+      "Type": "String"
+    },
+    {
+      "Name": "ConfigStateId",
+      "Type": "Long"
+    },
+    {
+      "Name": "ConfigStateMd5Hash",
+      "Type": "String"
+    },
+    {
+      "Name": "RelatedEvents",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "Relationships",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "Tags",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "Configuration",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "SupplementaryConfiguration",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "MessageType",
+      "Type": "String"
+    },
+    {
+      "Name": "SourceFile",
+      "Type": "String"
+    },
+    {
+      "Name": "RawItem",
+      "Type": "Dynamic"
+    }
+  ]
+}

--- a/DataConnectors/AWS-Config/AWSConfig_CL.json
+++ b/DataConnectors/AWS-Config/AWSConfig_CL.json
@@ -1,0 +1,85 @@
+{
+  "Name": "AWSConfig_CL",
+  "Properties": [
+    {
+      "Name": "TimeGenerated",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "CaptureTime",
+      "Type": "DateTime"
+    },
+    {
+      "Name": "AwsAccountId",
+      "Type": "String"
+    },
+    {
+      "Name": "AwsRegion",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceType",
+      "Type": "String"
+    },
+    {
+      "Name": "ResourceId",
+      "Type": "String"
+    },
+    {
+      "Name": "Arn",
+      "Type": "String"
+    },
+    {
+      "Name": "AvailabilityZone",
+      "Type": "String"
+    },
+    {
+      "Name": "ConfigItemStatus",
+      "Type": "String"
+    },
+    {
+      "Name": "ConfigItemVersion",
+      "Type": "String"
+    },
+    {
+      "Name": "ConfigStateId",
+      "Type": "Long"
+    },
+    {
+      "Name": "ConfigStateMd5Hash",
+      "Type": "String"
+    },
+    {
+      "Name": "RelatedEvents",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "Relationships",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "Tags",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "Configuration",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "SupplementaryConfiguration",
+      "Type": "Dynamic"
+    },
+    {
+      "Name": "MessageType",
+      "Type": "String"
+    },
+    {
+      "Name": "SourceFile",
+      "Type": "String"
+    },
+    {
+      "Name": "RawItem",
+      "Type": "Dynamic"
+    }
+  ]
+}

--- a/DataConnectors/AWS-Config/AWSConfig_Sentinel_CCF.json
+++ b/DataConnectors/AWS-Config/AWSConfig_Sentinel_CCF.json
@@ -1,0 +1,704 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workspaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Log Analytics / Microsoft Sentinel workspace name. Deploy into the resource group that contains this workspace."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "westeurope",
+      "metadata": {
+        "description": "Azure region for the DCE, DCR, Sentinel content resources, and workspace location. Example: westeurope."
+      }
+    }
+  },
+  "variables": {
+    "dceName": "dce-awsconfig",
+    "dcrName": "dcr-awsconfig",
+    "tableName": "AWSConfig_CL",
+    "tablePlan": "Analytics",
+    "tableTotalRetentionDays": 365,
+    "customStreamName": "[concat('Custom-', variables('tableName'))]",
+    "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
+    "dceId": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', variables('dceName'))]",
+    "dcrId": "[resourceId('Microsoft.Insights/dataCollectionRules', variables('dcrName'))]",
+    "solutionName": "AWS Config CCF Connector",
+    "solutionId": "azuresentinel.azure-sentinel-solution-awsconfig-ccf",
+    "solutionVersion": "1.0.1",
+    "solutionAuthor": "KanenasCS",
+    "connectorDefinitionName": "AWSConfigLogsDefinition",
+    "connectionContentId": "AWSConfigLogsConnection",
+    "dataConnectorVersionConnectorDefinition": "1.0.0",
+    "dataConnectorVersionConnections": "1.0.1",
+    "definitionTemplateName": "[concat(parameters('workspaceName'),'-dc-',uniqueString(variables('connectorDefinitionName')))]",
+    "connectionTemplateName": "[concat(parameters('workspaceName'),'-rdc-',uniqueString(variables('connectionContentId')))]",
+    "connectorDefinitionResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces/providers/dataConnectorDefinitions', parameters('workspaceName'), 'Microsoft.SecurityInsights', variables('connectorDefinitionName'))]",
+    "solutionContentProductId": "[concat(substring(variables('solutionId'), 0, 50),'-sl-',uniqueString(concat(variables('solutionId'),'-Solution-',variables('solutionId'),'-',variables('solutionVersion'))))]",
+    "dataConnectorContentProductId": "[concat(substring(variables('solutionId'), 0, 50),'-dc-',uniqueString(concat(variables('solutionId'),'-DataConnector-',variables('connectorDefinitionName'),'-',variables('dataConnectorVersionConnectorDefinition'))))]",
+    "resourcesDataConnectorContentProductId": "[concat(substring(variables('solutionId'), 0, 50),'-rdc-',uniqueString(concat(variables('solutionId'),'-ResourcesDataConnector-',variables('connectionContentId'),'-',variables('dataConnectorVersionConnections'))))]",
+    "solutionProvider": "Community",
+    "connectionDataConnectorName": "AWSConfigItemsConnectorUI"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/tables",
+      "apiVersion": "2025-02-01",
+      "name": "[concat(parameters('workspaceName'), '/', variables('tableName'))]",
+      "properties": {
+        "plan": "[variables('tablePlan')]",
+        "totalRetentionInDays": "[variables('tableTotalRetentionDays')]",
+        "schema": {
+          "name": "[variables('tableName')]",
+          "columns": [
+            {
+              "name": "TimeGenerated",
+              "type": "dateTime"
+            },
+            {
+              "name": "CaptureTime",
+              "type": "dateTime"
+            },
+            {
+              "name": "AwsAccountId",
+              "type": "string"
+            },
+            {
+              "name": "AwsRegion",
+              "type": "string"
+            },
+            {
+              "name": "ResourceType",
+              "type": "string"
+            },
+            {
+              "name": "ResourceId",
+              "type": "string"
+            },
+            {
+              "name": "Arn",
+              "type": "string"
+            },
+            {
+              "name": "AvailabilityZone",
+              "type": "string"
+            },
+            {
+              "name": "ConfigItemStatus",
+              "type": "string"
+            },
+            {
+              "name": "ConfigItemVersion",
+              "type": "string"
+            },
+            {
+              "name": "ConfigStateId",
+              "type": "long"
+            },
+            {
+              "name": "ConfigStateMd5Hash",
+              "type": "string"
+            },
+            {
+              "name": "RelatedEvents",
+              "type": "dynamic"
+            },
+            {
+              "name": "Relationships",
+              "type": "dynamic"
+            },
+            {
+              "name": "Tags",
+              "type": "dynamic"
+            },
+            {
+              "name": "Configuration",
+              "type": "dynamic"
+            },
+            {
+              "name": "SupplementaryConfiguration",
+              "type": "dynamic"
+            },
+            {
+              "name": "MessageType",
+              "type": "string"
+            },
+            {
+              "name": "SourceFile",
+              "type": "string"
+            },
+            {
+              "name": "RawItem",
+              "type": "dynamic"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/dataCollectionEndpoints",
+      "apiVersion": "2023-03-11",
+      "name": "[variables('dceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "networkAcls": {
+          "publicNetworkAccess": "Enabled"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[variables('dcrName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces/tables', parameters('workspaceName'), variables('tableName'))]",
+        "[variables('dceId')]"
+      ],
+      "properties": {
+        "dataCollectionEndpointId": "[variables('dceId')]",
+        "streamDeclarations": {
+          "[variables('customStreamName')]": {
+            "columns": [
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "CaptureTime",
+                "type": "datetime"
+              },
+              {
+                "name": "AwsAccountId",
+                "type": "string"
+              },
+              {
+                "name": "AwsRegion",
+                "type": "string"
+              },
+              {
+                "name": "ResourceType",
+                "type": "string"
+              },
+              {
+                "name": "ResourceId",
+                "type": "string"
+              },
+              {
+                "name": "Arn",
+                "type": "string"
+              },
+              {
+                "name": "AvailabilityZone",
+                "type": "string"
+              },
+              {
+                "name": "ConfigItemStatus",
+                "type": "string"
+              },
+              {
+                "name": "ConfigItemVersion",
+                "type": "string"
+              },
+              {
+                "name": "ConfigStateId",
+                "type": "long"
+              },
+              {
+                "name": "ConfigStateMd5Hash",
+                "type": "string"
+              },
+              {
+                "name": "RelatedEvents",
+                "type": "dynamic"
+              },
+              {
+                "name": "Relationships",
+                "type": "dynamic"
+              },
+              {
+                "name": "Tags",
+                "type": "dynamic"
+              },
+              {
+                "name": "Configuration",
+                "type": "dynamic"
+              },
+              {
+                "name": "SupplementaryConfiguration",
+                "type": "dynamic"
+              },
+              {
+                "name": "MessageType",
+                "type": "string"
+              },
+              {
+                "name": "SourceFile",
+                "type": "string"
+              },
+              {
+                "name": "RawItem",
+                "type": "dynamic"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[variables('workspaceResourceId')]",
+              "name": "sentinelWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "[variables('customStreamName')]"
+            ],
+            "destinations": [
+              "sentinelWorkspace"
+            ],
+            "transformKql": "source | extend CaptureTime = todatetime(CaptureTime) | extend TimeGenerated = iif(isnull(CaptureTime), now(), CaptureTime)",
+            "outputStream": "[variables('customStreamName')]"
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/contentPackages",
+      "apiVersion": "2023-04-01-preview",
+      "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/', variables('solutionId'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "version": "[variables('solutionVersion')]",
+        "kind": "Solution",
+        "contentSchemaVersion": "3.0.0",
+        "contentId": "[variables('solutionId')]",
+        "source": {
+          "kind": "Solution",
+          "name": "[variables('solutionName')]",
+          "sourceId": "[variables('solutionId')]"
+        },
+        "author": {
+          "name": "[variables('solutionAuthor')]"
+        },
+        "support": {
+          "name": "[variables('solutionAuthor')]",
+          "tier": "Community"
+        },
+        "dependencies": {
+          "operator": "AND",
+          "criteria": [
+            {
+              "kind": "DataConnector",
+              "contentId": "[variables('connectorDefinitionName')]",
+              "version": "[variables('dataConnectorVersionConnectorDefinition')]"
+            }
+          ]
+        },
+        "providers": [
+          "[variables('solutionProvider')]"
+        ],
+        "categories": {
+          "domains": [
+            "Security - Cloud Security"
+          ]
+        },
+        "contentKind": "Solution",
+        "packageId": "[variables('solutionId')]",
+        "contentProductId": "[variables('solutionContentProductId')]",
+        "displayName": "[variables('solutionName')]",
+        "publisherDisplayName": "[variables('solutionProvider')]",
+        "descriptionHtml": "AWS Config custom API connector for Microsoft Sentinel using the Codeless Connector Framework. Endpoint and API key are provided during connector configuration.",
+        "icon": "Azure_Sentinel",
+        "firstPublishDate": "2026-06-09"
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectorDefinitions",
+      "apiVersion": "2023-11-01-preview",
+      "name": "[concat(parameters('workspaceName'), '/Microsoft.SecurityInsights/', variables('connectorDefinitionName'))]",
+      "location": "[parameters('location')]",
+      "kind": "Customizable",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces/tables', parameters('workspaceName'), variables('tableName'))]",
+        "[resourceId('Microsoft.Insights/dataCollectionRules', variables('dcrName'))]"
+      ],
+      "properties": {
+        "connectorUiConfig": {
+          "id": "[variables('connectorDefinitionName')]",
+          "title": "AWS Config (via Codeless Connector Framework)",
+          "publisher": "Community",
+          "descriptionMarkdown": "Poll a customer-specific AWS Config custom API and ingest configuration items into **AWSConfig_CL**. Enter the API endpoint and x-api-key value below, then select **Connect**.",
+          "graphQueriesTableName": "[variables('tableName')]",
+          "graphQueries": [
+            {
+              "metricName": "Total Config items received",
+              "legend": "AWS Config items",
+              "baseQuery": "{{graphQueriesTableName}}"
+            }
+          ],
+          "sampleQueries": [
+            {
+              "description": "Recent AWS Config items",
+              "query": "{{graphQueriesTableName}} | sort by TimeGenerated desc"
+            },
+            {
+              "description": "AWS Config items by resource type",
+              "query": "{{graphQueriesTableName}} | summarize Count=count() by ResourceType | sort by Count desc"
+            }
+          ],
+          "dataTypes": [
+            {
+              "name": "{{graphQueriesTableName}}",
+              "lastDataReceivedQuery": "{{graphQueriesTableName}} | summarize Time = max(TimeGenerated) | where isnotempty(Time)"
+            }
+          ],
+          "connectivityCriteria": [
+            {
+              "type": "HasDataConnectors"
+            }
+          ],
+          "availability": {
+            "status": 1,
+            "isPreview": true
+          },
+          "permissions": {
+            "resourceProvider": [
+              {
+                "provider": "Microsoft.OperationalInsights/workspaces",
+                "permissionsDisplayText": "Read and write permissions are required on the Microsoft Sentinel workspace.",
+                "providerDisplayName": "Workspace",
+                "scope": "Workspace",
+                "requiredPermissions": {
+                  "write": true,
+                  "read": true,
+                  "delete": true
+                }
+              }
+            ],
+            "customs": [
+              {
+                "name": "AWS Config custom API endpoint",
+                "description": "The customer/environment-specific API Gateway endpoint, including the /logs path."
+              },
+              {
+                "name": "AWS Config custom API key",
+                "description": "The x-api-key value used to authenticate to the API."
+              }
+            ]
+          },
+          "instructionSteps": [
+            {
+              "title": "Connect AWS Config custom API",
+              "description": "Provide the customer/environment-specific API endpoint and the API key. These values are stored on the data connector connection, not in the initial ARM deployment parameters.",
+              "instructions": [
+                {
+                  "type": "Textbox",
+                  "parameters": {
+                    "label": "API endpoint",
+                    "placeholder": "https://example.execute-api.eu-west-2.amazonaws.com/prod/logs",
+                    "type": "text",
+                    "name": "apiEndpoint",
+                    "validations": {
+                      "required": true
+                    }
+                  }
+                },
+                {
+                  "type": "Textbox",
+                  "parameters": {
+                    "label": "API key",
+                    "placeholder": "x-api-key value",
+                    "type": "password",
+                    "name": "apiKey",
+                    "validations": {
+                      "required": true
+                    }
+                  }
+                },
+                {
+                  "type": "ConnectionToggleButton",
+                  "parameters": {
+                    "name": "connectAwsConfigApi",
+                    "connectLabel": "Connect",
+                    "disconnectLabel": "Disconnect",
+                    "isPrimary": true
+                  }
+                }
+              ]
+            }
+          ],
+          "isConnectivityCriteriasMatchSome": false
+        }
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/contentTemplates",
+      "apiVersion": "2023-04-01-preview",
+      "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/', variables('definitionTemplateName'), variables('dataConnectorVersionConnectorDefinition'))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces/providers/contentPackages', parameters('workspaceName'), 'Microsoft.SecurityInsights', variables('solutionId'))]",
+        "[variables('connectorDefinitionResourceId')]"
+      ],
+      "properties": {
+        "contentId": "[variables('connectorDefinitionName')]",
+        "displayName": "[variables('solutionName')]",
+        "contentKind": "DataConnector",
+        "mainTemplate": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "[variables('dataConnectorVersionConnectorDefinition')]",
+          "parameters": {},
+          "variables": {},
+          "resources": [
+            {
+              "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+              "apiVersion": "2022-01-01-preview",
+              "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/',concat('DataConnector-', variables('connectorDefinitionName')))]",
+              "properties": {
+                "parentId": "[variables('connectorDefinitionResourceId')]",
+                "contentId": "[variables('connectorDefinitionName')]",
+                "kind": "DataConnector",
+                "version": "[variables('dataConnectorVersionConnectorDefinition')]",
+                "source": {
+                  "sourceId": "[variables('solutionId')]",
+                  "name": "[variables('solutionName')]",
+                  "kind": "Solution"
+                },
+                "author": {
+                  "name": "[variables('solutionAuthor')]"
+                },
+                "support": {
+                  "name": "[variables('solutionAuthor')]",
+                  "tier": "Community"
+                },
+                "dependencies": {
+                  "criteria": [
+                    {
+                      "version": "[variables('dataConnectorVersionConnections')]",
+                      "contentId": "[variables('connectionContentId')]",
+                      "kind": "ResourcesDataConnector"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "packageKind": "Solution",
+        "packageVersion": "[variables('solutionVersion')]",
+        "packageName": "[variables('solutionName')]",
+        "contentProductId": "[variables('dataConnectorContentProductId')]",
+        "packageId": "[variables('solutionId')]",
+        "contentSchemaVersion": "3.0.0",
+        "version": "[variables('solutionVersion')]"
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/contentTemplates",
+      "apiVersion": "2023-04-01-preview",
+      "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/', variables('connectionTemplateName'), variables('dataConnectorVersionConnections'))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces/providers/contentPackages', parameters('workspaceName'), 'Microsoft.SecurityInsights', variables('solutionId'))]",
+        "[resourceId('Microsoft.Insights/dataCollectionRules', variables('dcrName'))]",
+        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', variables('dceName'))]"
+      ],
+      "properties": {
+        "contentId": "[variables('connectionContentId')]",
+        "displayName": "AWS Config custom API connection",
+        "contentKind": "ResourcesDataConnector",
+        "mainTemplate": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "[variables('dataConnectorVersionConnections')]",
+          "parameters": {
+            "apiEndpoint": {
+              "type": "string",
+              "minLength": 1,
+              "metadata": {
+                "description": "Customer/environment-specific AWS Config API endpoint, including path /logs."
+              }
+            },
+            "apiKey": {
+              "type": "securestring",
+              "minLength": 1,
+              "metadata": {
+                "description": "x-api-key value."
+              }
+            },
+            "connectorDefinitionName": {
+              "type": "string",
+              "defaultValue": "[variables('connectorDefinitionName')]",
+              "minLength": 1
+            },
+            "workspace": {
+              "type": "string",
+              "defaultValue": "[parameters('workspaceName')]"
+            },
+            "workspaceLocation": {
+              "type": "string",
+              "defaultValue": "[parameters('location')]"
+            },
+            "dcrConfig": {
+              "type": "object",
+              "defaultValue": {
+                "dataCollectionEndpoint": "[reference(variables('dceId'), '2023-03-11').logsIngestion.endpoint]",
+                "dataCollectionRuleImmutableId": "[reference(variables('dcrId'), '2023-03-11').immutableId]"
+              }
+            }
+          },
+          "variables": {
+            "connectionContentId": "[variables('connectionContentId')]",
+            "connectionDataConnectorName": "[variables('connectionDataConnectorName')]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.OperationalInsights/workspaces/providers/dataConnectors",
+              "apiVersion": "2023-11-01-preview",
+              "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/', variables('connectionDataConnectorName'))]",
+              "location": "[parameters('location')]",
+              "kind": "RestApiPoller",
+              "properties": {
+                "connectorDefinitionName": "[variables('connectorDefinitionName')]",
+                "dataType": "AWSConfig_CL",
+                "isActive": true,
+                "dcrConfig": {
+                  "streamName": "Custom-AWSConfig_CL",
+                  "dataCollectionEndpoint": "[[parameters('dcrConfig').dataCollectionEndpoint]",
+                  "dataCollectionRuleImmutableId": "[[parameters('dcrConfig').dataCollectionRuleImmutableId]"
+                },
+                "auth": {
+                  "type": "APIKey",
+                  "ApiKey": "[[parameters('apiKey')]",
+                  "ApiKeyName": "x-api-key",
+                  "ApiKeyIdentifier": ""
+                },
+                "request": {
+                  "apiEndpoint": "[[parameters('apiEndpoint')]",
+                  "httpMethod": "Get",
+                  "queryWindowInMin": 5,
+                  "queryTimeFormat": "yyyy-MM-ddTHH:mm:ssZ",
+                  "startTimeAttributeName": "startTime",
+                  "endTimeAttributeName": "endTime",
+                  "retryCount": 3,
+                  "timeoutInSeconds": 60,
+                  "headers": {
+                    "Accept": "application/json"
+                  }
+                },
+                "paging": {
+                  "pagingType": "NextPageToken",
+                  "nextPageParaName": "nextToken",
+                  "nextPageTokenJsonPath": "$.nextToken",
+                  "pagingInfoPlacement": "QueryString"
+                },
+                "response": {
+                  "eventsJsonPaths": [
+                    "$.events[*]"
+                  ],
+                  "format": "json"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+              "apiVersion": "2022-01-01-preview",
+              "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/',concat('DataConnector-', variables('connectionContentId')))]",
+              "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces/providers/dataConnectors', parameters('workspaceName'), 'Microsoft.SecurityInsights', variables('connectionDataConnectorName'))]"
+              ],
+              "properties": {
+                "parentId": "[resourceId('Microsoft.OperationalInsights/workspaces/providers/dataConnectors', parameters('workspaceName'), 'Microsoft.SecurityInsights', variables('connectionDataConnectorName'))]",
+                "contentId": "[variables('connectionContentId')]",
+                "kind": "ResourcesDataConnector",
+                "version": "[variables('dataConnectorVersionConnections')]",
+                "source": {
+                  "sourceId": "[variables('solutionId')]",
+                  "name": "[variables('solutionName')]",
+                  "kind": "Solution"
+                },
+                "author": {
+                  "name": "[variables('solutionAuthor')]"
+                },
+                "support": {
+                  "name": "[variables('solutionAuthor')]",
+                  "tier": "Community"
+                }
+              }
+            }
+          ]
+        },
+        "packageKind": "Solution",
+        "packageVersion": "[variables('solutionVersion')]",
+        "packageName": "[variables('solutionName')]",
+        "contentProductId": "[variables('resourcesDataConnectorContentProductId')]",
+        "packageId": "[variables('solutionId')]",
+        "contentSchemaVersion": "3.0.0",
+        "version": "[variables('solutionVersion')]"
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/metadata",
+      "apiVersion": "2022-01-01-preview",
+      "name": "[concat(parameters('workspaceName'),'/Microsoft.SecurityInsights/',concat('DataConnector-', variables('connectorDefinitionName')))]",
+      "dependsOn": [
+        "[variables('connectorDefinitionResourceId')]",
+        "[resourceId('Microsoft.OperationalInsights/workspaces/providers/contentTemplates', parameters('workspaceName'), 'Microsoft.SecurityInsights', concat(variables('connectionTemplateName'), variables('dataConnectorVersionConnections')))]"
+      ],
+      "properties": {
+        "parentId": "[variables('connectorDefinitionResourceId')]",
+        "contentId": "[variables('connectorDefinitionName')]",
+        "kind": "DataConnector",
+        "version": "[variables('dataConnectorVersionConnectorDefinition')]",
+        "source": {
+          "sourceId": "[variables('solutionId')]",
+          "name": "[variables('solutionName')]",
+          "kind": "Solution"
+        },
+        "author": {
+          "name": "[variables('solutionAuthor')]"
+        },
+        "support": {
+          "name": "[variables('solutionAuthor')]",
+          "tier": "Community"
+        },
+        "dependencies": {
+          "criteria": [
+            {
+              "version": "[variables('dataConnectorVersionConnections')]",
+              "contentId": "[variables('connectionContentId')]",
+              "kind": "ResourcesDataConnector"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "tableName": {
+      "type": "string",
+      "value": "[variables('tableName')]"
+    },
+    "streamName": {
+      "type": "string",
+      "value": "[variables('customStreamName')]"
+    },
+    "connectorDefinitionName": {
+      "type": "string",
+      "value": "[variables('connectorDefinitionName')]"
+    },
+    "dceLogsIngestionEndpoint": {
+      "type": "string",
+      "value": "[reference(variables('dceId'), '2023-03-11').logsIngestion.endpoint]"
+    },
+    "dcrImmutableId": {
+      "type": "string",
+      "value": "[reference(variables('dcrId'), '2023-03-11').immutableId]"
+    }
+  }
+}

--- a/DataConnectors/AWS-Config/CloudFormation/template_1_AWS_Config_v2.yaml
+++ b/DataConnectors/AWS-Config/CloudFormation/template_1_AWS_Config_v2.yaml
@@ -1,513 +1,526 @@
-AWSTemplateFormatVersion: "2010-09-09"
-Description: >
-  Microsoft Sentinel integration for AWS Config logs (CCF custom-API pull pattern).
-  Creates a time-indexed DynamoDB store, an ingest Lambda (SNS-subscribed to the
-  AWS Config delivery channel), a query Lambda, and an API Gateway REST API secured
-  with an API key. Microsoft Sentinel's CCF RestApiPoller polls GET /logs by time
-  window. Unlike the native CloudTrail connector, Sentinel does NOT assume an IAM
-  role here; it authenticates with the API key. The "role" below is the Lambda
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Microsoft Sentinel integration for AWS Config logs (CCF custom-API pull pattern). Creates a time-indexed DynamoDB
+  store, an ingest Lambda (SNS-subscribed to the AWS Config delivery channel), a query Lambda, and an API Gateway REST API
+  secured with an API key. Microsoft Sentinel''s CCF RestApiPoller polls GET /logs by time window. Unlike the native CloudTrail
+  connector, Sentinel does NOT assume an IAM role here; it authenticates with the API key. The "role" below is the Lambda
   execution role.
 
+  '
 Metadata:
   cfn-lint:
     config:
       ignore_checks:
-        - W1030   # ExistingSnsTopicArn default is only used on the "existing topic" branch, guarded by a Rule
+      - W1030
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label: { default: "Account / naming" }
-        Parameters: [ AwsAccountId, DynamoDBTableName, LambdaExecutionRoleName, IngestFunctionName, QueryFunctionName ]
-      - Label: { default: "AWS Config notifications (SNS)" }
-        Parameters: [ CreateSnsTopic, SnsTopicName, ExistingSnsTopicArn ]
-      - Label: { default: "API Gateway" }
-        Parameters: [ ApiName, ApiStageName, ApiKeyName, ApiKeyValue, ThrottleRateLimit, ThrottleBurstLimit, DailyQuota ]
-      - Label: { default: "Retention & sizing" }
-        Parameters: [ TtlDays, LambdaMemory, LambdaTimeout, LogRetentionDays ]
+    - Label:
+        default: Account / naming
+      Parameters:
+      - AwsAccountId
+      - DynamoDBTableName
+      - LambdaExecutionRoleName
+      - IngestFunctionName
+      - QueryFunctionName
+    - Label:
+        default: AWS Config notifications (SNS)
+      Parameters:
+      - CreateSnsTopic
+      - SnsTopicName
+      - ExistingSnsTopicArn
+    - Label:
+        default: API Gateway
+      Parameters:
+      - ApiName
+      - ApiStageName
+      - ApiKeyName
+      - ApiKeyValue
+      - ThrottleRateLimit
+      - ThrottleBurstLimit
+      - DailyQuota
+    - Label:
+        default: Retention & sizing
+      Parameters:
+      - TtlDays
+      - LambdaMemory
+      - LambdaTimeout
+      - LogRetentionDays
     ParameterLabels:
-      AwsAccountId: { default: "AWS account ID (12 digits)" }
-      DynamoDBTableName: { default: "DynamoDB table name" }
-      LambdaExecutionRoleName: { default: "Lambda execution role name" }
-      ApiKeyValue: { default: "API key value (paste into the Sentinel connector)" }
-
+      AwsAccountId:
+        default: AWS account ID (12 digits)
+      DynamoDBTableName:
+        default: DynamoDB table name
+      LambdaExecutionRoleName:
+        default: Lambda execution role name
+      ApiKeyValue:
+        default: API key value (paste into the Sentinel connector)
 Parameters:
-
   AwsAccountId:
     Type: String
-    AllowedPattern: "^[0-9]{12}$"
-    Description: >
-      The 12-digit AWS account ID you are deploying into. Validated against the
-      actual deployment account (see Rules) to catch wrong-account mistakes.
+    AllowedPattern: ^[0-9]{12}$
+    Description: 'The 12-digit AWS account ID you are deploying into. Validated against the actual deployment account (see
+      Rules) to catch wrong-account mistakes.
 
+      '
   DynamoDBTableName:
     Type: String
     Default: SentinelConfigLogs
-    AllowedPattern: "^[a-zA-Z0-9_.-]{3,255}$"
+    AllowedPattern: ^[a-zA-Z0-9_.-]{3,255}$
     Description: Name of the time-indexed DynamoDB table buffering Config items.
-
   LambdaExecutionRoleName:
     Type: String
     Default: sentinel-config-lambda-role
-    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    AllowedPattern: ^[-_a-zA-Z0-9]+$
     Description: Name of the IAM execution role shared by the ingest and query Lambdas.
-
   IngestFunctionName:
     Type: String
     Default: sentinel-config-ingest
-    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    AllowedPattern: ^[-_a-zA-Z0-9]+$
     Description: Name of the Lambda that normalizes Config SNS notifications into DynamoDB.
-
   QueryFunctionName:
     Type: String
     Default: sentinel-config-query
-    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    AllowedPattern: ^[-_a-zA-Z0-9]+$
     Description: Name of the Lambda behind API Gateway that Sentinel polls.
-
   CreateSnsTopic:
     Type: String
-    AllowedValues: ["true", "false"]
-    Default: "true"
-    Description: >
-      "true" to create a new SNS topic for AWS Config notifications (then point your
-      Config delivery channel at the output topic ARN). "false" to subscribe the
-      ingest Lambda to an existing topic given in ExistingSnsTopicArn.
+    AllowedValues:
+    - 'true'
+    - 'false'
+    Default: 'true'
+    Description: '"true" to create a new SNS topic for AWS Config notifications (then point your Config delivery channel at
+      the output topic ARN). "false" to subscribe the ingest Lambda to an existing topic given in ExistingSnsTopicArn.
 
+      '
   SnsTopicName:
     Type: String
     Default: sentinel-config-notifications
-    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    AllowedPattern: ^[-_a-zA-Z0-9]+$
     Description: Name of the SNS topic to create (used only when CreateSnsTopic is "true").
-
   ExistingSnsTopicArn:
     Type: String
-    Default: ""
+    Default: ''
     Description: ARN of an existing SNS topic (used only when CreateSnsTopic is "false").
-
   ApiName:
     Type: String
     Default: sentinel-config-api
-    AllowedPattern: "^[-_a-zA-Z0-9 ]+$"
+    AllowedPattern: ^[-_a-zA-Z0-9 ]+$
     Description: Name of the API Gateway REST API.
-
   ApiStageName:
     Type: String
     Default: prod
-    AllowedPattern: "^[a-zA-Z0-9_-]+$"
+    AllowedPattern: ^[a-zA-Z0-9_-]+$
     Description: Deployment stage name (forms part of the invoke URL).
-
   ApiKeyName:
     Type: String
     Default: sentinel-config-key
-    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    AllowedPattern: ^[-_a-zA-Z0-9]+$
     Description: Name of the API key.
-
   ApiKeyValue:
     Type: String
     NoEcho: true
     MinLength: 20
     MaxLength: 128
-    Description: >
-      The API key value Sentinel will send in the x-api-key header. Choose a long
-      random string; you paste this same value into the CCF connector. Not echoed.
+    Description: 'The API key value Sentinel will send in the x-api-key header. Choose a long random string; you paste this
+      same value into the CCF connector. Not echoed.
 
+      '
   ThrottleRateLimit:
     Type: Number
     Default: 20
     Description: Steady-state request rate limit (req/s) for the usage plan.
-
   ThrottleBurstLimit:
     Type: Number
     Default: 50
     Description: Burst request limit for the usage plan.
-
   DailyQuota:
     Type: Number
     Default: 1000000
     Description: Maximum requests per day for the usage plan.
-
   TtlDays:
     Type: Number
     Default: 90
     MinValue: 1
     Description: Days to retain items in the DynamoDB buffer (TTL). Sentinel is the system of record.
-
   LambdaMemory:
     Type: Number
     Default: 256
     MinValue: 128
     MaxValue: 10240
     Description: Memory (MB) for both Lambdas.
-
   LambdaTimeout:
     Type: Number
     Default: 30
     MinValue: 3
     MaxValue: 900
     Description: Timeout (seconds) for both Lambdas.
-
   LogRetentionDays:
     Type: Number
     Default: 30
-    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    AllowedValues:
+    - 1
+    - 3
+    - 5
+    - 7
+    - 14
+    - 30
+    - 60
+    - 90
+    - 120
+    - 150
+    - 180
+    - 365
+    - 400
+    - 545
+    - 731
+    - 1827
+    - 3653
     Description: CloudWatch Logs retention for the Lambda log groups (controls log cost).
-
 Rules:
   ValidateAccountId:
     Assertions:
-      - Assert: !Equals [ !Ref AwsAccountId, !Ref "AWS::AccountId" ]
-        AssertDescription: AwsAccountId must match the account this stack is deployed into.
-
+    - Assert:
+        Fn::Equals:
+        - Ref: AwsAccountId
+        - Ref: AWS::AccountId
+      AssertDescription: AwsAccountId must match the account this stack is deployed into.
   RequireExistingTopicArn:
-    RuleCondition: !Equals [ !Ref CreateSnsTopic, "false" ]
+    RuleCondition:
+      Fn::Equals:
+      - Ref: CreateSnsTopic
+      - 'false'
     Assertions:
-      - Assert: !Not [ !Equals [ !Ref ExistingSnsTopicArn, "" ] ]
-        AssertDescription: ExistingSnsTopicArn is required when CreateSnsTopic is "false".
-
+    - Assert:
+        Fn::Not:
+        - Fn::Equals:
+          - Ref: ExistingSnsTopicArn
+          - ''
+      AssertDescription: ExistingSnsTopicArn is required when CreateSnsTopic is "false".
 Conditions:
-  CreateSnsTopicCondition: !Equals [ !Ref CreateSnsTopic, "true" ]
-
+  CreateSnsTopicCondition:
+    Fn::Equals:
+    - Ref: CreateSnsTopic
+    - 'true'
 Resources:
-
-  # ---------- Storage ----------
   ConfigLogsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Ref DynamoDBTableName
+      TableName:
+        Ref: DynamoDBTableName
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
-        - AttributeName: bucket
-          AttributeType: S
-        - AttributeName: ts_id
-          AttributeType: S
+      - AttributeName: bucket
+        AttributeType: S
+      - AttributeName: ts_id
+        AttributeType: S
       KeySchema:
-        - AttributeName: bucket
-          KeyType: HASH
-        - AttributeName: ts_id
-          KeyType: RANGE
+      - AttributeName: bucket
+        KeyType: HASH
+      - AttributeName: ts_id
+        KeyType: RANGE
       TimeToLiveSpecification:
         AttributeName: expireAt
         Enabled: true
       Tags:
-        - Key: DeployedInAccount
-          Value: !Ref AwsAccountId
-        - Key: Solution
-          Value: sentinel-aws-config-ccf
-
-  # ---------- Notifications ----------
+      - Key: DeployedInAccount
+        Value:
+          Ref: AwsAccountId
+      - Key: Solution
+        Value: sentinel-aws-config-ccf
   ConfigNotificationTopic:
     Type: AWS::SNS::Topic
     Condition: CreateSnsTopicCondition
     Properties:
-      TopicName: !Ref SnsTopicName
-
+      TopicName:
+        Ref: SnsTopicName
   ConfigNotificationTopicPolicy:
     Type: AWS::SNS::TopicPolicy
     Condition: CreateSnsTopicCondition
     Properties:
       Topics:
-        - !Ref ConfigNotificationTopic
+      - Ref: ConfigNotificationTopic
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Sid: AllowConfigPublish
-            Effect: Allow
-            Principal:
-              Service: config.amazonaws.com
-            Action: "SNS:Publish"
-            Resource: !Ref ConfigNotificationTopic
-
-  # ---------- IAM ----------
+        - Sid: AllowConfigPublish
+          Effect: Allow
+          Principal:
+            Service: config.amazonaws.com
+          Action: SNS:Publish
+          Resource:
+            Ref: ConfigNotificationTopic
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Ref LambdaExecutionRoleName
+      RoleName:
+        Ref: LambdaExecutionRoleName
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action: sts:AssumeRole
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
       Policies:
-        - PolicyName: DynamoDBAccess
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Sid: DdbReadWrite
-                Effect: Allow
-                Action:
-                  - dynamodb:PutItem
-                  - dynamodb:BatchWriteItem
-                  - dynamodb:Query
-                  - dynamodb:GetItem
-                Resource: !GetAtt ConfigLogsTable.Arn
-        - PolicyName: Logs
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Sid: WriteLogs
-                Effect: Allow
-                Action:
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${IngestFunctionName}:*"
-                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${QueryFunctionName}:*"
-
-  # ---------- Log groups (explicit, for retention/cost control) ----------
+      - PolicyName: DynamoDBAccess
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Sid: DdbReadWrite
+            Effect: Allow
+            Action:
+            - dynamodb:PutItem
+            - dynamodb:BatchWriteItem
+            - dynamodb:Query
+            - dynamodb:GetItem
+            Resource:
+              Fn::GetAtt: ConfigLogsTable.Arn
+      - PolicyName: Logs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Sid: WriteLogs
+            Effect: Allow
+            Action:
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource:
+            - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${IngestFunctionName}:*
+            - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${QueryFunctionName}:*
   IngestLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${IngestFunctionName}"
-      RetentionInDays: !Ref LogRetentionDays
-
+      LogGroupName:
+        Fn::Sub: /aws/lambda/${IngestFunctionName}
+      RetentionInDays:
+        Ref: LogRetentionDays
   QueryLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${QueryFunctionName}"
-      RetentionInDays: !Ref LogRetentionDays
-
-  # ---------- Ingest Lambda ----------
+      LogGroupName:
+        Fn::Sub: /aws/lambda/${QueryFunctionName}
+      RetentionInDays:
+        Ref: LogRetentionDays
   IngestFunction:
     Type: AWS::Lambda::Function
     DependsOn: IngestLogGroup
     Properties:
-      FunctionName: !Ref IngestFunctionName
+      FunctionName:
+        Ref: IngestFunctionName
       Runtime: python3.12
       Handler: index.handler
-      MemorySize: !Ref LambdaMemory
-      Timeout: !Ref LambdaTimeout
-      Role: !GetAtt LambdaExecutionRole.Arn
+      MemorySize:
+        Ref: LambdaMemory
+      Timeout:
+        Ref: LambdaTimeout
+      Role:
+        Fn::GetAtt: LambdaExecutionRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: !Ref DynamoDBTableName
-          TTL_DAYS: !Ref TtlDays
+          TABLE_NAME:
+            Ref: DynamoDBTableName
+          TTL_DAYS:
+            Ref: TtlDays
       Code:
-        ZipFile: |
-          import json,os,uuid,decimal,datetime as dt,boto3
-          T=boto3.resource("dynamodb").Table(os.environ["TABLE_NAME"])
-          D=int(os.environ.get("TTL_DAYS","90"))
-          def pt(v):
-            try:return dt.datetime.fromisoformat(v.replace("Z","+00:00"))
-            except Exception:return None
-          def ti(v):
-            try:return int(v)
-            except (TypeError,ValueError):return None
-          def norm(m):
-            ci=m.get("configurationItem") or {}
-            ev=m.get("newEvaluationResult") or {}
-            w=pt(ci.get("configurationItemCaptureTime")) or pt(m.get("notificationCreationTime")) or dt.datetime.now(dt.timezone.utc)
-            iso=w.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
-            return w,{"CaptureTime":iso,
-              "AwsAccountId":ci.get("awsAccountId") or m.get("awsAccountId"),
-              "AwsRegion":ci.get("awsRegion") or m.get("awsRegion"),
-              "ResourceType":ci.get("resourceType") or ev.get("complianceResourceType"),
-              "ResourceId":ci.get("resourceId") or ev.get("complianceResourceId"),
-              "Arn":ci.get("ARN") or ci.get("arn"),
-              "AvailabilityZone":ci.get("availabilityZone"),
-              "ConfigItemStatus":ci.get("configurationItemStatus"),
-              "ConfigItemVersion":ci.get("version"),
-              "ConfigStateId":ti(ci.get("configurationStateId")),
-              "ConfigStateMd5Hash":ci.get("configurationItemMD5Hash"),
-              "RelatedEvents":ci.get("relatedEvents"),
-              "Relationships":ci.get("relationships"),
-              "Tags":ci.get("tags"),
-              "Configuration":ci.get("configuration"),
-              "SupplementaryConfiguration":ci.get("supplementaryConfiguration"),
-              "MessageType":m.get("messageType","Unknown"),
-              "SourceFile":None,
-              "RawItem":m}
-          def handler(e,c):
-            exp=int((dt.datetime.now(dt.timezone.utc)+dt.timedelta(days=D)).timestamp())
-            n=0
-            with T.batch_writer() as b:
-              for r in e.get("Records",[]):
-                raw=r["Sns"]["Message"]
-                try:m=json.loads(raw)
-                except Exception:m={"messageType":"Raw","RawItem":raw}
-                w,it=norm(m)
-                iso=w.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
-                it["bucket"]=iso[:13];it["ts_id"]=iso+"#"+str(uuid.uuid4());it["expireAt"]=exp
-                it=json.loads(json.dumps(it,default=str),parse_float=decimal.Decimal)
-                b.put_item(Item={k:v for k,v in it.items() if v not in (None,"")})
-                n+=1
-            return {"ingested":n}
-
+        ZipFile: "import json,os,uuid,decimal,datetime as dt,boto3\nT=boto3.resource(\"dynamodb\").Table(os.environ[\"TABLE_NAME\"\
+          ])\nD=int(os.environ.get(\"TTL_DAYS\",\"90\"))\ndef pt(v):\n  try:return dt.datetime.fromisoformat(v.replace(\"\
+          Z\",\"+00:00\"))\n  except Exception:return None\ndef ti(v):\n  try:return int(v)\n  except (TypeError,ValueError):return\
+          \ None\ndef norm(m):\n  ci=m.get(\"configurationItem\") or {}\n  ev=m.get(\"newEvaluationResult\") or {}\n  w=pt(ci.get(\"\
+          configurationItemCaptureTime\")) or pt(m.get(\"notificationCreationTime\")) or dt.datetime.now(dt.timezone.utc)\n\
+          \  iso=w.astimezone(dt.timezone.utc).isoformat().replace(\"+00:00\",\"Z\")\n  return w,{\"CaptureTime\":iso,\n \
+          \   \"AwsAccountId\":ci.get(\"awsAccountId\") or m.get(\"awsAccountId\"),\n    \"AwsRegion\":ci.get(\"awsRegion\"\
+          ) or m.get(\"awsRegion\"),\n    \"ResourceType\":ci.get(\"resourceType\") or ev.get(\"complianceResourceType\"),\n\
+          \    \"ResourceId\":ci.get(\"resourceId\") or ev.get(\"complianceResourceId\"),\n    \"Arn\":ci.get(\"ARN\") or\
+          \ ci.get(\"arn\"),\n    \"AvailabilityZone\":ci.get(\"availabilityZone\"),\n    \"ConfigItemStatus\":ci.get(\"configurationItemStatus\"\
+          ),\n    \"ConfigItemVersion\":ci.get(\"version\"),\n    \"ConfigStateId\":ti(ci.get(\"configurationStateId\")),\n\
+          \    \"ConfigStateMd5Hash\":ci.get(\"configurationItemMD5Hash\"),\n    \"RelatedEvents\":ci.get(\"relatedEvents\"\
+          ),\n    \"Relationships\":ci.get(\"relationships\"),\n    \"Tags\":ci.get(\"tags\"),\n    \"Configuration\":ci.get(\"\
+          configuration\"),\n    \"SupplementaryConfiguration\":ci.get(\"supplementaryConfiguration\"),\n    \"MessageType\"\
+          :m.get(\"messageType\",\"Unknown\"),\n    \"SourceFile\":None,\n    \"RawItem\":m}\ndef handler(e,c):\n  exp=int((dt.datetime.now(dt.timezone.utc)+dt.timedelta(days=D)).timestamp())\n\
+          \  n=0\n  with T.batch_writer() as b:\n    for r in e.get(\"Records\",[]):\n      raw=r[\"Sns\"][\"Message\"]\n\
+          \      try:m=json.loads(raw)\n      except Exception:m={\"messageType\":\"Raw\",\"RawItem\":raw}\n      w,it=norm(m)\n\
+          \      iso=w.astimezone(dt.timezone.utc).isoformat().replace(\"+00:00\",\"Z\")\n      it[\"bucket\"]=iso[:13];it[\"\
+          ts_id\"]=iso+\"#\"+str(uuid.uuid4());it[\"expireAt\"]=exp\n      it=json.loads(json.dumps(it,default=str),parse_float=decimal.Decimal)\n\
+          \      b.put_item(Item={k:v for k,v in it.items() if v not in (None,\"\")})\n      n+=1\n  return {\"ingested\"\
+          :n}\n"
   IngestSnsInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref IngestFunction
+      FunctionName:
+        Ref: IngestFunction
       Principal: sns.amazonaws.com
-      SourceArn: !If [ CreateSnsTopicCondition, !Ref ConfigNotificationTopic, !Ref ExistingSnsTopicArn ]
-
+      SourceArn:
+        Fn::If:
+        - CreateSnsTopicCondition
+        - Ref: ConfigNotificationTopic
+        - Ref: ExistingSnsTopicArn
   IngestSnsSubscription:
     Type: AWS::SNS::Subscription
     Properties:
       Protocol: lambda
-      TopicArn: !If [ CreateSnsTopicCondition, !Ref ConfigNotificationTopic, !Ref ExistingSnsTopicArn ]
-      Endpoint: !GetAtt IngestFunction.Arn
-
-  # ---------- Query Lambda ----------
+      TopicArn:
+        Fn::If:
+        - CreateSnsTopicCondition
+        - Ref: ConfigNotificationTopic
+        - Ref: ExistingSnsTopicArn
+      Endpoint:
+        Fn::GetAtt: IngestFunction.Arn
   QueryFunction:
     Type: AWS::Lambda::Function
     DependsOn: QueryLogGroup
     Properties:
-      FunctionName: !Ref QueryFunctionName
+      FunctionName:
+        Ref: QueryFunctionName
       Runtime: python3.12
       Handler: index.handler
-      MemorySize: !Ref LambdaMemory
-      Timeout: !Ref LambdaTimeout
-      Role: !GetAtt LambdaExecutionRole.Arn
+      MemorySize:
+        Ref: LambdaMemory
+      Timeout:
+        Ref: LambdaTimeout
+      Role:
+        Fn::GetAtt: LambdaExecutionRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: !Ref DynamoDBTableName
-          MAX_LIMIT: "5000"
-          DEFAULT_LIMIT: "1000"
+          TABLE_NAME:
+            Ref: DynamoDBTableName
+          MAX_LIMIT: '5000'
+          DEFAULT_LIMIT: '1000'
       Code:
-        ZipFile: |
-          import base64,json,os,decimal,datetime as dt,boto3
-          from boto3.dynamodb.conditions import Key
-          T=boto3.resource("dynamodb").Table(os.environ["TABLE_NAME"])
-          ML=int(os.environ.get("MAX_LIMIT","5000"));DL=int(os.environ.get("DEFAULT_LIMIT","1000"))
-          SKIP={"bucket","ts_id","expireAt"}
-          class E(json.JSONEncoder):
-            def default(self,o):
-              if isinstance(o,decimal.Decimal):return int(o) if o==o.to_integral_value() else float(o)
-              return str(o)
-          def resp(c,b):return {"statusCode":c,"headers":{"Content-Type":"application/json"},"body":json.dumps(b,cls=E)}
-          def piso(v):return dt.datetime.fromisoformat(v.replace("Z","+00:00"))
-          def buckets(s,e):
-            c=s.replace(minute=0,second=0,microsecond=0);o=[]
-            while c<=e:o.append(c.strftime("%Y-%m-%dT%H"));c+=dt.timedelta(hours=1)
-            return o
-          def enc(s):return base64.urlsafe_b64encode(json.dumps(s).encode()).decode()
-          def dec(t):return json.loads(base64.urlsafe_b64decode(t.encode()).decode())
-          def handler(ev,ctx):
-            q=ev.get("queryStringParameters") or {}
-            try:
-              s=piso(q["startTime"]);e=piso(q["endTime"])
-            except Exception:
-              return resp(400,{"error":"startTime and endTime (ISO 8601) are required"})
-            lim=min(int(q.get("limit",DL)),ML)
-            si=s.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
-            ei=e.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
-            bs=buckets(s,e)
-            st=dec(q["nextToken"]) if q.get("nextToken") else {"i":0,"lek":None}
-            out=[];i=st["i"];lek=st["lek"]
-            while i<len(bs) and len(out)<lim:
-              kw={"KeyConditionExpression":Key("bucket").eq(bs[i]) & Key("ts_id").between(si+"#",ei+"#\uffff"),"Limit":lim-len(out)}
-              if lek:kw["ExclusiveStartKey"]=lek
-              p=T.query(**kw)
-              for it in p.get("Items",[]):
-                out.append({k:v for k,v in it.items() if k not in SKIP})
-              lek=p.get("LastEvaluatedKey")
-              if not lek:i+=1
-              if len(out)>=lim:break
-            body={"events":out}
-            if i<len(bs):body["nextToken"]=enc({"i":i,"lek":lek})
-            return resp(200,body)
-
-  # ---------- API Gateway ----------
+        ZipFile: "import base64,json,os,decimal,datetime as dt,boto3\nfrom boto3.dynamodb.conditions import Key\nT=boto3.resource(\"\
+          dynamodb\").Table(os.environ[\"TABLE_NAME\"])\nML=int(os.environ.get(\"MAX_LIMIT\",\"5000\"));DL=int(os.environ.get(\"\
+          DEFAULT_LIMIT\",\"1000\"))\nSKIP={\"bucket\",\"ts_id\",\"expireAt\"}\nclass E(json.JSONEncoder):\n  def default(self,o):\n\
+          \    if isinstance(o,decimal.Decimal):return int(o) if o==o.to_integral_value() else float(o)\n    return str(o)\n\
+          def resp(c,b):return {\"statusCode\":c,\"headers\":{\"Content-Type\":\"application/json\"},\"body\":json.dumps(b,cls=E)}\n\
+          def piso(v):return dt.datetime.fromisoformat(v.replace(\"Z\",\"+00:00\"))\ndef buckets(s,e):\n  c=s.replace(minute=0,second=0,microsecond=0);o=[]\n\
+          \  while c<=e:o.append(c.strftime(\"%Y-%m-%dT%H\"));c+=dt.timedelta(hours=1)\n  return o\ndef enc(s):return base64.urlsafe_b64encode(json.dumps(s).encode()).decode()\n\
+          def dec(t):return json.loads(base64.urlsafe_b64decode(t.encode()).decode())\ndef handler(ev,ctx):\n  q=ev.get(\"\
+          queryStringParameters\") or {}\n  try:\n    s=piso(q[\"startTime\"]);e=piso(q[\"endTime\"])\n  except Exception:\n\
+          \    return resp(400,{\"error\":\"startTime and endTime (ISO 8601) are required\"})\n  lim=min(int(q.get(\"limit\"\
+          ,DL)),ML)\n  si=s.astimezone(dt.timezone.utc).isoformat().replace(\"+00:00\",\"Z\")\n  ei=e.astimezone(dt.timezone.utc).isoformat().replace(\"\
+          +00:00\",\"Z\")\n  bs=buckets(s,e)\n  st=dec(q[\"nextToken\"]) if q.get(\"nextToken\") else {\"i\":0,\"lek\":None}\n\
+          \  out=[];i=st[\"i\"];lek=st[\"lek\"]\n  while i<len(bs) and len(out)<lim:\n    kw={\"KeyConditionExpression\":Key(\"\
+          bucket\").eq(bs[i]) & Key(\"ts_id\").between(si+\"#\",ei+\"#\\uffff\"),\"Limit\":lim-len(out)}\n    if lek:kw[\"\
+          ExclusiveStartKey\"]=lek\n    p=T.query(**kw)\n    for it in p.get(\"Items\",[]):\n      out.append({k:v for k,v\
+          \ in it.items() if k not in SKIP})\n    lek=p.get(\"LastEvaluatedKey\")\n    if not lek:i+=1\n    if len(out)>=lim:break\n\
+          \  body={\"events\":out}\n  if i<len(bs):body[\"nextToken\"]=enc({\"i\":i,\"lek\":lek})\n  return resp(200,body)\n"
   RestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: !Ref ApiName
+      Name:
+        Ref: ApiName
       Description: Exposes AWS Config logs by time window for the Sentinel CCF poller.
       EndpointConfiguration:
-        Types: [ REGIONAL ]
-
+        Types:
+        - REGIONAL
   LogsResource:
     Type: AWS::ApiGateway::Resource
     Properties:
-      RestApiId: !Ref RestApi
-      ParentId: !GetAtt RestApi.RootResourceId
+      RestApiId:
+        Ref: RestApi
+      ParentId:
+        Fn::GetAtt: RestApi.RootResourceId
       PathPart: logs
-
   LogsGetMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      RestApiId: !Ref RestApi
-      ResourceId: !Ref LogsResource
+      RestApiId:
+        Ref: RestApi
+      ResourceId:
+        Ref: LogsResource
       HttpMethod: GET
       AuthorizationType: NONE
       ApiKeyRequired: true
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${QueryFunction.Arn}/invocations"
-
+        Uri:
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${QueryFunction.Arn}/invocations
   QueryApiInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref QueryFunction
+      FunctionName:
+        Ref: QueryFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/GET/logs"
-
+      SourceArn:
+        Fn::Sub: arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/GET/logs
   ApiDeployment:
     Type: AWS::ApiGateway::Deployment
     DependsOn: LogsGetMethod
     Properties:
-      RestApiId: !Ref RestApi
-
+      RestApiId:
+        Ref: RestApi
   ApiStage:
     Type: AWS::ApiGateway::Stage
     Properties:
-      RestApiId: !Ref RestApi
-      DeploymentId: !Ref ApiDeployment
-      StageName: !Ref ApiStageName
-
+      RestApiId:
+        Ref: RestApi
+      DeploymentId:
+        Ref: ApiDeployment
+      StageName:
+        Ref: ApiStageName
   ApiKey:
     Type: AWS::ApiGateway::ApiKey
     DependsOn: ApiStage
     Properties:
-      Name: !Ref ApiKeyName
+      Name:
+        Ref: ApiKeyName
       Enabled: true
-      Value: !Ref ApiKeyValue
-
+      Value:
+        Ref: ApiKeyValue
   UsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     DependsOn: ApiStage
     Properties:
-      UsagePlanName: !Sub "${ApiName}-plan"
+      UsagePlanName:
+        Fn::Sub: ${ApiName}-plan
       ApiStages:
-        - ApiId: !Ref RestApi
-          Stage: !Ref ApiStageName
+      - ApiId:
+          Ref: RestApi
+        Stage:
+          Ref: ApiStageName
       Throttle:
-        RateLimit: !Ref ThrottleRateLimit
-        BurstLimit: !Ref ThrottleBurstLimit
+        RateLimit:
+          Ref: ThrottleRateLimit
+        BurstLimit:
+          Ref: ThrottleBurstLimit
       Quota:
-        Limit: !Ref DailyQuota
+        Limit:
+          Ref: DailyQuota
         Period: DAY
-
   UsagePlanKey:
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
-      KeyId: !Ref ApiKey
+      KeyId:
+        Ref: ApiKey
       KeyType: API_KEY
-      UsagePlanId: !Ref UsagePlan
-
+      UsagePlanId:
+        Ref: UsagePlan
 Outputs:
   ApiEndpoint:
     Description: Use this as the CCF apiEndpoint (path /logs is already included).
-    Value: !Sub "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}/logs"
-
+    Value:
+      Fn::Sub: https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}/logs
   ConfigNotificationTopicArn:
     Description: Point the AWS Config delivery channel snsTopicARN at this topic.
-    Value: !If [ CreateSnsTopicCondition, !Ref ConfigNotificationTopic, !Ref ExistingSnsTopicArn ]
-
+    Value:
+      Fn::If:
+      - CreateSnsTopicCondition
+      - Ref: ConfigNotificationTopic
+      - Ref: ExistingSnsTopicArn
   DynamoDBTableNameOutput:
     Description: Name of the DynamoDB buffer table.
-    Value: !Ref ConfigLogsTable
-
+    Value:
+      Ref: ConfigLogsTable
   IngestFunctionArn:
     Description: ARN of the ingest Lambda.
-    Value: !GetAtt IngestFunction.Arn
-
+    Value:
+      Fn::GetAtt: IngestFunction.Arn
   QueryFunctionArn:
     Description: ARN of the query Lambda.
-    Value: !GetAtt QueryFunction.Arn
-
+    Value:
+      Fn::GetAtt: QueryFunction.Arn
   LambdaExecutionRoleArn:
     Description: ARN of the shared Lambda execution role.
-    Value: !GetAtt LambdaExecutionRole.Arn
+    Value:
+      Fn::GetAtt: LambdaExecutionRole.Arn

--- a/DataConnectors/AWS-Config/CloudFormation/template_1_AWS_Config_v2.yaml
+++ b/DataConnectors/AWS-Config/CloudFormation/template_1_AWS_Config_v2.yaml
@@ -1,0 +1,513 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Microsoft Sentinel integration for AWS Config logs (CCF custom-API pull pattern).
+  Creates a time-indexed DynamoDB store, an ingest Lambda (SNS-subscribed to the
+  AWS Config delivery channel), a query Lambda, and an API Gateway REST API secured
+  with an API key. Microsoft Sentinel's CCF RestApiPoller polls GET /logs by time
+  window. Unlike the native CloudTrail connector, Sentinel does NOT assume an IAM
+  role here; it authenticates with the API key. The "role" below is the Lambda
+  execution role.
+
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W1030   # ExistingSnsTopicArn default is only used on the "existing topic" branch, guarded by a Rule
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label: { default: "Account / naming" }
+        Parameters: [ AwsAccountId, DynamoDBTableName, LambdaExecutionRoleName, IngestFunctionName, QueryFunctionName ]
+      - Label: { default: "AWS Config notifications (SNS)" }
+        Parameters: [ CreateSnsTopic, SnsTopicName, ExistingSnsTopicArn ]
+      - Label: { default: "API Gateway" }
+        Parameters: [ ApiName, ApiStageName, ApiKeyName, ApiKeyValue, ThrottleRateLimit, ThrottleBurstLimit, DailyQuota ]
+      - Label: { default: "Retention & sizing" }
+        Parameters: [ TtlDays, LambdaMemory, LambdaTimeout, LogRetentionDays ]
+    ParameterLabels:
+      AwsAccountId: { default: "AWS account ID (12 digits)" }
+      DynamoDBTableName: { default: "DynamoDB table name" }
+      LambdaExecutionRoleName: { default: "Lambda execution role name" }
+      ApiKeyValue: { default: "API key value (paste into the Sentinel connector)" }
+
+Parameters:
+
+  AwsAccountId:
+    Type: String
+    AllowedPattern: "^[0-9]{12}$"
+    Description: >
+      The 12-digit AWS account ID you are deploying into. Validated against the
+      actual deployment account (see Rules) to catch wrong-account mistakes.
+
+  DynamoDBTableName:
+    Type: String
+    Default: SentinelConfigLogs
+    AllowedPattern: "^[a-zA-Z0-9_.-]{3,255}$"
+    Description: Name of the time-indexed DynamoDB table buffering Config items.
+
+  LambdaExecutionRoleName:
+    Type: String
+    Default: sentinel-config-lambda-role
+    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    Description: Name of the IAM execution role shared by the ingest and query Lambdas.
+
+  IngestFunctionName:
+    Type: String
+    Default: sentinel-config-ingest
+    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    Description: Name of the Lambda that normalizes Config SNS notifications into DynamoDB.
+
+  QueryFunctionName:
+    Type: String
+    Default: sentinel-config-query
+    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    Description: Name of the Lambda behind API Gateway that Sentinel polls.
+
+  CreateSnsTopic:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "true"
+    Description: >
+      "true" to create a new SNS topic for AWS Config notifications (then point your
+      Config delivery channel at the output topic ARN). "false" to subscribe the
+      ingest Lambda to an existing topic given in ExistingSnsTopicArn.
+
+  SnsTopicName:
+    Type: String
+    Default: sentinel-config-notifications
+    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    Description: Name of the SNS topic to create (used only when CreateSnsTopic is "true").
+
+  ExistingSnsTopicArn:
+    Type: String
+    Default: ""
+    Description: ARN of an existing SNS topic (used only when CreateSnsTopic is "false").
+
+  ApiName:
+    Type: String
+    Default: sentinel-config-api
+    AllowedPattern: "^[-_a-zA-Z0-9 ]+$"
+    Description: Name of the API Gateway REST API.
+
+  ApiStageName:
+    Type: String
+    Default: prod
+    AllowedPattern: "^[a-zA-Z0-9_-]+$"
+    Description: Deployment stage name (forms part of the invoke URL).
+
+  ApiKeyName:
+    Type: String
+    Default: sentinel-config-key
+    AllowedPattern: "^[-_a-zA-Z0-9]+$"
+    Description: Name of the API key.
+
+  ApiKeyValue:
+    Type: String
+    NoEcho: true
+    MinLength: 20
+    MaxLength: 128
+    Description: >
+      The API key value Sentinel will send in the x-api-key header. Choose a long
+      random string; you paste this same value into the CCF connector. Not echoed.
+
+  ThrottleRateLimit:
+    Type: Number
+    Default: 20
+    Description: Steady-state request rate limit (req/s) for the usage plan.
+
+  ThrottleBurstLimit:
+    Type: Number
+    Default: 50
+    Description: Burst request limit for the usage plan.
+
+  DailyQuota:
+    Type: Number
+    Default: 1000000
+    Description: Maximum requests per day for the usage plan.
+
+  TtlDays:
+    Type: Number
+    Default: 90
+    MinValue: 1
+    Description: Days to retain items in the DynamoDB buffer (TTL). Sentinel is the system of record.
+
+  LambdaMemory:
+    Type: Number
+    Default: 256
+    MinValue: 128
+    MaxValue: 10240
+    Description: Memory (MB) for both Lambdas.
+
+  LambdaTimeout:
+    Type: Number
+    Default: 30
+    MinValue: 3
+    MaxValue: 900
+    Description: Timeout (seconds) for both Lambdas.
+
+  LogRetentionDays:
+    Type: Number
+    Default: 30
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    Description: CloudWatch Logs retention for the Lambda log groups (controls log cost).
+
+Rules:
+  ValidateAccountId:
+    Assertions:
+      - Assert: !Equals [ !Ref AwsAccountId, !Ref "AWS::AccountId" ]
+        AssertDescription: AwsAccountId must match the account this stack is deployed into.
+
+  RequireExistingTopicArn:
+    RuleCondition: !Equals [ !Ref CreateSnsTopic, "false" ]
+    Assertions:
+      - Assert: !Not [ !Equals [ !Ref ExistingSnsTopicArn, "" ] ]
+        AssertDescription: ExistingSnsTopicArn is required when CreateSnsTopic is "false".
+
+Conditions:
+  CreateSnsTopicCondition: !Equals [ !Ref CreateSnsTopic, "true" ]
+
+Resources:
+
+  # ---------- Storage ----------
+  ConfigLogsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref DynamoDBTableName
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: bucket
+          AttributeType: S
+        - AttributeName: ts_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: bucket
+          KeyType: HASH
+        - AttributeName: ts_id
+          KeyType: RANGE
+      TimeToLiveSpecification:
+        AttributeName: expireAt
+        Enabled: true
+      Tags:
+        - Key: DeployedInAccount
+          Value: !Ref AwsAccountId
+        - Key: Solution
+          Value: sentinel-aws-config-ccf
+
+  # ---------- Notifications ----------
+  ConfigNotificationTopic:
+    Type: AWS::SNS::Topic
+    Condition: CreateSnsTopicCondition
+    Properties:
+      TopicName: !Ref SnsTopicName
+
+  ConfigNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Condition: CreateSnsTopicCondition
+    Properties:
+      Topics:
+        - !Ref ConfigNotificationTopic
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowConfigPublish
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: "SNS:Publish"
+            Resource: !Ref ConfigNotificationTopic
+
+  # ---------- IAM ----------
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref LambdaExecutionRoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: DynamoDBAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: DdbReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:BatchWriteItem
+                  - dynamodb:Query
+                  - dynamodb:GetItem
+                Resource: !GetAtt ConfigLogsTable.Arn
+        - PolicyName: Logs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: WriteLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${IngestFunctionName}:*"
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${QueryFunctionName}:*"
+
+  # ---------- Log groups (explicit, for retention/cost control) ----------
+  IngestLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${IngestFunctionName}"
+      RetentionInDays: !Ref LogRetentionDays
+
+  QueryLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${QueryFunctionName}"
+      RetentionInDays: !Ref LogRetentionDays
+
+  # ---------- Ingest Lambda ----------
+  IngestFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: IngestLogGroup
+    Properties:
+      FunctionName: !Ref IngestFunctionName
+      Runtime: python3.12
+      Handler: index.handler
+      MemorySize: !Ref LambdaMemory
+      Timeout: !Ref LambdaTimeout
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref DynamoDBTableName
+          TTL_DAYS: !Ref TtlDays
+      Code:
+        ZipFile: |
+          import json,os,uuid,decimal,datetime as dt,boto3
+          T=boto3.resource("dynamodb").Table(os.environ["TABLE_NAME"])
+          D=int(os.environ.get("TTL_DAYS","90"))
+          def pt(v):
+            try:return dt.datetime.fromisoformat(v.replace("Z","+00:00"))
+            except Exception:return None
+          def ti(v):
+            try:return int(v)
+            except (TypeError,ValueError):return None
+          def norm(m):
+            ci=m.get("configurationItem") or {}
+            ev=m.get("newEvaluationResult") or {}
+            w=pt(ci.get("configurationItemCaptureTime")) or pt(m.get("notificationCreationTime")) or dt.datetime.now(dt.timezone.utc)
+            iso=w.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
+            return w,{"CaptureTime":iso,
+              "AwsAccountId":ci.get("awsAccountId") or m.get("awsAccountId"),
+              "AwsRegion":ci.get("awsRegion") or m.get("awsRegion"),
+              "ResourceType":ci.get("resourceType") or ev.get("complianceResourceType"),
+              "ResourceId":ci.get("resourceId") or ev.get("complianceResourceId"),
+              "Arn":ci.get("ARN") or ci.get("arn"),
+              "AvailabilityZone":ci.get("availabilityZone"),
+              "ConfigItemStatus":ci.get("configurationItemStatus"),
+              "ConfigItemVersion":ci.get("version"),
+              "ConfigStateId":ti(ci.get("configurationStateId")),
+              "ConfigStateMd5Hash":ci.get("configurationItemMD5Hash"),
+              "RelatedEvents":ci.get("relatedEvents"),
+              "Relationships":ci.get("relationships"),
+              "Tags":ci.get("tags"),
+              "Configuration":ci.get("configuration"),
+              "SupplementaryConfiguration":ci.get("supplementaryConfiguration"),
+              "MessageType":m.get("messageType","Unknown"),
+              "SourceFile":None,
+              "RawItem":m}
+          def handler(e,c):
+            exp=int((dt.datetime.now(dt.timezone.utc)+dt.timedelta(days=D)).timestamp())
+            n=0
+            with T.batch_writer() as b:
+              for r in e.get("Records",[]):
+                raw=r["Sns"]["Message"]
+                try:m=json.loads(raw)
+                except Exception:m={"messageType":"Raw","RawItem":raw}
+                w,it=norm(m)
+                iso=w.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
+                it["bucket"]=iso[:13];it["ts_id"]=iso+"#"+str(uuid.uuid4());it["expireAt"]=exp
+                it=json.loads(json.dumps(it,default=str),parse_float=decimal.Decimal)
+                b.put_item(Item={k:v for k,v in it.items() if v not in (None,"")})
+                n+=1
+            return {"ingested":n}
+
+  IngestSnsInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref IngestFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !If [ CreateSnsTopicCondition, !Ref ConfigNotificationTopic, !Ref ExistingSnsTopicArn ]
+
+  IngestSnsSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: lambda
+      TopicArn: !If [ CreateSnsTopicCondition, !Ref ConfigNotificationTopic, !Ref ExistingSnsTopicArn ]
+      Endpoint: !GetAtt IngestFunction.Arn
+
+  # ---------- Query Lambda ----------
+  QueryFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: QueryLogGroup
+    Properties:
+      FunctionName: !Ref QueryFunctionName
+      Runtime: python3.12
+      Handler: index.handler
+      MemorySize: !Ref LambdaMemory
+      Timeout: !Ref LambdaTimeout
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref DynamoDBTableName
+          MAX_LIMIT: "5000"
+          DEFAULT_LIMIT: "1000"
+      Code:
+        ZipFile: |
+          import base64,json,os,decimal,datetime as dt,boto3
+          from boto3.dynamodb.conditions import Key
+          T=boto3.resource("dynamodb").Table(os.environ["TABLE_NAME"])
+          ML=int(os.environ.get("MAX_LIMIT","5000"));DL=int(os.environ.get("DEFAULT_LIMIT","1000"))
+          SKIP={"bucket","ts_id","expireAt"}
+          class E(json.JSONEncoder):
+            def default(self,o):
+              if isinstance(o,decimal.Decimal):return int(o) if o==o.to_integral_value() else float(o)
+              return str(o)
+          def resp(c,b):return {"statusCode":c,"headers":{"Content-Type":"application/json"},"body":json.dumps(b,cls=E)}
+          def piso(v):return dt.datetime.fromisoformat(v.replace("Z","+00:00"))
+          def buckets(s,e):
+            c=s.replace(minute=0,second=0,microsecond=0);o=[]
+            while c<=e:o.append(c.strftime("%Y-%m-%dT%H"));c+=dt.timedelta(hours=1)
+            return o
+          def enc(s):return base64.urlsafe_b64encode(json.dumps(s).encode()).decode()
+          def dec(t):return json.loads(base64.urlsafe_b64decode(t.encode()).decode())
+          def handler(ev,ctx):
+            q=ev.get("queryStringParameters") or {}
+            try:
+              s=piso(q["startTime"]);e=piso(q["endTime"])
+            except Exception:
+              return resp(400,{"error":"startTime and endTime (ISO 8601) are required"})
+            lim=min(int(q.get("limit",DL)),ML)
+            si=s.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
+            ei=e.astimezone(dt.timezone.utc).isoformat().replace("+00:00","Z")
+            bs=buckets(s,e)
+            st=dec(q["nextToken"]) if q.get("nextToken") else {"i":0,"lek":None}
+            out=[];i=st["i"];lek=st["lek"]
+            while i<len(bs) and len(out)<lim:
+              kw={"KeyConditionExpression":Key("bucket").eq(bs[i]) & Key("ts_id").between(si+"#",ei+"#\uffff"),"Limit":lim-len(out)}
+              if lek:kw["ExclusiveStartKey"]=lek
+              p=T.query(**kw)
+              for it in p.get("Items",[]):
+                out.append({k:v for k,v in it.items() if k not in SKIP})
+              lek=p.get("LastEvaluatedKey")
+              if not lek:i+=1
+              if len(out)>=lim:break
+            body={"events":out}
+            if i<len(bs):body["nextToken"]=enc({"i":i,"lek":lek})
+            return resp(200,body)
+
+  # ---------- API Gateway ----------
+  RestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Ref ApiName
+      Description: Exposes AWS Config logs by time window for the Sentinel CCF poller.
+      EndpointConfiguration:
+        Types: [ REGIONAL ]
+
+  LogsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref RestApi
+      ParentId: !GetAtt RestApi.RootResourceId
+      PathPart: logs
+
+  LogsGetMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref RestApi
+      ResourceId: !Ref LogsResource
+      HttpMethod: GET
+      AuthorizationType: NONE
+      ApiKeyRequired: true
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${QueryFunction.Arn}/invocations"
+
+  QueryApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref QueryFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/GET/logs"
+
+  ApiDeployment:
+    Type: AWS::ApiGateway::Deployment
+    DependsOn: LogsGetMethod
+    Properties:
+      RestApiId: !Ref RestApi
+
+  ApiStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId: !Ref RestApi
+      DeploymentId: !Ref ApiDeployment
+      StageName: !Ref ApiStageName
+
+  ApiKey:
+    Type: AWS::ApiGateway::ApiKey
+    DependsOn: ApiStage
+    Properties:
+      Name: !Ref ApiKeyName
+      Enabled: true
+      Value: !Ref ApiKeyValue
+
+  UsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    DependsOn: ApiStage
+    Properties:
+      UsagePlanName: !Sub "${ApiName}-plan"
+      ApiStages:
+        - ApiId: !Ref RestApi
+          Stage: !Ref ApiStageName
+      Throttle:
+        RateLimit: !Ref ThrottleRateLimit
+        BurstLimit: !Ref ThrottleBurstLimit
+      Quota:
+        Limit: !Ref DailyQuota
+        Period: DAY
+
+  UsagePlanKey:
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !Ref ApiKey
+      KeyType: API_KEY
+      UsagePlanId: !Ref UsagePlan
+
+Outputs:
+  ApiEndpoint:
+    Description: Use this as the CCF apiEndpoint (path /logs is already included).
+    Value: !Sub "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}/logs"
+
+  ConfigNotificationTopicArn:
+    Description: Point the AWS Config delivery channel snsTopicARN at this topic.
+    Value: !If [ CreateSnsTopicCondition, !Ref ConfigNotificationTopic, !Ref ExistingSnsTopicArn ]
+
+  DynamoDBTableNameOutput:
+    Description: Name of the DynamoDB buffer table.
+    Value: !Ref ConfigLogsTable
+
+  IngestFunctionArn:
+    Description: ARN of the ingest Lambda.
+    Value: !GetAtt IngestFunction.Arn
+
+  QueryFunctionArn:
+    Description: ARN of the query Lambda.
+    Value: !GetAtt QueryFunction.Arn
+
+  LambdaExecutionRoleArn:
+    Description: ARN of the shared Lambda execution role.
+    Value: !GetAtt LambdaExecutionRole.Arn

--- a/DataConnectors/AWS-Config/README.md
+++ b/DataConnectors/AWS-Config/README.md
@@ -1,0 +1,297 @@
+# AWS Config Microsoft Sentinel Connector
+
+## Introduction
+
+The AWS Config Microsoft Sentinel connector ingests AWS Config configuration item notifications into Microsoft Sentinel by using the Codeless Connector Framework (CCF).
+
+The connector uses an AWS-hosted HTTPS API that is deployed with the included AWS CloudFormation template. Microsoft Sentinel polls this API over HTTPS and authenticates by using an API key in the `x-api-key` header.
+
+The connector stores data in the following custom table:
+
+```text
+AWSConfig_CL
+```
+
+## Configuration process
+
+The CloudFormation template can be used to automatically configure the required AWS resources.
+
+At a high level, the template does the following:
+
+1. Creates a DynamoDB table to buffer AWS Config notification events.
+2. Creates a new SNS topic for AWS Config notifications, or uses an existing SNS topic.
+3. Creates an ingest Lambda function that receives AWS Config notifications from SNS.
+4. Stores normalized AWS Config items in DynamoDB.
+5. Creates a query Lambda function that returns events by time window.
+6. Creates an Amazon API Gateway REST API with a `GET /logs` endpoint.
+7. Creates an API Gateway API key and usage plan.
+8. Creates CloudWatch log groups for the Lambda functions.
+
+When the deployment is complete, the CloudFormation stack outputs the API endpoint that must be entered in the Microsoft Sentinel data connector page.
+
+## Template prerequisites
+
+You must have the following before using the template:
+
+- AWS CLI installed and configured.
+- Permissions to deploy CloudFormation stacks.
+- Permissions to create or update IAM roles, Lambda functions, DynamoDB tables, SNS topics or subscriptions, API Gateway resources, and CloudWatch log groups.
+- AWS Config enabled in the AWS account and region that you want to monitor.
+- A Microsoft Sentinel workspace where the AWS Config data connector has been deployed.
+
+Run the following command to confirm that the AWS CLI is configured:
+
+```bash
+aws sts get-caller-identity
+```
+
+## Using the template
+
+Download the CloudFormation template to your computer:
+
+```text
+template_1_AWS_Config_v2.yaml
+```
+
+Generate an API key value. The same value must be used later in the Microsoft Sentinel connector page.
+
+```bash
+API_KEY_VALUE="$(openssl rand -hex 32)"
+AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+```
+
+Deploy the CloudFormation stack:
+
+```bash
+aws cloudformation deploy \
+  --template-file template_1_AWS_Config_v2.yaml \
+  --stack-name sentinel-aws-config-ccf \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    AwsAccountId="$AWS_ACCOUNT_ID" \
+    ApiKeyValue="$API_KEY_VALUE" \
+    CreateSnsTopic="true"
+```
+
+> IMPORTANT: The deployment requires `CAPABILITY_NAMED_IAM` because the template creates a named IAM role for the Lambda functions.
+
+## Configure AWS Config notifications
+
+After the stack deployment completes, retrieve the SNS topic ARN:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name sentinel-aws-config-ccf \
+  --query "Stacks[0].Outputs[?OutputKey=='ConfigNotificationTopicArn'].OutputValue" \
+  --output text
+```
+
+Configure AWS Config to publish notifications to this SNS topic.
+
+If AWS Config already publishes notifications to an existing SNS topic, use the existing SNS topic deployment option below instead.
+
+## Using an existing SNS topic
+
+If AWS Config already publishes notifications to an existing SNS topic, deploy the template with `CreateSnsTopic=false` and provide the topic ARN:
+
+```bash
+aws cloudformation deploy \
+  --template-file template_1_AWS_Config_v2.yaml \
+  --stack-name sentinel-aws-config-ccf \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    AwsAccountId="$AWS_ACCOUNT_ID" \
+    ApiKeyValue="$API_KEY_VALUE" \
+    CreateSnsTopic="false" \
+    ExistingSnsTopicArn="arn:aws:sns:<region>:<account-id>:<topic-name>"
+```
+
+The template subscribes the ingest Lambda function to the existing SNS topic.
+
+## Get the API endpoint
+
+Retrieve the API endpoint from the CloudFormation stack outputs:
+
+```bash
+API_ENDPOINT="$(aws cloudformation describe-stacks \
+  --stack-name sentinel-aws-config-ccf \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" \
+  --output text)"
+
+echo "$API_ENDPOINT"
+```
+
+The output already includes the `/logs` path.
+
+## Test the API endpoint
+
+Use a recent time window to test the endpoint before configuring Microsoft Sentinel:
+
+```bash
+START_TIME="$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')"
+END_TIME="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+curl -sS \
+  -H "x-api-key: $API_KEY_VALUE" \
+  -H "Accept: application/json" \
+  "$API_ENDPOINT?startTime=$START_TIME&endTime=$END_TIME"
+```
+
+Expected response format:
+
+```json
+{
+  "events": [
+    {
+      "CaptureTime": "2026-06-09T12:00:00Z",
+      "AwsAccountId": "123456789012",
+      "AwsRegion": "eu-west-2",
+      "ResourceType": "AWS::EC2::Instance",
+      "ResourceId": "i-0123456789abcdef0",
+      "ConfigItemStatus": "OK",
+      "MessageType": "ConfigurationItemChangeNotification"
+    }
+  ],
+  "nextToken": "optional-next-page-token"
+}
+```
+
+The Microsoft Sentinel connector expects:
+
+| Setting | Value |
+|---|---|
+| HTTP method | `GET` |
+| API key header | `x-api-key` |
+| Start time query parameter | `startTime` |
+| End time query parameter | `endTime` |
+| Paging query parameter | `nextToken` |
+| Events JSON path | `$.events` |
+
+## Configure Microsoft Sentinel
+
+In the Azure portal, open the Microsoft Sentinel data connector page.
+
+```text
+Microsoft Sentinel
+-> Data connectors
+-> AWS Config
+-> Open connector page
+```
+
+Enter the following values:
+
+```text
+API endpoint: <ApiEndpoint CloudFormation output>
+API key:      <API_KEY_VALUE used during CloudFormation deployment>
+```
+
+Then select **Connect**.
+
+## Validate data in Microsoft Sentinel
+
+Allow several polling intervals for data to appear, then run:
+
+```kql
+AWSConfig_CL
+| sort by TimeGenerated desc
+| take 20
+```
+
+To check ingestion health:
+
+```kql
+AWSConfig_CL
+| summarize Count=count(), LastEvent=max(TimeGenerated), LastIngestion=max(ingestion_time())
+```
+
+To summarize by AWS account, region, and resource type:
+
+```kql
+AWSConfig_CL
+| summarize Count=count() by AwsAccountId, AwsRegion, ResourceType
+| sort by Count desc
+```
+
+## Troubleshooting
+
+### No data appears in Microsoft Sentinel
+
+Check the following:
+
+1. AWS Config is enabled in the target account and region.
+2. AWS Config is publishing notifications to the SNS topic used by the stack.
+3. The ingest Lambda function has recent invocations in CloudWatch Logs.
+4. The DynamoDB table contains recent items.
+5. The API endpoint returns `HTTP 200` when called with the correct `x-api-key`.
+6. The API response contains an `events` array.
+7. `CaptureTime` values are inside the requested time window.
+8. The API endpoint configured in Microsoft Sentinel exactly matches the `ApiEndpoint` stack output.
+
+### API returns 403
+
+A `403` response usually means the API key is missing or incorrect.
+
+Confirm that the Sentinel connector uses the same value provided to the CloudFormation `ApiKeyValue` parameter, and confirm that the header name is:
+
+```text
+x-api-key
+```
+
+### API returns 400
+
+A `400` response usually means `startTime` or `endTime` is missing or malformed.
+
+Use UTC ISO 8601 format:
+
+```text
+yyyy-MM-ddTHH:mm:ssZ
+```
+
+Example:
+
+```text
+2026-06-09T12:00:00Z
+```
+
+### SNS topic exists but no events arrive
+
+If `CreateSnsTopic=true`, the template creates the SNS topic and subscribes the ingest Lambda function. AWS Config must still be configured to publish notifications to that topic.
+
+If `CreateSnsTopic=false`, confirm that AWS Config is already publishing to the existing SNS topic provided in `ExistingSnsTopicArn`.
+
+## Advanced usage
+
+The CloudFormation template supports the following parameters:
+
+| Parameter | Description |
+|---|---|
+| `AwsAccountId` | The 12-digit AWS account ID. The template validates that it matches the deployment account. |
+| `DynamoDBTableName` | Name of the DynamoDB table used to buffer AWS Config events. |
+| `LambdaExecutionRoleName` | Name of the IAM role shared by the ingest and query Lambda functions. |
+| `IngestFunctionName` | Name of the Lambda function that receives SNS notifications. |
+| `QueryFunctionName` | Name of the Lambda function used by API Gateway. |
+| `CreateSnsTopic` | Set to `true` to create a new SNS topic, or `false` to use an existing SNS topic. |
+| `SnsTopicName` | Name of the SNS topic to create when `CreateSnsTopic=true`. |
+| `ExistingSnsTopicArn` | ARN of an existing SNS topic when `CreateSnsTopic=false`. |
+| `ApiName` | Name of the API Gateway REST API. |
+| `ApiStageName` | API Gateway stage name. |
+| `ApiKeyName` | Name of the API Gateway API key. |
+| `ApiKeyValue` | API key value sent by Microsoft Sentinel in the `x-api-key` header. |
+| `ThrottleRateLimit` | API Gateway steady-state request rate limit. |
+| `ThrottleBurstLimit` | API Gateway burst request limit. |
+| `DailyQuota` | API Gateway daily request quota. |
+| `TtlDays` | Number of days to retain buffered events in DynamoDB. |
+| `LambdaMemory` | Memory size for the Lambda functions. |
+| `LambdaTimeout` | Timeout for the Lambda functions. |
+| `LogRetentionDays` | CloudWatch Logs retention for the Lambda log groups. |
+
+## Cleanup
+
+To remove the AWS resources created by the template, run:
+
+```bash
+aws cloudformation delete-stack \
+  --stack-name sentinel-aws-config-ccf
+```
+
+If the stack created the SNS topic and AWS Config was configured to use it, update the AWS Config delivery channel as needed before or after deleting the stack.


### PR DESCRIPTION
Change(s):

Added a new AWS Config Microsoft Sentinel data connector under DataConnectors/AWS-Config/.
Added a Codeless Connector Framework (CCF) data connector for ingesting AWS Config configuration item notifications into the AWSConfig_CL custom table.
Added an AWS CloudFormation template that deploys the required AWS-side API backend, including API Gateway, Lambda functions, DynamoDB, SNS integration, API key authentication, usage plan, IAM role, and CloudWatch log groups.
Added a README with deployment, configuration, API testing, Microsoft Sentinel connector configuration, validation queries, troubleshooting, and cleanup steps.

Reason for Change(s):

This contribution provides a community AWS Config connector for Microsoft Sentinel using the Codeless Connector Framework.
AWS Config notifications are collected through an AWS-hosted API endpoint deployed by CloudFormation and polled by Microsoft Sentinel using API key authentication.
The connector enables AWS Config resource configuration visibility in Microsoft Sentinel through the AWSConfig_CL table.

Version Updated:

Not applicable. This PR does not add or update Detections/Analytic Rule templates.

Testing Completed:

Yes.
Validated the CloudFormation deployment flow.
Validated that the AWS API endpoint supports GET /logs.
Validated API key authentication using the x-api-key header.
Validated the expected API response structure with an events array.
Validated the Microsoft Sentinel connector configuration values documented in the README.

Checked that the validations are passing and have addressed any issues that are present:
-