### PR TITLE
Update CEF and Syslog data connector templates to AMA/marketplace pat…

### DIFF
--- a/DataConnectors/Templates/Connector_CEF_template.json
+++ b/DataConnectors/Templates/Connector_CEF_template.json
@@ -2,7 +2,8 @@
     "id": "ProviderNameApplianceName",
     "title": "PROVIDER NAME APPLIANCE NAME",
     "publisher": "PROVIDER NAME",
-    "descriptionMarkdown": "Common Event Format (CEF) is an industry standard format on top of Syslog messages, used by many security vendors to allow event interoperability among different platforms. By connecting your CEF logs to Azure Sentinel, you can take advantage of search & correlation, alerting, and threat intelligence enrichment for each log.",
+    "descriptionMarkdown": "The PROVIDER NAME APPLIANCE NAME data connector ingests Common Event Format (CEF) logs from APPLIANCE NAME into Microsoft Sentinel. CEF is an industry standard format on top of Syslog messages, used by many security vendors to allow event interoperability. Logs are collected using the Azure Monitor Agent (AMA) via the Microsoft **Common Event Format (CEF) via AMA** solution, which must be installed in your workspace before configuring this connector.\n\n[Learn more about the CEF via AMA connector >](https://learn.microsoft.com/azure/sentinel/connect-cef-ama)",
+    "additionalRequirementBanner": "This data connector depends on a parser based on a Kusto Function to work as expected. The [**KUSTO_FUNCTION_ALIAS**](LINK_TO_PARSER_ON_GITHUB) parser is deployed with the Microsoft Sentinel solution. If your connector does not use a custom parser, remove this field.",
     "graphQueries": [
         {
             "metricName": "Total data received",
@@ -12,8 +13,12 @@
     ],
     "sampleQueries": [
         {
-            "description" : "One-line title for your sample query 1",
-            "query": "Kusto Query 1"
+            "description": "All APPLIANCE NAME events",
+            "query": "CommonSecurityLog\n| where DeviceVendor == \"PROVIDER NAME\"\n| where DeviceProduct == \"APPLIANCE NAME\"\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "APPLIANCE NAME events – last 24 hours",
+            "query": "CommonSecurityLog\n| where DeviceVendor == \"PROVIDER NAME\"\n| where DeviceProduct == \"APPLIANCE NAME\"\n| where TimeGenerated > ago(24h)\n| sort by TimeGenerated desc"
         }
     ],
     "dataTypes": [
@@ -32,7 +37,7 @@
     ],
     "availability": {
         "status": 1,
-        "isPreview": true
+        "isPreview": false
     },
     "permissions": {
         "resourceProvider": [
@@ -46,69 +51,25 @@
                     "write": true,
                     "delete": true
                 }
+            }
+        ],
+        "customs": [
+            {
+                "description": "To collect data from non-Azure VMs, they must have Azure Arc installed and enabled. [Learn more](https://learn.microsoft.com/azure/azure-monitor/agents/azure-monitor-agent-install)"
             },
             {
-                "provider": "Microsoft.OperationalInsights/workspaces/sharedKeys",
-                "permissionsDisplayText": "read permissions to shared keys for the workspace are required. [See the documentation to learn more about workspace keys](https://docs.microsoft.com/azure/azure-monitor/platform/agent-windows#obtain-workspace-id-and-key).",
-                "providerDisplayName": "Keys",
-                "scope": "Workspace",
-                "requiredPermissions": {
-                    "action": true
-                }
+                "description": "The **Common Event Format (CEF) via AMA** solution must be installed in your Microsoft Sentinel workspace. [Install from Microsoft Marketplace](https://marketplace.microsoft.com/en-us/product/saas/azuresentinel.azure-sentinel-solution-commoneventformat)"
             }
         ]
     },
     "instructionSteps": [
         {
-            "title": "1. Linux Syslog agent configuration",
-            "description": "Install and configure the Linux agent to collect your Common Event Format (CEF) Syslog messages and forward them to Azure Sentinel.\n\n> Notice that the data from all regions will be stored in the selected workspace",
-            "innerSteps": [
-                {
-                    "title": "1.1 Select or create a Linux machine",
-                    "description": "Select or create a Linux machine that Azure Sentinel will use as the proxy between your security solution and Azure Sentinel this machine can be on your on-prem environment, Azure or other clouds."
-                },
-                {
-                    "title": "1.2 Install the CEF collector on the Linux machine",
-                    "description": "Install the Microsoft Monitoring Agent on your Linux machine and configure the machine to listen on the necessary port and forward messages to your Azure Sentinel workspace. The CEF collector collects CEF messages on port 514 TCP.\n\n> 1. Make sure that you have Python on your machine using the following command: python -version.\n\n> 2. You must have elevated permissions (sudo) on your machine.",
-                    "instructions": [
-                        {
-                            "parameters": {
-                                "fillWith": [
-                                    "WorkspaceId",
-                                    "PrimaryKey"
-                                ],
-                                "label": "Run the following command to install and apply the CEF collector:",
-                                "value": "sudo wget -O cef_installer.py https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/CEF/cef_installer.py&&sudo python cef_installer.py {0} {1}"
-                            },
-                            "type": "CopyableLabel"
-                        }
-                    ]
-                }
-            ]
+            "title": "1. Configure APPLIANCE NAME to forward CEF logs",
+            "description": "Configure APPLIANCE NAME to forward Syslog messages in CEF format to a Linux log forwarder machine on port 514 TCP.\n\n> Replace this step with your product-specific instructions for enabling CEF output. Include the destination IP/hostname of the log forwarder and any product-side configuration steps the customer must complete."
         },
         {
-            "title": "2. Forward Common Event Format (CEF) logs to Syslog agent",
-            "description": "Set your security solution to send Syslog messages in CEF format to the proxy machine. Make sure you to send the logs to port 514 TCP on the machine's IP address."
-        },
-        {
-            "title": "3. Validate connection",
-            "description": "Follow the instructions to validate your connectivity:\n\nOpen Log Analytics to check if the logs are received using the CommonSecurityLog schema.\n\n>It may take about 20 minutes until the connection streams data to your workspace.\n\nIf the logs are not received, run the following connectivity validation script:\n\n> 1. Make sure that you have Python on your machine using the following command: python -version\n\n>2. You must have elevated permissions (sudo) on your machine",
-            "instructions": [
-                {
-                    "parameters": {
-                        "fillWith": [
-                            "WorkspaceId"
-                        ],
-                        "label": "Run the following command to validate your connectivity:",
-                        "value": "sudo wget  -O cef_troubleshoot.py https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/CEF/cef_troubleshoot.py&&sudo python cef_troubleshoot.py  {0}"
-                    },
-                    "type": "CopyableLabel"
-                }
-            ]
-        },
-        {
-            "title": "4. Secure your machine ",
-            "description": "Make sure to configure the machine's security according to your organization's security policy\n\n\n[Learn more >](https://aka.ms/SecureCEF)"
+            "title": "2. Install the Common Event Format (CEF) via AMA solution",
+            "description": "This connector relies on the Microsoft **Common Event Format (CEF) via AMA** solution to collect CEF data into your workspace using the Azure Monitor Agent. If you have not already installed it, install it from the Microsoft Marketplace and create a Data Collection Rule (DCR) to collect CEF logs from your log forwarder.\n\n[Install Common Event Format (CEF) via AMA from Microsoft Marketplace](https://marketplace.microsoft.com/en-us/product/saas/azuresentinel.azure-sentinel-solution-commoneventformat)"
         }
     ],
     "metadata": {

--- a/DataConnectors/Templates/Connector_Syslog_template.json
+++ b/DataConnectors/Templates/Connector_Syslog_template.json
@@ -2,38 +2,42 @@
     "id": "ProviderNameAppliance",
     "title": "PROVIDER NAME APPLIANCE NAME",
     "publisher": "PROVIDER NAME",
-    "descriptionMarkdown": "Syslog is an event logging protocol that is common to Linux. Applications will send messages that may be stored on the local machine or delivered to a Syslog collector. When the Agent for Linux is installed, it configures the local Syslog daemon to forward messages to the agent. The agent then sends the message to the workspace.\n\n[Learn more >](https://aka.ms/sysLogInfo)",
-    "additionalRequirementBanner": "This data connector depends on a parser based on a Kusto Function to work as expected [**enter the Kusto Function alias**](Link to Kusto Function on Azure Sentinel GitHub) which is deployed with the Azure Sentinel Solution.",
+    "descriptionMarkdown": "The PROVIDER NAME APPLIANCE NAME data connector ingests Syslog events from APPLIANCE NAME into Microsoft Sentinel. Logs are collected using the Azure Monitor Agent (AMA) via the Microsoft **Syslog via AMA** solution, which must be installed in your workspace before configuring this connector.\n\n[Learn more about the Syslog via AMA connector >](https://learn.microsoft.com/azure/sentinel/connect-syslog)",
+    "additionalRequirementBanner": "This data connector depends on a parser based on a Kusto Function to work as expected. The [**KUSTO_FUNCTION_ALIAS**](LINK_TO_PARSER_ON_GITHUB) parser is deployed with the Microsoft Sentinel solution. If your connector does not use a custom parser, remove this field.",
     "graphQueries": [
         {
             "metricName": "Total data received",
             "legend": "DATATYPE_NAME",
-            "baseQuery": "DATATYPE_NAME"
+            "baseQuery": "Syslog\n| where ProcessName == \"PROCESS_NAME\""
         }
     ],
     "sampleQueries": [
         {
-            "description" : "One-line title for your sample query 1",
-            "query": "Kusto Query 1"
+            "description": "All APPLIANCE NAME events",
+            "query": "Syslog\n| where ProcessName == \"PROCESS_NAME\"\n| sort by TimeGenerated desc"
+        },
+        {
+            "description": "APPLIANCE NAME events – last 24 hours",
+            "query": "Syslog\n| where ProcessName == \"PROCESS_NAME\"\n| where TimeGenerated > ago(24h)\n| sort by TimeGenerated desc"
         }
     ],
     "dataTypes": [
         {
             "name": "Syslog (DATATYPE_NAME)",
-            "lastDataReceivedQuery": "DATATYPE_NAME\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+            "lastDataReceivedQuery": "Syslog\n| where ProcessName == \"PROCESS_NAME\"\n| summarize Time = max(TimeGenerated)\n| where isnotempty(Time)"
         }
     ],
     "connectivityCriterias": [
         {
             "type": "IsConnectedQuery",
             "value": [
-                "DATATYPE_NAME\n            | summarize LastLogReceived = max(TimeGenerated)\n            | project IsConnected = LastLogReceived > ago(30d)"
+                "Syslog\n| where ProcessName == \"PROCESS_NAME\"\n| summarize LastLogReceived = max(TimeGenerated)\n| project IsConnected = LastLogReceived > ago(30d)"
             ]
         }
     ],
     "availability": {
         "status": 1,
-        "isPreview": true
+        "isPreview": false
     },
     "permissions": {
         "resourceProvider": [
@@ -47,64 +51,24 @@
                     "delete": true
                 }
             }
+        ],
+        "customs": [
+            {
+                "description": "To collect data from non-Azure VMs, they must have Azure Arc installed and enabled. [Learn more](https://learn.microsoft.com/azure/azure-monitor/agents/azure-monitor-agent-install)"
+            },
+            {
+                "description": "The **Syslog via AMA** solution must be installed in your Microsoft Sentinel workspace. [Install from Microsoft Marketplace](https://marketplace.microsoft.com/en-us/product/azuresentinel.azure-sentinel-solution-syslog)"
+            }
         ]
     },
     "instructionSteps": [
         {
-            "title": "", 
-            "description": ">This data connector depends on a parser based on a Kusto Function to work as expected [**enter the Kusto Function alias**](Link to Kusto Function on Azure Sentinel GitHub) which is deployed with the Azure Sentinel Solution.",
-            "instructions": [ 
-            ]    
-        }, 
-        {
-            "title": "1. Install and onboard the agent for Linux",
-            "description": "Typically, you should install the agent on a different computer from the one on which the logs are generated.\n\n>  Syslog logs are collected only from **Linux** agents.",
-            "instructions": [
-                {
-                    "parameters": {
-                        "title": "Choose where to install the agent:",
-                        "instructionSteps": [
-                            {
-                                "title": "Install agent on Azure Linux Virtual Machine",
-                                "description": "Select the machine to install the agent on and then click **Connect**.",
-                                "instructions": [
-                                    {
-                                        "parameters": {
-                                            "linkType": "InstallAgentOnLinuxVirtualMachine"
-                                        },
-                                        "type": "InstallAgent"
-                                    }
-                                ]
-                            },
-                            {
-                                "title": "Install agent on a non-Azure Linux Machine",
-                                "description": "Download the agent on the relevant machine and follow the instructions.",
-                                "instructions": [
-                                    {
-                                        "parameters": {
-                                            "linkType": "InstallAgentOnLinuxNonAzure"
-                                        },
-                                        "type": "InstallAgent"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "type": "InstructionStepsGroup"
-                }
-            ]
+            "title": "1. Configure APPLIANCE NAME to forward Syslog messages",
+            "description": "Configure APPLIANCE NAME to forward Syslog messages to a Linux log forwarder machine on port 514 UDP/TCP.\n\n> Replace this step with your product-specific instructions for enabling Syslog output. Include the relevant facility and severity settings your product uses, the destination IP/hostname of the log forwarder, and any product-side configuration steps the customer must complete."
         },
         {
-            "title": "2. Configure the logs to be collected",
-            "description": "Configure the facilities you want to collect and their severities.\n\n1.  Under workspace advanced settings **Configuration**, select **Data** and then **Syslog**.\n2.  Select **Apply below configuration to my machines** and select the facilities and severities.\n3.  Click **Save**.",
-            "instructions": [
-                {
-                    "parameters": {
-                        "linkType": "OpenSyslogSettings"
-                    },
-                    "type": "InstallAgent"
-                }
-            ]
+            "title": "2. Install the Syslog via AMA solution",
+            "description": "This connector relies on the Microsoft **Syslog via AMA** solution to collect Syslog data into your workspace using the Azure Monitor Agent. If you have not already installed it, install it from the Microsoft Marketplace and create a Data Collection Rule (DCR) that includes the Syslog facilities forwarded by APPLIANCE NAME.\n\n[Install Syslog via AMA from Microsoft Marketplace](https://marketplace.microsoft.com/en-us/product/azuresentinel.azure-sentinel-solution-syslog)"
         }
     ],
     "metadata": {


### PR DESCRIPTION
Update CEF and Syslog data connector templates to AMA/marketplace pattern

Change(s):
- DataConnectors/Templates/Connector_CEF_template.json
  - Updated descriptionMarkdown to reference AMA-based ingestion and CEF via AMA solution
  - Added additionalRequirementBanner placeholder for optional parser dependency
  - Replaced generic sample queries with vendor-filtered queries on CommonSecurityLog using DeviceVendor + DeviceProduct
  - Removed sharedKeys resourceProvider permission (MMA artifact, not required for AMA)
  - Added customs permissions: Azure Arc requirement for non-Azure VMs, and marketplace link to CEF via AMA solution
  - Replaced four MMA instruction steps (cef_installer.py, Linux agent install, validation script, secure machine) with two-step AMA pattern: ISV product CEF config placeholder + install CEF via AMA from marketplace
  - Set isPreview: false

- DataConnectors/Templates/Connector_Syslog_template.json
  - Updated descriptionMarkdown to reference AMA-based ingestion and Syslog via AMA solution
  - Added additionalRequirementBanner placeholder for optional parser dependency
  - Replaced generic baseQuery/sampleQueries/dataTypes/connectivityCriterias with vendor-filtered queries on Syslog table using ProcessName
  - Added customs permissions: Azure Arc requirement for non-Azure VMs, and marketplace link to Syslog via AMA solution
  - Replaced three MMA instruction steps (InstallAgentOnLinuxVirtualMachine, InstallAgentOnLinuxNonAzure, OpenSyslogSettings) with two-step AMA pattern: ISV product Syslog config placeholder + install Syslog via AMA from marketplace
  - Set isPreview: false

Reason for Change(s):
- The Microsoft Monitoring Agent (MMA/Log Analytics Agent) was retired. Both templates were still instructing ISVs to install MMA via cef_installer.py and the InstallAgentOnLinux portal links, which no longer represent the supported ingestion path
- The current pattern for CEF and Syslog connectors is a UI-only connector that depends on the Microsoft-published CEF via AMA or Syslog via AMA solution for the actual data collection. Neither template reflected this
- The sharedKeys permission in the CEF template was an MMA artifact — AMA uses DCR + managed identity and does not require workspace key access
- The generic placeholder queries (DATATYPE_NAME, "Kusto Query 1") provided no guidance on how to correctly filter a shared table. The updated templates show ISVs the correct pattern for discriminating their data from other sources in CommonSecurityLog and Syslog

Version Updated:
- N/A — these are connector UI definition templates, not Analytic Rule templates

Testing Completed:
- Template structure validated against existing published AMA connectors in the repository (AI Analyst Darktrace, Delinea Secret Server) to confirm field alignment
- No KQL execution required — queries are placeholder patterns using standard Syslog and CommonSecurityLog schemas

Checked that the validations are passing and have addressed any issues that are present:
- Yes — changes are limited to two JSON template files with no KQL, YAML, or ARM deployment content that would trigger detection schema or KQL validation checks