### PR TITLE
Fix broken reference links in Microsoft 365 Defender hunting queries

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/APT Baby Shark.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/APT Baby Shark.yaml
@@ -1,7 +1,7 @@
 id: 26721b80-a9b7-4594-9b0f-ec21e5da1bc2
 name: APT Baby Shark
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_babyshark.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/Malware/BabyShark/proc_creation_win_malware_babyshark.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/APT Baby Shark.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/APT Baby Shark.yaml
@@ -1,7 +1,7 @@
 id: 26721b80-a9b7-4594-9b0f-ec21e5da1bc2
 name: APT Baby Shark
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/Malware/BabyShark/proc_creation_win_malware_babyshark.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/Malware/BabyShark/proc_creation_win_malware_babyshark.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/APT29 thinktanks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/APT29 thinktanks.yaml
@@ -1,7 +1,7 @@
 id: 40446d6e-745d-4689-a477-6b6a43a15755
 name: APT29 thinktanks
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_apt29_thinktanks.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_apt29_thinktanks.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/APT29 thinktanks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/APT29 thinktanks.yaml
@@ -1,7 +1,7 @@
 id: 40446d6e-745d-4689-a477-6b6a43a15755
 name: APT29 thinktanks
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_apt29_thinktanks.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_apt29_thinktanks.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Bear Activity GTR 2019.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Bear Activity GTR 2019.yaml
@@ -1,7 +1,7 @@
 id: 376d30db-e3ab-49fb-852a-00d1ade65a54
 name: Bear Activity GTR 2019
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_bear_activity_gtr19.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/TA/Bear-APT-Activity/proc_creation_win_apt_bear_activity_gtr19.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Bear Activity GTR 2019.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Bear Activity GTR 2019.yaml
@@ -1,7 +1,7 @@
 id: 376d30db-e3ab-49fb-852a-00d1ade65a54
 name: Bear Activity GTR 2019
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/TA/Bear-APT-Activity/proc_creation_win_apt_bear_activity_gtr19.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/TA/Bear-APT-Activity/proc_creation_win_apt_bear_activity_gtr19.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Cloud Hopper.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Cloud Hopper.yaml
@@ -1,7 +1,7 @@
 id: 8c54c0f3-fbd4-426b-8f58-363efbdc09fa
 name: Cloud Hopper
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_cloudhopper.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/APT10/proc_creation_win_apt_apt10_cloud_hopper.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Cloud Hopper.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Cloud Hopper.yaml
@@ -1,7 +1,7 @@
 id: 8c54c0f3-fbd4-426b-8f58-363efbdc09fa
 name: Cloud Hopper
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/APT10/proc_creation_win_apt_apt10_cloud_hopper.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/APT10/proc_creation_win_apt_apt10_cloud_hopper.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Dragon Fly.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Dragon Fly.yaml
@@ -1,7 +1,7 @@
 id: 0132d53e-8457-4ed3-b9be-e3ef5ea7d273
 name: Dragon Fly
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_dragonfly.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_dragonfly.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Dragon Fly.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Dragon Fly.yaml
@@ -1,7 +1,7 @@
 id: 0132d53e-8457-4ed3-b9be-e3ef5ea7d273
 name: Dragon Fly
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_dragonfly.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_dragonfly.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Elise backdoor.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Elise backdoor.yaml
@@ -1,7 +1,7 @@
 id: 2a044f6d-a670-4977-9c7b-da556aa6c8d0
 name: Elise backdoor
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_elise.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/Malware/Elise-Backdoor/proc_creation_win_malware_elise.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Elise backdoor.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Elise backdoor.yaml
@@ -1,7 +1,7 @@
 id: 2a044f6d-a670-4977-9c7b-da556aa6c8d0
 name: Elise backdoor
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/Malware/Elise-Backdoor/proc_creation_win_malware_elise.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/Malware/Elise-Backdoor/proc_creation_win_malware_elise.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Equation Group C2 Communication.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Equation Group C2 Communication.yaml
@@ -1,7 +1,7 @@
 id: 4f0fdeab-1d34-4c1e-9121-8ac800988de8
 name: Equation Group C2 Communication
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_equationgroup_c2.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/Equation-Group/net_firewall_apt_equationgroup_c2.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Equation Group C2 Communication.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Equation Group C2 Communication.yaml
@@ -1,7 +1,7 @@
 id: 4f0fdeab-1d34-4c1e-9121-8ac800988de8
 name: Equation Group C2 Communication
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/Equation-Group/net_firewall_apt_equationgroup_c2.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/Equation-Group/net_firewall_apt_equationgroup_c2.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Hurricane Panda activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Hurricane Panda activity.yaml
@@ -1,7 +1,7 @@
 id: c8a459ae-cb3e-46c0-82b1-670649dd3e7a
 name: Hurricane Panda activity
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_hurricane_panda.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_hurricane_panda.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Hurricane Panda activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Hurricane Panda activity.yaml
@@ -1,7 +1,7 @@
 id: c8a459ae-cb3e-46c0-82b1-670649dd3e7a
 name: Hurricane Panda activity
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_hurricane_panda.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/deprecated/windows/proc_creation_win_apt_hurricane_panda.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Judgement Panda exfil activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Judgement Panda exfil activity.yaml
@@ -1,7 +1,7 @@
 id: ae8a5c5d-4cfb-4a59-9adb-eb6c6c219620
 name: Judgement Panda exfil activity
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_judgement_panda_gtr19.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/TA/APT31/proc_creation_win_apt_apt31_judgement_panda.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/Judgement Panda exfil activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/Judgement Panda exfil activity.yaml
@@ -1,7 +1,7 @@
 id: ae8a5c5d-4cfb-4a59-9adb-eb6c6c219620
 name: Judgement Panda exfil activity
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/TA/APT31/proc_creation_win_apt_apt31_judgement_panda.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2019/TA/APT31/proc_creation_win_apt_apt31_judgement_panda.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/OceanLotus registry activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/OceanLotus registry activity.yaml
@@ -1,7 +1,7 @@
 id: 3e571521-6f73-423f-9280-aff6170c9d81
 name: OceanLotus registry activity
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_oceanlotus_registry.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/APT32-Oceanlotus/registry_event_apt_oceanlotus_registry.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/OceanLotus registry activity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/OceanLotus registry activity.yaml
@@ -1,7 +1,7 @@
 id: 3e571521-6f73-423f-9280-aff6170c9d81
 name: OceanLotus registry activity
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/APT32-Oceanlotus/registry_event_apt_oceanlotus_registry.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/APT32-Oceanlotus/registry_event_apt_oceanlotus_registry.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/apt sofacy.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/apt sofacy.yaml
@@ -1,7 +1,7 @@
 id: 36a6028d-f977-455f-be11-669e993a25d6
 name: apt sofacy
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_sofacy.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/APT28/proc_creation_win_apt_sofacy.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/apt sofacy.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/apt sofacy.yaml
@@ -1,7 +1,7 @@
 id: 36a6028d-f977-455f-be11-669e993a25d6
 name: apt sofacy
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/APT28/proc_creation_win_apt_sofacy.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/APT28/proc_creation_win_apt_sofacy.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/apt ta17 293a ps.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/apt ta17 293a ps.yaml
@@ -1,7 +1,7 @@
 id: 6ee810f8-aeca-45c7-81d8-5646ed558961
 name: apt ta17 293a ps
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_ta17_293a_ps.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/Dragonfly/proc_creation_win_apt_ta17_293a_ps.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/apt ta17 293a ps.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/apt ta17 293a ps.yaml
@@ -1,7 +1,7 @@
 id: 6ee810f8-aeca-45c7-81d8-5646ed558961
 name: apt ta17 293a ps
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/Dragonfly/proc_creation_win_apt_ta17_293a_ps.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2017/TA/Dragonfly/proc_creation_win_apt_ta17_293a_ps.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/apt tropictrooper.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/apt tropictrooper.yaml
@@ -1,7 +1,7 @@
 id: f035c5e9-af5f-4ba7-8242-03faf3e096cf
 name: apt tropictrooper
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/apt/apt_tropictrooper.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/TropicTrooper/proc_creation_win_apt_tropictrooper.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Campaigns/apt tropictrooper.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Campaigns/apt tropictrooper.yaml
@@ -1,7 +1,7 @@
 id: f035c5e9-af5f-4ba7-8242-03faf3e096cf
 name: apt tropictrooper
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/TropicTrooper/proc_creation_win_apt_tropictrooper.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules-emerging-threats/2018/TA/TropicTrooper/proc_creation_win_apt_tropictrooper.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/UpdateStsRefreshToken[Solorigate].yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/UpdateStsRefreshToken[Solorigate].yaml
@@ -2,7 +2,7 @@ id: 634dfbd6-0a42-40da-854e-2161cf137f14
 name: UpdateStsRefreshToken[Solorigate]
 description: |
   This will show Active Directory Security Token Service (STS) refresh token modifications by Service Principals and Applications other than DirectorySync. Refresh tokens are used to validate identification and obtain access tokens. This event is most often generated when legitimate administrators troubleshoot frequent Entra ID user sign-ins but may also be generated as a result of malicious token extensions. Confirm that the activity is related to an administrator legitimately modifying STS refresh tokens and check the new token validation time period for high values.
-  Query insprired by Azure Sentinel detection https://github.com/Azure/Azure-Sentinel/blob/master/Detections/AuditLogs/StsRefreshTokenModification.yaml
+  Query insprired by Azure Sentinel detection https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Cloud%20Identity%20Threat%20Protection%20Essentials/Hunting%20Queries/StsRefreshTokenModification.yaml
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:

--- a/Hunting Queries/Microsoft 365 Defender/Defense evasion/UpdateStsRefreshToken[Solorigate].yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Defense evasion/UpdateStsRefreshToken[Solorigate].yaml
@@ -2,7 +2,7 @@ id: 634dfbd6-0a42-40da-854e-2161cf137f14
 name: UpdateStsRefreshToken[Solorigate]
 description: |
   This will show Active Directory Security Token Service (STS) refresh token modifications by Service Principals and Applications other than DirectorySync. Refresh tokens are used to validate identification and obtain access tokens. This event is most often generated when legitimate administrators troubleshoot frequent Entra ID user sign-ins but may also be generated as a result of malicious token extensions. Confirm that the activity is related to an administrator legitimately modifying STS refresh tokens and check the new token validation time period for high values.
-  Query insprired by Azure Sentinel detection https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Cloud%20Identity%20Threat%20Protection%20Essentials/Hunting%20Queries/StsRefreshTokenModification.yaml
+  Query inspired by Azure Sentinel detection https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/Cloud%20Identity%20Threat%20Protection%20Essentials/Hunting%20Queries/StsRefreshTokenModification.yaml
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:

--- a/Hunting Queries/Microsoft 365 Defender/Execution/detect-anomalous-process-trees.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Execution/detect-anomalous-process-trees.yaml
@@ -4,7 +4,7 @@ description: |
   This query generates process trees of given processes and performs anomaly detection on the process trees. It generates process trees up to 7th level.
   The query can be used as a template to perform anomaly detection on specific processes like winword.exe, powerpnt.exe, w3wp.exe, etc. The query runs without any performance issues in large environments.
   Detailed explanation can be found here
-  Reference - https://mergene.medium.com/detecting-threats-with-process-tree-analysis-without-machine-learning-838d85f78b2c
+  Reference - https://posts.bluraven.io/detecting-threats-with-process-tree-analysis-without-machine-learning-838d85f78b2c
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:

--- a/Hunting Queries/Microsoft 365 Defender/Persistence/scheduled task creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Persistence/scheduled task creation.yaml
@@ -1,7 +1,7 @@
 id: 34208765-264e-4abe-805b-f645925fbadb
 name: scheduled task creation
 description: |
-  Original Sigma Rule: https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_susp_schtask_creation.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_schtasks_creation.yml.
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Persistence/scheduled task creation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Persistence/scheduled task creation.yaml
@@ -1,7 +1,7 @@
 id: 34208765-264e-4abe-805b-f645925fbadb
 name: scheduled task creation
 description: |
-  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_schtasks_creation.yml.
+  Original Sigma Rule: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_schtasks_creation.yml
   Questions via Twitter: @janvonkirchheim.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection

--- a/Hunting Queries/Microsoft 365 Defender/Protection events/ExploitGuardAsrDescriptions.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Protection events/ExploitGuardAsrDescriptions.yaml
@@ -6,7 +6,7 @@ description: |
   However, it could still be useful to have a more human-friendly description in the results.
   Also, this query is a good example for how you could define your own lookup tables and join with them.
   The events in the DeviceEvents table contain a GUID for the various ASR rules rather than a full description of the rule.
-  This query will create a table which has the description for each ASR rule as per https://docs.microsoft.com/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.
+  This query will create a table which has the description for each ASR rule as per https://learn.microsoft.com/en-us/defender-endpoint/enable-attack-surface-reduction.
   This table is then joined to the output of a query against the DeviceEvents table and shows a summary count of the events by the newly defined description.
   This query shows the ability to use joins and custom dimension tables.
   See https://docs.loganalytics.io/docs/Language-Reference/Tabular-operators/join-operator for more information on the join syntax.

--- a/Hunting Queries/Microsoft 365 Defender/Protection events/ExploitGuardAsrDescriptions.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Protection events/ExploitGuardAsrDescriptions.yaml
@@ -6,7 +6,7 @@ description: |
   However, it could still be useful to have a more human-friendly description in the results.
   Also, this query is a good example for how you could define your own lookup tables and join with them.
   The events in the DeviceEvents table contain a GUID for the various ASR rules rather than a full description of the rule.
-  This query will create a table which has the description for each ASR rule as per https://learn.microsoft.com/en-us/defender-endpoint/enable-attack-surface-reduction.
+  This query will create a table which has the description for each ASR rule as per https://learn.microsoft.com/defender-endpoint/enable-attack-surface-reduction
   This table is then joined to the output of a query against the DeviceEvents table and shows a summary count of the events by the newly defined description.
   This query shows the ability to use joins and custom dimension tables.
   See https://docs.loganalytics.io/docs/Language-Reference/Tabular-operators/join-operator for more information on the join syntax.


### PR DESCRIPTION
Change(s):
- Repaired 17 dead reference links across 17 files under `Hunting Queries/Microsoft 365 Defender/`:
  - **14 Sigma rule links** — the `Original Sigma Rule` links point at `rules/apt/...` paths in `github.com/Neo23x0/sigma` that no longer exist: the repository is now `SigmaHQ/sigma` and the rules were moved (mostly under `rules-emerging-threats/`) and renamed with logsource prefixes. Each link now targets the rule's current path, verified to exist on SigmaHQ/sigma `master`. The `scheduled task creation` retarget was additionally confirmed by the rule's unchanged `id` GUID (`92626ddd-662c-49e3-ac59-f6535f12d189`).
  - **1 blog reference** (`Execution/detect-anomalous-process-trees.yaml`) — the article moved from `mergene.medium.com` to `posts.bluraven.io` (same slug; verified live).
  - **1 documentation link** (`Protection events/ExploitGuardAsrDescriptions.yaml`) — the `docs.microsoft.com/.../enable-attack-surface-reduction` page 404s; now points at its current home, `learn.microsoft.com/en-us/defender-endpoint/enable-attack-surface-reduction` (verified live).
  - **1 self-repo link** (`Defense evasion/UpdateStsRefreshToken[Solorigate].yaml`) — `Detections/AuditLogs/StsRefreshTokenModification.yaml` no longer exists; the query moved to `Solutions/Cloud Identity Threat Protection Essentials/Hunting Queries/` (verified on `master`).

Reason for Change(s):
- These are all human-facing reference links in descriptions and comments; every one currently 404s or dead-ends, so readers can't reach the cited source material. All replacement URLs verified resolving. Links whose targets no longer exist anywhere (three retired Sigma rules, a withdrawn PDF) were deliberately left untouched rather than guessed at, and the one dead URL inside an `externaldata()` data source was also left alone — replacing a query's live data feed is a functional change, not a link repair.
- Follows the same link-integrity audit as #14684 and #14691.

Version Updated:
- N/A — none of the touched files carry a `version` field (legacy hunting queries); no query logic or schema fields changed.

Testing Completed:
- Yes — link-integrity change only, no functional edits. All 17 files strict-parsed as YAML; every rewritten URL verified (SigmaHQ paths checked against the live repository tree, web targets return 200, self-repo target exists on `master`); no new spelling issues introduced.

Checked that the validations are passing and have addressed any issues that are present:
- Yes — description/comment text only; no KQL logic touched.