### PR TITLE
Encode MDE machine IDs in unisolate requests

### DIFF
--- a/Playbooks/AS-MDE-Unisolate-Machine/azuredeploy.json
+++ b/Playbooks/AS-MDE-Unisolate-Machine/azuredeploy.json
@@ -181,7 +181,7 @@
                                                     "Authorization": "Bearer @{body('Parse_JSON_-_Token')?['access_token']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "https://api.securitycenter.microsoft.com/api/machines/@{items('For_each_-_Host')?['additionalData']?['MdatpDeviceId']}/unisolate"
+                                                "uri": "https://api.securitycenter.microsoft.com/api/machines/@{encodeURIComponent(items('For_each_-_Host')?['additionalData']?['MdatpDeviceId'])}/unisolate"
                                             },
                                             "runAfter": {},
                                             "type": "Http"


### PR DESCRIPTION
## Summary

URL-encodes the Sentinel-provided MDE device identifier before placing it in the privileged unisolate endpoint path.

## AI scan items

- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/130370

## Validation

ARM template JSON parsing passed.