### PR TITLE
Fix malformed migration links in Hunting Queries/AWSCloudTrail

### DIFF
--- a/Hunting Queries/AWSCloudTrail/AWS_IAM_PolicyChange.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_IAM_PolicyChange.yaml
@@ -1,4 +1,4 @@
 id: f8a0808c-4c22-44a8-8aa4-a6caa35afc31
 name: Changes made to AWS IAM policy 
 description: |
-  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%Web%Services/Hunting%Queries/AWS_IAM_PolicyChange.yaml'  
+  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%20Web%20Services/Hunting%20Queries/AWS_IAM_PolicyChange.yaml'  

--- a/Hunting Queries/AWSCloudTrail/AWS_IAM_PrivilegeEscalationbyAttachment.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_IAM_PrivilegeEscalationbyAttachment.yaml
@@ -1,4 +1,4 @@
 id: 4b746dd8-80e6-4f5f-a2a4-881ba9f1ee00
 name: IAM Privilege Escalation by Instance Profile attachment
 description: |
-  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%Web%Services/Hunting%Queries/AWS_IAM_PrivilegeEscalationbyAttachment.yaml'  
+  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%20Web%20Services/Hunting%20Queries/AWS_IAM_PrivilegeEscalationbyAttachment.yaml'  

--- a/Hunting Queries/AWSCloudTrail/AWS_PrivilegedRoleAttachedToInstance.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_PrivilegedRoleAttachedToInstance.yaml
@@ -1,4 +1,4 @@
 id: c9c217f3-1540-4293-b328-d0c5f736244f
 name: Privileged role attached to Instance
 description: |
-  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%Web%Services/Hunting%Queries/AWS_PrivilegedRoleAttachedToInstance.yaml'  
+  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%20Web%20Services/Hunting%20Queries/AWS_PrivilegedRoleAttachedToInstance.yaml'  

--- a/Hunting Queries/AWSCloudTrail/AWS_SuspiciousCredentialTokenAccessOfValid_IAM_Roles.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_SuspiciousCredentialTokenAccessOfValid_IAM_Roles.yaml
@@ -1,4 +1,4 @@
 id: 13258fd7-2ee6-4204-b5fb-15c48b5dea49
 name: Suspicious credential token access of valid IAM Roles
 description: |
-  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%Web%Services/Hunting%Queries/AWS_SuspiciousCredentialTokenAccessOfValid_IAM_Roles.yaml'
+  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%20Web%20Services/Hunting%20Queries/AWS_SuspiciousCredentialTokenAccessOfValid_IAM_Roles.yaml'

--- a/Hunting Queries/AWSCloudTrail/AWS_Unused_UnsupportedCloudRegions.yaml
+++ b/Hunting Queries/AWSCloudTrail/AWS_Unused_UnsupportedCloudRegions.yaml
@@ -1,4 +1,4 @@
 id: 06bc1995-6e36-4cd0-be2b-53789476aec6
 name: Unused or Unsupported Cloud Regions
 description: |
-  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%Web%Services/Hunting%Queries/AWS_Unused_UnsupportedCloudRegions.yaml'
+  'As part of content migration, this file is moved to new location. You can find here: https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Amazon%20Web%20Services/Hunting%20Queries/AWS_Unused_UnsupportedCloudRegions.yaml'


### PR DESCRIPTION
Change(s):
- Fixed the "moved to new location" links in the descriptions of all five files under `Hunting Queries/AWSCloudTrail/`. The URL encoding was malformed: `Solutions/Amazon%Web%Services/Hunting%Queries/...` (the `%20` escapes were truncated to a bare `%`), so every link returns 404. Restored proper `%20` encoding.

Reason for Change(s):
- These files are migration stubs whose only purpose is pointing readers at the current content location under `Solutions/Amazon Web Services/Hunting Queries/`; with the broken encoding they point nowhere. All five corrected URLs resolve to existing files on `master`.

Version Updated:
- N/A — the touched files are description-only migration stubs and carry no `version` field; no rule logic or KQL changed.

Testing Completed:
- Yes — verified each corrected URL maps to an existing file at `Solutions/Amazon Web Services/Hunting Queries/` on `master`; strict-parsed the five YAML files; cspell passes.

Checked that the validations are passing and have addressed any issues that are present:
- Yes — description-only change, no KQL or schema fields touched.