### PR TITLE
[ASIM] Updates to ASimSchemaTester to use both selected schema and common fields

### DIFF
--- a/ASIM/dev/ASimTester/ASimSchemaTester.json
+++ b/ASIM/dev/ASimTester/ASimSchemaTester.json
@@ -2,45 +2,35 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-      "Workspace": {
-        "type": "string",
-        "metadata": {
-          "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
-        }
-      },
-      "WorkspaceRegion": {
-        "type": "string",
-        "defaultValue": "[resourceGroup().location]",
-        "metadata": {
-          "description": "The region of the selected workspace. The default value will use the Region selection above."
-        }
+    "Workspace": {
+      "type": "string",
+      "metadata": {
+        "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
+    },
+    "WorkspaceRegion": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The region of the selected workspace. The default value will use the Region selection above."
+      }
+    }
   },
   "resources": [
     {
-      "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2017-03-15-preview",
-      "name": "[parameters('Workspace')]",
+      "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+      "apiVersion": "2020-08-01",
+      "name": "[concat(parameters('Workspace'), '/ASimSchemaTester')]",
       "location": "[parameters('WorkspaceRegion')]",
-      "resources": [
-        {
-          "type": "savedSearches",
-          "apiVersion": "2020-08-01",
-          "name": "ASimSchemaTester",
-          "dependsOn": [
-            "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
-          ],
-          "properties": {
-            "etag": "*",
-            "displayName": "ASIM Schema tester",
-            "category": "Security",
-            "FunctionAlias": "ASimSchemaTester",
-            "query": "let ASimFields = materialize(externaldata (ColumnName: string, ColumnType: string, Class: string, Schema: string, LogicalType:string, ListOfValues: string, AliasedField: string)\r\n        [@\"https:\/\/raw.githubusercontent.com\/Azure\/Azure-Sentinel\/master\/ASIM\/dev\/ASimTester\/ASimTester.csv\"] with (format=\"csv\", IgnoreFirstRecord=true)\r\n        | where Schema =~ selected_schema);\r\n    let ASimFieldsWithAliases = materialize(ASimFields | project-rename SchemaColumn = ColumnName, SchemaType = ColumnType | lookup (ASimFields | project ParentClass = Class, ParentColumn = ColumnName) on $left.AliasedField == $right.ParentColumn);\r\n    let ParserFields = toscalar (T | summarize make_set(ColumnName));\r\n    T \r\n    | join kind=fullouter ASimFieldsWithAliases on $left.ColumnName == $right.SchemaColumn\r\n    | extend Result = case(\r\n        ColumnName == \"\" and Class == \"Mandatory\",  strcat (\"(0) Error: Missing mandatory field [\", SchemaColumn, \"]\"),\r\n        ColumnName == \"\" and Class == \"Recommended\", strcat (\"(1) Warning: Missing recommended field [\", SchemaColumn, \"]\"),\r\n        ColumnName == \"\" and Class == \"Conditional\" and ParentClass == \"Mandatory\", \r\n           strcat (\"(0) Error: Missing field [\", SchemaColumn, \"] is mandatory when mandatory column [\", AliasedField, \"] exists\"),\r\n        ColumnName == \"\" and Class == \"Conditional\" and AliasedField in (ParserFields), \r\n           strcat (\"(0) Error: Missing field [\", SchemaColumn, \"] is mandatory when field [\", AliasedField, \"] exists\"),  \r\n        ColumnName == \"\" and Class == \"Alias\", \r\n            case \r\n              (ParentClass == \"Mandatory\", \r\n                    iff (AliasedField in (ParserFields),  \r\n                        strcat (\"(0) Error: Missing mandatory alias [\", SchemaColumn, \"] aliasing existing column [\", AliasedField, \"]\"),\r\n                        strcat (\"(0) Error: Missing mandatory alias [\", SchemaColumn, \"] aliasing missing column [\", AliasedField, \"]\")\r\n                    ),\r\n               ParentClass == \"Recommended\" , \r\n                    iff (AliasedField in (ParserFields),\r\n                        strcat (\"(0) Error: Missing recommended alias [\", SchemaColumn, \"] aliasing existing column [\", AliasedField, \"]\"),  \r\n                        strcat (\"(2) Info: Missing recommended alias [\", SchemaColumn, \"] aliasing non-existent column [\", AliasedField, \"]\")\r\n                    ),\r\n                \/\/ -- default: ParentClass is optional\r\n                iff (AliasedField in (ParserFields),\r\n                    strcat (\"(0) Error: Missing optional alias [\", SchemaColumn, \"] aliasing existing column [\", AliasedField, \"]\"),\r\n                    strcat (\"(2) Info: Missing optional alias [\", SchemaColumn, \"] aliasing non-existent column [\", AliasedField, \"]\")\r\n                )\r\n            ),\r\n        ColumnName == \"\" and Class == \"Optional\", strcat (\"(2) Info: Missing optional field [\", SchemaColumn, \"]\"),\r\n        SchemaColumn == \"\", strcat (\"(2) Info: extra unnormalized column [\", ColumnName, \"]\"),\r\n        ColumnName != \"\" and ColumnType != SchemaType, strcat (\"(0) Error: type mismatch for column [\", ColumnName, \"]. It is currently \", ColumnType, \" and should be \", SchemaType),\r\n        'None'\r\n        )\r\n    | where Result != \"None\" | sort by Result asc | project Result\r\n",
-            "version": 1,
-            "functionParameters": "T:(ColumnName:string,ColumnType:string),selected_schema:string"
-          }
-        }
-      ]
+      "properties": {
+        "etag": "*",
+        "displayName": "ASIM Schema tester",
+        "category": "ASIM",
+        "FunctionAlias": "ASimSchemaTester",
+        "query": "let ASimFields = materialize(externaldata (ColumnName: string, ColumnType: string, Class: string, Schema: string, LogicalType:string, ListOfValues: string, AliasedField: string)\n  [@\"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/ASIM/dev/ASimTester/ASimTester.csv\"] with (format=\"csv\", IgnoreFirstRecord=true)\n  | where Schema =~ selected_schema or Schema =~ \"Common\"\n  | extend _Priority = iif(Schema =~ selected_schema, 0, 1)\n  | summarize arg_min(_Priority, ColumnType, Class, Schema, LogicalType, ListOfValues, AliasedField) by ColumnName\n  | project-away _Priority);\nlet ASimFieldsWithAliases = materialize(ASimFields | project-rename SchemaColumn = ColumnName, SchemaType = ColumnType | lookup (ASimFields | project ParentClass = Class, ParentColumn = ColumnName) on $left.AliasedField == $right.ParentColumn);\nlet ParserFields = toscalar (T | summarize make_set(ColumnName));\nT\n| join kind=fullouter ASimFieldsWithAliases on $left.ColumnName == $right.SchemaColumn\n| extend Result = case(\n    ColumnName == \"\" and Class == \"Mandatory\",  strcat (\"(0) Error: Missing mandatory field [\", SchemaColumn, \"]\"),\n    ColumnName == \"\" and Class == \"Recommended\", strcat (\"(1) Warning: Missing recommended field [\", SchemaColumn, \"]\"),\n    ColumnName == \"\" and Class == \"Conditional\" and ParentClass == \"Mandatory\",\n        strcat (\"(0) Error: Missing field [\", SchemaColumn, \"] is mandatory when mandatory column [\", AliasedField, \"] exists\"),\n    ColumnName == \"\" and Class == \"Conditional\" and AliasedField in (ParserFields),\n        strcat (\"(0) Error: Missing field [\", SchemaColumn, \"] is mandatory when field [\", AliasedField, \"] exists\"),\n    ColumnName == \"\" and Class == \"Alias\",\n        case\n          (ParentClass == \"Mandatory\",\n                iff (AliasedField in (ParserFields),\n                    strcat (\"(0) Error: Missing mandatory alias [\", SchemaColumn, \"] aliasing existing column [\", AliasedField, \"]\"),\n                    strcat (\"(0) Error: Missing mandatory alias [\", SchemaColumn, \"] aliasing missing column [\", AliasedField, \"]\")\n                ),\n            ParentClass == \"Recommended\" ,\n                iff (AliasedField in (ParserFields),\n                    strcat (\"(0) Error: Missing recommended alias [\", SchemaColumn, \"] aliasing existing column [\", AliasedField, \"]\"),\n                    strcat (\"(2) Info: Missing recommended alias [\", SchemaColumn, \"] aliasing non-existent column [\", AliasedField, \"]\")\n                ),\n            // -- default: ParentClass is optional\n            iff (AliasedField in (ParserFields),\n                strcat (\"(0) Error: Missing optional alias [\", SchemaColumn, \"] aliasing existing column [\", AliasedField, \"]\"),\n                strcat (\"(2) Info: Missing optional alias [\", SchemaColumn, \"] aliasing non-existent column [\", AliasedField, \"]\")\n            )\n        ),\n    ColumnName == \"\" and Class == \"Optional\", strcat (\"(2) Info: Missing optional field [\", SchemaColumn, \"]\"),\n    SchemaColumn == \"\", strcat (\"(2) Info: extra unnormalized column [\", ColumnName, \"]\"),\n    ColumnName != \"\" and ColumnType != SchemaType, strcat (\"(0) Error: type mismatch for column [\", ColumnName, \"]. It is currently \", ColumnType, \" and should be \", SchemaType),\n    'None'\n    )\n| where Result != \"None\" | sort by Result asc | project Result",
+        "version": 1,
+        "functionParameters": "T:(ColumnName:string,ColumnType:string),selected_schema:string=''"
+      }
     }
   ]
 }

--- a/ASIM/dev/ASimTester/Testers/ASimSchemaTester.yaml
+++ b/ASIM/dev/ASimTester/Testers/ASimSchemaTester.yaml
@@ -1,0 +1,57 @@
+Parser:
+  Title: ASIM Schema tester
+  Version: '1.0.0'
+  LastUpdated: Mar 06, 2026
+Product:
+  Name: Source agnostic
+Description: |
+  This KQL function tests if the schema present in your parser or ASim table conforms with the ASim schema provided.
+ParserName: ASimSchemaTester
+ParserParams:
+  - Name: T
+    Type: (ColumnName:string,ColumnType:string)
+  - Name: selected_schema
+    Type: string
+    Default: ''
+ParserQuery: |
+  let ASimFields = materialize(externaldata (ColumnName: string, ColumnType: string, Class: string, Schema: string, LogicalType:string, ListOfValues: string, AliasedField: string)
+    [@"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/ASIM/dev/ASimTester/ASimTester.csv"] with (format="csv", IgnoreFirstRecord=true)
+    | where Schema =~ selected_schema or Schema =~ "Common"
+    | extend _Priority = iif(Schema =~ selected_schema, 0, 1)
+    | summarize arg_min(_Priority, ColumnType, Class, Schema, LogicalType, ListOfValues, AliasedField) by ColumnName
+    | project-away _Priority);
+  let ASimFieldsWithAliases = materialize(ASimFields | project-rename SchemaColumn = ColumnName, SchemaType = ColumnType | lookup (ASimFields | project ParentClass = Class, ParentColumn = ColumnName) on $left.AliasedField == $right.ParentColumn);
+  let ParserFields = toscalar (T | summarize make_set(ColumnName));
+  T
+  | join kind=fullouter ASimFieldsWithAliases on $left.ColumnName == $right.SchemaColumn
+  | extend Result = case(
+      ColumnName == "" and Class == "Mandatory",  strcat ("(0) Error: Missing mandatory field [", SchemaColumn, "]"),
+      ColumnName == "" and Class == "Recommended", strcat ("(1) Warning: Missing recommended field [", SchemaColumn, "]"),
+      ColumnName == "" and Class == "Conditional" and ParentClass == "Mandatory",
+          strcat ("(0) Error: Missing field [", SchemaColumn, "] is mandatory when mandatory column [", AliasedField, "] exists"),
+      ColumnName == "" and Class == "Conditional" and AliasedField in (ParserFields),
+          strcat ("(0) Error: Missing field [", SchemaColumn, "] is mandatory when field [", AliasedField, "] exists"),
+      ColumnName == "" and Class == "Alias",
+          case
+            (ParentClass == "Mandatory",
+                  iff (AliasedField in (ParserFields),
+                      strcat ("(0) Error: Missing mandatory alias [", SchemaColumn, "] aliasing existing column [", AliasedField, "]"),
+                      strcat ("(0) Error: Missing mandatory alias [", SchemaColumn, "] aliasing missing column [", AliasedField, "]")
+                  ),
+              ParentClass == "Recommended" ,
+                  iff (AliasedField in (ParserFields),
+                      strcat ("(0) Error: Missing recommended alias [", SchemaColumn, "] aliasing existing column [", AliasedField, "]"),
+                      strcat ("(2) Info: Missing recommended alias [", SchemaColumn, "] aliasing non-existent column [", AliasedField, "]")
+                  ),
+              // -- default: ParentClass is optional
+              iff (AliasedField in (ParserFields),
+                  strcat ("(0) Error: Missing optional alias [", SchemaColumn, "] aliasing existing column [", AliasedField, "]"),
+                  strcat ("(2) Info: Missing optional alias [", SchemaColumn, "] aliasing non-existent column [", AliasedField, "]")
+              )
+          ),
+      ColumnName == "" and Class == "Optional", strcat ("(2) Info: Missing optional field [", SchemaColumn, "]"),
+      SchemaColumn == "", strcat ("(2) Info: extra unnormalized column [", ColumnName, "]"),
+      ColumnName != "" and ColumnType != SchemaType, strcat ("(0) Error: type mismatch for column [", ColumnName, "]. It is currently ", ColumnType, " and should be ", SchemaType),
+      'None'
+      )
+  | where Result != "None" | sort by Result asc | project Result


### PR DESCRIPTION
Prior experience:
ASimSchemaTester only takes from selected_schema and not from Common.

Now:
Add to the function to take from both, but priortize selected_schema if both are present