### PR TITLE
Replaced the direct unixtime_milliseconds_todatetime() calls with a safe fallback pattern

### DIFF
--- a/Solutions/GitHub/Parsers/GitHubAuditData.yaml
+++ b/Solutions/GitHub/Parsers/GitHubAuditData.yaml
@@ -1,8 +1,8 @@
 id: 32d7c900-875f-43d6-9e48-987fd5df3762
 Function:
   Title: Parser for GitHubAuditData
-  Version: '1.1.0'
-  LastUpdated: '2026-06-26'
+  Version: '1.2.0'
+  LastUpdated: '2026-08-05'
 Category: Microsoft Sentinel Parser
 FunctionName: GitHubAuditData
 FunctionAlias: GitHubAuditData
@@ -10,7 +10,7 @@ FunctionQuery: |
     let GitHubAuditLogPolling_view = view () {
     GitHubAuditLogPolling_CL
        | extend 
-           TimeGenerated=unixtime_milliseconds_todatetime(created_at_d),
+           TimeGenerated=coalesce(unixtime_milliseconds_todatetime(column_ifexists('created_at_d', real(null))), TimeGenerated),
            Organization=column_ifexists('org_s', ''),
            Action=column_ifexists('action_s', ''),
            Repository=column_ifexists('repo_s', ''),
@@ -28,7 +28,7 @@ FunctionQuery: |
     let GitHubAuditLogsV2_view = view () {
     GitHubAuditLogsV2_CL
        | extend 
-           TimeGenerated=unixtime_milliseconds_todatetime(CreatedAt),
+           TimeGenerated=coalesce(unixtime_milliseconds_todatetime(column_ifexists('CreatedAt', real(null))), TimeGenerated),
            Organization=column_ifexists('Org', ''),
            Action=column_ifexists('Action', ''),
            Repository=column_ifexists('Repo', ''),
@@ -46,7 +46,7 @@ FunctionQuery: |
     let GitHubAuditLogsV3_view = view () {
     GitHubAuditLogsV3_CL
        | extend 
-           TimeGenerated=unixtime_milliseconds_todatetime(CreatedAt),
+           TimeGenerated=coalesce(unixtime_milliseconds_todatetime(column_ifexists('CreatedAt', real(null))), TimeGenerated),
            Organization=column_ifexists('Org', ''),
            Action=column_ifexists('Action', ''),
            Repository=column_ifexists('Repo', ''),

--- a/Solutions/GitHub/ReleaseNotes.md
+++ b/Solutions/GitHub/ReleaseNotes.md
@@ -1,5 +1,6 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                                                       |
 |-------------|--------------------------------|--------------------------------------------------------------------------|
+| 3.5.1       | 05-08-2026                     | Fixed **GitHubAuditData** parser: `TimeGenerated` now falls back to the ingestion `TimeGenerated` when `created_at_d` / `CreatedAt` is absent or null, preventing rows from being silently dropped. |
 | 3.5.0       | 30-07-2026                     | Promoted the GitHub Azure Storage Audit Logs data connector to GA, add multi-stream support, and updated its generated configuration with advanced Event Grid filters. |
 | 3.4.0       | 25-06-2026                     | Added all api.request fields and created V3 table for AzStorage connector         |
 | 3.3.1       | 17-06-2026                     | Added SAS related instruction.          |


### PR DESCRIPTION
Replaced the direct unixtime_milliseconds_todatetime() calls with a safe fallback pattern in all three table views:

<html>
<body>
<!--StartFragment-->
Before | After
-- | --
TimeGenerated=unixtime_milliseconds_todatetime(CreatedAt) | TimeGenerated=coalesce(unixtime_milliseconds_todatetime(column_ifexists('CreatedAt', real(null))), TimeGenerated)

<!--EndFragment-->
</body>
</html>