### PR TITLE
Update CONTRIBUTING.md with link to contribution guidelines

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,3 @@
 First off, thanks for contributing to Orion repo hosted in Azure organization!
+
+The contribution guidelines for this repository are maintained in the `Azure-Sentinel/README.md` file. Please refer to the [Contribution Guidelines](https://github.com/Azure/Azure-Sentinel/blob/70d13ec638f559d8347efa93258bbc1018d53cfb/README.md#contribution-guidelines) for the latest instructions and guidance on contributing.


### PR DESCRIPTION
   Change(s):
   - Updated `Azure-Sentinel/docs/CONTRIBUTING.md` to include a reference link to the contribution guidelines maintained in   `Azure-Sentinel/README.md`.

   Reason for Change(s):
   - The `CONTRIBUTING.md` file previously contained only a welcome message, which could cause confusion for contributors looking for contribution instructions. This change provides a clear reference to the latest contribution guidelines and ensures the documentation remains consistent and easier to navigate.

   Version Updated:
   - Not Required

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes