### PR TITLE
Secure client secret handling in Affected Key Credentials playbook

### DIFF
--- a/Playbooks/Affected-Key-Credentials-CVE-2021-42306/azuredeploy.json
+++ b/Playbooks/Affected-Key-Credentials-CVE-2021-42306/azuredeploy.json
@@ -55,7 +55,7 @@
 			}
 		},
 		"ClientSecret": {
-			"type": "string",
+			"type": "securestring",
 			"metadata": {
 				"description": "Azure AAD ClientSecret"
 			}
@@ -140,7 +140,7 @@
 						},
 						"ClientSecret": {
 							"defaultValue": "[parameters('ClientSecret')]",
-							"type": "string"
+							"type": "SecureString"
 						},
 						"WatchListAlias": {
 							"defaultValue": "[parameters('WatchListAlias')]",
@@ -174,23 +174,6 @@
 										"name": "ClientId",
 										"type": "string",
 										"value": "@{parameters('ClientId')}"
-									}
-								]
-							}
-						},
-						"Client_Secret": {
-							"runAfter": {
-								"Client_Id": [
-									"Succeeded"
-								]
-							},
-							"type": "InitializeVariable",
-							"inputs": {
-								"variables": [
-									{
-										"name": "ClientSecret",
-										"type": "string",
-										"value": "@{parameters('ClientSecret')}"
 									}
 								]
 							}
@@ -309,12 +292,20 @@
 								"authentication": {
 									"audience": "@variables('ResourceUrl')",
 									"clientId": "@variables('ClientId')",
-									"secret": "@variables('ClientSecret')",
+									"secret": "@parameters('ClientSecret')",
 									"tenant": "@variables('TenantId')",
 									"type": "ActiveDirectoryOAuth"
 								},
 								"method": "GET",
 								"uri": "@{variables('ResourceUrl')}/beta/myorganization/@{variables('ObjectClass')}s?$select=displayName,id,appId,keyCredentials"
+							},
+							"runtimeConfiguration": {
+								"secureData": {
+									"properties": [
+										"inputs",
+										"outputs"
+									]
+								}
 							}
 						},
 						"Key_Credentials_Body": {
@@ -548,7 +539,7 @@
 						},
 						"Watch_List_Alias": {
 							"runAfter": {
-								"Client_Secret": [
+								"Client_Id": [
 									"Succeeded"
 								]
 							},


### PR DESCRIPTION
## Summary

Changes the deployment and workflow client-secret parameters to secure strings, removes the plaintext Logic App variable, and masks the authenticated request inputs and outputs.

## AI scan items

- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/130068

## Validation

ARM template JSON parsing passed.