### PR TITLE
Fix Syslog-VMSS-AMA template: NSG bugs, EOL Ubuntu 18.04->24.04, API/AMA modernization

### DIFF
--- a/DataConnectors/Syslog-VMSS-AMA/README.md
+++ b/DataConnectors/Syslog-VMSS-AMA/README.md
@@ -1,6 +1,6 @@
 # Scalable Syslog collection using VMSS and Azure Monitor Agent
 
-This ARM template  will deploy an Ubuntu Virtual Machine Scale Set to forward Syslog to Microsoft Sentinel using Azure Monitor Agent (AMA). This has been built based on the previous solution we had for CEF with Log Analytics Agent (MMA) [CEF-VMSS]( https://github.com/mariavaladas/Azure-Sentinel/tree/master/DataConnectors/CEF-VMSS)
+This ARM template  will deploy an Ubuntu 24.04 LTS Virtual Machine Scale Set to forward Syslog to Microsoft Sentinel using Azure Monitor Agent (AMA). This has been built based on the previous solution we had for CEF with Log Analytics Agent (MMA) [CEF-VMSS]( https://github.com/mariavaladas/Azure-Sentinel/tree/master/DataConnectors/CEF-VMSS)
 
 The ARM template will deploy everything needed:
 * Virtual Machine Scale Set
@@ -11,7 +11,7 @@ The ARM template will deploy everything needed:
 * Public IP Address
 * Load Balancer
 * Data Collection Rule
-* Data Colection Rule association
+* Data Collection Rule association
 * Managed identity required for AMA to authenticate
 
 The ARM template includes a cloud init to run the required to commands on the VM instances to enable syslog collection.
@@ -19,3 +19,18 @@ The ARM template includes a cloud init to run the required to commands on the VM
 ## Deploy Ubuntu VMSS
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FDataConnectors%2FSyslog-VMSS-AMA%2FazureDeploy.json)
 [![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FDataConnectors%2FSyslog-VMSS-AMA%2FazureDeploy.json)
+
+## Notes
+
+This template was updated with the following fixes and modernizations:
+
+* **Base image** upgraded from Ubuntu 18.04-LTS (end-of-life since April 2023) to Ubuntu 24.04 LTS.
+* **NSG bug fixes:**
+  * The `Allow-SSH` rule used `protocol: UDP`, which blocked SSH (TCP/22) reachable through the load balancer's inbound NAT pool — corrected to `Tcp`.
+  * The `Allow-Syslog` rule used `protocol: UDP` only, which did not match the load balancer's TCP/514 syslog rule — broadened to `*` (TCP + UDP).
+  * The subnet's NSG reference used an invalid resource provider `Microsoft.Networks/networkSecurityGroups` (extra "s") — corrected to `Microsoft.Network/networkSecurityGroups`.
+* **AMA** Azure Monitor Linux Agent extension bumped from `1.22` to `1.33` (auto-upgrade remains enabled).
+* **Autoscale** API version updated from `2014-04-01` to `2022-10-01`, and the scale-in/scale-out cooldown increased from 1 minute to 5 minutes to reduce scaling thrash.
+* **Data Collection Rule / association** API version updated from `2021-09-01-preview` to the GA `2022-06-01`.
+
+> Looking for **Syslog/CEF over TLS (port 6514)**? A community reference implementation that extends this template with mutual-TLS-capable certificate handling is available at [sentinel-syslog-tls-collector](https://github.com/x3nc0n/sentinel-syslog-tls-collector).

--- a/DataConnectors/Syslog-VMSS-AMA/azureDeploy.json
+++ b/DataConnectors/Syslog-VMSS-AMA/azureDeploy.json
@@ -153,7 +153,7 @@
 				"[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg_Name'))]"
 			],
 			"properties": {
-				"protocol": "UDP",
+				"protocol": "*",
 				"sourcePortRange": "*",
 				"destinationPortRange": "514",
 				"sourceAddressPrefix": "*",
@@ -175,7 +175,7 @@
 				"[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg_Name'))]"
 			],
 			"properties": {
-				"protocol": "UDP",
+				"protocol": "Tcp",
 				"sourcePortRange": "*",
 				"destinationPortRange": "22",
 				"sourceAddressPrefix": "*",
@@ -231,7 +231,7 @@
 			"properties": {
 				"addressPrefix": "10.0.0.0/24",
 				"networkSecurityGroup": {
-					"id": "[resourceId('Microsoft.Networks/networkSecurityGroups', variables('nsg_Name'))]"
+					"id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsg_Name'))]"
 				},
 				"serviceEndpoints": [],
 				"delegations": [],
@@ -400,7 +400,7 @@
 							"name": "AMA",
 							"properties": {
 								"publisher": "Microsoft.Azure.Monitor",
-								"typeHandlerVersion": "1.22",
+								"typeHandlerVersion": "1.33",
 								"autoUpgradeMinorVersion": true,
 								"enableAutomaticUpgrade": true,
 								"type": "AzureMonitorLinuxAgent"
@@ -422,8 +422,8 @@
 						},
 						"imageReference": {
 							"publisher": "Canonical",
-							"offer": "UbuntuServer",
-							"sku": "18.04-LTS",
+							"offer": "ubuntu-24_04-lts",
+							"sku": "server",
 							"version": "latest"
 						}
 					},
@@ -463,7 +463,7 @@
 		},
 		{
 			"type": "Microsoft.Insights/autoscalesettings",
-			"apiVersion": "2014-04-01",
+			"apiVersion": "2022-10-01",
 			"name": "[variables('autoscale_Name')]",
 			"location": "[resourceGroup().location]",
 			"dependsOn": [
@@ -495,7 +495,7 @@
 								"direction": "Increase",
 								"type": "ChangeCount",
 								"value": "1",
-								"cooldown": "PT1M"
+								"cooldown": "PT5M"
 							}
 						},
 						{
@@ -516,7 +516,7 @@
 								"direction": "Decrease",
 								"type": "ChangeCount",
 								"value": "1",
-								"cooldown": "PT1M"
+								"cooldown": "PT5M"
 							}
 						}
 					]
@@ -528,7 +528,7 @@
 		},
 		{
 			"type": "Microsoft.Insights/dataCollectionRules",
-			"apiVersion": "2021-09-01-preview",
+			"apiVersion": "2022-06-01",
 			"name": "default",
 			"location": "[resourceGroup().location]",
 			"dependsOn": [],
@@ -575,7 +575,7 @@
 		},
 		{
 			"type": "Microsoft.Insights/dataCollectionRuleAssociations",
-			"apiVersion": "2021-09-01-preview",
+			"apiVersion": "2022-06-01",
 			"dependsOn": [
 				"[resourceId('Microsoft.Insights/dataCollectionRules', 'default')]",
 				"[resourceId('Microsoft.Compute/virtualMachineScaleSets', variables('vmss_Name'))]"


### PR DESCRIPTION
## Summary

This PR fixes several deployment bugs and modernizes the **Syslog-VMSS-AMA** data connector template (`DataConnectors/Syslog-VMSS-AMA/`). All changes are scoped to that folder (`azureDeploy.json` + `README.md`). The base image is moved off an end-of-life OS, and three concrete NSG defects are corrected.

These changes were identified while building and **deploying a working derivative of this template end-to-end** (Ubuntu 24.04, AMA → DCR → Log Analytics validated).

## Bug fixes

1. **`Allow-SSH` NSG rule protocol was `UDP`.**
   SSH is TCP. As written, the rule does not permit SSH (TCP/22) that the load balancer exposes via its `inboundNatPool`, so administrative access is blocked. Corrected to `Tcp`.

2. **`Allow-Syslog` NSG rule protocol was `UDP` only.**
   The load balancer defines **both** a TCP/514 (`LBSyslogTCPRule`) and a UDP/514 (`LBSyslogUDPRule`) rule, but the NSG only allowed UDP, silently dropping TCP syslog. Broadened to `*` (TCP + UDP).

3. **Invalid resource provider in the subnet's NSG reference.**
   The standalone `Microsoft.Network/virtualNetworks/subnets` resource referenced `Microsoft.Networks/networkSecurityGroups` (note the extra "s" — `Networks`), which is not a valid resource provider namespace. Corrected to `Microsoft.Network/networkSecurityGroups`.

## End-of-life OS

4. **Ubuntu 18.04-LTS → Ubuntu 24.04 LTS.**
   `18.04-LTS` reached end of standard support in **April 2023** and no longer receives security updates. Updated the image reference to the current LTS:
   `Canonical` / `ubuntu-24_04-lts` / `server` / `latest`.
   This image was validated by deploying it with this template's VMSS/AMA configuration.

## Modernization

5. **AMA extension `typeHandlerVersion` `1.22` → `1.33`** (auto-upgrade remains enabled).
6. **Autoscale** API version `2014-04-01` → `2022-10-01`; scale-in/scale-out **cooldown `PT1M` → `PT5M`** to reduce scaling thrash on a syslog relay.
7. **Data Collection Rule and association** API version `2021-09-01-preview` → GA **`2022-06-01`** (preview API versions are eventually retired).

## Out of scope (intentionally not bundled)

To keep this PR small and reviewable, the following are **not** included here and are noted as potential follow-ups:

* Migrating the deprecated `inboundNatPools` to `inboundNatRules`.
* Restricting the `Allow-SSH` / `Allow-Syslog` source from `*` to an operator-supplied CIDR.
* Bumping the remaining (network/compute/managed-identity) API versions.
* **Syslog/CEF over TLS (6514).** A community reference implementation that layers mutual-TLS-capable certificate handling on top of this connector is linked from the README.

## Validation

* `azureDeploy.json` is valid JSON and the edits are surgical (original formatting preserved — diff is value-only).
* The Ubuntu 24.04 image reference, AMA `1.33`, and the DCR GA API version were exercised in a real deployment of a template derived from this one.

---
*Note: I was unable to confirm whether the Azure Sentinel team prefers protocol `*` vs. an explicit dual TCP/UDP rule for syslog — happy to adjust to whichever convention you prefer.*
