### PR TITLE
Use js-yaml load in YAML validators

### DIFF
--- a/.script/local-validation/validate.ts
+++ b/.script/local-validation/validate.ts
@@ -350,7 +350,7 @@ async function validateYamlSyntax(filePath: string, _fileKind: string): Promise<
   try {
     // Dynamic import for js-yaml since it may not be typed
     const yamlModule = await import("js-yaml");
-    const yamlLoad = yamlModule.default?.safeLoad || yamlModule.safeLoad;
+    const yamlLoad = yamlModule.default?.load || yamlModule.load;
     yamlLoad(fs.readFileSync(filePath, "utf8"));
     return { validator: "YAML Syntax", filePath, passed: true };
   } catch (e: unknown) {

--- a/.script/yamlFileValidator.ts
+++ b/.script/yamlFileValidator.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import * as logger from "./utils/logger.js";
 
 export async function IsValidYamlFile(filePath: string): Promise<ExitCode> {
-  yaml.safeLoad(fs.readFileSync(filePath, "utf8"));
+  yaml.load(fs.readFileSync(filePath, "utf8"));
   return ExitCode.SUCCESS;
 }
 


### PR DESCRIPTION
Replaced deprecated `safeLoad` calls with `load` in both local validation scripts. This aligns with current `js-yaml` APIs and keeps YAML syntax validation working across the validation pipeline.

   Required items, please complete
   
   Change(s):
   - See guidance below

   Reason for Change(s):
   - See guidance below

   Version Updated:
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

   Checked that the validations are passing and have addressed any issues that are present:
   - See guidance below


# Guidance <- remove section before submitting
-----------------------------------------------------------------------------------------------------------
## Before submitting this PR please ensure that you have read the following sections and filled out the changes, reason for change and testing complete sections:

Thank you for your contribution to the Microsoft Sentinel Github repo.

> Details of the code changes in your submitted PR.  Providing descriptions for pull requests ensures there is context to changes being made and greatly enhances the code review process.  Providing associated Issues that this resolves also easily connects the reason.
   
   Change(s):
   - Updated syntax for XYZ.yaml

   Reason for Change(s):
   - New schema used for XYZ.yaml
   - Resolves ISSUE #1234

   Version updated:
   - Yes
   - Detections/Analytic Rule templates are required to have the version updated

> The code should have been tested in a Microsoft Sentinel environment that does not have any custom parsers, functions or tables, so that you validate no incorrect syntax and execution functions properly.  If your submission requires a custom parser or function, it must be submitted with the PR.

   Testing Completed:
   - Yes/No/Need Help

_Note: If updating a detection, you must update the version field._

> Before the submission has been made, please look at running the KQL and Yaml Validation Checks locally.
> https://github.com/Azure/Azure-Sentinel#run-kql-validation-locally

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes/No/Need Help
   
   _Note: Let us know if you have tried fixing the validation error and need help._

> References: 
> - [Guidance for Detection checks](https://github.com/Azure/Azure-Sentinel#pull-request-detection-template-structure-validation-check)
> - [General contribution guidance](https://github.com/Azure/Azure-Sentinel/wiki#what-can-you-contribute-and-how-can-you-create-contributions)
> - [PR validation troubleshooting](https://github.com/Azure/Azure-Sentinel#pull-request)


-----------------------------------------------------------------------------------------------------------
