### PR TITLE
Update ASIM skills for entity placeholders

### DIFF
--- a/.github/skills/asim-parser-create-parser/SKILL.md
+++ b/.github/skills/asim-parser-create-parser/SKILL.md
@@ -61,12 +61,15 @@ Parsers are KQL functions that follow a clear flow: **Filter → Parse → Map**
 ### Required columns
 
 - Include the column `Type` in the output of the ASIM parser. This column indicates the source table name.
-- Include `entityKey`, `AdditionalIds`, and `additionalEntities` in the parser output. Until mappings for these fields are defined, set `entityKey` to an empty string and both `AdditionalIds` and `additionalEntities` to empty dynamic arrays:
+- Determine the placeholder entity fields applicable to the parser from the target schema and `Common` rows in `ASimTester.csv`. Include every defined column whose name ends in `EntityKey` or `AdditionalIds`, as well as `AdditionalEntities` when it is defined for the schema.
+- Preserve the exact field names and casing from `ASimTester.csv`. Entity fields are role-specific (for example, `ActorUserEntityKey`, `SrcSystemEntityKey`, and `ActorUserAdditionalIds`); do not replace them with generic names such as `entityKey` or `AdditionalIds`.
+- Until mappings for these fields are defined, set every `*EntityKey` field to an empty string and every `*AdditionalIds` field and `AdditionalEntities` to an empty dynamic array. For example:
 
   ```kusto
-  entityKey = "",
-  AdditionalIds = dynamic([]),
-  additionalEntities = dynamic([])
+  ActorUserEntityKey = "",
+  SrcSystemEntityKey = "",
+  ActorUserAdditionalIds = dynamic([]),
+  AdditionalEntities = dynamic([])
   ```
 
 ### Required parameters

--- a/.github/skills/asim-parser-create-parser/SKILL.md
+++ b/.github/skills/asim-parser-create-parser/SKILL.md
@@ -61,6 +61,13 @@ Parsers are KQL functions that follow a clear flow: **Filter → Parse → Map**
 ### Required columns
 
 - Include the column `Type` in the output of the ASIM parser. This column indicates the source table name.
+- Include `entityKey`, `AdditionalIds`, and `additionalEntities` in the parser output. Until mappings for these fields are defined, set `entityKey` to an empty string and both `AdditionalIds` and `additionalEntities` to empty dynamic arrays:
+
+  ```kusto
+  entityKey = "",
+  AdditionalIds = dynamic([]),
+  additionalEntities = dynamic([])
+  ```
 
 ### Required parameters
 

--- a/.github/skills/asim-parser-pr-reviewer/SKILL.md
+++ b/.github/skills/asim-parser-pr-reviewer/SKILL.md
@@ -46,7 +46,7 @@ Review the parameter-less parser for the following:
 
 - **`pack` parameter**: If the query uses `AdditionalFields`, verify that a `pack: bool = false` parameter is included. This allows users to choose whether to populate `AdditionalFields` or return an empty dynamic, improving performance for users who do not need the extra information.
 
-- **Placeholder entity fields**: Verify that the parser outputs `entityKey = ""`, `AdditionalIds = dynamic([])`, and `additionalEntities = dynamic([])`. These fields must remain empty until mappings for them are defined.
+- **Placeholder entity fields**: Determine the complete set of applicable fields from the target schema and `Common` rows in `ASimTester.csv`. Verify that the parser includes every defined `*EntityKey` and `*AdditionalIds` field, plus `AdditionalEntities` when defined. Names and casing must exactly match `ASimTester.csv`; generic names such as `entityKey` or `AdditionalIds` are invalid. Every `*EntityKey` must be an empty string, and every `*AdditionalIds` field and `AdditionalEntities` must be an empty dynamic array until mappings are defined.
 
 - **Parsing operator efficiency**: Check that high-performance parsing operators are used (`split`, `parse-kv`, `parse`) and that regular expressions are avoided where simpler operators would work.
 
@@ -83,7 +83,7 @@ Please review:
 2. **Filter efficiency**: Are the parameter-based filters using native columns and indexed fields where possible?
 3. **Redundant computation**: Are there any calculated fields or parsing operations that occur before the parameter filters, when they could be moved after?
 4. **Parameter completeness**: Are the filtering parameters comprehensive enough to allow efficient querying for common use cases?
-5. **Placeholder entity fields**: Does the parameterized parser preserve `entityKey = ""`, `AdditionalIds = dynamic([])`, and `additionalEntities = dynamic([])`? Flag this only when the fields are present in the parameter-less parser but missing or populated in the parameterized parser, so the same issue is not reported twice.
+5. **Placeholder entity field consistency**: Compare the parameterized parser's placeholder fields and values with the parameter-less parser. Report fields missing from both parsers only in the parameter-less review above. In this section, report only differences introduced by the parameterized parser, such as a placeholder that is omitted, renamed, or populated when the parameter-less parser defines it correctly. Matching omissions are not acceptable; they are already reported in the parameter-less review.
 
 **Output format:**
 

--- a/.github/skills/asim-parser-pr-reviewer/SKILL.md
+++ b/.github/skills/asim-parser-pr-reviewer/SKILL.md
@@ -46,6 +46,8 @@ Review the parameter-less parser for the following:
 
 - **`pack` parameter**: If the query uses `AdditionalFields`, verify that a `pack: bool = false` parameter is included. This allows users to choose whether to populate `AdditionalFields` or return an empty dynamic, improving performance for users who do not need the extra information.
 
+- **Placeholder entity fields**: Verify that the parser outputs `entityKey = ""`, `AdditionalIds = dynamic([])`, and `additionalEntities = dynamic([])`. These fields must remain empty until mappings for them are defined.
+
 - **Parsing operator efficiency**: Check that high-performance parsing operators are used (`split`, `parse-kv`, `parse`) and that regular expressions are avoided where simpler operators would work.
 
 - **General KQL performance**: Flag any other inefficient patterns such as unnecessary `let` statements, redundant filters, expensive joins, or operations that could be reordered for better performance.
@@ -81,6 +83,7 @@ Please review:
 2. **Filter efficiency**: Are the parameter-based filters using native columns and indexed fields where possible?
 3. **Redundant computation**: Are there any calculated fields or parsing operations that occur before the parameter filters, when they could be moved after?
 4. **Parameter completeness**: Are the filtering parameters comprehensive enough to allow efficient querying for common use cases?
+5. **Placeholder entity fields**: Does the parameterized parser preserve `entityKey = ""`, `AdditionalIds = dynamic([])`, and `additionalEntities = dynamic([])`? Flag this only when the fields are present in the parameter-less parser but missing or populated in the parameterized parser, so the same issue is not reported twice.
 
 **Output format:**
 


### PR DESCRIPTION
## Summary
- require ASIM parser creation to emit every schema-defined entity placeholder
- preserve the exact role-specific field names and casing from `ASimTester.csv`
- require ASIM PR reviews to validate completeness in parameter-less parsers and consistency in parameterized parsers

## Placeholder behavior
- fields are selected from the target schema and applicable `Common` rows
- every `*EntityKey` is emitted as an empty string
- every `*AdditionalIds` field and `AdditionalEntities` is emitted as an empty dynamic array
- placeholders remain empty until mappings are defined

## Dependency
The entity field definitions follow the schema changes proposed in #14628. This PR should merge after #14628, or be reconciled with its final field inventory if that proposal changes.