### PR TITLE
ci: pin trufflesecurity/trufflehog to a full commit SHA (v3.95.9)

### DIFF
--- a/.github/workflows/ScanSecrets.yaml
+++ b/.github/workflows/ScanSecrets.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           fetch-depth: 10
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
         with:
           extra_args: --exclude-paths=.script/SecretScanning/Excludepathlist --only-verified


### PR DESCRIPTION
Hi, and thank you for Azure Sentinel.

Small CI supply-chain hardening, one line. `ScanSecrets.yaml` runs the secret scanner from a **mutable branch ref**:

```yaml
uses: trufflesecurity/trufflehog@main
```

The job carries `pull-requests: write` and checks out PR code, so whatever `trufflehog@main` happens to point at executes with the repo's `GITHUB_TOKEN`. A branch can move after review; a full commit SHA cannot (GitHub's own hardening guidance recommends SHA-pinning third-party actions).

This PR pins it to the commit behind the current release, keeping the version visible as a comment:

```yaml
uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
```

Verified: `gh api repos/trufflesecurity/trufflehog/git/ref/tags/v3.95.9` → `27b0417c…`. Behavior today is unchanged; future updates become a deliberate one-line bump (Dependabot can manage SHA pins, not branch refs).

For transparency: I used AI assistance to spot and draft this; I verified the workflow content and the release SHA myself.
