### PR TITLE
Update CEF AMA stream name

### DIFF
--- a/DataConnectors/Syslog/Sentinel_AMA_troubleshoot.py
+++ b/DataConnectors/Syslog/Sentinel_AMA_troubleshoot.py
@@ -346,7 +346,7 @@ class DCRConfigurationVerifications:
     # CONSTANTS
     DCR_DOC = "https://docs.microsoft.com/azure/azure-monitor/agents/data-collection-rule-overview"
     DCRA_DOC = "https://docs.microsoft.com/rest/api/monitor/data-collection-rule-associations"
-    CEF_STREAM_NAME = "SECURITY_CEF_BLOB"
+    CEF_STREAM_NAME = "Microsoft-CommonSecurityLog"
     CISCO_STREAM_NAME = "SECURITY_CISCO_ASA_BLOB"
     SYSLOG_STREAM_NAME = "LINUX_SYSLOGS_BLOB"
     STREAM_NAME = {"cef": CEF_STREAM_NAME, "asa": CISCO_STREAM_NAME, "syslog": SYSLOG_STREAM_NAME}


### PR DESCRIPTION
## Proposed change
Update the CEF stream constant used by `DataConnectors/Syslog/Sentinel_AMA_troubleshoot.py` from the legacy `SECURITY_CEF_BLOB` value to `Microsoft-CommonSecurityLog`.

## Why
The current Microsoft Sentinel CEF via AMA documentation says the DCR `streams` field should be set to `Microsoft-CommonSecurityLog` for CEF messages:
https://learn.microsoft.com/en-us/azure/sentinel/connect-cef-syslog-ama?tabs=api

## Validation
- `python -m py_compile DataConnectors/Syslog/Sentinel_AMA_troubleshoot.py`