### PR TITLE
Add AI agent configuration drift hunting queries

### DIFF
--- a/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
@@ -14,6 +14,7 @@ query: |
       IdentityInfo
       | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
                IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where IdentityTimestamp >= ago(lookback)
       | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
       | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
       | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);

--- a/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
@@ -42,14 +42,15 @@ query: |
   | extend PreviousInstructionsHash = hash_sha256(PreviousInstructions),
            CurrentInstructionsHash = hash_sha256(CurrentInstructions),
            InstructionsLengthDelta = strlen(CurrentInstructions) - strlen(PreviousInstructions)
-  | extend OwnerId = tostring(Owners[0])
+  | extend OwnerIds = iff(array_length(coalesce(Owners, dynamic([]))) > 0, Owners, dynamic([""]))
+  | mv-expand OwnerId = OwnerIds to typeof(string)
   | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
   | project-rename OwnerUpn = AccountUpn
   | extend OwnerAccountName = tostring(split(OwnerUpn, "@")[0]),
            OwnerAccountUPNSuffix = tostring(split(OwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
            PreviousInstructionsHash, CurrentInstructionsHash, InstructionsLengthDelta,
-           OwnerUpn, OwnerAccountName, OwnerAccountUPNSuffix
+           OwnerId, OwnerUpn, OwnerAccountName, OwnerAccountUPNSuffix
   | sort by Timestamp desc
 entityMappings:
   - entityType: Account
@@ -58,4 +59,6 @@ entityMappings:
         columnName: OwnerAccountName
       - identifier: UPNSuffix
         columnName: OwnerAccountUPNSuffix
+      - identifier: AadUserId
+        columnName: OwnerId
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
@@ -59,12 +59,3 @@ entityMappings:
       - identifier: HostName
         columnName: Name
 version: 1.0.0
-metadata:
-  source:
-    kind: Community
-  author:
-    name: Marcel Graewer
-  support:
-    tier: Community
-  categories:
-    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
@@ -1,7 +1,7 @@
 id: 662eae7f-494f-41a8-bfef-23dd80361795
 name: AI Agents - Instructions changed on previously published agent
 description: |
-  Identifies instruction changes on AI agents that were published in both current and baseline snapshots. Review the changed prompt and audit records to confirm whether the update was authorized.
+  Identifies instruction changes on AI agents that were published in both current and baseline snapshots. Review the changed prompt and audit records to confirm whether the update was authorized. Run within 2 days of a change to retain coverage.
 requiredDataConnectors: []
 tactics:
   - Impact

--- a/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
@@ -1,0 +1,70 @@
+id: 662eae7f-494f-41a8-bfef-23dd80361795
+name: AI Agents - Instructions changed on previously published agent
+description: |
+  Identifies instruction changes on AI agents that were published in both current and baseline snapshots. Review the changed prompt and audit records to confirm whether the update was authorized.
+requiredDataConnectors: []
+tactics:
+  - Impact
+relevantTechniques:
+  - T1565.001
+query: |
+  let lookback = 14d;
+  let recent = 2d;
+  let IdentityIdtoUPN = materialize(
+      IdentityInfo
+      | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
+               IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
+      | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
+      | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);
+  let CurrentState =
+      AgentsInfo
+      | where Timestamp > ago(recent)
+      | summarize arg_max(Timestamp, *) by AgentId
+      | where LifecycleStatus != "Deleted"
+      | where PublishedStatus == "Published"
+      | where isnotempty(Instructions) and Instructions != "N/A"
+      | project AgentId, Timestamp, Name, Platform, CreatedDateTime, Owners,
+                CurrentInstructions = Instructions;
+  let BaselineState =
+      AgentsInfo
+      | where Timestamp between (ago(lookback) .. ago(recent))
+      | summarize arg_max(Timestamp, *) by AgentId
+      | where PublishedStatus == "Published"
+      | where isnotempty(Instructions) and Instructions != "N/A"
+      | project AgentId, PreviousTimestamp = Timestamp,
+                PreviousInstructions = Instructions;
+  CurrentState
+  | join kind=inner BaselineState on AgentId
+  | where CurrentInstructions != PreviousInstructions
+  | extend PreviousInstructionsHash = hash_sha256(PreviousInstructions),
+           CurrentInstructionsHash = hash_sha256(CurrentInstructions),
+           InstructionsLengthDelta = strlen(CurrentInstructions) - strlen(PreviousInstructions),
+           PreviousInstructionsPreview = substring(PreviousInstructions, 0, 500),
+           CurrentInstructionsPreview = substring(CurrentInstructions, 0, 500)
+  | extend OwnerId = tostring(Owners[0])
+  | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
+  | project-rename OwnerUpn = AccountUpn
+  | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
+            PreviousInstructionsHash, CurrentInstructionsHash, InstructionsLengthDelta,
+            PreviousInstructionsPreview, CurrentInstructionsPreview, OwnerUpn
+  | sort by Timestamp desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: OwnerUpn
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: Name
+version: 1.0.0
+metadata:
+  source:
+    kind: Community
+  author:
+    name: Marcel Graewer
+  support:
+    tier: Community
+  categories:
+    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoInstructionsChangedOnPublishedAgent.yaml
@@ -29,6 +29,7 @@ query: |
   let BaselineState =
       AgentsInfo
       | where Timestamp between (ago(lookback) .. ago(recent))
+      | where LifecycleStatus != "Deleted"
       | summarize arg_max(Timestamp, *) by AgentId
       | where PublishedStatus == "Published"
       | where isnotempty(Instructions) and Instructions != "N/A"
@@ -39,23 +40,21 @@ query: |
   | where CurrentInstructions != PreviousInstructions
   | extend PreviousInstructionsHash = hash_sha256(PreviousInstructions),
            CurrentInstructionsHash = hash_sha256(CurrentInstructions),
-           InstructionsLengthDelta = strlen(CurrentInstructions) - strlen(PreviousInstructions),
-           PreviousInstructionsPreview = substring(PreviousInstructions, 0, 500),
-           CurrentInstructionsPreview = substring(CurrentInstructions, 0, 500)
+           InstructionsLengthDelta = strlen(CurrentInstructions) - strlen(PreviousInstructions)
   | extend OwnerId = tostring(Owners[0])
   | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
   | project-rename OwnerUpn = AccountUpn
+  | extend OwnerAccountName = tostring(split(OwnerUpn, "@")[0]),
+           OwnerAccountUPNSuffix = tostring(split(OwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
-            PreviousInstructionsHash, CurrentInstructionsHash, InstructionsLengthDelta,
-            PreviousInstructionsPreview, CurrentInstructionsPreview, OwnerUpn
+           PreviousInstructionsHash, CurrentInstructionsHash, InstructionsLengthDelta,
+           OwnerUpn, OwnerAccountName, OwnerAccountUPNSuffix
   | sort by Timestamp desc
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: OwnerUpn
-  - entityType: Host
-    fieldMappings:
-      - identifier: HostName
-        columnName: Name
+      - identifier: Name
+        columnName: OwnerAccountName
+      - identifier: UPNSuffix
+        columnName: OwnerAccountUPNSuffix
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
@@ -1,0 +1,73 @@
+id: d6ab015a-0a76-47f4-959f-54f49edff3f3
+name: AI Agents - Newly observed MCP server on existing agent
+description: |
+  Identifies MCP server names newly observed on an existing AI agent compared with its latest baseline snapshot. Review inventory and audit records to confirm whether the configuration change was authorized.
+requiredDataConnectors: []
+tactics: []
+relevantTechniques: []
+query: |
+  let lookback = 14d;
+  let recent = 2d;
+  let IdentityIdtoUPN = materialize(
+      IdentityInfo
+      | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
+               IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
+      | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
+      | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);
+  let CurrentRaw = materialize(
+      AgentsInfo
+      | where Timestamp > ago(recent)
+      | summarize arg_max(Timestamp, *) by AgentId
+      | where LifecycleStatus != "Deleted");
+  let CurrentMcp =
+      CurrentRaw
+      | mv-expand Mcp = McpServers
+      | extend McpName = tostring(Mcp.name)
+      | where isnotempty(McpName)
+      | summarize CurrentMcpServers = make_set(McpName) by AgentId;
+  let BaselineRaw = materialize(
+      AgentsInfo
+      | where Timestamp between (ago(lookback) .. ago(recent))
+      | summarize arg_max(Timestamp, *) by AgentId);
+  let BaselineMcp =
+      BaselineRaw
+      | mv-expand Mcp = McpServers
+      | extend McpName = tostring(Mcp.name)
+      | where isnotempty(McpName)
+      | summarize KnownMcpServers = make_set(McpName) by AgentId;
+  let Baseline =
+      BaselineRaw
+      | join kind=leftouter BaselineMcp on AgentId
+      | extend BaselineMcpServers = coalesce(KnownMcpServers, dynamic([]))
+      | project AgentId, PreviousTimestamp = Timestamp, BaselineMcpServers;
+  CurrentRaw
+  | join kind=inner CurrentMcp on AgentId
+  | join kind=inner Baseline on AgentId
+  | extend AddedMcpServers = set_difference(CurrentMcpServers, BaselineMcpServers)
+  | where array_length(AddedMcpServers) > 0
+  | extend OwnerId = tostring(Owners[0])
+  | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
+  | project-rename OwnerUpn = AccountUpn
+  | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
+            AddedMcpServers, BaselineMcpServers, CurrentMcpServers, OwnerUpn
+  | sort by Timestamp desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: OwnerUpn
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: Name
+version: 1.0.0
+metadata:
+  source:
+    kind: Community
+  author:
+    name: Marcel Graewer
+  support:
+    tier: Community
+  categories:
+    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
@@ -12,6 +12,7 @@ query: |
       IdentityInfo
       | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
                IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where IdentityTimestamp >= ago(lookback)
       | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
       | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
       | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);

--- a/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
@@ -62,12 +62,3 @@ entityMappings:
       - identifier: HostName
         columnName: Name
 version: 1.0.0
-metadata:
-  source:
-    kind: Community
-  author:
-    name: Marcel Graewer
-  support:
-    tier: Community
-  categories:
-    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
@@ -29,6 +29,7 @@ query: |
   let BaselineRaw = materialize(
       AgentsInfo
       | where Timestamp between (ago(lookback) .. ago(recent))
+      | where LifecycleStatus != "Deleted"
       | summarize arg_max(Timestamp, *) by AgentId);
   let BaselineMcp =
       BaselineRaw
@@ -49,16 +50,17 @@ query: |
   | extend OwnerId = tostring(Owners[0])
   | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
   | project-rename OwnerUpn = AccountUpn
+  | extend OwnerAccountName = tostring(split(OwnerUpn, "@")[0]),
+           OwnerAccountUPNSuffix = tostring(split(OwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
-            AddedMcpServers, BaselineMcpServers, CurrentMcpServers, OwnerUpn
+           AddedMcpServers, BaselineMcpServers, CurrentMcpServers, OwnerUpn,
+           OwnerAccountName, OwnerAccountUPNSuffix
   | sort by Timestamp desc
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: OwnerUpn
-  - entityType: Host
-    fieldMappings:
-      - identifier: HostName
-        columnName: Name
+      - identifier: Name
+        columnName: OwnerAccountName
+      - identifier: UPNSuffix
+        columnName: OwnerAccountUPNSuffix
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
@@ -1,7 +1,7 @@
 id: d6ab015a-0a76-47f4-959f-54f49edff3f3
 name: AI Agents - Newly observed MCP server on existing agent
 description: |
-  Identifies MCP server names newly observed on an existing AI agent compared with its latest baseline snapshot. Review inventory and audit records to confirm whether the configuration change was authorized.
+  Identifies MCP server names newly observed on an existing AI agent compared with its latest baseline snapshot. Review inventory and audit records to confirm whether the configuration change was authorized. Run within 2 days of a change to retain coverage.
 requiredDataConnectors: []
 tactics: []
 relevantTechniques: []

--- a/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoNewlyObservedMcpServer.yaml
@@ -48,13 +48,14 @@ query: |
   | join kind=inner Baseline on AgentId
   | extend AddedMcpServers = set_difference(CurrentMcpServers, BaselineMcpServers)
   | where array_length(AddedMcpServers) > 0
-  | extend OwnerId = tostring(Owners[0])
+  | extend OwnerIds = iff(array_length(coalesce(Owners, dynamic([]))) > 0, Owners, dynamic([""]))
+  | mv-expand OwnerId = OwnerIds to typeof(string)
   | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
   | project-rename OwnerUpn = AccountUpn
   | extend OwnerAccountName = tostring(split(OwnerUpn, "@")[0]),
            OwnerAccountUPNSuffix = tostring(split(OwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
-           AddedMcpServers, BaselineMcpServers, CurrentMcpServers, OwnerUpn,
+           AddedMcpServers, BaselineMcpServers, CurrentMcpServers, OwnerId, OwnerUpn,
            OwnerAccountName, OwnerAccountUPNSuffix
   | sort by Timestamp desc
 entityMappings:
@@ -64,4 +65,6 @@ entityMappings:
         columnName: OwnerAccountName
       - identifier: UPNSuffix
         columnName: OwnerAccountUPNSuffix
+      - identifier: AadUserId
+        columnName: OwnerId
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
@@ -1,7 +1,7 @@
 id: c35b5a60-71ee-448c-935d-f60f4a4c7f2b
 name: AI Agents - Owner added to MCP-enabled agent
 description: |
-  Identifies owners newly observed on existing AI agents with MCP servers configured. Review the added owners and audit records to confirm whether privileged access was authorized.
+  Identifies owners newly observed on existing AI agents with MCP servers configured. Review the added owners and audit records to confirm whether privileged access was authorized. Run within 2 days of a change to retain coverage.
 requiredDataConnectors: []
 tactics:
   - Persistence

--- a/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
@@ -29,6 +29,7 @@ query: |
   let BaselineState =
       AgentsInfo
       | where Timestamp between (ago(lookback) .. ago(recent))
+      | where LifecycleStatus != "Deleted"
       | summarize arg_max(Timestamp, *) by AgentId
       | project AgentId, PreviousTimestamp = Timestamp,
                 PreviousOwners = coalesce(Owners, dynamic([]));
@@ -47,20 +48,21 @@ query: |
   | mv-expand Mcp = McpServers
   | extend McpName = tostring(Mcp.name)
   | summarize McpServersConfigured = make_set_if(McpName, isnotempty(McpName)),
-              take_any(Timestamp, PreviousTimestamp, Name, Platform, CreatedDateTime,
-                       PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
-                       UnresolvedAddedOwnerIds, AddedOwnerUpn) by AgentId
+             take_any(Timestamp, PreviousTimestamp, Name, Platform, CreatedDateTime,
+                      PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
+                      UnresolvedAddedOwnerIds, AddedOwnerUpn) by AgentId
+  | extend AddedOwnerAccountName = tostring(split(AddedOwnerUpn, "@")[0]),
+           AddedOwnerAccountUPNSuffix = tostring(split(AddedOwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
-            PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
-            UnresolvedAddedOwnerIds, AddedOwnerUpn, McpServersConfigured
+           PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
+           UnresolvedAddedOwnerIds, AddedOwnerUpn, AddedOwnerAccountName,
+           AddedOwnerAccountUPNSuffix, McpServersConfigured
   | sort by Timestamp desc
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: AddedOwnerUpn
-  - entityType: Host
-    fieldMappings:
-      - identifier: HostName
-        columnName: Name
+      - identifier: Name
+        columnName: AddedOwnerAccountName
+      - identifier: UPNSuffix
+        columnName: AddedOwnerAccountUPNSuffix
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
@@ -15,6 +15,7 @@ query: |
       IdentityInfo
       | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
                IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where IdentityTimestamp >= ago(lookback)
       | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
       | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
       | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);

--- a/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
@@ -1,0 +1,75 @@
+id: c35b5a60-71ee-448c-935d-f60f4a4c7f2b
+name: AI Agents - Owner added to MCP-enabled agent
+description: |
+  Identifies owners newly observed on existing AI agents with MCP servers configured. Review the added owners and audit records to confirm whether privileged access was authorized.
+requiredDataConnectors: []
+tactics:
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1098
+query: |
+  let lookback = 14d;
+  let recent = 2d;
+  let IdentityIdtoUPN = materialize(
+      IdentityInfo
+      | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
+               IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
+      | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
+      | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);
+  let CurrentState =
+      AgentsInfo
+      | where Timestamp > ago(recent)
+      | summarize arg_max(Timestamp, *) by AgentId
+      | where LifecycleStatus != "Deleted"
+      | where array_length(coalesce(McpServers, dynamic([]))) > 0
+      | project AgentId, Timestamp, Name, Platform, CreatedDateTime,
+                CurrentOwners = coalesce(Owners, dynamic([])), McpServers;
+  let BaselineState =
+      AgentsInfo
+      | where Timestamp between (ago(lookback) .. ago(recent))
+      | summarize arg_max(Timestamp, *) by AgentId
+      | project AgentId, PreviousTimestamp = Timestamp,
+                PreviousOwners = coalesce(Owners, dynamic([]));
+  CurrentState
+  | join kind=inner BaselineState on AgentId
+  | extend AddedOwners = set_difference(CurrentOwners, PreviousOwners)
+  | where array_length(AddedOwners) > 0
+  | mv-expand AddedOwnerId = AddedOwners to typeof(string)
+  | join kind=leftouter IdentityIdtoUPN on $left.AddedOwnerId == $right.AccountObjectId
+  | summarize AddedOwnerUpns = make_set_if(AccountUpn, isnotempty(AccountUpn)),
+              UnresolvedAddedOwnerIds = make_set_if(AddedOwnerId, isempty(AccountUpn)),
+              take_any(Timestamp, PreviousTimestamp, Name, Platform, CreatedDateTime,
+                       PreviousOwners, CurrentOwners, AddedOwners, McpServers) by AgentId
+  | extend AddedOwnerUpns = array_sort_asc(AddedOwnerUpns),
+           AddedOwnerUpn = tostring(AddedOwnerUpns[0])
+  | mv-expand Mcp = McpServers
+  | extend McpName = tostring(Mcp.name)
+  | summarize McpServersConfigured = make_set_if(McpName, isnotempty(McpName)),
+              take_any(Timestamp, PreviousTimestamp, Name, Platform, CreatedDateTime,
+                       PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
+                       UnresolvedAddedOwnerIds, AddedOwnerUpn) by AgentId
+  | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
+            PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
+            UnresolvedAddedOwnerIds, AddedOwnerUpn, McpServersConfigured
+  | sort by Timestamp desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AddedOwnerUpn
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: Name
+version: 1.0.0
+metadata:
+  source:
+    kind: Community
+  author:
+    name: Marcel Graewer
+  support:
+    tier: Community
+  categories:
+    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
@@ -19,14 +19,19 @@ query: |
       | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
       | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
       | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);
-  let CurrentState =
+  let CurrentState = materialize(
       AgentsInfo
       | where Timestamp > ago(recent)
       | summarize arg_max(Timestamp, *) by AgentId
       | where LifecycleStatus != "Deleted"
       | where array_length(coalesce(McpServers, dynamic([]))) > 0
       | project AgentId, Timestamp, Name, Platform, CreatedDateTime,
-                CurrentOwners = coalesce(Owners, dynamic([])), McpServers;
+                CurrentOwners = coalesce(Owners, dynamic([])), McpServers);
+  let CurrentMcp =
+      CurrentState
+      | mv-expand Mcp = McpServers
+      | extend McpName = tostring(Mcp.name)
+      | summarize McpServersConfigured = make_set_if(McpName, isnotempty(McpName)) by AgentId;
   let BaselineState =
       AgentsInfo
       | where Timestamp between (ago(lookback) .. ago(recent))
@@ -35,28 +40,19 @@ query: |
       | project AgentId, PreviousTimestamp = Timestamp,
                 PreviousOwners = coalesce(Owners, dynamic([]));
   CurrentState
+  | join kind=inner CurrentMcp on AgentId
   | join kind=inner BaselineState on AgentId
   | extend AddedOwners = set_difference(CurrentOwners, PreviousOwners)
   | where array_length(AddedOwners) > 0
   | mv-expand AddedOwnerId = AddedOwners to typeof(string)
   | join kind=leftouter IdentityIdtoUPN on $left.AddedOwnerId == $right.AccountObjectId
-  | summarize AddedOwnerUpns = make_set_if(AccountUpn, isnotempty(AccountUpn)),
-              UnresolvedAddedOwnerIds = make_set_if(AddedOwnerId, isempty(AccountUpn)),
-              take_any(Timestamp, PreviousTimestamp, Name, Platform, CreatedDateTime,
-                       PreviousOwners, CurrentOwners, AddedOwners, McpServers) by AgentId
-  | extend AddedOwnerUpns = array_sort_asc(AddedOwnerUpns),
-           AddedOwnerUpn = tostring(AddedOwnerUpns[0])
-  | mv-expand Mcp = McpServers
-  | extend McpName = tostring(Mcp.name)
-  | summarize McpServersConfigured = make_set_if(McpName, isnotempty(McpName)),
-             take_any(Timestamp, PreviousTimestamp, Name, Platform, CreatedDateTime,
-                      PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
-                      UnresolvedAddedOwnerIds, AddedOwnerUpn) by AgentId
+  | extend AddedOwnerUpn = AccountUpn,
+           UnresolvedAddedOwnerId = iff(isempty(AccountUpn), AddedOwnerId, "")
   | extend AddedOwnerAccountName = tostring(split(AddedOwnerUpn, "@")[0]),
            AddedOwnerAccountUPNSuffix = tostring(split(AddedOwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
-           PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerUpns,
-           UnresolvedAddedOwnerIds, AddedOwnerUpn, AddedOwnerAccountName,
+           PreviousOwners, CurrentOwners, AddedOwners, AddedOwnerId,
+           UnresolvedAddedOwnerId, AddedOwnerUpn, AddedOwnerAccountName,
            AddedOwnerAccountUPNSuffix, McpServersConfigured
   | sort by Timestamp desc
 entityMappings:
@@ -66,4 +62,6 @@ entityMappings:
         columnName: AddedOwnerAccountName
       - identifier: UPNSuffix
         columnName: AddedOwnerAccountUPNSuffix
+      - identifier: AadUserId
+        columnName: AddedOwnerId
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoOwnerAddedToMcpAgent.yaml
@@ -64,12 +64,3 @@ entityMappings:
       - identifier: HostName
         columnName: Name
 version: 1.0.0
-metadata:
-  source:
-    kind: Community
-  author:
-    name: Marcel Graewer
-  support:
-    tier: Community
-  categories:
-    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
@@ -51,12 +51,3 @@ entityMappings:
       - identifier: HostName
         columnName: Name
 version: 1.0.0
-metadata:
-  source:
-    kind: Community
-  author:
-    name: Marcel Graewer
-  support:
-    tier: Community
-  categories:
-    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
@@ -1,7 +1,7 @@
 id: dbdba9cc-d7a0-434d-9c3d-82d2203a79fd
 name: AI Agents - Sharing expanded to organization-wide
 description: |
-  Identifies existing AI agents that were restricted in the baseline snapshot and are now shared organization-wide. Prioritize agents with MCP servers or declared tools for review.
+  Identifies existing AI agents that were restricted in the baseline snapshot and are now shared organization-wide. Prioritize agents with MCP servers or declared tools for review. Run within 2 days of a change to retain coverage.
 requiredDataConnectors: []
 tactics: []
 relevantTechniques: []

--- a/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
@@ -12,6 +12,7 @@ query: |
       IdentityInfo
       | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
                IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where IdentityTimestamp >= ago(lookback)
       | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
       | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
       | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);

--- a/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
@@ -1,0 +1,62 @@
+id: dbdba9cc-d7a0-434d-9c3d-82d2203a79fd
+name: AI Agents - Sharing expanded to organization-wide
+description: |
+  Identifies existing AI agents that were restricted in the baseline snapshot and are now shared organization-wide. Prioritize agents with MCP servers or declared tools for review.
+requiredDataConnectors: []
+tactics: []
+relevantTechniques: []
+query: |
+  let lookback = 14d;
+  let recent = 2d;
+  let IdentityIdtoUPN = materialize(
+      IdentityInfo
+      | extend ResolvedAccountUpn = tostring(column_ifexists("AccountUpn", column_ifexists("AccountUPN", ""))),
+               IdentityTimestamp = todatetime(column_ifexists("Timestamp", column_ifexists("TimeGenerated", datetime(null))))
+      | where isnotempty(AccountObjectId) and isnotempty(ResolvedAccountUpn)
+      | summarize arg_max(IdentityTimestamp, ResolvedAccountUpn) by AccountObjectId
+      | project AccountObjectId = tostring(AccountObjectId), AccountUpn = ResolvedAccountUpn);
+  let CurrentState =
+      AgentsInfo
+      | where Timestamp > ago(recent)
+      | summarize arg_max(Timestamp, *) by AgentId
+      | where LifecycleStatus != "Deleted"
+      | where set_has_element(coalesce(SharedWith, dynamic([])), "*")
+      | extend McpServerCount = array_length(coalesce(McpServers, dynamic([]))),
+               DeclaredToolCount = array_length(coalesce(DeclaredTools, dynamic([])))
+      | project AgentId, Timestamp, Name, Platform, CreatedDateTime, Owners,
+                SharedWith, McpServerCount, DeclaredToolCount;
+  let BaselineState =
+      AgentsInfo
+      | where Timestamp between (ago(lookback) .. ago(recent))
+      | summarize arg_max(Timestamp, *) by AgentId
+      | where not(set_has_element(coalesce(SharedWith, dynamic([])), "*"))
+      | project AgentId, PreviousTimestamp = Timestamp, PreviousSharedWith = SharedWith;
+  CurrentState
+  | join kind=inner BaselineState on AgentId
+  | extend HasElevatedCapabilities = McpServerCount > 0 or DeclaredToolCount > 0
+  | extend OwnerId = tostring(Owners[0])
+  | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
+  | project-rename OwnerUpn = AccountUpn
+  | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
+            PreviousSharedWith, SharedWith, McpServerCount, DeclaredToolCount,
+            HasElevatedCapabilities, OwnerUpn
+  | sort by HasElevatedCapabilities desc, Timestamp desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: OwnerUpn
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: Name
+version: 1.0.0
+metadata:
+  source:
+    kind: Community
+  author:
+    name: Marcel Graewer
+  support:
+    tier: Community
+  categories:
+    domains: ["Security - Threat Protection"]

--- a/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
@@ -28,6 +28,7 @@ query: |
   let BaselineState =
       AgentsInfo
       | where Timestamp between (ago(lookback) .. ago(recent))
+      | where LifecycleStatus != "Deleted"
       | summarize arg_max(Timestamp, *) by AgentId
       | where not(set_has_element(coalesce(SharedWith, dynamic([])), "*"))
       | project AgentId, PreviousTimestamp = Timestamp, PreviousSharedWith = SharedWith;
@@ -37,17 +38,17 @@ query: |
   | extend OwnerId = tostring(Owners[0])
   | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
   | project-rename OwnerUpn = AccountUpn
+  | extend OwnerAccountName = tostring(split(OwnerUpn, "@")[0]),
+           OwnerAccountUPNSuffix = tostring(split(OwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
-            PreviousSharedWith, SharedWith, McpServerCount, DeclaredToolCount,
-            HasElevatedCapabilities, OwnerUpn
+           PreviousSharedWith, SharedWith, McpServerCount, DeclaredToolCount,
+           HasElevatedCapabilities, OwnerUpn, OwnerAccountName, OwnerAccountUPNSuffix
   | sort by HasElevatedCapabilities desc, Timestamp desc
 entityMappings:
   - entityType: Account
     fieldMappings:
-      - identifier: FullName
-        columnName: OwnerUpn
-  - entityType: Host
-    fieldMappings:
-      - identifier: HostName
-        columnName: Name
+      - identifier: Name
+        columnName: OwnerAccountName
+      - identifier: UPNSuffix
+        columnName: OwnerAccountUPNSuffix
 version: 1.0.0

--- a/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
+++ b/Hunting Queries/AI Agents/AgentsInfoSharingExpandedToOrgWide.yaml
@@ -36,14 +36,15 @@ query: |
   CurrentState
   | join kind=inner BaselineState on AgentId
   | extend HasElevatedCapabilities = McpServerCount > 0 or DeclaredToolCount > 0
-  | extend OwnerId = tostring(Owners[0])
+  | extend OwnerIds = iff(array_length(coalesce(Owners, dynamic([]))) > 0, Owners, dynamic([""]))
+  | mv-expand OwnerId = OwnerIds to typeof(string)
   | join kind=leftouter IdentityIdtoUPN on $left.OwnerId == $right.AccountObjectId
   | project-rename OwnerUpn = AccountUpn
   | extend OwnerAccountName = tostring(split(OwnerUpn, "@")[0]),
            OwnerAccountUPNSuffix = tostring(split(OwnerUpn, "@")[1])
   | project Timestamp, PreviousTimestamp, AgentId, Name, Platform, CreatedDateTime,
            PreviousSharedWith, SharedWith, McpServerCount, DeclaredToolCount,
-           HasElevatedCapabilities, OwnerUpn, OwnerAccountName, OwnerAccountUPNSuffix
+           HasElevatedCapabilities, OwnerId, OwnerUpn, OwnerAccountName, OwnerAccountUPNSuffix
   | sort by HasElevatedCapabilities desc, Timestamp desc
 entityMappings:
   - entityType: Account
@@ -52,4 +53,6 @@ entityMappings:
         columnName: OwnerAccountName
       - identifier: UPNSuffix
         columnName: OwnerAccountUPNSuffix
+      - identifier: AadUserId
+        columnName: OwnerId
 version: 1.0.0


### PR DESCRIPTION
Change(s):
- Added four new Microsoft Sentinel hunting queries under `Hunting Queries/AI Agents`:
  - Detect changes to instructions on published agents.
  - Detect newly observed MCP servers configured for agents.
  - Detect owners added to MCP-enabled agents.
  - Detect agent sharing expanded to the entire organization.
- Added compatibility handling for both Microsoft Sentinel and Microsoft Defender `IdentityInfo` schema variants.
- Each query compares a recent 2-day activity window against the preceding baseline within a 14-day lookback period.
- Added entity mappings to all four queries and MITRE ATT&CK mappings where a defensible technique applies. The MCP server and organization-wide sharing queries intentionally omit ATT&CK mappings because no sufficiently precise technique was identified.

Reason for Change(s):
- Changes to AI agent instructions, ownership, MCP server configuration, and sharing scope can materially alter an agent's behavior, access, or exposure.
- These hunting queries help security teams identify potentially risky AI agent configuration drift recorded in the `AgentsInfo` table.
- The queries provide focused hunting coverage for security-relevant AI agent changes without requiring custom parsers or functions.

Version Updated:
- Not applicable. These are new hunting queries, not Detections/Analytic Rule templates.

Testing Completed:
- Yes.
- All four queries were executed in Microsoft Sentinel without syntax or semantic errors.
- No custom parsers, functions, or custom tables are required.
- The production workspace contained no `AgentsInfo` records during the tested lookback period, so the production queries correctly returned zero results.
- Synthetic validation data was therefore used to exercise the detection logic.
- The four synthetic tests returned the expected result counts: `2 / 1 / 2 / 2`.
- Compatibility with the observed Microsoft Sentinel `IdentityInfo` schema (`AccountUPN` and `TimeGenerated`) and the repository validation schema (`AccountUpn` and `Timestamp`) was verified.

Checked that the validations are passing and have addressed any issues that are present:
- Yes