### PR TITLE
Harden ARM-TTK execution and download

### DIFF
--- a/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/V2/createSolutionV2.ps1
@@ -2687,7 +2687,7 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
     $armTtkFolder = "$PSScriptRoot/../arm-ttk"
     if (!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)) {
         Write-Output "Missing arm-ttk validations. Downloading module..."
-        Invoke-Expression "$armTtkFolder/download-arm-ttk.ps1"
+        & (Join-Path $armTtkFolder "download-arm-ttk.ps1")
     }
-    Invoke-Expression ". '$armTtkFolder/run-arm-ttk-in-automation.ps1' '$solutionName'"
+    & (Join-Path $armTtkFolder "run-arm-ttk-in-automation.ps1") -SolutionName $solutionName
 }

--- a/Tools/Create-Azure-Sentinel-Solution/arm-ttk/download-arm-ttk.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/arm-ttk/download-arm-ttk.ps1
@@ -1,9 +1,8 @@
-# ARM-TTK release 20260213 (module 0.27), commit
-# 0ec9a41a4503e970a0ec8efb0cd08415cc172175.
+# ARM-TTK release 20260213 (module 0.27), commit 0ec9a41a4503e970a0ec8efb0cd08415cc172175.
 $armTtkUri = "https://github.com/Azure/arm-ttk/releases/download/20260213/arm-ttk.zip"
 $expectedSha256 = "2A2D21F17CC31299BA2C78CAF97DEF3C1F9F37EB3A7BAB7900CDA18C95D4C657"
 
-$root = Join-Path $PSScriptRoot ".."
+$root = Split-Path -Parent $PSScriptRoot
 $tmp = Join-Path $root "tmp"
 $ttkZip = Join-Path $tmp "AzTemplateToolKit.zip"
 $extractPath = Join-Path $tmp "arm-ttk-extract"
@@ -13,7 +12,14 @@ $moduleManifest = Join-Path $modulePath "arm-ttk.psd1"
 New-Item -Path $tmp -ItemType Directory -Force | Out-Null
 
 try {
-    Invoke-WebRequest -Uri $armTtkUri -OutFile $ttkZip -UseBasicParsing
+    $webRequestParameters = @{
+        Uri = $armTtkUri
+        OutFile = $ttkZip
+    }
+    if ($PSVersionTable.PSEdition -eq "Desktop") {
+        $webRequestParameters.UseBasicParsing = $true
+    }
+    Invoke-WebRequest @webRequestParameters
 
     $actualSha256 = (Get-FileHash -Path $ttkZip -Algorithm SHA256).Hash
     if ($actualSha256 -ne $expectedSha256) {
@@ -23,7 +29,7 @@ try {
     Remove-Item -Path $extractPath -Recurse -Force -ErrorAction SilentlyContinue
     Expand-Archive -Path $ttkZip -DestinationPath $extractPath -Force
 
-    $extractedModulePath = Join-Path $extractPath "arm-ttk/arm-ttk"
+    $extractedModulePath = Join-Path (Join-Path $extractPath "arm-ttk") "arm-ttk"
     $extractedModuleManifest = Join-Path $extractedModulePath "arm-ttk.psd1"
     if (-not (Test-Path -Path $extractedModuleManifest -PathType Leaf)) {
         throw "ARM-TTK archive does not contain the expected module manifest."

--- a/Tools/Create-Azure-Sentinel-Solution/arm-ttk/download-arm-ttk.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/arm-ttk/download-arm-ttk.ps1
@@ -1,19 +1,42 @@
-# Download and un-pack latest arm-ttk
-# This is the same way the certification team automation works, from the aka.ms URL
+# ARM-TTK release 20260213 (module 0.27), commit
+# 0ec9a41a4503e970a0ec8efb0cd08415cc172175.
+$armTtkUri = "https://github.com/Azure/arm-ttk/releases/download/20260213/arm-ttk.zip"
+$expectedSha256 = "2A2D21F17CC31299BA2C78CAF97DEF3C1F9F37EB3A7BAB7900CDA18C95D4C657"
 
-$root="$PSScriptRoot/.."
-$tmp="$root/tmp"
-New-Item -Path $tmp -ItemType Directory -Force
+$root = Join-Path $PSScriptRoot ".."
+$tmp = Join-Path $root "tmp"
+$ttkZip = Join-Path $tmp "AzTemplateToolKit.zip"
+$extractPath = Join-Path $tmp "arm-ttk-extract"
+$modulePath = Join-Path $tmp "arm-ttk"
+$moduleManifest = Join-Path $modulePath "arm-ttk.psd1"
 
-# Download arm-ttk and unpack it
-$ttkZip="$tmp/AzTemplateToolKit.zip"
+New-Item -Path $tmp -ItemType Directory -Force | Out-Null
 
-# we download the latest arm-ttk, DARSy uses the same steps
-# the arm-ttk is hosted on the public github here: https://github.com/Azure/arm-ttk
-Invoke-WebRequest -Uri "https://aka.ms/arm-ttk-latest" -OutFile $ttkZip -Verbose
-Expand-Archive -Path $ttkZip -DestinationPath $tmp -Force
+try {
+    Invoke-WebRequest -Uri $armTtkUri -OutFile $ttkZip -UseBasicParsing
 
-# try and import the module to see it works
-if(!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)){
-    Import-Module "$tmp/arm-ttk/arm-ttk.psd1"
+    $actualSha256 = (Get-FileHash -Path $ttkZip -Algorithm SHA256).Hash
+    if ($actualSha256 -ne $expectedSha256) {
+        throw "ARM-TTK archive checksum mismatch. Expected $expectedSha256 but received $actualSha256."
+    }
+
+    Remove-Item -Path $extractPath -Recurse -Force -ErrorAction SilentlyContinue
+    Expand-Archive -Path $ttkZip -DestinationPath $extractPath -Force
+
+    $extractedModulePath = Join-Path $extractPath "arm-ttk/arm-ttk"
+    $extractedModuleManifest = Join-Path $extractedModulePath "arm-ttk.psd1"
+    if (-not (Test-Path -Path $extractedModuleManifest -PathType Leaf)) {
+        throw "ARM-TTK archive does not contain the expected module manifest."
+    }
+
+    Remove-Item -Path $modulePath -Recurse -Force -ErrorAction SilentlyContinue
+    Move-Item -Path $extractedModulePath -Destination $modulePath
+}
+finally {
+    Remove-Item -Path $ttkZip -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $extractPath -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if (-not (Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)) {
+    Import-Module $moduleManifest
 }

--- a/Tools/Create-Azure-Sentinel-Solution/arm-ttk/run-arm-ttk-in-automation.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/arm-ttk/run-arm-ttk-in-automation.ps1
@@ -11,10 +11,11 @@ param(
 # Paths
 $repoRoot = $(git rev-parse --show-toplevel)
 $root="$repoRoot/Solutions"
-$tmp="$PSScriptRoot/tmp"
+$tmp = Join-Path (Split-Path -Parent $PSScriptRoot) "tmp"
+$moduleManifest = Join-Path (Join-Path $tmp "arm-ttk") "arm-ttk.psd1"
 
 if(!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)){
-    Import-Module "$tmp/arm-ttk/arm-ttk.psd1"
+    Import-Module $moduleManifest
 }
 
 # Run 'Test-AzTemplate' from the arm-ttk for given solution package

--- a/Tools/Create-Azure-Sentinel-Solution/arm-ttk/run-arm-ttk-in-automation.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/arm-ttk/run-arm-ttk-in-automation.ps1
@@ -3,11 +3,15 @@
 # This is a simplified version of run-arm-ttk.ps1 which outputs the results as is,
 #  without accounting for ADO Unit Test Formatting.
 
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$SolutionName
+)
+
 # Paths
 $repoRoot = $(git rev-parse --show-toplevel)
 $root="$repoRoot/Solutions"
 $tmp="$PSScriptRoot/tmp"
-$solutionName=$args[0]
 
 if(!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)){
     Import-Module "$tmp/arm-ttk/arm-ttk.psd1"
@@ -15,8 +19,8 @@ if(!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)){
 
 # Run 'Test-AzTemplate' from the arm-ttk for given solution package
 $solutions = Get-ChildItem $root -Directory
-if($solutionName){
-    $solutions = Get-Item "$root/$solutionName/Package"
+if($SolutionName){
+    $solutions = Get-Item "$root/$SolutionName/Package"
 }
 $fails = @()
 $skip = "poc","template", "automation"

--- a/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/common/commonFunctions.ps1
@@ -3014,9 +3014,9 @@ function RunArmTtkOnPackage {
         $armTtkFolder = "$PSScriptRoot/../arm-ttk"
         if (!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)) {
             Write-Output "Missing arm-ttk validations. Downloading module..."
-            Invoke-Expression "$armTtkFolder/download-arm-ttk.ps1"
+            & (Join-Path $armTtkFolder "download-arm-ttk.ps1")
         }
-        Invoke-Expression "& '$armTtkFolder/run-arm-ttk-in-automation.ps1' '$solutionName'"
+        & (Join-Path $armTtkFolder "run-arm-ttk-in-automation.ps1") -SolutionName $solutionName
     }
 }
 

--- a/Tools/Create-Azure-Sentinel-Solution/createSolution.ps1
+++ b/Tools/Create-Azure-Sentinel-Solution/createSolution.ps1
@@ -1406,7 +1406,7 @@ foreach ($inputFile in $(Get-ChildItem $path)) {
     $armTtkFolder = "$PSScriptRoot/arm-ttk"
     if (!$(Get-Command Test-AzTemplate -ErrorAction SilentlyContinue)) {
         Write-Output "Missing arm-ttk validations. Downloading module..."
-        Invoke-Expression "$armTtkFolder/download-arm-ttk.ps1"
+        & (Join-Path $armTtkFolder "download-arm-ttk.ps1")
     }
-    Invoke-Expression "$armTtkFolder/run-arm-ttk-in-automation.ps1 '$solutionName'"
+    & (Join-Path $armTtkFolder "run-arm-ttk-in-automation.ps1") -SolutionName $solutionName
 }


### PR DESCRIPTION
## Summary

Replaces Invoke-Expression with direct script invocation and argument passing, pins ARM-TTK to release 20260213, and verifies its SHA-256 before extraction and import.

## AI scan items

- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/129996
- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/130105

## Validation

PowerShell parsing passed; the pinned archive checksum and download/extraction path were verified.