### PR TITLE
Fix Isolate-MDEMachine readme: missing Machine.Read.All permission

### DIFF
--- a/Solutions/MicrosoftDefenderForEndpoint/Playbooks/Isolate-MDEMachine/readme.md
+++ b/Solutions/MicrosoftDefenderForEndpoint/Playbooks/Isolate-MDEMachine/readme.md
@@ -36,17 +36,21 @@ After deployment, you can run this playbook manually on an alert or attach it to
    - Select Role - Microsoft Sentinel Responder,
    - Click Save.
 2. You will need to grant Machine.Isolate permissions to the managed identity.  Run the following code replacing the managed identity object id.  You find the managed identity object id on the Identity blade under Settings for the Logic App.
+
+   > **Note:** `Machine.Isolate` alone is not sufficient. The playbook also looks up the device (e.g. by hostname) before isolating it, which requires `Machine.Read.All`. Without it, the playbook fails with `Forbidden: Missing application roles. API required roles: Machine.Read.All,Machine.ReadWrite.All`. Grant both permissions as shown below.
 ```powershell
 $MIGuid = "<Enter your managed identity guid here>"
 $MI = Get-AzureADServicePrincipal -ObjectId $MIGuid
 
 $MDEAppId = "fc780465-2017-40d4-a0c5-307022471b92"
-$PermissionName = "Machine.Isolate" 
+$PermissionNames = "Machine.Isolate","Machine.Read.All"
 
 $MDEServicePrincipal = Get-AzureADServicePrincipal -Filter "appId eq '$MDEAppId'"
-$AppRole = $MDEServicePrincipal.AppRoles | Where-Object {$_.Value -eq $PermissionName -and $_.AllowedMemberTypes -contains "Application"}
-New-AzureAdServiceAppRoleAssignment -ObjectId $MI.ObjectId -PrincipalId $MI.ObjectId `
--ResourceId $MDEServicePrincipal.ObjectId -Id $AppRole.Id
+foreach ($PermissionName in $PermissionNames) {
+    $AppRole = $MDEServicePrincipal.AppRoles | Where-Object {$_.Value -eq $PermissionName -and $_.AllowedMemberTypes -contains "Application"}
+    New-AzureAdServiceAppRoleAssignment -ObjectId $MI.ObjectId -PrincipalId $MI.ObjectId `
+    -ResourceId $MDEServicePrincipal.ObjectId -Id $AppRole.Id
+}
 ```
 
 ## Screenshots


### PR DESCRIPTION
## Summary

The Post Deployment instructions for the **Isolate-MDEMachine** playbook only grant the managed identity the `Machine.Isolate` application permission. In practice this is not sufficient - the playbook also performs a device lookup (e.g. by hostname) before isolating it, which requires `Machine.Read.All` (or `Machine.ReadWrite.All`).

Without the read permission, the playbook fails at runtime with:

```json
{
  "error": {
    "code": "Forbidden",
    "message": "Missing application roles. API required roles: Machine.Read.All,Machine.ReadWrite.All, application roles: Machine.Isolate."
  }
}
```

## Change
- Updated the PowerShell snippet in `readme.md` to grant both `Machine.Isolate` and `Machine.Read.All` in a loop.
- Added a short note explaining why both permissions are required.

## Testing
Reproduced the failure with only `Machine.Isolate` granted, then confirmed the playbook runs successfully after also granting `Machine.Read.All`