### PR TITLE
Handle nonstandard ASIM empty parser names

### DIFF
--- a/.script/tests/asimParsersTest/ASimFilteringTest.py
+++ b/.script/tests/asimParsersTest/ASimFilteringTest.py
@@ -296,7 +296,8 @@ def main():
         else:
             SchemaName = None
         # Check if changed file is a union parser. If Yes, skip the file
-        if PARSER_FILE_NAME.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml', f'vim{SchemaName}Empty.yaml')):
+        is_empty_parser = os.path.basename(PARSER_FILE_NAME).startswith('vim') and PARSER_FILE_NAME.endswith('Empty.yaml')
+        if PARSER_FILE_NAME.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml')) or is_empty_parser:
             continue
         parser_file_path = PARSER_FILE_NAME
         sys.stdout.flush()  # Explicitly flush stdout

--- a/.script/tests/asimParsersTest/VerifyASimParserTemplate.py
+++ b/.script/tests/asimParsersTest/VerifyASimParserTemplate.py
@@ -87,7 +87,8 @@ def run():
     for parser in parser_yaml_files:
         
         schema_name = extract_schema_name(parser)
-        if parser.endswith((f'ASim{schema_name}.yaml', f'im{schema_name}.yaml', f'vim{schema_name}Empty.yaml')):
+        is_empty_parser = os.path.basename(parser).startswith('vim') and parser.endswith('Empty.yaml')
+        if parser.endswith((f'ASim{schema_name}.yaml', f'im{schema_name}.yaml')) or is_empty_parser:
             print(f"{YELLOW}Skipping '{parser}' as this is a union or empty parser file. This file won't be tested.{RESET}")
             continue
         # Skip vim parser file if the corresponding ASim parser file is not present

--- a/.script/tests/asimParsersTest/ingestASimSampleData.py
+++ b/.script/tests/asimParsersTest/ingestASimSampleData.py
@@ -400,7 +400,8 @@ for file in parser_yaml_files:
     else:
         SchemaName = None
     # Check if changed file is a union or empty parser. If Yes, skip the file
-    if file.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml', f'vim{SchemaName}Empty.yaml')):
+    is_empty_parser = os.path.basename(file).startswith('vim') and file.endswith('Empty.yaml')
+    if file.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml')) or is_empty_parser:
         print(f"Ignoring this {file} because it is a union or empty parser file")
         continue        
     print(f"Starting ingestion for sample data present in {file}")


### PR DESCRIPTION
## Summary
- detect ASIM empty parsers by the `vim*Empty.yaml` naming convention
- stop deriving an `ASim*Empty.yaml` filename when the schema and parser filenames differ
- apply the same detection in template validation, sample-data ingestion, and filtering tests

## Motivation
PR #14628 updates `vimProcessEmpty.yaml`. The current validator assumes the filename is `vimProcessEventEmpty.yaml`, then attempts to open the nonexistent `ASimProcessEmpty.yaml`. The ASIM workflow downloads these trusted scripts from `master`, so this fix must merge before #14628 can pass its required ASIM checks.

## Validation
- compiled all three modified Python scripts
- ran `VerifyASimParserTemplate.py`
- verified `vimProcessEmpty.yaml` and standard `vim*Empty.yaml` names are recognized while source-specific parsers are not
- `git diff --check`
