### PR TITLE
Update analytic rule to include AppId and CloudApplication

### DIFF
--- a/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
@@ -80,7 +80,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-   - entityType: CloudApplication
+  - entityType: CloudApplication
     fieldMappings:
       - identifier: AppId
         columnName: AppId

--- a/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
+++ b/Solutions/Microsoft Entra ID/Analytic Rules/NRT_NewAppOrServicePrincipalCredential.yaml
@@ -43,10 +43,10 @@ query: |
   | parse diff with * "KeyIdentifier=" keyIdentifier:string ",KeyType=" keyType:string ",KeyUsage=" keyUsage:string ",DisplayName=" keyDisplayName:string "]" *
   | where keyUsage =~ "Verify"
   | mv-apply AdditionalDetail = AdditionalDetails on 
-    (
-        where AdditionalDetail.key =~ "User-Agent"
-        | extend UserAgent = tostring(AdditionalDetail.value)
-    )
+  (
+    summarize UserAgent = tostring(anyif(AdditionalDetail.value, AdditionalDetail.key =~ "User-Agent")),
+              AppId     = tostring(anyif(AdditionalDetail.value, AdditionalDetail.key =~ "AppId"))
+  )
   | extend InitiatingAppName = tostring(InitiatedBy.app.displayName)
   | extend InitiatingAppServicePrincipalId = tostring(InitiatedBy.app.servicePrincipalId)
   | extend InitiatingUserPrincipalName = tostring(InitiatedBy.user.userPrincipalName)
@@ -55,7 +55,7 @@ query: |
   // The below line is currently commented out but Microsoft Sentinel users can modify this query to show only Application or only Service Principal events in their environment
   //| where targetType =~ "Application" // or targetType =~ "ServicePrincipal"
   | project-away diff, new_value_set, old_value_set
-  | project-reorder TimeGenerated, OperationName, InitiatingUserPrincipalName, InitiatingAadUserId, InitiatingAppName, InitiatingAppServicePrincipalId, InitiatingIpAddress, UserAgent, targetDisplayName, targetId, targetType, keyDisplayName, keyType, keyUsage, keyIdentifier, CorrelationId, TenantId
+  | project-reorder TimeGenerated, OperationName, InitiatingUserPrincipalName, InitiatingAadUserId, InitiatingAppName, InitiatingAppServicePrincipalId, InitiatingIpAddress, UserAgent, AppId, targetDisplayName, targetId, targetType, keyDisplayName, keyType, keyUsage, keyIdentifier, CorrelationId, TenantId
   | extend InitiatedByName = tostring(split(InitiatingUserPrincipalName,'@',0)[0]), InitiatedByUPNSuffix = tostring(split(InitiatingUserPrincipalName,'@',1)[0])
 entityMappings:
   - entityType: Account
@@ -80,5 +80,11 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: InitiatingIpAddress
-version: 1.0.5
+   - entityType: CloudApplication
+    fieldMappings:
+      - identifier: AppId
+        columnName: AppId
+      - identifier: InstanceName
+        columnName: targetDisplayName
+version: 1.0.6
 kind: NRT


### PR DESCRIPTION
Added parsing for AppId to ensure that can be added to the entity mapping

   Required items, please complete
   
   Change(s):
   -  Updated section to include AppId from AdditionalDetail .
   | mv-apply AdditionalDetail = AdditionalDetails on 
  (
    summarize UserAgent = tostring(anyif(AdditionalDetail.value, AdditionalDetail.key =~ "User-Agent")),
              AppId     = tostring(anyif(AdditionalDetail.value, AdditionalDetail.key =~ "AppId"))
  )

   Reason for Change(s):
   - Reduces need to read into AdditionalDetail  and have this under entity mapping. 
   Version Updated:
   -Yes

   Testing Completed:
   - Yes


