### PR TITLE
Restrict unsupported patterns in ASIM parser skills

### DIFF
--- a/.github/skills/asim-parser-create-parameter-parser/SKILL.md
+++ b/.github/skills/asim-parser-create-parameter-parser/SKILL.md
@@ -27,13 +27,13 @@ Add the contents of the parameter-less version of the parser to the new file.
 
 The parameterized parser must preserve all development guidelines and prohibited patterns from the `asim-parser-create-parser` skill. Adding parameters or filters must not introduce:
 
-- Same-table enrichment, such as a second source-table read or self-join.
-- Cross-table or other table-shaped enrichment, including `join`, `lookup`, secondary `union` branches, `externaldata`, or inline `datatable` mappings.
+- Same-table event enrichment, such as a second source-table read, self-join, or event-record correlation.
+- Cross-table enrichment from another workspace table, a watchlist, `externaldata`, or another external tabular source.
 - One-to-many fan-out; each source record must still produce at most one normalized record.
 - Any `mv-*` operator, including `mv-expand` and `mv-apply`.
-- Aggregation, reaggregation, correlation, or deduplication, including `summarize`, `distinct`, `arg_min`, or `arg_max`.
+- Event-record aggregation, reaggregation, correlation, or deduplication, including `summarize`, `distinct`, `arg_min`, or `arg_max`.
 
-Use native source columns and scalar predicates for parameter filtering. If a parameter cannot be applied without a prohibited pattern, retain the standard empty-parameter check without adding enrichment, row expansion, or aggregation.
+Query-local static mappings created with `datatable` and applied with `lookup` remain allowed when each lookup key is unique. Use native source columns and scalar predicates for parameter filtering. If a parameter cannot be applied without a prohibited pattern, retain the standard empty-parameter check without adding event enrichment, row expansion, or event-record aggregation.
 
 ## Add parameters
 

--- a/.github/skills/asim-parser-create-parameter-parser/SKILL.md
+++ b/.github/skills/asim-parser-create-parameter-parser/SKILL.md
@@ -23,6 +23,18 @@ The file name should be prefixed with vim, followed by the name of the schema, e
 
 Add the contents of the parameter-less version of the parser to the new file.
 
+## Preserve parser development restrictions
+
+The parameterized parser must preserve all development guidelines and prohibited patterns from the `asim-parser-create-parser` skill. Adding parameters or filters must not introduce:
+
+- Same-table enrichment, such as a second source-table read or self-join.
+- Cross-table or other table-shaped enrichment, including `join`, `lookup`, secondary `union` branches, `externaldata`, or inline `datatable` mappings.
+- One-to-many fan-out; each source record must still produce at most one normalized record.
+- Any `mv-*` operator, including `mv-expand` and `mv-apply`.
+- Aggregation, reaggregation, correlation, or deduplication, including `summarize`, `distinct`, `arg_min`, or `arg_max`.
+
+Use native source columns and scalar predicates for parameter filtering. If a parameter cannot be applied without a prohibited pattern, retain the standard empty-parameter check without adding enrichment, row expansion, or aggregation.
+
 ## Add parameters
 
 From the parameters you have gathered, add it to function arguments for both the function and the function call.

--- a/.github/skills/asim-parser-create-parser/SKILL.md
+++ b/.github/skills/asim-parser-create-parser/SKILL.md
@@ -40,10 +40,22 @@ Parsers are KQL functions that follow a clear flow: **Filter → Parse → Map**
 - Use indexes so only relevant extents are scanned.
 - Filter early on native columns before parsing to improve performance.
 - Use high-performance parsing operators (`split`, `parse-kv`, `parse`) and avoid regular expressions for string parsing.
-- Normalize values with `iff`, `case`, or lookup tables rather than copying source values directly.
+- Normalize values with scalar expressions such as `iff` or `case` rather than copying source values directly.
 - Use `project-rename` for mapping, `extend` for calculated or normalized fields.
 - Try to map as many fields as possible, including optional ones. This increases usefulness and future-proofs the parser for schema changes.
 - Do not use `project-away` to remove unmapped columns. Use `project` instead, as `project-away` does not protect the parser from schema changes in the source data.
+
+### Prohibited patterns
+
+ASIM parsers must remain a single pipeline over the declared source table. Do not use:
+
+- **Same-table enrichment** — including a second read of the source table, a self-join, or a tabular subquery used to add fields.
+- **Cross-table or other table-shaped enrichment** — including `join`, `lookup`, a secondary `union` branch, `externaldata`, or inline `datatable` mappings.
+- **One-to-many fan-out** — each source record must produce at most one normalized record. Do not expand one record into multiple normalized records; this indicates that the connector or source event shape must be corrected.
+- **Any `mv-*` operator** — including `mv-expand` and `mv-apply`.
+- **Aggregation, reaggregation, correlation, or deduplication** — including `summarize`, `distinct`, `arg_min`, `arg_max`, or any other operation that combines source records or collapses expanded rows.
+
+Use only values available on the current source row and preserve its record cardinality. Prefer scalar expressions, scalar dynamic-value access, and direct parsing. If a field cannot be mapped without a prohibited enrichment, fan-out, `mv-*`, or aggregation pattern, leave it unmapped.
 
 ### Parsing operators by performance ranking
 

--- a/.github/skills/asim-parser-create-parser/SKILL.md
+++ b/.github/skills/asim-parser-create-parser/SKILL.md
@@ -40,22 +40,22 @@ Parsers are KQL functions that follow a clear flow: **Filter → Parse → Map**
 - Use indexes so only relevant extents are scanned.
 - Filter early on native columns before parsing to improve performance.
 - Use high-performance parsing operators (`split`, `parse-kv`, `parse`) and avoid regular expressions for string parsing.
-- Normalize values with scalar expressions such as `iff` or `case` rather than copying source values directly.
+- Normalize values with `iff`, `case`, or query-local lookup tables rather than copying source values directly.
 - Use `project-rename` for mapping, `extend` for calculated or normalized fields.
 - Try to map as many fields as possible, including optional ones. This increases usefulness and future-proofs the parser for schema changes.
 - Do not use `project-away` to remove unmapped columns. Use `project` instead, as `project-away` does not protect the parser from schema changes in the source data.
 
 ### Prohibited patterns
 
-ASIM parsers must remain a single pipeline over the declared source table. Do not use:
+ASIM parsers must read event records from one declared source table. Query-local static mappings created with `datatable` and applied with `lookup` are allowed because they do not read or correlate additional event records. Each lookup key must be unique so the mapping cannot fan out a source record. Do not use:
 
-- **Same-table enrichment** — including a second read of the source table, a self-join, or a tabular subquery used to add fields.
-- **Cross-table or other table-shaped enrichment** — including `join`, `lookup`, a secondary `union` branch, `externaldata`, or inline `datatable` mappings.
+- **Same-table enrichment** — including a second read of the source table, a self-join, or a tabular subquery that correlates event records.
+- **Cross-table enrichment** — including reading event records from another workspace table, a watchlist, `externaldata`, or another external tabular source.
 - **One-to-many fan-out** — each source record must produce at most one normalized record. Do not expand one record into multiple normalized records; this indicates that the connector or source event shape must be corrected.
 - **Any `mv-*` operator** — including `mv-expand` and `mv-apply`.
-- **Aggregation, reaggregation, correlation, or deduplication** — including `summarize`, `distinct`, `arg_min`, `arg_max`, or any other operation that combines source records or collapses expanded rows.
+- **Event-record aggregation, reaggregation, correlation, or deduplication** — including `summarize`, `distinct`, `arg_min`, `arg_max`, or any other operation that combines source records or collapses expanded rows.
 
-Use only values available on the current source row and preserve its record cardinality. Prefer scalar expressions, scalar dynamic-value access, and direct parsing. If a field cannot be mapped without a prohibited enrichment, fan-out, `mv-*`, or aggregation pattern, leave it unmapped.
+Use values available on the current source row, constants, and query-local static lookup mappings while preserving event-record cardinality. Prefer scalar expressions, scalar dynamic-value access, and direct parsing. If a field cannot be mapped without prohibited event enrichment, fan-out, `mv-*`, or event-record aggregation, leave it unmapped.
 
 ### Parsing operators by performance ranking
 

--- a/.github/skills/asim-parser-pr-reviewer/SKILL.md
+++ b/.github/skills/asim-parser-pr-reviewer/SKILL.md
@@ -44,13 +44,23 @@ Review the parameter-less parser for the following:
 
 - **No `project-away`**: The query must NOT use `project-away` to remove unmapped columns. It should use `project` instead, as `project-away` does not protect the parser from schema changes in the source data.
 
+- **No same-table or cross-table enrichment**: Verify that the query is a single pipeline over the declared source table. Flag any second read of the source table, self-join, cross-table reference, `join`, `lookup`, secondary `union` branch, `externaldata`, inline `datatable` mapping, or equivalent table-shaped enrichment. If a field cannot be produced from the current source row, it should remain unmapped rather than be enriched.
+
+- **One source record produces at most one normalized record**: Flag any operation that fans out one source record into multiple normalized records, regardless of operator. Fan-out indicates a connector or source event-shape defect that should be corrected rather than supported in the parser.
+
+- **No `mv-*` operators**: Flag any KQL operator whose name begins with `mv-`, including `mv-expand` and `mv-apply`. The parser should use scalar dynamic-value access or other scalar expressions instead. If a field cannot be mapped without row expansion, it should remain unmapped.
+
+- **No aggregation, reaggregation, correlation, or deduplication**: Flag `summarize`, `distinct`, `arg_min`, `arg_max`, or any equivalent operation that combines source records or collapses expanded rows. An ASIM parser should normalize each source record independently rather than correlate, deduplicate, or reaggregate records.
+
 - **`pack` parameter**: If the query uses `AdditionalFields`, verify that a `pack: bool = false` parameter is included. This allows users to choose whether to populate `AdditionalFields` or return an empty dynamic, improving performance for users who do not need the extra information.
 
 - **Placeholder entity fields**: Determine the complete set of applicable fields from the target schema and `Common` rows in `ASimTester.csv`. Verify that the parser includes every defined `*EntityKey` and `*AdditionalIds` field, plus `AdditionalEntities` when defined. Names and casing must exactly match `ASimTester.csv`; generic names such as `entityKey` or `AdditionalIds` are invalid. Every `*EntityKey` must be an empty string, and every `*AdditionalIds` field and `AdditionalEntities` must be an empty dynamic array until mappings are defined.
 
 - **Parsing operator efficiency**: Check that high-performance parsing operators are used (`split`, `parse-kv`, `parse`) and that regular expressions are avoided where simpler operators would work.
 
-- **General KQL performance**: Flag any other inefficient patterns such as unnecessary `let` statements, redundant filters, expensive joins, or operations that could be reordered for better performance.
+- **General KQL performance**: Flag any other inefficient patterns such as unnecessary `let` statements, redundant filters, or operations that could be reordered for better performance.
+
+Treat every same-table enrichment, cross-table/table-shaped enrichment, fan-out, `mv-*`, or aggregation/reaggregation violation as 🔴 High priority.
 
 **Output format:**
 
@@ -58,6 +68,7 @@ Return your findings as a markdown table with the following columns:
 
 | #   | Priority | Issue | Suggestion |
 | --- | -------- | ----- | ---------- |
+
 
 Where:
 
@@ -84,6 +95,7 @@ Please review:
 3. **Redundant computation**: Are there any calculated fields or parsing operations that occur before the parameter filters, when they could be moved after?
 4. **Parameter completeness**: Are the filtering parameters comprehensive enough to allow efficient querying for common use cases?
 5. **Placeholder entity field consistency**: Compare the parameterized parser's placeholder fields and values with the parameter-less parser. Report fields missing from both parsers only in the parameter-less review above. In this section, report only differences introduced by the parameterized parser, such as a placeholder that is omitted, renamed, or populated when the parameter-less parser defines it correctly. Matching omissions are not acceptable; they are already reported in the parameter-less review.
+6. **Prohibited pattern consistency**: Report any same-table enrichment, cross-table/table-shaped enrichment, fan-out, `mv-*`, or aggregation/reaggregation introduced only by the parameterized parser as 🔴 High priority. If the same violation exists in both parser versions, report it only in the parameter-less review above.
 
 **Output format:**
 
@@ -91,6 +103,7 @@ Return findings as a markdown table:
 
 | #   | Priority | Issue | Suggestion |
 | --- | -------- | ----- | ---------- |
+
 
 Where Priority is one of: 🔴 High, 🟡 Medium, 🟢 Low.
 Only include issues specific to the filtering/parameter logic.

--- a/.github/skills/asim-parser-pr-reviewer/SKILL.md
+++ b/.github/skills/asim-parser-pr-reviewer/SKILL.md
@@ -44,13 +44,13 @@ Review the parameter-less parser for the following:
 
 - **No `project-away`**: The query must NOT use `project-away` to remove unmapped columns. It should use `project` instead, as `project-away` does not protect the parser from schema changes in the source data.
 
-- **No same-table or cross-table enrichment**: Verify that the query is a single pipeline over the declared source table. Flag any second read of the source table, self-join, cross-table reference, `join`, `lookup`, secondary `union` branch, `externaldata`, inline `datatable` mapping, or equivalent table-shaped enrichment. If a field cannot be produced from the current source row, it should remain unmapped rather than be enriched.
+- **No same-table or cross-table event enrichment**: Verify that the parser reads event records from one declared source table. Flag a second read of that table, a self-join, event-record correlation, a workspace-table or watchlist reference, `externaldata`, or another external tabular source. Allow query-local static mappings defined with `datatable` and applied with `lookup`; these map values without reading or correlating additional event records. Verify that each lookup key is unique so the mapping cannot fan out a source record. If a field cannot be produced from the current source row or a static mapping, it should remain unmapped rather than be enriched from event data.
 
 - **One source record produces at most one normalized record**: Flag any operation that fans out one source record into multiple normalized records, regardless of operator. Fan-out indicates a connector or source event-shape defect that should be corrected rather than supported in the parser.
 
 - **No `mv-*` operators**: Flag any KQL operator whose name begins with `mv-`, including `mv-expand` and `mv-apply`. The parser should use scalar dynamic-value access or other scalar expressions instead. If a field cannot be mapped without row expansion, it should remain unmapped.
 
-- **No aggregation, reaggregation, correlation, or deduplication**: Flag `summarize`, `distinct`, `arg_min`, `arg_max`, or any equivalent operation that combines source records or collapses expanded rows. An ASIM parser should normalize each source record independently rather than correlate, deduplicate, or reaggregate records.
+- **No event-record aggregation, reaggregation, correlation, or deduplication**: Flag `summarize`, `distinct`, `arg_min`, `arg_max`, or any equivalent operation that combines source records or collapses expanded rows. An ASIM parser should normalize each source record independently rather than correlate, deduplicate, or reaggregate event records.
 
 - **`pack` parameter**: If the query uses `AdditionalFields`, verify that a `pack: bool = false` parameter is included. This allows users to choose whether to populate `AdditionalFields` or return an empty dynamic, improving performance for users who do not need the extra information.
 
@@ -60,7 +60,7 @@ Review the parameter-less parser for the following:
 
 - **General KQL performance**: Flag any other inefficient patterns such as unnecessary `let` statements, redundant filters, or operations that could be reordered for better performance.
 
-Treat every same-table enrichment, cross-table/table-shaped enrichment, fan-out, `mv-*`, or aggregation/reaggregation violation as 🔴 High priority.
+Treat every same-table or cross-table event enrichment, fan-out, `mv-*`, or event-record aggregation/reaggregation violation as 🔴 High priority.
 
 **Output format:**
 
@@ -95,7 +95,7 @@ Please review:
 3. **Redundant computation**: Are there any calculated fields or parsing operations that occur before the parameter filters, when they could be moved after?
 4. **Parameter completeness**: Are the filtering parameters comprehensive enough to allow efficient querying for common use cases?
 5. **Placeholder entity field consistency**: Compare the parameterized parser's placeholder fields and values with the parameter-less parser. Report fields missing from both parsers only in the parameter-less review above. In this section, report only differences introduced by the parameterized parser, such as a placeholder that is omitted, renamed, or populated when the parameter-less parser defines it correctly. Matching omissions are not acceptable; they are already reported in the parameter-less review.
-6. **Prohibited pattern consistency**: Report any same-table enrichment, cross-table/table-shaped enrichment, fan-out, `mv-*`, or aggregation/reaggregation introduced only by the parameterized parser as 🔴 High priority. If the same violation exists in both parser versions, report it only in the parameter-less review above.
+6. **Prohibited pattern consistency**: Report any same-table or cross-table event enrichment, fan-out, `mv-*`, or event-record aggregation/reaggregation introduced only by the parameterized parser as 🔴 High priority. Query-local static `datatable` and `lookup` mappings are allowed. If the same violation exists in both parser versions, report it only in the parameter-less review above.
 
 **Output format:**
 


### PR DESCRIPTION
## Summary
- keep ASIM parser creation as a single event-source, per-record normalization pipeline
- allow query-local static `datatable` + `lookup` mappings with unique keys
- prohibit same-table and cross-table event enrichment
- prohibit one-to-many fan-out, all `mv-*` operators, and event-record aggregation or reaggregation
- add matching High-priority checks to the ASIM PR reviewer for both ASim and vim parsers
- preserve the schema-aware entity-placeholder guidance merged in #14776

## DCR gap analysis alignment
This applies the guidance from section 6 of `AsimDcrGapAnalysis.pdf` while preserving translator-supported static lookup mappings:
- no same-table or cross-table event enrichment
- no normalization fan-out from one source record to multiple records
- no `mv-*` followed by `summarize` or other event-record aggregation/reaggregation patterns
- query-local static lookups remain valid and can be translated to scalar `case` expressions

## Local skill tests
Ran the project skills locally through Copilot CLI using synthetic KQL cases:

| Scenario | Expected | Result |
|---|---|---|
| Static `datatable` + `lookup` with unique keys | Allowed | Passed |
| External event-table `join` | High-priority finding | Passed |
| `mv-expand` fan-out | High-priority finding | Passed |
| `summarize arg_max` event deduplication | High-priority finding | Passed |
| Scalar `case` mapping | Allowed | Passed |
| Parameterized parser preserving static lookup with early native filtering | Allowed | Passed |

## Rebase validation
- rebased the two intended commits onto current `master`
- preserved both entity-placeholder consistency checks from #14776 and prohibited-pattern checks
- resolved the overlap by keeping query-local static mappings allowed
- confirmed the final diff contains only the three ASIM skill files

## Validation
- Prettier 1.19.1 formatting check
- skill YAML frontmatter check
- `git diff --check`
