### PR TITLE
Deny auto BlockIP on ML-only Firepower incidents (Gate/Prove)

### DIFF
--- a/Solutions/Cisco Firepower EStreamer/Data/Solution_Cisco Firepower EStreamer.json
+++ b/Solutions/Cisco Firepower EStreamer/Data/Solution_Cisco Firepower EStreamer.json
@@ -17,7 +17,7 @@
     "azuresentinel.azure-sentinel-solution-commoneventformat"
    ],
   "BasePath": "C:\\Github\\Azure-Sentinel\\Solutions\\Cisco Firepower EStreamer",
-  "Version": "3.0.1",
+  "Version": "3.0.3",
   "Metadata": "SolutionMetadata.json",
   "TemplateSpec": true,
   "Is1Pconnector": false

--- a/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-NetworkGroup/azuredeploy.json
+++ b/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-NetworkGroup/azuredeploy.json
@@ -2,49 +2,63 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "metadata": {
-        "title": "Block IP - Cisco Firepower", 
-        "description": "This playbook allows blocking of IPs in Cisco Firepower, using a **Network Group object**. This allows making changes to a Network Group selected members, instead of making Access List Entries. The Network Group object itself should be part of an Access List Entry.",
-        "mainSteps": ["When a new Sentinel incident is created, this playbook gets triggered and performs below actions.",
+        "title": "Block IP - Cisco Firepower",
+        "description": "Blocks IPs in Cisco Firepower via a Network Group object, with a Gate/Prove pre-check that DENIES automatic BlockIP when the incident is ML-only (SnortML / GID 411 / is_ml_only). Machine-learning confidence is not treated as a classic signature true positive. Signature or corroborated incidents still block.",
+        "mainSteps": [
+            "When a new Sentinel incident is created, this playbook gets triggered and performs below actions.",
+            "0. Gate/Prove: if incident title/description indicates ML-only (SnortML, GID 411, is_ml_only) without corroboration, comment and cancel - do not call FMC BlockIP.",
             "1. For the IPs we check if they are already selected for the Network Group object",
             "2. For the IPs not already selected for the Network Group object, add it so it gets blocked",
-            "3. Comment is added to Microsoft Sentinel incident", 
-            "![Microsoft Sentinel comment](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Cisco%20Firepower%20EStreamer/Playbooks/CiscoFirepower-BlockFQDN-NetworkGroup/Images/BlockFQDN-NetworkGroup-AzureSentinel-Comments.png)",
-            "** IP is added to Cisco Firepower Network Group object:**", 
-            "![Cisco Firepower Network Group object](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Cisco%20Firepower%20EStreamer/Playbooks/CiscoFirepower-BlockFQDN-NetworkGroup/Images/BlockFQDN-NetworkGroup-CiscoFirepowerAdd.png)"
+            "3. Comment is added to Microsoft Sentinel incident"
         ],
-        "prerequisites": ["1. Cisco Firepower custom connector needs to be deployed prior to the deployment of this playbook, in the same resource group and region. Relevant instructions can be found in the connector doc pages.",
+        "prerequisites": [
+            "1. Cisco Firepower custom connector needs to be deployed prior to the deployment of this playbook, in the same resource group and region. Relevant instructions can be found in the connector doc pages.",
             "2. In Cisco Firepower there needs to be a Network Group object. [Creating Network Objects](https://www.cisco.com/c/en/us/td/docs/security/firepower/630/configuration/guide/fpmc-config-guide-v63/reusable_objects.html#ariaid-title15)"
         ],
         "prerequisitesDeployTemplateFile": "../CustomConnector/azuredeploy.json",
-        "postDeployment": ["**a. Authorize connections**", 
-            "Once deployment is complete, you will need to authorize each connection.", 
-            "1. Click the Microsoft Sentinel connection resource", 
-            "2. Click edit API connection", 
-            "3. Click Authorize", 
-            "4. Sign in", 
-            "5. Click Save", 
-            "6. Repeat steps for other connections such as Cisco Firepower (For authorizing the Cisco Firepower API connection, the username and password needs to be provided)", 
-            "**b. Configurations in Sentinel**", 
-            "1. In Microsoft sentinel analytical rules should be configured to trigger an incident with IP Entity.", 
-            "2. Configure the automation rules to trigger this playbook"
+        "postDeployment": [
+            "**a. Authorize connections**",
+            "Once deployment is complete, you will need to authorize each connection.",
+            "1. Click the Microsoft Sentinel connection resource",
+            "2. Click edit API connection",
+            "3. Click Authorize",
+            "4. Sign in",
+            "5. Click Save",
+            "6. Repeat steps for other connections such as Cisco Firepower (For authorizing the Cisco Firepower API connection, the username and password needs to be provided)",
+            "**b. Configurations in Sentinel**",
+            "1. In Microsoft sentinel analytical rules should be configured to trigger an incident with IP Entity.",
+            "2. Configure the automation rules to trigger this playbook",
+            "**c. Dual-signal / Gate-Prove**",
+            "Do not attach this playbook to ML-only analytics (SnortML GID 411). Pair with the dual-signal analytic rules in this solution. Attach auto-BlockIP only to signature-high or signature+ML corroboration incidents. ML-only must escalate, not contain."
         ],
-        "lastUpdateTime": "2022-07-20T00:00:00.000Z", 
-        "entities": ["Ip"], 
-        "tags": ["Remediation"],
+        "lastUpdateTime": "2026-08-16T00:00:00.000Z",
+        "entities": [
+            "Ip"
+        ],
+        "tags": [
+            "Remediation"
+        ],
         "support": {
-            "tier": "Microsoft" 
+            "tier": "Microsoft"
         },
         "author": {
             "name": "Lior Tamir"
         },
         "releaseNotes": [
-        {
-            "version": "1.0.0",
-            "title": "Block IP - Cisco Firepower",
-            "notes": [
-            "Initial version"
-            ]
-        }
+            {
+                "version": "1.0.0",
+                "title": "Block IP - Cisco Firepower",
+                "notes": [
+                    "Initial version"
+                ]
+            },
+            {
+                "version": "1.1.0",
+                "title": "Gate/Prove ML-only deny auto-contain",
+                "notes": [
+                    "Deny automatic BlockIP when incident context is ML-only (SnortML / GID 411). Signature and corroborated paths unchanged."
+                ]
+            }
         ]
     },
     "parameters": {
@@ -114,7 +128,7 @@
             ],
             "tags": {
                 "hidden-SentinelTemplateName": "BlockIP-CiscoFirepower",
-                "hidden-SentinelTemplateVersion": "1.0"
+                "hidden-SentinelTemplateVersion": "1.1"
             },
             "identity": {
                 "type": "SystemAssigned"
@@ -152,7 +166,11 @@
                     },
                     "actions": {
                         "Entities_-_Get_IPs": {
-                            "runAfter": {},
+                            "runAfter": {
+                                "Gate_Prove_ML_only_deny_auto_contain": [
+                                    "Succeeded"
+                                ]
+                            },
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",
@@ -693,6 +711,137 @@
                                 "method": "post",
                                 "path": "/api/fmc_platform/v1/auth/revokeaccess"
                             }
+                        },
+                        "Initialize_Dual_signal_context": {
+                            "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "DualSignalContext",
+                                        "type": "string",
+                                        "value": "@{toLower(concat(coalesce(triggerBody()?['object']?['properties']?['title'], ''), ' ', coalesce(triggerBody()?['object']?['properties']?['description'], '')))}"
+                                    }
+                                ]
+                            },
+                            "description": "Concatenate incident title+description for dual-signal Gate/Prove (ML-only vs signature/corroborated)."
+                        },
+                        "Gate_Prove_ML_only_deny_auto_contain": {
+                            "actions": {
+                                "Add_comment_to_incident_(V3):_ML_only_deny_auto_contain": {
+                                    "runAfter": {},
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "body": {
+                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                            "message": "<p><span style=\"font-size: 16px\"><strong>Gate/Prove: ML-only - auto-contain DENIED</strong></span><br>This incident matches an ML-only path (SnortML / GID 411 / is_ml_only). Machine-learning confidence is <strong>not</strong> equivalent to a classic signature true positive. Automatic BlockIP was not applied. Escalate for corroboration (signature or dual-signal) before containment. Do not attach this playbook to ML-only analytics.</p>"
+                                        },
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/Incidents/Comment"
+                                    }
+                                },
+                                "Terminate:_ML_only_deny_auto_contain": {
+                                    "runAfter": {
+                                        "Add_comment_to_incident_(V3):_ML_only_deny_auto_contain": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Terminate",
+                                    "inputs": {
+                                        "runStatus": "Cancelled"
+                                    },
+                                    "description": "Kill-switch: do not call FMC BlockIP / Network Group APIs on ML-only incidents."
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_Dual_signal_context": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "else": {
+                                "actions": {}
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "or": [
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "gid 411"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "gid:411"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "generator id 411"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "snortml"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "is_ml_only"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "ml-only"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "dual-signal:ml-only"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "not": {
+                                            "or": [
+                                                {
+                                                    "contains": [
+                                                        "@variables('DualSignalContext')",
+                                                        "is_corroborated"
+                                                    ]
+                                                },
+                                                {
+                                                    "contains": [
+                                                        "@variables('DualSignalContext')",
+                                                        "dual-signal:corroborated"
+                                                    ]
+                                                },
+                                                {
+                                                    "contains": [
+                                                        "@variables('DualSignalContext')",
+                                                        "signature and ml"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "type": "If",
+                            "description": "Gate/Prove: deny auto-contain when ML-only (GID 411 / SnortML). Signature or corroborated incidents continue to BlockIP."
                         }
                     },
                     "outputs": {}

--- a/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-NetworkGroup/readme.md
+++ b/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-NetworkGroup/readme.md
@@ -5,6 +5,7 @@
 This playbook allows blocking of IPs in Cisco Firepower, using a **Network Group object**. This allows making changes to a Network Group selected members, instead of making Access List Entries. The Network Group object itself should be part of an Access List Entry.
 
 When a new Sentinel incident is created, this playbook gets triggered and performs below actions.
+0. **Gate/Prove:** if the incident title/description indicates **ML-only** (SnortML / GID 411 / `is_ml_only`) without signature or dual-signal corroboration, the playbook comments on the incident and **cancels** - it does **not** call FMC BlockIP. Machine-learning confidence is not treated as a classic signature true positive.
 1. For the IPs we check if they are already selected for the Network Group object
 2. For the IPs not already selected for the Network Group object, add it so it gets blocked
 3. Comment is added to Microsoft Sentinel incident<br>
@@ -49,3 +50,4 @@ Once deployment is complete, you will need to authorize each connection.
 ### b. Configurations in Sentinel
 1. In Microsoft sentinel analytical rules should be configured to trigger an incident with IP Entity.
 2. Configure the automation rules to trigger this playbook
+3. **Do not** attach this auto-contain playbook to ML-only analytics (SnortML GID 411). Attach it only to signature-high or signature+ML corroboration incidents. Use the Teams HITL playbook when an analyst must review an ML-only alert.

--- a/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-Teams/azuredeploy.json
+++ b/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-Teams/azuredeploy.json
@@ -3,8 +3,9 @@
     "contentVersion": "1.0.0.0",
     "metadata": {
         "title": "Block IP - Take Action from Teams - Cisco Firepower", 
-        "description": "This playbook allows blocking of IPs in Cisco Firepower, using a **Network Group object**. This allows making changes to a Network Group selected members, instead of making Access List Entries. The Network Group object itself should be part of an Access List Entry.",
+        "description": "HITL BlockIP via Teams Adaptive Card. Adds a Gate/Prove warning when the incident is ML-only (SnortML / GID 411 / is_ml_only). Analysts must not treat ML confidence as a signature true positive. Teams confirmation remains required before BlockIP.",
         "mainSteps":  ["When a new Sentinel incident is created, this playbook gets triggered and performs below actions.",
+            "0. Gate/Prove: if incident title/description indicates ML-only without corroboration, add an incident comment warning. Do not auto-block; Teams HITL continues.",
             "1. For the IPs we check if they are already selected for the Network Group object",
             "2. An adaptive card is sent to a Teams channel with information about the incident and giving the option to ignore an IP, or depending on it's current status block it by adding it to the Network Group object or unblock it by removing it from the Network Group object", 
             "![Teams Adaptive Card preview](https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Solutions/Cisco%20Firepower%20EStreamer/Playbooks/CiscoFirepower-BlockIP-Teams/Images/BlockIP-Teams-AdaptiveCard.png)", 
@@ -19,7 +20,7 @@
             "2. In Cisco Firepower there needs to be a Network Group object. [Creating Network Objects](https://www.cisco.com/c/en/us/td/docs/security/firepower/630/configuration/guide/fpmc-config-guide-v63/reusable_objects.html#ariaid-title15)"
         ],
         "prerequisitesDeployTemplateFile": "../CustomConnector/azuredeploy.json",
-        "lastUpdateTime": "2022-07-20T00:00:00.000Z", 
+        "lastUpdateTime": "2026-08-16T00:00:00.000Z", 
         "entities": ["Ip"], 
         "tags": ["Remediation", "Response from teams"],
         "postDeployment":["**a. Authorize connections**", 
@@ -39,7 +40,9 @@
             "5. Save the Logic App", 
             "**c. Configurations in Sentinel**", 
             "1. In Microsoft sentinel analytical rules should be configured to trigger an incident with IP Entity.", 
-            "2. Configure the automation rules to trigger this playbook"
+            "2. Configure the automation rules to trigger this playbook",
+            "**d. Dual-signal / Gate-Prove**",
+            "Prefer this HITL playbook for ML-only analytics (SnortML GID 411). Auto-BlockIP (NetworkGroup) must not be attached to ML-only incidents. Do not treat ML confidence as a signature true positive."
         ],
         "support": {
             "tier": "Microsoft" 
@@ -53,6 +56,13 @@
             "title": "Block IP - Take Action from Teams - Cisco Firepower",
             "notes": [
             "Initial version"
+            ]
+        },
+        {
+            "version": "1.1.0",
+            "title": "Gate/Prove ML-only HITL warning",
+            "notes": [
+            "Warn Teams operators when incident context is ML-only (SnortML / GID 411) before offering BlockIP. Does not auto-contain."
             ]
         }
         ]
@@ -139,7 +149,7 @@
             "tags": {
                 "LogicAppsCategory": "security",
                 "hidden-SentinelTemplateName": "BlockIP-Firepower-Teams",
-                "hidden-SentinelTemplateVersion": "1.0"
+                "hidden-SentinelTemplateVersion": "1.1"
             },
             "identity": {
                 "type": "SystemAssigned"
@@ -176,8 +186,131 @@
                         }
                     },
                     "actions": {
-                        "Entities_-_Get_IPs": {
+                        "Initialize_Dual_signal_context": {
                             "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "DualSignalContext",
+                                        "type": "string",
+                                        "value": "@{toLower(concat(coalesce(triggerBody()?['object']?['properties']?['title'], ''), ' ', coalesce(triggerBody()?['object']?['properties']?['description'], '')))}"
+                                    }
+                                ]
+                            },
+                            "description": "Concatenate incident title+description for dual-signal Gate/Prove warning on HITL BlockIP."
+                        },
+                        "Gate_Prove_ML_only_HITL_warning": {
+                            "actions": {
+                                "Add_comment_to_incident_(V3):_ML_only_HITL_warning": {
+                                    "runAfter": {},
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "body": {
+                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                            "message": "<p><span style=\"font-size: 16px\"><strong>Gate/Prove HITL warning: ML-only</strong></span><br>This incident matches an ML-only path (SnortML / GID 411 / is_ml_only). Do <strong>not</strong> equate ML confidence to a signature true positive. Prefer Ignore unless a classic signature or dual-signal corroboration is present. Analyst confirmation in Teams is still required before BlockIP.</p>"
+                                        },
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/Incidents/Comment"
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_Dual_signal_context": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "else": {
+                                "actions": {}
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "or": [
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "gid 411"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "gid:411"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "generator id 411"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "snortml"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "is_ml_only"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "ml-only"
+                                                ]
+                                            },
+                                            {
+                                                "contains": [
+                                                    "@variables('DualSignalContext')",
+                                                    "dual-signal:ml-only"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "not": {
+                                            "or": [
+                                                {
+                                                    "contains": [
+                                                        "@variables('DualSignalContext')",
+                                                        "is_corroborated"
+                                                    ]
+                                                },
+                                                {
+                                                    "contains": [
+                                                        "@variables('DualSignalContext')",
+                                                        "dual-signal:corroborated"
+                                                    ]
+                                                },
+                                                {
+                                                    "contains": [
+                                                        "@variables('DualSignalContext')",
+                                                        "signature and ml"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "type": "If",
+                            "description": "Gate/Prove: warn HITL operators when the incident is ML-only. Does not auto-block; Teams confirmation remains required."
+                        },
+                        "Entities_-_Get_IPs": {
+                            "runAfter": {
+                                "Gate_Prove_ML_only_HITL_warning": [
+                                    "Succeeded"
+                                ]
+                            },
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": "@triggerBody()?['object']?['properties']?['relatedEntities']",

--- a/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-Teams/readme.md
+++ b/Solutions/Cisco Firepower EStreamer/Playbooks/CiscoFirepower-BlockIP-Teams/readme.md
@@ -5,11 +5,12 @@
 This playbook allows blocking of IPs in Cisco Firepower, using a **Network Group object**. This allows making changes to a Network Group selected members, instead of making Access List Entries. The Network Group object itself should be part of an Access List Entry.
 
 When a new Sentinel incident is created, this playbook gets triggered and performs below actions.
-1. For the IPs we check if they are already selected for the Network Group object
-2. An adaptive card is sent to a Teams channel with information about the incident and giving the option to ignore an IP, or depending on it's current status block it by adding it to the Network Group object or unblock it by removing it from the Network Group object
+1. **Gate/Prove:** if the incident title/description indicates **ML-only** (SnortML / GID 411 / `is_ml_only`) without corroboration, an incident comment warns the operator. The playbook does **not** auto-block; Teams confirmation is still required. Do not treat ML confidence as a signature true positive.
+2. For the IPs we check if they are already selected for the Network Group object
+3. An adaptive card is sent to a Teams channel with information about the incident and giving the option to ignore an IP, or depending on it's current status block it by adding it to the Network Group object or unblock it by removing it from the Network Group object
     ![Teams Adaptive Card preview](./Images/BlockIP-Teams-AdaptiveCard.png)
-3. The chosen changes are applied to the Network Group object
-4. Comment is added to Microsoft Sentinel incident
+4. The chosen changes are applied to the Network Group object
+5. Comment is added to Microsoft Sentinel incident
     ![Microsoft Sentinel comment](./Images/BlockIP-Teams-AzureSentinel-Comments.png)
 
 ** IP is added to Cisco Firepower Network Group object:**
@@ -58,3 +59,4 @@ The Teams channel to which the adaptive card will be posted will need to be conf
 #### c. Configurations in Sentinel
 1. In Microsoft sentinel analytical rules should be configured to trigger an incident with IP Entity.
 2. Configure the automation rules to trigger this playbook
+3. Prefer this HITL playbook for ML-only analytics (SnortML GID 411). Do not attach the auto-contain NetworkGroup playbook to ML-only incidents.

--- a/Solutions/Cisco Firepower EStreamer/Playbooks/readme.md
+++ b/Solutions/Cisco Firepower EStreamer/Playbooks/readme.md
@@ -82,8 +82,8 @@ Custom connector should be deployed in the Resource Group where the playbooks th
 ## 2. Deploy the required playbook template (or create your own playbook from scratch)
 This integration offers 3 playbook templates that blocks IP in 3 different methods. Each one has it's own documentation and quick deployment button:
 * [Cisco Firepower - Add FQDN to a Network Group object](./CiscoFirepower-BlockFQDN-NetworkGroup#deployment-instructions)
-* [Cisco Firepower - Add IP Addresses to a Network Group object](./CiscoFirepower-BlockIP-NetworkGroup#deployment-instructions)
-* [Cisco Firepower - Add IP Addresses to a Network Group object with Teams](./CiscoFirepower-BlockIP-Teams#deployment-instructions)
+* [Cisco Firepower - Add IP Addresses to a Network Group object](./CiscoFirepower-BlockIP-NetworkGroup#deployment-instructions) — auto-contain. **Gate/Prove:** denied when the incident is ML-only (SnortML / GID 411). Attach only to signature-high or corroborated analytics.
+* [Cisco Firepower - Add IP Addresses to a Network Group object with Teams](./CiscoFirepower-BlockIP-Teams#deployment-instructions) — HITL. Warns on ML-only; analyst confirmation is still required before BlockIP.
 
 
 <a name="references"></a>

--- a/Solutions/Cisco Firepower EStreamer/ReleaseNotes.md
+++ b/Solutions/Cisco Firepower EStreamer/ReleaseNotes.md
@@ -1,4 +1,5 @@
 | **Version** | **Date Modified (DD-MM-YYYY)** | **Change History**                                                  | 
 |-------------|--------------------------------|---------------------------------------------------------------------|
+| 3.0.3       | 16-08-2026                     | Gate/Prove on BlockIP playbooks: deny auto-contain for ML-only (SnortML GID 411); Teams HITL warning. |
 | 3.0.1       | 10-07-2024                     |    Deprecating data connectors.                                     |
 | 3.0.0       | 26-09-2023                     |	Addition of new Cisco Firepower EStreamer AMA **Data Connector** |


### PR DESCRIPTION
## Proposed Changes

Compounds [#14925](https://github.com/Azure/Azure-Sentinel/pull/14925): the dual-signal analytic rules are not enough if **CiscoFirepower-BlockIP-NetworkGroup** still auto-contains on ML-only incidents.

**Hard rule:** ML confidence ≠ signature true positive.

| Playbook | Gate/Prove behavior |
|---|---|
| **CiscoFirepower-BlockIP-NetworkGroup** (auto-contain) | If incident title/description is ML-only (SnortML / GID 411 / `is_ml_only`) **without** corroboration (`is_corroborated` / signature+ML), comment and **Terminate/Cancelled** — no FMC Network Group APIs |
| **CiscoFirepower-BlockIP-Teams** (HITL) | Same ML-only path: **warning comment only**. Teams Adaptive Card still requires analyst confirmation before BlockIP |

Signature-high and signature+ML corroborated incidents are unchanged (NetworkGroup still blocks; Teams still HITL).

Solution metadata bumped to `3.0.3` (playbooks). If #14925 (`3.0.2`) is not merged yet, maintainers can collapse versions on merge. Playbook template version `1.0` → `1.1`.

### Wiring

- Attach **auto-BlockIP (NetworkGroup)** only to signature-high or corroboration analytics.
- Attach **Teams HITL** when an analyst must review ML-only (GID 411) alerts.
- Do **not** attach NetworkGroup auto-contain to ML-only analytics.

### Portable sisters

- Analytics (this solution): https://github.com/Azure/Azure-Sentinel/pull/14925
- OCSF: https://github.com/ocsf/ocsf-schema/pull/1732
- Sigma: https://github.com/SigmaHQ/sigma/pull/6237
- Elastic: https://github.com/elastic/detection-rules/pull/6662
- OpenCTI: https://github.com/OpenCTI-Platform/connectors/pull/7298
- Splunk: https://github.com/splunk/security_content/issues/4220

Optional production Gate/Prove consumer (paid Continuous Trust, not unpaid R&D): https://github.com/AAH20/aegis-decision-fabric · https://a2zsoc.com/consultation

### Checklist

- [x] ARM JSON remains valid (`json.loads`)
- [x] NetworkGroup: ML-only → comment + Terminate before `Entities - Get IPs`
- [x] Teams: ML-only → warning comment; does **not** terminate; HITL continues
- [x] Playbook `hidden-SentinelTemplateVersion` 1.1 + releaseNotes 1.1.0
- [ ] CLA signed if prompted (personal CLA already agreed on #14925)
- [ ] Package rebuild by maintainers if required for Content Hub publish

### Test plan

- [ ] Deploy NetworkGroup playbook; trigger with incident title containing `SnortML` / `GID 411` / `is_ml_only` and **no** corroboration markers → incident comment, run Cancelled, **no** FMC BlockIP
- [ ] Same playbook with signature-high or `is_corroborated` / `signature and ml` in the incident → BlockIP path unchanged
- [ ] Deploy Teams playbook; ML-only incident → warning comment **and** Adaptive Card still posted
- [ ] Confirm automation rules: NetworkGroup **not** bound to ML-only analytics

Made with [Cursor](https://cursor.com)