### PR TITLE
Limit GitHub App private key exposure in ASIM workflow

### DIFF
--- a/.github/workflows/convertKqlFunctionYamlToArmTemplate.yaml
+++ b/.github/workflows/convertKqlFunctionYamlToArmTemplate.yaml
@@ -22,10 +22,6 @@ on:
       - "Parsers/ASimAssetEntity/Parsers/**"
       - "Parsers/ASimAgentEvent/Parsers/**"
 
-env:
-  GITHUB_APPS_ID: "${{ secrets.APPLICATION_ID }}"
-  GITHUB_APPS_KEY: "${{ secrets.APPLICATION_PRIVATE_KEY }}"
-
 jobs:
   kqlFuncYaml2Arm:
     # The workflow should not run on forked repositories for security reasons
@@ -36,8 +32,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
         with:
-          app-id: ${{ env.GITHUB_APPS_ID }}
-          private-key: ${{ env.GITHUB_APPS_KEY }}
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
 
       - name: Checkout pull request branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/convertKqlFunctionYamlToArmTemplate.yaml
+++ b/.github/workflows/convertKqlFunctionYamlToArmTemplate.yaml
@@ -31,9 +31,11 @@ jobs:
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        env:
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
-          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout pull request branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
## Summary

Removes workflow-global secret environment variables and passes the GitHub App credentials only to the token-generation action.

## AI scan items

- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/130335

## Validation

Workflow YAML parsing passed.