### PR TITLE
Refactoring Logstash plugin directory into old and new directories for deprecated and active versions of the plugin

### DIFF
--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/CHANGELOG.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/CHANGELOG.md
@@ -1,29 +1,5 @@
-## 2.3.0
-- Added optional Id configuration value for telemetry.
-- Added DCR stream to sent-batches logging.
-- Enabled functionality with logstash 9.4.
-- Bumped dependency versions for external libraries (azure-sdk-bom, logback, slf4j, Netty).
-
-## 2.2.1
-- Adds info-level logging line when batches are successfully sent.
-
-## 2.2.0
-- Adds ability to use either new or old configuration values.
-
-## 2.1.2
-- Documentation updates
-
-## 2.1.1
-- Improved efficiency.
-
-## 2.1.0
-- Fixed event normalization.
-
-## 2.0.0
-- Refactored the plugin from Ruby to Java.
-- Added ManagedIdentity authentication.
-- Moved codebase from GitHub to Azure DevOps.
-- Closed codebase.
+> **⚠️ DEPRECATED — Ruby version**
+> This is the changelog for the deprecated Ruby version (1.x.x) of the Microsoft Sentinel Logstash output plugin. The plugin has since been refactored from Ruby to Java (2.x.x and later), and the Ruby version is no longer actively maintained. For the current version and its changelog, see [microsoft-sentinel-log-analytics-logstash-output-plugin_java](../microsoft-sentinel-log-analytics-logstash-output-plugin_java/CHANGELOG.md).
 
 ## 1.2.0
 - Adds managed identity authentication support for Azure VMs/VMSS (system-assigned and user-assigned via IMDS).

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
@@ -1,239 +1,315 @@
-# Microsoft Sentinel Output Plugin for Logstash 
+> **⚠️ DEPRECATED — Ruby version**
+> This documentation describes the deprecated Ruby version (1.x.x) of the Microsoft Sentinel Logstash output plugin. The plugin has since been refactored from Ruby to Java (2.x.x and later), and the Ruby version is no longer actively maintained. For the current version and documentation, see [microsoft-sentinel-log-analytics-logstash-output-plugin_java](../microsoft-sentinel-log-analytics-logstash-output-plugin_java/README.md).
+
+# Microsoft Sentinel output plugin for Logstash 
 
 Microsoft Sentinel provides a new output plugin for Logstash. Use this output plugin to send any log via Logstash to the Microsoft Sentinel/Log Analytics workspace. This is done with the Log Analytics DCR-based API.
-You may send logs to custom or standard tables.  
+You may send logs to custom or standard tables.
 
-Plugin version: v2.3.0  
-Released on: 2026-06-17  
+Plugin version: v1.2.0
+Released on: 2026-02-05
 
-This plugin is currently in development and is free to use. We request and appreciate feedback from users.  
+This plugin is currently in development and is free to use. We welcome contributions from the open source community on this project, and we request and appreciate feedback from users.
 
 ## Installation Instructions
-1) Install the plugin  
-2) Create a sample file  
-3) Create the required DCR-related resources  
-4) Configure Logstash configuration file  
+1) Install the plugin
+2) Create a sample file
+3) Create the required DCR-related resources
+4) Configure Logstash configuration file
+5) Basic logs transmission
 
 
 ## 1. Install the plugin
 
-Microsoft Sentinel provides Logstash output plugin to Log analytics workspace using DCR based logs API.  
+Microsoft Sentinel provides Logstash output plugin to Log analytics workspace using DCR based logs API.
 
-The plugin is published on [RubyGems](https://rubygems.org/gems/microsoft-sentinel-log-analytics-logstash-output-plugin/versions/2.3.0-java). To install to an existing logstash installation, run `logstash-plugin install microsoft-sentinel-log-analytics-logstash-output-plugin`.  
+The plugin is published on [RubyGems](https://rubygems.org/gems/microsoft-sentinel-log-analytics-logstash-output-plugin). To install to an existing logstash installation, run `logstash-plugin install microsoft-sentinel-log-analytics-logstash-output-plugin`.
 
 If you do not have a direct internet connection, you can install the plugin to another logstash installation, and then export and import a plugin bundle to the offline host. For more information, see [Logstash Offline Plugin Management instruction](<https://www.elastic.co/guide/en/logstash/current/offline-plugins.html>).  
 
-Microsoft Sentinel's Logstash output plugin supports the following versions  
-- 7.0 - 7.17.13  
-- 8.0 - 8.9 (NOTE: these versions require a security update, according to Logstash!)  
-- 8.11 - 8.15 (NOTE: these versions require a security update, according to Logstash!)  
-- 8.19.2 (NOTE: this version requires a security update, according to Logstash!)  
-- 9.0.8 (NOTE: this version requires a security update, according to Logstash!)  
-- 9.1.10 (NOTE: this version requires a security update, according to Logstash!)  
-- 9.2.4 - 9.2.5 (NOTE: these versions require a security update, according to Logstash! [Security Update](https://discuss.elastic.co/t/logstash-8-19-14-9-2-8-9-3-3-security-update-esa-2026-29/385816))  
-- 9.3.3
-- 9.4.0
+Microsoft Sentinel's Logstash output plugin supports the following versions
+- 7.0 - 7.17.13
+- 8.0 - 8.9 (NOTE: these versions require a security update, according to Logstash!)
+- 8.11 - 8.15 (NOTE: these versions require a security update, according to Logstash!)
+- 8.19.2 (NOTE: this version requires a security update, according to Logstash!)
+- 9.0.8 (NOTE: this version requires a security update, according to Logstash!)
+- 9.1.10 (NOTE: this version requires a security update, according to Logstash!)
+- 9.2.4 - 9.2.5 (NOTE: these versions require a security update, according to Logstash! [Security Update](https://discuss.elastic.co/t/logstash-8-19-14-9-2-8-9-3-3-security-update-esa-2026-29/385816))
 
-Please note that when using Logstash 8, it is recommended to disable ECS in the pipeline. For more information refer to [Logstash documentation.](<https://www.elastic.co/guide/en/logstash/8.4/ecs-ls.html>)  
+Note: The Ruby version of this plugin is deprecated. It may work with newer, up-to-date Logstash versions beyond those listed above, but compatibility with such versions is not something we guarantee or support, since this version is no longer actively maintained. For ongoing support and the latest Logstash version compatibility, use the [Java version of the plugin](../microsoft-sentinel-log-analytics-logstash-output-plugin_java/README.md).
+
+Please note that when using Logstash 8, it is recommended to disable ECS in the pipeline. For more information refer to [Logstash documentation.](<https://www.elastic.co/guide/en/logstash/8.4/ecs-ls.html>)
+
 
 ## 2. Create a sample file
-To create a sample file, follow the following steps:  
-1)	Copy the output plugin configuration below to your Logstash configuration file:  
-    ```
-    output {
-        microsoft-sentinel-log-analytics-logstash-output-plugin {
-            create_sample_file => true
-            sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
-        }
+To create a sample file, follow the following steps:
+1)	Copy the output plugin configuration below to your Logstash configuration file:
+```
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+        create_sample_file => true
+        sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
     }
-    ```
-Note: make sure that the path exists before creating the sample file.  
-2) Start Logstash. The plugin will collect up to 10 records to a sample.  
-3) The file named "sampleFile<epoch seconds>.json" in the configured path will be created once there are 10 events to sample or when the Logstash process exited gracefully. (for example: "c:\temp\sampleFile1648453501.json").  
+}
+```
+Note: make sure that the path exists before creating the sample file.
+2) Start Logstash. The plugin will collect up to 10 records to a sample.
+3) The file named "sampleFile<epoch seconds>.json" in the configured path will be created once there are 10 events to sample or when the Logstash process exited gracefully. (for example: "c:\temp\sampleFile1648453501.json").
 
 
 ### Configurations:
-The following parameters are optional and should be used to create a sample file.  
-- **create_sample_file** - Boolean, False by default. When enabled, up to 10 events will be written to a sample json file.  
-- **sample_file_path** - Number, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.  
+The following parameters are optional and should be used to create a sample file.
+- **create_sample_file** - Boolean, False by default. When enabled, up to 10 events will be written to a sample json file.
+- **sample_file_path** - Number, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.
 
 ### Complete example
-1. set the pipeline.conf with the following configuration:  
-    ```
-    input {
-          generator {
-            lines => [ "This is a test log message"]
-            count => 10
-          }
-    }
+1. set the pipeline.conf with the following configuration:
+```
+input {
+      generator {
+        lines => [ "This is a test log message"]
+        count => 10
+      }
+}
 
-    output {
-        microsoft-sentinel-log-analytics-logstash-output-plugin {
-            create_sample_file => true
-            sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
-        }
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+        create_sample_file => true
+        sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
     }
-    ```
+}
+```
 
-2. the following sample file will be generated:  
-    ```
-    [
-      {
-        "host": "logstashMachine",
-        "sequence": 0,
-        "message": "This is a test log message",
-        "ls_timestamp": "2022-10-29T13:19:28.116Z",
-        "ls_version": "1"
-      },
-      ...
-    ]
-    ```
+2. the following sample file will be generated:
+```
+[
+	{
+		"host": "logstashMachine",
+		"sequence": 0,
+		"message": "This is a test log message",
+		"ls_timestamp": "2022-10-29T13:19:28.116Z",
+		"ls_version": "1"
+	},
+	...
+]
+```
 
 ## 3. Create the required DCR-related resources
-To configure Microsoft Sentinel Logstash plugin you first need to create the DCR-related resources. To create these resources, follow one of the following tutorials:  
-1) To ingest the data to a custom table use [Tutorial - Send custom logs to Azure Monitor Logs (preview) - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs>) tutorial. Note that as part of creating the table and the DCR you will need to provide the sample file that you've created in the previous section.  
-2) To ingest the data to a standard table like Syslog or CommonSecurityLog use [Tutorial - Send custom logs to Azure Monitor Logs using resource manager templates - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs-api>).  
-
-*Note:* The identity (service principal or managed identity) must have the **Monitoring Metrics Publisher** role on the target DCR:  
-
-    az role assignment create \
-      --assignee <object-id-of-identity> \
-      --role "Monitoring Metrics Publisher" \
-      --scope "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Insights/dataCollectionRules/<dcr-name>"
+To configure Microsoft Sentinel Logstash plugin you first need to create the DCR-related resources. To create these resources, follow one of the following tutorials:
+1) To ingest the data to a custom table use [Tutorial - Send custom logs to Azure Monitor Logs (preview) - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs>) tutorial. Note that as part of creating the table and the DCR you will need to provide the sample file that you've created in the previous section.
+2) To ingest the data to a standard table like Syslog or CommonSecurityLog use [Tutorial - Send custom logs to Azure Monitor Logs using resource manager templates - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs-api>).
 
 
 ## 4. Configure Logstash configuration file
 
-Add the `microsoft-sentinel-log-analytics-logstash-output-plugin` block to the `output` section of your Logstash configuration file (e.g., `logstash.conf`). The plugin requires three values from your Azure DCR resources plus authentication credentials depending on your method.  
+The plugin supports two authentication methods: **service principal** (client credentials) and **managed identity** (passwordless). Choose the method that suits your environment.
 
-### Required Config Values (needed for all methods)
+### 4a. Service principal authentication
 
-| Key | Description |  
-|---|---|  
-| `data_collection_endpoint` | Your DCE logsIngestion URI |  
-| `dcr_id` | The immutable ID of your Data Collection Rule |  
-| `stream_name` | The stream name from your DCR (e.g., `Custom-MyTableRawData_CL`) |  
+Use the tutorial from the previous section to retrieve the following attributes:
+- **client_app_Id** - String, The 'Application (client) ID' value created in step #3 of the "Configure Application" section of the tutorial you used in the previous step.
+- **client_app_secret** - String, The value of the client secret created in step #5 of the "Configure Application" section of the tutorial you used in the previous step.
+- **tenant_id** - String, Your subscription's tenant id. You can find in the following path: Home -> Microsoft Entra ID -> Overview Under 'Basic Information'.
+- **data_collection_endpoint** - String, The value of the logsIngestion URI (see step #3 of the "Create data collection endpoint" section in Tutorial [Tutorial - Send custom logs to Azure Monitor Logs using resource manager templates - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs-api#create-data-collection-endpoint>).
+- **dcr_immutable_id** - String, The value of the DCR immutableId (see the "Collect information from DCR" section in [Tutorial - Send custom logs to Azure Monitor Logs (preview) - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs#collect-information-from-dcr>).
+- **dcr_stream_name** - String, The name of the data stream (Go to the json view of the DCR as explained in the "Collect information from DCR" section in [Tutorial - Send custom logs to Azure Monitor Logs (preview) - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs#collect-information-from-dcr>) and copy the value of the "dataFlows -> streams" property (see circled in red in the below example).
 
----
+After retrieving the required values replace the output section of the Logstash configuration file created in the previous steps with the example below. Then, replace the strings in the brackets below with the corresponding values. Make sure you change the "create_sample_file" attribute to false.
 
-### Authentication Examples
-
-The plugin auto-detects the auth method based on which config values are present.  
-
-#### Option 1: Client Secret (App Registration)
-
-Provide `client_id`, `client_secret`, and `tenant_id` for your Azure App Registration / service principal.  
-
-    output {
-      microsoft-sentinel-log-analytics-logstash-output-plugin {
-        data_collection_endpoint => "https://<your-dce-name>.<region>.ingest.monitor.azure.com"
-        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        stream_name              => "Custom-MyTableRawData_CL"
-        client_id                => "<your-app-client-id>"
-        client_secret            => "<your-app-client-secret>"
-        tenant_id                => "<your-azure-tenant-id>"
-      }
+Here is an example for the output plugin configuration section:
+```
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+        client_app_Id => "<enter your client_app_id value here>"
+        client_app_secret => "<enter your client_app_secret value here>"
+        tenant_id => "<enter your tenant id here>"
+        data_collection_endpoint => "<enter your DCE logsIngestion URI here>"
+        dcr_immutable_id => "<enter your DCR immutableId here>"
+        dcr_stream_name => "<enter your stream name here>"
+        create_sample_file=> false
+        sample_file_path => "c:\\temp"
     }
+}
+```
 
+### 4b. Managed identity authentication (passwordless)
 
-#### Option 2: Managed Identity
+When `managed_identity` is set to `true`, the plugin authenticates without a client secret. The plugin automatically detects the appropriate identity mechanism at runtime in the following order:
 
-When running on an Azure VM with a system-assigned managed identity, omit `client_id`, `client_secret`, and `tenant_id`. The plugin will automatically use the VM's managed identity.  
+1. **AKS Workload Identity** — If the environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE` are present (set automatically by AKS), the plugin performs an OIDC token exchange.
+2. **Azure Arc** — If the Azure Connected Machine Agent (`azcmagent`) is detected on the host, the plugin uses the Arc managed identity endpoint for hybrid and on-premises servers.
+3. **IMDS** — Otherwise, the plugin falls back to the Azure Instance Metadata Service (IMDS) for Azure VMs and VMSS.
 
-    output {
-      microsoft-sentinel-log-analytics-logstash-output-plugin {
-        data_collection_endpoint => "https://<your-dce-name>.<region>.ingest.monitor.azure.com"
-        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        stream_name              => "Custom-MyTableRawData_CL"
-      }
+Required configuration for managed identity:
+- **managed_identity** - Boolean, false by default. Set to `true` to enable passwordless authentication.
+- **data_collection_endpoint** - String, The logsIngestion URI for your DCE.
+- **dcr_immutable_id** - String, The DCR immutableId.
+- **dcr_stream_name** - String, The name of the data stream.
+
+Optional:
+- **managed_identity_object_id** - String, Empty by default. The object ID of a user-assigned managed identity. Required when the VM has multiple user-assigned identities. Omit this for system-assigned managed identity.
+
+Example using system-assigned managed identity:
+```
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+        managed_identity => true
+        data_collection_endpoint => "<enter your DCE logsIngestion URI here>"
+        dcr_immutable_id => "<enter your DCR immutableId here>"
+        dcr_stream_name => "<enter your stream name here>"
     }
+}
+```
 
-#### Option 3: Client Secret + Sovereign Cloud
-
-To authenticate against a sovereign cloud, add `azure_cloud`. Supported values: `AzurePublicCloud` (default), `AzureUSGovernment`, `AzureChinaCloud`, `AzureGermanyCloud`.  
-
-    output {
-      microsoft-sentinel-log-analytics-logstash-output-plugin {
-        data_collection_endpoint => "https://<your-dce-ingestion-endpoint>"
-        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        stream_name              => "Custom-MyTableRawData_CL"
-        client_id                => "<your-app-client-id>"
-        client_secret            => "<your-app-client-secret>"
-        tenant_id                => "<your-tenant-id>"
-        azure_cloud              => "AzureUSGovernment"
-      }
+Example using user-assigned managed identity:
+```
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+        managed_identity => true
+        managed_identity_object_id => "<enter the object ID of your user-assigned identity>"
+        data_collection_endpoint => "<enter your DCE logsIngestion URI here>"
+        dcr_immutable_id => "<enter your DCR immutableId here>"
+        dcr_stream_name => "<enter your stream name here>"
     }
+}
+```
 
-#### Option 4: Managed Identity + Sovereign Cloud
+> **Note:** When using Azure Arc, the Logstash process must run as a user that is a member of the `himds` group to read the challenge token. See the [Azure Arc managed identity documentation](<https://learn.microsoft.com/azure/azure-arc/servers/managed-identity-authentication>) for details.
 
-    output {
-      microsoft-sentinel-log-analytics-logstash-output-plugin {
-        data_collection_endpoint => "https://<your-dce-ingestion-endpoint>"
-        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        stream_name              => "Custom-MyTableRawData_CL"
-        azure_cloud              => "AzureUSGovernment"
-      }
+### Optional configuration
+- **key_names** – Array of strings, if you wish to send a subset of the columns to Log Analytics.
+- **plugin_flush_interval** – Number, 5 by default. Defines the maximal time difference (in seconds) between sending two messages to Log Analytics.
+- **retransmission_time** - Number, 10 by default. This will set the amount of time in seconds given for retransmitting messages once sending has failed.
+- **compress_data** - Boolean, false by default. When this field is true, the event data is compressed before using the API. Recommended for high throughput pipelines
+- **proxy** - String, Empty by default. Specify which proxy URL to use for API calls for all of the communications with Azure.
+- **proxy_aad** - String, Empty by default. Specify which proxy URL to use for API calls for the Microsoft Entra ID service. Overrides the proxy setting.
+- **proxy_endpoint** - String, Empty by default. Specify which proxy URL to use when sending log data to the endpoint. Overrides the proxy setting.
+- **azure_cloud** - String, Empty by default. Used to specify the name of the Azure cloud that is being used, AzureCloud is set as default. Available values are: AzureCloud, AzureChinaCloud and AzureUSGovernment.
+
+#### Note: When setting an empty string as a value for a proxy setting, it will unset any system wide proxy setting.
+
+Security notice: We recommend not to implicitly state client_app_Id, client_app_secret, tenant_id, data_collection_endpoint, and dcr_immutable_id in your Logstash configuration for security reasons.
+                 It is best to store this sensitive information in a Logstash KeyStore as described here- ['Secrets Keystore'](<https://www.elastic.co/guide/en/logstash/current/keystore.html>)
+
+
+## 5. Basic logs transmission
+
+Here is an example configuration that parses Syslog incoming data into a custom stream named "Custom-MyTableRawData".
+
+### Example Configuration
+
+- Using filebeat input pipe
+
+```
+input {
+    beats {
+        port => "5044"
     }
----
-Security notice: We recommend not to implicitly state client_id, client_secret, tenant_id, data_collection_endpoint, and dcr_id in your Logstash configuration for security reasons.  
-                 It is best to store this sensitive information in a Logstash KeyStore as described here- ['Secrets Keystore'](<https://www.elastic.co/guide/en/logstash/current/keystore.html>)  
-
----
-
-## Full Pipeline Example
-
-A complete `logstash.conf` using client secret auth with a Beats input:  
-
-    input {
-      beats {
-        port => 5044
-      }
+}
+ filter {
+}
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+      client_app_Id => "619c1731-15ca-4403-9c61-xxxxxxxxxxxx"
+      client_app_secret => "xxxxxxxxxxxxxxxx"
+      tenant_id => "72f988bf-86f1-41af-91ab-xxxxxxxxxxxx"
+      data_collection_endpoint => "https://my-customlogsv2-test-jz2a.eastus2-1.ingest.monitor.azure.com"
+      dcr_immutable_id => "dcr-xxxxxxxxxxxxxxxxac23b8978251433a"
+      dcr_stream_name => "Custom-MyTableRawData"
+      proxy_aad => "http://proxy.example.com"
     }
+}
 
-    filter {
+```
+- Or using the tcp input pipe
+
+```
+input {
+    tcp {
+        port => "514"
+        type => syslog #optional, will effect log type in table
     }
-
-    output {
-      microsoft-sentinel-log-analytics-logstash-output-plugin {
-        data_collection_endpoint => "https://my-dce.eastus2-1.ingest.monitor.azure.com"
-        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        stream_name              => "Custom-MyTableRawData_CL"
-        client_id                => "619c1731-15ca-4403-9c61-xxxxxxxxxxxx"
-        client_secret            => "xxxxxxxxxxxxxxxx"
-        tenant_id                => "72f988bf-86f1-41af-91ab-xxxxxxxxxxxx"
-      }
+}
+ filter {
+}
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+      client_app_Id => "619c1731-15ca-4403-9c61-xxxxxxxxxxxx"
+      client_app_secret => "xxxxxxxxxxxxxxxx"
+      tenant_id => "72f988bf-86f1-41af-91ab-xxxxxxxxxxxx"
+      data_collection_endpoint => "https://my-customlogsv2-test-jz2a.eastus2-1.ingest.monitor.azure.com"
+      dcr_immutable_id => "dcr-xxxxxxxxxxxxxxxxac23b8978251433a"
+      dcr_stream_name => "Custom-MyTableRawData"
     }
----
+}
+```
 
-## Optional Config Values
+<u>Advanced Configuration</u>
+```
+input {
+  syslog {
+    port => 514
+  }
+}
 
-| Key | Default | Description |  
-|---|---|---|  
-| `azure_cloud` | `AzurePublicCloud` | Azure cloud environment |  
-| `keys_to_keep` | *(all)* | Array of field names to send (subset filtering) |  
-| `max_retries_num` | `3` | Max retry attempts for failed sends |  
-| `initial_wait_time_seconds` | `1` | Initial backoff between retries |  
-| `max_graceful_shutdown_time_seconds` | `60` | Max wait for graceful shutdown |  
-| `max_waiting_time_for_batch_seconds` | `10` | Max wait before flushing a batch |  
-| `max_waiting_for_unifier_time_seconds` | `10` | Max wait before flushing the unifier |  
-| `max_batch_size` | `10000` | Maximum number of events per batch. When a batch reaches this size it is flushed immediately, regardless of the time window |  
-| `input_queue_capacity` | `50000` | Maximum capacity of the input queue. Bounds memory usage under high-volume ingestion. When full, back-pressure is applied to the Logstash pipeline |  
-| `internal_queue_capacity` | `500` | Maximum capacity of the internal queues between batcher, unifier, and sender workers. Bounds memory usage for in-flight batches |  
-| `worker_sleep_time_millis` | `10` | Delay between worker iterations |  
-| `batcher_workers_count` | *(auto)* | Number of batcher threads |  
-| `sender_workers_count` | *(auto)* | Number of sender threads |  
-| `unifier_workers_count` | *(auto)* | Number of unifier threads |  
-| `id` | `None` | A custom identification tag to be added to sent-batches logs |  
+output {
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+      client_app_Id => "${CLIENT_APP_ID}"
+      client_app_secret => "${CLIENT_APP_SECRET}"
+      tenant_id => "${TENANT_ID}"
+      data_collection_endpoint => "${DATA_COLLECTION_ENDPOINT}"
+      dcr_immutable_id => "${DCR_IMMUTABLE_ID}"
+      dcr_stream_name => "Custom-MyTableRawData"
+	  key_names => ['PRI','TIME_TAG','HOSTNAME','MSG']
+    }
+}
+
+```
+
+Now you are able to run logstash with the example configuration and send mock data using the 'logger' command.
+
+For example: 
+```
+logger -p local4.warn --rfc3164 --tcp -t CEF "0|Microsoft|Device|cef-test|example|data|1|here is some more data for the example" -P 514 -d -n 127.0.0.1
+```
+
+Which will produce this content in the sample file:
+
+```
+[
+	{
+		"logsource": "logstashMachine",
+		"facility": 20,
+		"severity_label": "Warning",
+		"severity": 4,
+		"timestamp": "Apr  7 08:26:04",
+		"program": "CEF:",
+		"host": "127.0.0.1",
+		"facility_label": "local4",
+		"priority": 164,
+		"message": "0|Microsoft|Device|cef-test|example|data|1|here is some more data for the example",
+		"ls_timestamp": "2022-04-07T08:26:04.000Z",
+		"ls_version": "1"
+	}
+]
+```
+
 
 ## Known issues
  
-When using Logstash installed on a Docker image of Lite Ubuntu, the following warning may appear:  
+When using Logstash installed on a Docker image of Lite Ubuntu, the following warning may appear:
 
-    java.lang.RuntimeException: getprotobyname_r failed
+```
+java.lang.RuntimeException: getprotobyname_r failed
+```
 
-To resolve it, use the following commands to install the *netbase* package within your Dockerfile:  
-    ```
-    USER root
-    RUN apt install netbase -y
-    ```  
-For more information, see [JNR regression in Logstash 7.17.0 (Docker)](https://github.com/elastic/logstash/issues/13703).  
+To resolve it, use the following commands to install the *netbase* package within your Dockerfile:
+```bash
+USER root
+RUN apt install netbase -y
+```
+For more information, see [JNR regression in Logstash 7.17.0 (Docker)](https://github.com/elastic/logstash/issues/13703).
+
+If your environment's event rate is low considering the number of allocated Logstash workers, we recommend increasing the value of *plugin_flush_interval* to 60 or more. This change will allow each worker to batch more events before uploading to the Data Collection Endpoint (DCE).  You can monitor the ingestion payload using [DCR metrics](https://learn.microsoft.com/azure/azure-monitor/essentials/data-collection-monitor#dcr-metrics).
+For more information on *plugin_flush_interval*, see the [Optional Configuration table](https://learn.microsoft.com/azure/sentinel/connect-logstash-data-connection-rules#optional-configuration) mentioned earlier.
+

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md
@@ -60,7 +60,7 @@ Note: make sure that the path exists before creating the sample file.
 ### Configurations:
 The following parameters are optional and should be used to create a sample file.
 - **create_sample_file** - Boolean, False by default. When enabled, up to 10 events will be written to a sample json file.
-- **sample_file_path** - Number, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.
+- **sample_file_path** - String, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.
 
 ### Complete example
 1. set the pipeline.conf with the following configuration:
@@ -99,6 +99,13 @@ To configure Microsoft Sentinel Logstash plugin you first need to create the DCR
 1) To ingest the data to a custom table use [Tutorial - Send custom logs to Azure Monitor Logs (preview) - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs>) tutorial. Note that as part of creating the table and the DCR you will need to provide the sample file that you've created in the previous section.
 2) To ingest the data to a standard table like Syslog or CommonSecurityLog use [Tutorial - Send custom logs to Azure Monitor Logs using resource manager templates - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs-api>).
 
+*Note:* The identity (service principal or managed identity) must have the **Monitoring Metrics Publisher** role on the target DCR:
+
+    az role assignment create \
+      --assignee <object-id-of-identity> \
+      --role "Monitoring Metrics Publisher" \
+      --scope "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Insights/dataCollectionRules/<dcr-name>"
+
 
 ## 4. Configure Logstash configuration file
 
@@ -120,7 +127,7 @@ Here is an example for the output plugin configuration section:
 ```
 output {
     microsoft-sentinel-log-analytics-logstash-output-plugin {
-        client_app_Id => "<enter your client_app_id value here>"
+        client_app_Id => "<enter your client_app_Id value here>"
         client_app_secret => "<enter your client_app_secret value here>"
         tenant_id => "<enter your tenant id here>"
         data_collection_endpoint => "<enter your DCE logsIngestion URI here>"
@@ -203,7 +210,7 @@ Here is an example configuration that parses Syslog incoming data into a custom 
 ```
 input {
     beats {
-        port => "5044"
+        port => 5044
     }
 }
  filter {
@@ -226,8 +233,8 @@ output {
 ```
 input {
     tcp {
-        port => "514"
-        type => syslog #optional, will effect log type in table
+        port => 514
+        type => syslog #optional, will affect log type in table
     }
 }
  filter {

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin_java/CHANGELOG.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin_java/CHANGELOG.md
@@ -1,0 +1,29 @@
+## 2.3.0
+- Added optional Id configuration value for telemetry.
+- Added DCR stream to sent-batches logging.
+- Enabled functionality with logstash 9.4.
+- Bumped dependency versions for external libraries (azure-sdk-bom, logback, slf4j, Netty).
+
+## 2.2.1
+- Adds info-level logging line when batches are successfully sent.
+
+## 2.2.0
+- Adds ability to use either new or old configuration values.
+
+## 2.1.2
+- Documentation updates
+
+## 2.1.1
+- Improved efficiency.
+
+## 2.1.0
+- Fixed event normalization.
+
+## 2.0.0
+- Refactored the plugin from Ruby to Java.
+- Added ManagedIdentity authentication.
+- Moved codebase from GitHub to Azure DevOps.
+- Closed codebase.
+
+## 1.x.x (Ruby - deprecated)
+The 1.x.x releases are the deprecated Ruby version of this plugin. For the 1.x.x changelog and documentation, see [microsoft-sentinel-log-analytics-logstash-output-plugin](../microsoft-sentinel-log-analytics-logstash-output-plugin/CHANGELOG.md).

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin_java/README.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin_java/README.md
@@ -1,0 +1,239 @@
+# Microsoft Sentinel Output Plugin for Logstash 
+
+Microsoft Sentinel provides a new output plugin for Logstash. Use this output plugin to send any log via Logstash to the Microsoft Sentinel/Log Analytics workspace. This is done with the Log Analytics DCR-based API.
+You may send logs to custom or standard tables.  
+
+Plugin version: v2.3.0  
+Released on: 2026-06-17  
+
+This plugin is currently in development and is free to use. We request and appreciate feedback from users.  
+
+## Installation Instructions
+1) Install the plugin  
+2) Create a sample file  
+3) Create the required DCR-related resources  
+4) Configure Logstash configuration file  
+
+
+## 1. Install the plugin
+
+Microsoft Sentinel provides Logstash output plugin to Log analytics workspace using DCR based logs API.  
+
+The plugin is published on [RubyGems](https://rubygems.org/gems/microsoft-sentinel-log-analytics-logstash-output-plugin/versions/2.3.0-java). To install to an existing logstash installation, run `logstash-plugin install microsoft-sentinel-log-analytics-logstash-output-plugin`.  
+
+If you do not have a direct internet connection, you can install the plugin to another logstash installation, and then export and import a plugin bundle to the offline host. For more information, see [Logstash Offline Plugin Management instruction](<https://www.elastic.co/guide/en/logstash/current/offline-plugins.html>).  
+
+Microsoft Sentinel's Logstash output plugin supports the following versions  
+- 7.0 - 7.17.13  
+- 8.0 - 8.9 (NOTE: these versions require a security update, according to Logstash!)  
+- 8.11 - 8.15 (NOTE: these versions require a security update, according to Logstash!)  
+- 8.19.2 (NOTE: this version requires a security update, according to Logstash!)  
+- 9.0.8 (NOTE: this version requires a security update, according to Logstash!)  
+- 9.1.10 (NOTE: this version requires a security update, according to Logstash!)  
+- 9.2.4 - 9.2.5 (NOTE: these versions require a security update, according to Logstash! [Security Update](https://discuss.elastic.co/t/logstash-8-19-14-9-2-8-9-3-3-security-update-esa-2026-29/385816))  
+- 9.3.3
+- 9.4.0
+
+Please note that when using Logstash 8, it is recommended to disable ECS in the pipeline. For more information refer to [Logstash documentation.](<https://www.elastic.co/guide/en/logstash/8.4/ecs-ls.html>)  
+
+## 2. Create a sample file
+To create a sample file, follow the following steps:  
+1)	Copy the output plugin configuration below to your Logstash configuration file:  
+    ```
+    output {
+        microsoft-sentinel-log-analytics-logstash-output-plugin {
+            create_sample_file => true
+            sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
+        }
+    }
+    ```
+Note: make sure that the path exists before creating the sample file.  
+2) Start Logstash. The plugin will collect up to 10 records to a sample.  
+3) The file named "sampleFile<epoch seconds>.json" in the configured path will be created once there are 10 events to sample or when the Logstash process exited gracefully. (for example: "c:\temp\sampleFile1648453501.json").  
+
+
+### Configurations:
+The following parameters are optional and should be used to create a sample file.  
+- **create_sample_file** - Boolean, False by default. When enabled, up to 10 events will be written to a sample json file.  
+- **sample_file_path** - Number, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.  
+
+### Complete example
+1. set the pipeline.conf with the following configuration:  
+    ```
+    input {
+          generator {
+            lines => [ "This is a test log message"]
+            count => 10
+          }
+    }
+
+    output {
+        microsoft-sentinel-log-analytics-logstash-output-plugin {
+            create_sample_file => true
+            sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
+        }
+    }
+    ```
+
+2. the following sample file will be generated:  
+    ```
+    [
+      {
+        "host": "logstashMachine",
+        "sequence": 0,
+        "message": "This is a test log message",
+        "ls_timestamp": "2022-10-29T13:19:28.116Z",
+        "ls_version": "1"
+      },
+      ...
+    ]
+    ```
+
+## 3. Create the required DCR-related resources
+To configure Microsoft Sentinel Logstash plugin you first need to create the DCR-related resources. To create these resources, follow one of the following tutorials:  
+1) To ingest the data to a custom table use [Tutorial - Send custom logs to Azure Monitor Logs (preview) - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs>) tutorial. Note that as part of creating the table and the DCR you will need to provide the sample file that you've created in the previous section.  
+2) To ingest the data to a standard table like Syslog or CommonSecurityLog use [Tutorial - Send custom logs to Azure Monitor Logs using resource manager templates - Azure Monitor | Microsoft Docs](<https://docs.microsoft.com/azure/azure-monitor/logs/tutorial-custom-logs-api>).  
+
+*Note:* The identity (service principal or managed identity) must have the **Monitoring Metrics Publisher** role on the target DCR:  
+
+    az role assignment create \
+      --assignee <object-id-of-identity> \
+      --role "Monitoring Metrics Publisher" \
+      --scope "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Insights/dataCollectionRules/<dcr-name>"
+
+
+## 4. Configure Logstash configuration file
+
+Add the `microsoft-sentinel-log-analytics-logstash-output-plugin` block to the `output` section of your Logstash configuration file (e.g., `logstash.conf`). The plugin requires three values from your Azure DCR resources plus authentication credentials depending on your method.  
+
+### Required Config Values (needed for all methods)
+
+| Key | Description |  
+|---|---|  
+| `data_collection_endpoint` | Your DCE logsIngestion URI |  
+| `dcr_id` | The immutable ID of your Data Collection Rule |  
+| `stream_name` | The stream name from your DCR (e.g., `Custom-MyTableRawData_CL`) |  
+
+---
+
+### Authentication Examples
+
+The plugin auto-detects the auth method based on which config values are present.  
+
+#### Option 1: Client Secret (App Registration)
+
+Provide `client_id`, `client_secret`, and `tenant_id` for your Azure App Registration / service principal.  
+
+    output {
+      microsoft-sentinel-log-analytics-logstash-output-plugin {
+        data_collection_endpoint => "https://<your-dce-name>.<region>.ingest.monitor.azure.com"
+        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        stream_name              => "Custom-MyTableRawData_CL"
+        client_id                => "<your-app-client-id>"
+        client_secret            => "<your-app-client-secret>"
+        tenant_id                => "<your-azure-tenant-id>"
+      }
+    }
+
+
+#### Option 2: Managed Identity
+
+When running on an Azure VM with a system-assigned managed identity, omit `client_id`, `client_secret`, and `tenant_id`. The plugin will automatically use the VM's managed identity.  
+
+    output {
+      microsoft-sentinel-log-analytics-logstash-output-plugin {
+        data_collection_endpoint => "https://<your-dce-name>.<region>.ingest.monitor.azure.com"
+        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        stream_name              => "Custom-MyTableRawData_CL"
+      }
+    }
+
+#### Option 3: Client Secret + Sovereign Cloud
+
+To authenticate against a sovereign cloud, add `azure_cloud`. Supported values: `AzurePublicCloud` (default), `AzureUSGovernment`, `AzureChinaCloud`, `AzureGermanyCloud`.  
+
+    output {
+      microsoft-sentinel-log-analytics-logstash-output-plugin {
+        data_collection_endpoint => "https://<your-dce-ingestion-endpoint>"
+        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        stream_name              => "Custom-MyTableRawData_CL"
+        client_id                => "<your-app-client-id>"
+        client_secret            => "<your-app-client-secret>"
+        tenant_id                => "<your-tenant-id>"
+        azure_cloud              => "AzureUSGovernment"
+      }
+    }
+
+#### Option 4: Managed Identity + Sovereign Cloud
+
+    output {
+      microsoft-sentinel-log-analytics-logstash-output-plugin {
+        data_collection_endpoint => "https://<your-dce-ingestion-endpoint>"
+        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        stream_name              => "Custom-MyTableRawData_CL"
+        azure_cloud              => "AzureUSGovernment"
+      }
+    }
+---
+Security notice: We recommend not to implicitly state client_id, client_secret, tenant_id, data_collection_endpoint, and dcr_id in your Logstash configuration for security reasons.  
+                 It is best to store this sensitive information in a Logstash KeyStore as described here- ['Secrets Keystore'](<https://www.elastic.co/guide/en/logstash/current/keystore.html>)  
+
+---
+
+## Full Pipeline Example
+
+A complete `logstash.conf` using client secret auth with a Beats input:  
+
+    input {
+      beats {
+        port => 5044
+      }
+    }
+
+    filter {
+    }
+
+    output {
+      microsoft-sentinel-log-analytics-logstash-output-plugin {
+        data_collection_endpoint => "https://my-dce.eastus2-1.ingest.monitor.azure.com"
+        dcr_id                   => "dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        stream_name              => "Custom-MyTableRawData_CL"
+        client_id                => "619c1731-15ca-4403-9c61-xxxxxxxxxxxx"
+        client_secret            => "xxxxxxxxxxxxxxxx"
+        tenant_id                => "72f988bf-86f1-41af-91ab-xxxxxxxxxxxx"
+      }
+    }
+---
+
+## Optional Config Values
+
+| Key | Default | Description |  
+|---|---|---|  
+| `azure_cloud` | `AzurePublicCloud` | Azure cloud environment |  
+| `keys_to_keep` | *(all)* | Array of field names to send (subset filtering) |  
+| `max_retries_num` | `3` | Max retry attempts for failed sends |  
+| `initial_wait_time_seconds` | `1` | Initial backoff between retries |  
+| `max_graceful_shutdown_time_seconds` | `60` | Max wait for graceful shutdown |  
+| `max_waiting_time_for_batch_seconds` | `10` | Max wait before flushing a batch |  
+| `max_waiting_for_unifier_time_seconds` | `10` | Max wait before flushing the unifier |  
+| `max_batch_size` | `10000` | Maximum number of events per batch. When a batch reaches this size it is flushed immediately, regardless of the time window |  
+| `input_queue_capacity` | `50000` | Maximum capacity of the input queue. Bounds memory usage under high-volume ingestion. When full, back-pressure is applied to the Logstash pipeline |  
+| `internal_queue_capacity` | `500` | Maximum capacity of the internal queues between batcher, unifier, and sender workers. Bounds memory usage for in-flight batches |  
+| `worker_sleep_time_millis` | `10` | Delay between worker iterations |  
+| `batcher_workers_count` | *(auto)* | Number of batcher threads |  
+| `sender_workers_count` | *(auto)* | Number of sender threads |  
+| `unifier_workers_count` | *(auto)* | Number of unifier threads |  
+| `id` | `None` | A custom identification tag to be added to sent-batches logs |  
+
+## Known issues
+ 
+When using Logstash installed on a Docker image of Lite Ubuntu, the following warning may appear:  
+
+    java.lang.RuntimeException: getprotobyname_r failed
+
+To resolve it, use the following commands to install the *netbase* package within your Dockerfile:  
+    ```
+    USER root
+    RUN apt install netbase -y
+    ```  
+For more information, see [JNR regression in Logstash 7.17.0 (Docker)](https://github.com/elastic/logstash/issues/13703).  

--- a/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin_java/README.md
+++ b/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin_java/README.md
@@ -55,7 +55,7 @@ Note: make sure that the path exists before creating the sample file.
 ### Configurations:
 The following parameters are optional and should be used to create a sample file.  
 - **create_sample_file** - Boolean, False by default. When enabled, up to 10 events will be written to a sample json file.  
-- **sample_file_path** - Number, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.  
+- **sample_file_path** - String, Empty by default. Required when create_sample_file is enabled. Should include a valid path in which to place the sample file generated.  
 
 ### Complete example
 1. set the pipeline.conf with the following configuration:  


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Reverted README and CHANGELOG files in microsoft-sentinel-log-analytics-logstash-output-plugin to their latest states under version 1.x.x, and added notes to each about the ruby-version plugin's deprecation, along with links to what will be the new version's documentation
   - Added new directory microsoft-sentinel-log-analytics-logstash-output-plugin_java to house documentation for the java-version

   Reason for Change(s):
   - The microsoft-sentinel-log-analytics-logstash-output-plugin directory houses the plugin for which it's named. We refactored the plugin from Ruby to Java, removing it from being open-sourced in the process
   - This change is to allow for the old directory to continue open-source behavior, while not losing accuracy regarding the new version's functionality
   - The new directory will house only documentation for the new java version, which will be linked to from RubyGems.org, which is the only publicly accessible source for the new version

   Version Updated:
   - No

   Testing Completed:
   - N/A - Documentation changes and directory refactoring

   Checked that the validations are passing and have addressed any issues that are present:
   - No validation breaking changes
