### PR TITLE
Add hunting queries: Entra ID group role assignment hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/ConditionalAccessPolicyExclusionAdded.yaml
+++ b/Hunting Queries/AuditLogs/ConditionalAccessPolicyExclusionAdded.yaml
@@ -1,0 +1,95 @@
+id: a14106c1-af19-41fb-9fbd-6d9ef402537b
+name: Conditional Access policy exclusion added
+description: |
+  Identifies Conditional Access policy updates that narrow scope via exclusions rather than change the enabled state, a technique attackers use to bypass enforcement without triggering state-change monitoring.
+description-detailed: |
+  An attacker with Conditional Access Administrator or Global Administrator
+  access can narrow a policy's scope by adding their own account, a compromised
+  guest account, or a service principal to its exclusion list. This achieves the
+  same practical bypass as disabling the policy, without the state change that
+  most defenses monitor for, and without interrupting enforcement for every other
+  user in the tenant.
+  This query intentionally excludes plain enabled/disabled state transitions,
+  which are covered separately, and instead surfaces condition-level edits so
+  analysts can review the raw old and new values for scope-narrowing changes
+  such as a growing exclude-users or exclude-groups list.
+  Analysts must validate every result. Benign matches include legitimate policy
+  tuning, break-glass account exclusions documented in change records, and
+  scheduled policy reviews. The signal is highest when the excluded identity is
+  privileged, recently created, or not a known break-glass account.
+  MITRE ATT&CK documents this exact pattern under T1556.009: threat actors,
+  including Scattered Spider, have added trusted locations and exclusions to
+  Conditional Access policies in real intrusions to maintain access after
+  initial compromise.
+  References:
+  - https://learn.microsoft.com/entra/identity/conditional-access/overview
+  - https://learn.microsoft.com/entra/identity/monitoring-health/reference-audit-activities
+  - https://attack.mitre.org/techniques/T1556/009/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - DefenseEvasion
+relevantTechniques:
+  - T1556.009
+query: |
+  let timeframe = 14d;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where Category =~ "Policy"
+  | where OperationName =~ "Update conditional access policy"
+  | where Result =~ "success"
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | extend PropName = tostring(ModProp.displayName)
+  | extend OldValue = tostring(ModProp.oldValue)
+  | extend NewValue = tostring(ModProp.newValue)
+  | where PropName !~ "State"
+  | where PropName has "Condition" or NewValue has "exclude" or OldValue has "exclude"
+  | extend PolicyName = tostring(TargetResources[0].displayName)
+  | extend PolicyId   = tostring(TargetResources[0].id)
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      PolicyName,
+      PolicyId,
+      PropName,
+      OldValue,
+      NewValue,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/MemberAddedToNewRoleAssignableGroup.yaml
+++ b/Hunting Queries/AuditLogs/MemberAddedToNewRoleAssignableGroup.yaml
@@ -1,0 +1,122 @@
+id: 17b75367-3b4e-4292-b985-30112acc2de0
+name: Member or owner added to a role-assignable group within 24 hours of its creation
+description: |
+  Identifies members or owners added to a role-assignable group within 24 hours of its creation, a pattern used to grant privileged access without generating a direct role-assignment audit event.
+description-detailed: |
+  Group role-assignability (isAssignableToRole set to true) can only be set at
+  group creation time, not added to an existing group. This chains two
+  individually low-signal events into a high-confidence indicator of privilege
+  escalation: an attacker who holds Privileged Role Administrator or Global
+  Administrator access creates a role-assignable group, then immediately adds
+  an account, often their own, or a service principal, as a member or owner.
+  That account inherits any directory role later assigned to the group without
+  ever generating an "Add member to role" audit event for itself, since the
+  role is granted to the group as a whole.
+  The group identity for "Add member to group" and "Add owner to group" events
+  is read from the "Group.ObjectID" and "Group.DisplayName" modifiedProperties
+  on the added principal's TargetResources entry rather than from a fixed
+  array index, matching the extraction pattern used elsewhere in this repo for
+  the same operations, since TargetResources ordering is not guaranteed to
+  place the group first.
+  Investigate whether the creation and the membership change were part of the
+  same documented change, whether the added identity already holds other
+  privileged access, and whether the group is subsequently assigned a
+  directory role.
+  References:
+  - https://learn.microsoft.com/entra/identity/role-based-access-control/groups-concept
+  - https://attack.mitre.org/techniques/T1098/003/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - PrivilegeEscalation
+  - Persistence
+relevantTechniques:
+  - T1098.003
+query: |
+  let timeframe = 1d;
+  let creationLookback = 14d;
+  let window = 24h;
+  let RecentlyCreatedRoleAssignableGroups =
+      AuditLogs
+      | where TimeGenerated >= ago(timeframe + creationLookback) and TimeGenerated < ago(0h)
+      | where Category =~ "GroupManagement"
+      | where OperationName =~ "Add group"
+      | where Result =~ "success"
+      | mv-expand ModProp = TargetResources[0].modifiedProperties
+      | extend PropName = tostring(ModProp.displayName)
+      | extend NewValue = tostring(ModProp.newValue)
+      | where PropName has "IsAssignableToRole" or NewValue has "isAssignableToRole"
+      | where NewValue has "true"
+      | extend GroupId = tolower(tostring(TargetResources[0].id))
+      | where isnotempty(GroupId)
+      | project GroupId, CreationTime = TimeGenerated;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where Category =~ "GroupManagement"
+  | where OperationName in~ ("Add member to group", "Add owner to group")
+  | where Result =~ "success"
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | mv-apply TargetResource = TargetResources on (
+        where TargetResource.type =~ "User"
+        | extend AddedUpn = tostring(TargetResource.userPrincipalName),
+                 AddedId  = tostring(TargetResource.id),
+                 Properties = TargetResource.modifiedProperties
+    )
+  | mv-apply Property = Properties on (
+        where Property.displayName =~ "Group.ObjectID"
+        | extend GroupId = tolower(trim('"', tostring(Property.newValue)))
+    )
+  | mv-apply Property = Properties on (
+        where Property.displayName =~ "Group.DisplayName"
+        | extend GroupName = trim('"', tostring(Property.newValue))
+    )
+  | where isnotempty(GroupId)
+  | join kind=inner RecentlyCreatedRoleAssignableGroups on GroupId
+  | where TimeGenerated >= CreationTime and TimeGenerated <= CreationTime + window
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      OperationName,
+      GroupName,
+      GroupId,
+      CreationTime,
+      AddedUpn,
+      AddedId,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/RoleAssignableGroupCreated.yaml
+++ b/Hunting Queries/AuditLogs/RoleAssignableGroupCreated.yaml
@@ -1,0 +1,91 @@
+id: 745c2179-a7db-4185-90c1-b33d78c5a6ac
+name: Role-assignable group created
+description: |
+  Identifies creation of a new Entra ID role-assignable group, a rare and tightly-permissioned event that can be a precursor to privilege escalation via later membership and role assignment changes.
+description-detailed: |
+  Group role-assignability (isAssignableToRole set to true) can only be set
+  when a group is created; Microsoft Entra ID does not allow converting an
+  existing group into a role-assignable one afterward, and creating one
+  requires the actor to hold at least the Privileged Role Administrator role.
+  By design there is no legitimate high-volume use of this event in a
+  well-run tenant, and a maximum of 500 role-assignable groups are permitted
+  per tenant, so every match here is inherently rare and should map to a
+  known change.
+  An attacker who has obtained Privileged Role Administrator or Global
+  Administrator access can create a role-assignable group with an innocuous
+  display name, then add members or owners to it and later assign a directory
+  role to the group. Because role-assignable groups exist specifically so that
+  group membership grants a role, standard "Add member to role" monitoring
+  never fires for the accounts that gain access this way; the group creation
+  and its membership changes are the only audit signal. See the companion
+  hunting query for member and owner additions shortly after creation.
+  Analysts should confirm the creation aligns with a documented change and
+  check which accounts currently hold the Privileged Role Administrator role.
+  References:
+  - https://learn.microsoft.com/entra/identity/role-based-access-control/groups-concept
+  - https://attack.mitre.org/techniques/T1098/003/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - PrivilegeEscalation
+  - Persistence
+relevantTechniques:
+  - T1098.003
+query: |
+  let timeframe = 14d;
+  AuditLogs
+  | where TimeGenerated >= ago(timeframe)
+  | where Category =~ "GroupManagement"
+  | where OperationName =~ "Add group"
+  | where Result =~ "success"
+  | mv-expand ModProp = TargetResources[0].modifiedProperties
+  | extend PropName = tostring(ModProp.displayName)
+  | extend NewValue = tostring(ModProp.newValue)
+  | where PropName has "IsAssignableToRole" or NewValue has "isAssignableToRole"
+  | where NewValue has "true"
+  | extend GroupName = tostring(TargetResources[0].displayName)
+  | extend GroupId   = tostring(TargetResources[0].id)
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend AccountName      = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[0]), Actor)
+  | extend AccountUPNSuffix = iff(ActorUpn has "@", tostring(split(ActorUpn, "@")[1]), "")
+  | project
+      TimeGenerated,
+      GroupName,
+      GroupId,
+      Actor,
+      AccountName,
+      AccountUPNSuffix,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: Actor
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]


### PR DESCRIPTION
## Summary

Three new Entra ID hunting queries covering group-based privilege escalation via role-assignable groups, plus a Conditional Access exclusion-based bypass that complements the existing state-change detection.

### RoleAssignableGroupCreated (AuditLogs)

Identifies creation of a new Entra ID group with `isAssignableToRole` set to true. This property can only be set at creation time and requires Privileged Role Administrator access, so every match is inherently rare (max 500 role-assignable groups per tenant) and should map to a known change.

MITRE: T1098.003, PrivilegeEscalation, Persistence

### MemberAddedToNewRoleAssignableGroup (AuditLogs)

Correlates role-assignable group creation with `Add member to group` / `Add owner to group` events within a 24-hour window, surfacing accounts that gained privileged access via group membership without ever generating a direct "Add member to role" audit event. Companion query to RoleAssignableGroupCreated.

MITRE: T1098.003, PrivilegeEscalation, Persistence

### ConditionalAccessPolicyExclusionAdded (AuditLogs)

Identifies Conditional Access policy updates that add or grow exclusion lists rather than change the enabled/disabled state, a scope-narrowing bypass that avoids the state-change signal most defenses monitor for. Intentionally excludes plain enable/disable transitions, which are covered by the existing ConditionalAccessPolicyDisabledOrDeleted query.

MITRE: T1556.009, DefenseEvasion

## Validation

- All three queries use `let timeframe` with no placeholder variables
- Descriptions are under 255 characters, with extended context moved to `description-detailed`
- Names are sentence case
- No non-ASCII characters
- GUIDs are unique (verified against existing queries in the repo)
- No duplicate/overlapping existing hunting queries in the repo
