### PR TITLE
Stop logging Cohesity ARM access tokens

### DIFF
--- a/Solutions/CohesitySecurity/Data Connectors/Helios2Sentinel/IncidentConsumer/IncidentConsumer.cs
+++ b/Solutions/CohesitySecurity/Data Connectors/Helios2Sentinel/IncidentConsumer/IncidentConsumer.cs
@@ -113,7 +113,6 @@ namespace IncidentConsumer
         {
             log.LogInformation("queueItem --> " + queueItem);
             string token = GetAccessTokenAsync($"{ARM_ENDPOINT}.default", log).Result;
-            log.LogInformation("token --> " + token);
             string subscription = Environment.GetEnvironmentVariable("subscription");
             string resourceGroup = Environment.GetEnvironmentVariable("resourceGroup");
             string workspace = Environment.GetEnvironmentVariable("Workspace");


### PR DESCRIPTION
## Summary

Removes plaintext bearer-token logging from the Cohesity incident consumer.

## AI scan items

- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/130268

## Validation

The source change is isolated; the existing project restore is blocked by a pre-existing Microsoft.Identity.Client package downgrade.