### PR TITLE
Adding msg_s column in AzureFirewall DNS parsers

### DIFF
--- a/Parsers/ASimDns/CHANGELOG/ASimDnsAzureFirewall.md
+++ b/Parsers/ASimDns/CHANGELOG/ASimDnsAzureFirewall.md
@@ -1,5 +1,9 @@
 # Changelog for ASimDnsAzureFirewall.yaml
 
+## Version 0.4.1
+
+- (2026-06-26) Use column_ifexists for msg_s in the legacy AzureDiagnostics branch to prevent union failures when msg_s is absent (resource-specific logging) - [PR #14609](https://github.com/Azure/Azure-Sentinel/pull/14609)
+
 ## Version 0.4.0
 
 - (2025-12-02) AZFW ASIM Parsers - [PR #13181](https://github.com/Azure/Azure-Sentinel/pull/13181)

--- a/Parsers/ASimDns/CHANGELOG/vimDnsAzureFirewall.md
+++ b/Parsers/ASimDns/CHANGELOG/vimDnsAzureFirewall.md
@@ -1,5 +1,9 @@
 # Changelog for vimDnsAzureFirewall.yaml
 
+## Version 0.4.1
+
+- (2026-06-26) Use column_ifexists for msg_s in the legacy AzureDiagnostics branch to prevent union failures when msg_s is absent (resource-specific logging) - [PR #14609](https://github.com/Azure/Azure-Sentinel/pull/14609)
+
 ## Version 0.4.0
 
 - (2025-12-02) AZFW ASIM Parsers - [PR #13181](https://github.com/Azure/Azure-Sentinel/pull/13181)

--- a/Parsers/ASimDns/Parsers/ASimDnsAzureFirewall.yaml
+++ b/Parsers/ASimDns/Parsers/ASimDnsAzureFirewall.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: DNS activity ASIM parser for Azure Firewall
-  Version: '0.4.0'
-  LastUpdated: Dec 2, 2025
+  Version: '0.4.1'
+  LastUpdated: Jun 26, 2026
 Product:
   Name: Azure Firewall
 Normalization:
@@ -25,6 +25,9 @@ ParserQuery: |
     AzureDiagnostics | where not(disabled)
     // | where ResourceType == "AZUREFIREWALLS" -- Implicit in the next line
     | where Category == "AzureFirewallDnsProxy"
+    // Use column_ifexists so the parser does not fail when AzureFirewallDnsProxy logs are
+    // sent only to the resource-specific AZFWDnsQuery table and msg_s is absent from AzureDiagnostics.
+    | extend msg_s = column_ifexists("msg_s", "")
     | where msg_s startswith "DNS Request:"
     | project msg_s, TimeGenerated, ResourceId, SubscriptionId
     | parse msg_s with
@@ -53,6 +56,9 @@ ParserQuery: |
     AzureDiagnostics | where not(disabled)
     // | where ResourceType == "AZUREFIREWALLS" -- Implicit in the next line
     | where Category == "AzureFirewallDnsProxy"
+    // Use column_ifexists so the parser does not fail when AzureFirewallDnsProxy logs are
+    // sent only to the resource-specific AZFWDnsQuery table and msg_s is absent from AzureDiagnostics.
+    | extend msg_s = column_ifexists("msg_s", "")
     | project msg_s, TimeGenerated, ResourceId, SubscriptionId
     | where msg_s startswith " Error:"
     | parse msg_s with 

--- a/Parsers/ASimDns/Parsers/vimDnsAzureFirewall.yaml
+++ b/Parsers/ASimDns/Parsers/vimDnsAzureFirewall.yaml
@@ -1,7 +1,7 @@
 Parser:
   Title: DNS activity ASIM filtering parser for Azure Firewall
-  Version: '0.4.0'
-  LastUpdated: Dec 2, 2025
+  Version: '0.4.1'
+  LastUpdated: Jun 26, 2026
 Product:
   Name: Azure Firewall
 Normalization:
@@ -56,6 +56,9 @@ ParserQuery: |
     AzureDiagnostics | where not(disabled)
     // | where ResourceType == "AZUREFIREWALLS" -- Implicit in the next line
     | where Category == "AzureFirewallDnsProxy"
+    // Use column_ifexists so the parser does not fail when AzureFirewallDnsProxy logs are
+    // sent only to the resource-specific AZFWDnsQuery table and msg_s is absent from AzureDiagnostics.
+    | extend msg_s = column_ifexists("msg_s", "")
     | project msg_s, TimeGenerated, ResourceId, SubscriptionId
     | where msg_s startswith "DNS Request:"
     //  --Pre-parsing filtering:
@@ -108,6 +111,9 @@ ParserQuery: |
     AzureDiagnostics
     // | where ResourceType == "AZUREFIREWALLS" -- Implicit in the next line
     | where Category == "AzureFirewallDnsProxy"
+    // Use column_ifexists so the parser does not fail when AzureFirewallDnsProxy logs are
+    // sent only to the resource-specific AZFWDnsQuery table and msg_s is absent from AzureDiagnostics.
+    | extend msg_s = column_ifexists("msg_s", "")
     | project msg_s, TimeGenerated, ResourceId, SubscriptionId
     | where msg_s startswith " Error:"
     //  --Pre-parsing filtering:


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Added msg_s = column_ifexists("msg_s", "") to both legacy AzureDiagnostics branches in ASimDnsAzureFirewall and vimDnsAzureFirewall DNS parsers.

   Reason for Change(s):
   - In resource-specific mode (logs go only to AZFWDnsQuery), msg_s doesn't exist in AzureDiagnostics, causing 'Failed to resolve scalar expression named 'msg_s'' which aborted the whole union. column_ifexists makes the reference safe and backward-compatible.

   Version Updated:
   - Both parsers bumped 0.4.0 → 0.4.1 (N/A for Detections/Analytic Rules).

   Testing Completed:
   - Yes