### PR TITLE
Add hunting queries: break-glass account hunting pack (3 queries)

### DIFF
--- a/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
@@ -15,9 +15,9 @@ description-detailed: |
   named `BreakGlassAccounts` with a single column, `AccountUPN`, listing the user principal names
   of the tenant's designated emergency access accounts.
   Every match should be checked against the change calendar for a planned access-recovery test
-  before escalating. A match with no corresponding test window, or one immediately followed by a
-  sign-in from the same account (see the companion hunting query), should be treated as high
-  priority.
+  before escalating. A match with no corresponding test window, or one closely followed by a
+  sign-in or a role and group membership change on the same account (see the two companion
+  hunting queries in this pack), should be treated as high priority.
   References:
   - https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access
   - https://attack.mitre.org/techniques/T1098/

--- a/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
@@ -55,7 +55,7 @@ query: |
   // official "Multiple Password Reset by user" analytic rule does it: any OperationName
   // that mentions a password/credential noun together with a change/reset verb, admin or
   // self-service alike, rather than an exact-string list that silently misses variants.
-  let PasswordWords = dynamic(["password", "credentials"]);
+  let PasswordWords = dynamic(["password", "credential", "credentials"]);
   let ChangeActionWords = dynamic(["change", "changed", "reset"]);
   AuditLogs
   | where TimeGenerated between (starttime .. endtime)

--- a/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
@@ -1,0 +1,104 @@
+id: 67657f61-a999-4c64-9093-e988d8d98f63
+name: Break-glass account credentials or MFA modified
+description: |
+  Identifies password resets, security-info registrations, and MFA changes made to an account
+  designated as an emergency break-glass account, which should otherwise remain untouched
+  between scheduled tests.
+description-detailed: |
+  Break-glass (emergency access) accounts exist to remain usable when every other authentication
+  path in the tenant has failed, which only works if their credentials and registered security
+  info stay exactly as documented between the periodic tests organizations run to validate them.
+  A password reset or a change to registered MFA methods outside a documented test window is a
+  strong signal that either the account is being repurposed by an attacker for persistence, or
+  that its emergency-access properties have silently drifted out of the state the runbook expects.
+  This query depends on the same watchlist as the companion sign-in hunting query: a watchlist
+  named `BreakGlassAccounts` with a single column, `AccountUPN`, listing the user principal names
+  of the tenant's designated emergency access accounts.
+  Every match should be checked against the change calendar for a planned access-recovery test
+  before escalating. A match with no corresponding test window, or one immediately followed by a
+  sign-in from the same account (see the companion hunting query), should be treated as high
+  priority.
+  References:
+  - https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access
+  - https://attack.mitre.org/techniques/T1098/
+  - https://attack.mitre.org/techniques/T1556/006/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - DefenseEvasion
+relevantTechniques:
+  - T1098
+  - T1556.006
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let BreakGlassAccounts = (
+      _GetWatchlist('BreakGlassAccounts')
+      | project AccountUPN = tolower(tostring(AccountUPN))
+  );
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where Result =~ "success"
+  | where Category =~ "UserManagement"
+  | where OperationName in~ (
+      "Admin registered security info",
+      "Admin updated security info",
+      "Admin deleted security info",
+      "User registered security info",
+      "User changed default security info",
+      "User deleted security info",
+      "User registered all required security info",
+      "User started security info registration",
+      "Reset password (self-service)",
+      "Reset user password",
+      "Change user password")
+  | extend TargetUpn = tolower(tostring(TargetResources[0].userPrincipalName))
+  | where TargetUpn in (BreakGlassAccounts)
+  | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+  | extend ActorApp = tostring(InitiatedBy.app.displayName)
+  | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+  | extend ActorIp  = iff(
+        isnotempty(tostring(InitiatedBy.user.ipAddress)),
+        tostring(InitiatedBy.user.ipAddress),
+        tostring(InitiatedBy.app.ipAddress))
+  | extend AccountName      = tostring(split(TargetUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(TargetUpn, "@")[1])
+  | project
+      TimeGenerated,
+      OperationName,
+      TargetUpn,
+      AccountName,
+      AccountUPNSuffix,
+      Actor,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: TargetUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+customDetails:
+  OperationName: OperationName
+  Actor: Actor
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
@@ -11,7 +11,7 @@ description-detailed: |
   A password reset or a change to registered MFA methods outside a documented test window is a
   strong signal that either the account is being repurposed by an attacker for persistence, or
   that its emergency-access properties have silently drifted out of the state the runbook expects.
-  This query depends on the same watchlist as the companion sign-in hunting query: a watchlist
+  This query depends on the same watchlist as the other two queries in this pack: a watchlist
   named `BreakGlassAccounts` with a single column, `AccountUPN`, listing the user principal names
   of the tenant's designated emergency access accounts.
   Every match should be checked against the change calendar for a planned access-recovery test
@@ -39,11 +39,7 @@ query: |
       _GetWatchlist('BreakGlassAccounts')
       | project AccountUPN = tolower(tostring(AccountUPN))
   );
-  AuditLogs
-  | where TimeGenerated between (starttime .. endtime)
-  | where Result =~ "success"
-  | where Category =~ "UserManagement"
-  | where OperationName in~ (
+  let SecurityInfoOps = dynamic([
       "Admin registered security info",
       "Admin updated security info",
       "Admin deleted security info",
@@ -51,11 +47,29 @@ query: |
       "User changed default security info",
       "User deleted security info",
       "User registered all required security info",
-      "User started security info registration",
-      "Reset password (self-service)",
-      "Reset user password",
-      "Change user password")
-  | extend TargetUpn = tolower(tostring(TargetResources[0].userPrincipalName))
+      "User started security info registration"
+  ]);
+  // Password reset/change operation names are not consistent across tenants and Entra ID
+  // service versions (this repo alone has three different exact-string lists for the same
+  // event in other hunting queries), so credential resets are matched the same way the
+  // official "Multiple Password Reset by user" analytic rule does it: any OperationName
+  // that mentions a password/credential noun together with a change/reset verb, admin or
+  // self-service alike, rather than an exact-string list that silently misses variants.
+  let PasswordWords = dynamic(["password", "credentials"]);
+  let ChangeActionWords = dynamic(["change", "changed", "reset"]);
+  AuditLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where Result =~ "success"
+  | where OperationName in~ (SecurityInfoOps)
+        or (OperationName has_any (PasswordWords) and OperationName has_any (ChangeActionWords))
+  // The target user is read from whichever TargetResources entry has type "User" rather
+  // than a fixed array index, since these operations do not consistently place the target
+  // first; this matches the extraction used elsewhere in this repository for password
+  // reset events specifically.
+  | mv-apply TargetResource = TargetResources on (
+        where TargetResource.type =~ "User"
+        | extend TargetUpn = tolower(tostring(TargetResource.userPrincipalName))
+    )
   | where TargetUpn in (BreakGlassAccounts)
   | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
   | extend ActorApp = tostring(InitiatedBy.app.displayName)

--- a/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountCredentialsModified.yaml
@@ -12,8 +12,8 @@ description-detailed: |
   strong signal that either the account is being repurposed by an attacker for persistence, or
   that its emergency-access properties have silently drifted out of the state the runbook expects.
   This query depends on the same watchlist as the other two queries in this pack: a watchlist
-  named `BreakGlassAccounts` with a single column, `AccountUPN`, listing the user principal names
-  of the tenant's designated emergency access accounts.
+  named `BreakGlassAccounts` whose `SearchKey` column holds the user principal names of the
+  tenant's designated emergency access accounts.
   Every match should be checked against the change calendar for a planned access-recovery test
   before escalating. A match with no corresponding test window, or one closely followed by a
   sign-in or a role and group membership change on the same account (see the two companion
@@ -37,7 +37,7 @@ query: |
   let endtime = todatetime('{{EndTimeISO}}');
   let BreakGlassAccounts = (
       _GetWatchlist('BreakGlassAccounts')
-      | project AccountUPN = tolower(tostring(AccountUPN))
+      | project AccountUPN = tolower(tostring(SearchKey))
   );
   let SecurityInfoOps = dynamic([
       "Admin registered security info",

--- a/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
@@ -13,10 +13,11 @@ description-detailed: |
   Two paths lead to the same outcome and both are covered here. A direct role assignment or
   removal shows up as an "Add member to role" or "Remove member from role" event with the
   break-glass account as the target. A group-mediated change, where the account is added to
-  or removed from a group, including a role-assignable group, is read from the same
-  TargetResources entry as the membership event itself rather than from a fixed array index,
-  since an audit event can carry multiple resources and their ordering is not guaranteed;
-  this mirrors the extraction used elsewhere in this repository for the same operations. An
+  or removed from a group, including a role-assignable group, shows up as a group membership
+  event instead. In both paths the account and the changed object are read from whichever
+  TargetResources entry describes the user rather than from a fixed array index, since an
+  audit event can carry multiple resources and their ordering is not guaranteed; this mirrors
+  the extraction used elsewhere in this repository for the same operations. An
   attacker who quietly folds a break-glass account into a role-assignable group inherits
   whatever role that group holds without ever generating a role-assignment event against the
   account directly, which is precisely why both paths need to be watched together.
@@ -55,17 +56,23 @@ query: |
   // build the name lookup, once as the left side of the join back to it). Without pinning
   // it to a single computed result, the two references would each re-evaluate new_guid()
   // independently, so the RowId used to join would never match itself.
+  // The break-glass account and the role name are both read from whichever TargetResources
+  // entry describes the user, not from a fixed array index, for the same reason as the
+  // group section below.
   let RoleChangesBase = materialize(
       AuditLogs
       | where TimeGenerated between (starttime .. endtime)
       | where Category =~ "RoleManagement"
-      | where OperationName in~ ("Add member to role", "Add member to role.", "Remove member from role")
+      | where OperationName in~ ("Add member to role", "Add member to role.", "Remove member from role", "Remove member from role.")
       | where Result =~ "success"
-      | extend TargetUpn = tolower(tostring(TargetResources[0].userPrincipalName))
+      | mv-apply TargetResource = TargetResources on (
+            where TargetResource.type =~ "User"
+            | extend TargetUpn = tolower(tostring(TargetResource.userPrincipalName)),
+                     RoleProps = TargetResource.modifiedProperties
+        )
       | where TargetUpn in (BreakGlassAccounts)
       | extend RowId      = new_guid()
       | extend ChangeType = iff(OperationName has "Add", "RoleAdded", "RoleRemoved")
-      | extend RoleProps  = TargetResources[0].modifiedProperties
       | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
       | extend ActorApp = tostring(InitiatedBy.app.displayName)
       | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
@@ -122,7 +129,7 @@ query: |
       | project RowId, Properties
       | mv-expand Property = Properties
       | where tostring(Property.displayName) =~ "Group.DisplayName"
-      | project RowId, ChangedObject = trim('"', tostring(Property.newValue));
+      | project RowId, ChangedObject = trim('"', tostring(coalesce(Property.newValue, Property.oldValue)));
   let GroupChanges =
       GroupChangesBase
       | join kind=leftouter GroupNames on RowId

--- a/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
@@ -51,7 +51,11 @@ query: |
   // A base row is always kept even when the property lookup below finds nothing, so a
   // removal event whose modifiedProperties happen to be shaped differently than expected
   // still surfaces instead of silently disappearing.
-  let RoleChangesBase =
+  // materialize() is required here: RoleChangesBase is referenced twice below (once to
+  // build the name lookup, once as the left side of the join back to it). Without pinning
+  // it to a single computed result, the two references would each re-evaluate new_guid()
+  // independently, so the RowId used to join would never match itself.
+  let RoleChangesBase = materialize(
       AuditLogs
       | where TimeGenerated between (starttime .. endtime)
       | where Category =~ "RoleManagement"
@@ -68,7 +72,8 @@ query: |
       | extend ActorIp  = iff(
             isnotempty(tostring(InitiatedBy.user.ipAddress)),
             tostring(InitiatedBy.user.ipAddress),
-            tostring(InitiatedBy.app.ipAddress));
+            tostring(InitiatedBy.app.ipAddress))
+  );
   let RoleNames =
       RoleChangesBase
       | project RowId, RoleProps
@@ -80,7 +85,10 @@ query: |
       | join kind=leftouter RoleNames on RowId
       | extend ChangedObject = iff(isempty(ChangedObject), "(role name unavailable)", ChangedObject)
       | project TimeGenerated, OperationName, ChangeType, ChangedObject, TargetUpn, Actor, ActorIp, CorrelationId;
-  let GroupChangesBase =
+  // Same reasoning as RoleChangesBase above: materialize() pins the result, including
+  // RowId, so the two references below see identical values instead of two independent
+  // new_guid() evaluations that would never match each other.
+  let GroupChangesBase = materialize(
       AuditLogs
       | where TimeGenerated between (starttime .. endtime)
       | where Category =~ "GroupManagement"
@@ -107,7 +115,8 @@ query: |
                      Properties = TargetResource.modifiedProperties
         )
       | where TargetUpn in (BreakGlassAccounts)
-      | extend RowId = new_guid();
+      | extend RowId = new_guid()
+  );
   let GroupNames =
       GroupChangesBase
       | project RowId, Properties

--- a/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
@@ -21,7 +21,7 @@ description-detailed: |
   whatever role that group holds without ever generating a role-assignment event against the
   account directly, which is precisely why both paths need to be watched together.
   This query depends on the same watchlist as the two companion break-glass hunting queries:
-  a watchlist named `BreakGlassAccounts` with a single column, `AccountUPN`, listing the user
+  a watchlist named `BreakGlassAccounts` whose `SearchKey` column holds the user
   principal names of the tenant's designated emergency access accounts.
   Every match should be checked against the change calendar for a documented emergency-access
   review or test. A change with no corresponding record, an unfamiliar actor, or one that
@@ -45,7 +45,7 @@ query: |
   let endtime = todatetime('{{EndTimeISO}}');
   let BreakGlassAccounts = (
       _GetWatchlist('BreakGlassAccounts')
-      | project AccountUPN = tolower(tostring(AccountUPN))
+      | project AccountUPN = tolower(tostring(SearchKey))
   );
   // Role and group names are extracted from modifiedProperties as an enrichment step only.
   // A base row is always kept even when the property lookup below finds nothing, so a

--- a/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
@@ -47,7 +47,11 @@ query: |
       _GetWatchlist('BreakGlassAccounts')
       | project AccountUPN = tolower(tostring(AccountUPN))
   );
-  let RoleChanges =
+  // Role and group names are extracted from modifiedProperties as an enrichment step only.
+  // A base row is always kept even when the property lookup below finds nothing, so a
+  // removal event whose modifiedProperties happen to be shaped differently than expected
+  // still surfaces instead of silently disappearing.
+  let RoleChangesBase =
       AuditLogs
       | where TimeGenerated between (starttime .. endtime)
       | where Category =~ "RoleManagement"
@@ -55,19 +59,28 @@ query: |
       | where Result =~ "success"
       | extend TargetUpn = tolower(tostring(TargetResources[0].userPrincipalName))
       | where TargetUpn in (BreakGlassAccounts)
-      | mv-expand ModProp = TargetResources[0].modifiedProperties
-      | where tostring(ModProp.displayName) =~ "Role.DisplayName"
-      | extend ChangedObject = trim('"', tostring(coalesce(ModProp.newValue, ModProp.oldValue)))
+      | extend RowId      = new_guid()
       | extend ChangeType = iff(OperationName has "Add", "RoleAdded", "RoleRemoved")
+      | extend RoleProps  = TargetResources[0].modifiedProperties
       | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
       | extend ActorApp = tostring(InitiatedBy.app.displayName)
       | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
       | extend ActorIp  = iff(
             isnotempty(tostring(InitiatedBy.user.ipAddress)),
             tostring(InitiatedBy.user.ipAddress),
-            tostring(InitiatedBy.app.ipAddress))
+            tostring(InitiatedBy.app.ipAddress));
+  let RoleNames =
+      RoleChangesBase
+      | project RowId, RoleProps
+      | mv-expand ModProp = RoleProps
+      | where tostring(ModProp.displayName) =~ "Role.DisplayName"
+      | project RowId, ChangedObject = trim('"', tostring(coalesce(ModProp.newValue, ModProp.oldValue)));
+  let RoleChanges =
+      RoleChangesBase
+      | join kind=leftouter RoleNames on RowId
+      | extend ChangedObject = iff(isempty(ChangedObject), "(role name unavailable)", ChangedObject)
       | project TimeGenerated, OperationName, ChangeType, ChangedObject, TargetUpn, Actor, ActorIp, CorrelationId;
-  let GroupChanges =
+  let GroupChangesBase =
       AuditLogs
       | where TimeGenerated between (starttime .. endtime)
       | where Category =~ "GroupManagement"
@@ -80,21 +93,31 @@ query: |
             isnotempty(tostring(InitiatedBy.user.ipAddress)),
             tostring(InitiatedBy.user.ipAddress),
             tostring(InitiatedBy.app.ipAddress))
+      | extend ChangeType = case(
+            OperationName has_cs "Add" and OperationName has_cs "owner", "GroupOwnerAdded",
+            OperationName has_cs "Add", "GroupMemberAdded",
+            OperationName has_cs "owner", "GroupOwnerRemoved",
+            "GroupMemberRemoved")
+      // The break-glass account is identified from the same TargetResources entry that
+      // carries its own modifiedProperties, not from a fixed array index, since an audit
+      // event can carry multiple resources and their ordering is not guaranteed.
       | mv-apply TargetResource = TargetResources on (
             where TargetResource.type =~ "User"
             | extend TargetUpn  = tolower(tostring(TargetResource.userPrincipalName)),
                      Properties = TargetResource.modifiedProperties
         )
       | where TargetUpn in (BreakGlassAccounts)
-      | mv-apply Property = Properties on (
-            where Property.displayName =~ "Group.DisplayName"
-            | extend ChangedObject = trim('"', tostring(Property.newValue))
-        )
-      | extend ChangeType = case(
-            OperationName has_cs "Add" and OperationName has_cs "owner", "GroupOwnerAdded",
-            OperationName has_cs "Add", "GroupMemberAdded",
-            OperationName has_cs "owner", "GroupOwnerRemoved",
-            "GroupMemberRemoved")
+      | extend RowId = new_guid();
+  let GroupNames =
+      GroupChangesBase
+      | project RowId, Properties
+      | mv-expand Property = Properties
+      | where tostring(Property.displayName) =~ "Group.DisplayName"
+      | project RowId, ChangedObject = trim('"', tostring(Property.newValue));
+  let GroupChanges =
+      GroupChangesBase
+      | join kind=leftouter GroupNames on RowId
+      | extend ChangedObject = iff(isempty(ChangedObject), "(group name unavailable)", ChangedObject)
       | project TimeGenerated, OperationName, ChangeType, ChangedObject, TargetUpn, Actor, ActorIp, CorrelationId;
   union RoleChanges, GroupChanges
   | extend AccountName      = tostring(split(TargetUpn, "@")[0])

--- a/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
+++ b/Hunting Queries/AuditLogs/BreakGlassAccountRoleOrGroupMembershipChanged.yaml
@@ -1,0 +1,140 @@
+id: 4f529b32-a4ed-40d0-b40b-7ac337a705be
+name: Break-glass account role or group membership changed
+description: |
+  Identifies role and group membership changes on an account designated as an emergency
+  break-glass account, whose access is meant to stay fixed to the single role documented
+  in the tenant's emergency-access runbook.
+description-detailed: |
+  A break-glass account earns its trust from being boring: it is provisioned once with a
+  single static directory role, usually Global Administrator, no group memberships, and no
+  further changes until the next scheduled test. That predictability is exactly what lets an
+  analyst treat every membership change on the account as significant rather than trying to
+  separate signal from routine administrative noise.
+  Two paths lead to the same outcome and both are covered here. A direct role assignment or
+  removal shows up as an "Add member to role" or "Remove member from role" event with the
+  break-glass account as the target. A group-mediated change, where the account is added to
+  or removed from a group, including a role-assignable group, is read from the same
+  TargetResources entry as the membership event itself rather than from a fixed array index,
+  since an audit event can carry multiple resources and their ordering is not guaranteed;
+  this mirrors the extraction used elsewhere in this repository for the same operations. An
+  attacker who quietly folds a break-glass account into a role-assignable group inherits
+  whatever role that group holds without ever generating a role-assignment event against the
+  account directly, which is precisely why both paths need to be watched together.
+  This query depends on the same watchlist as the two companion break-glass hunting queries:
+  a watchlist named `BreakGlassAccounts` with a single column, `AccountUPN`, listing the user
+  principal names of the tenant's designated emergency access accounts.
+  Every match should be checked against the change calendar for a documented emergency-access
+  review or test. A change with no corresponding record, an unfamiliar actor, or one that
+  lands close in time to a sign-in or credential change on the same account (see the two
+  companion hunting queries) should be treated as high priority.
+  References:
+  - https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access
+  - https://learn.microsoft.com/entra/identity/role-based-access-control/groups-concept
+  - https://attack.mitre.org/techniques/T1098/003/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+tactics:
+  - Persistence
+  - PrivilegeEscalation
+relevantTechniques:
+  - T1098.003
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let BreakGlassAccounts = (
+      _GetWatchlist('BreakGlassAccounts')
+      | project AccountUPN = tolower(tostring(AccountUPN))
+  );
+  let RoleChanges =
+      AuditLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where Category =~ "RoleManagement"
+      | where OperationName in~ ("Add member to role", "Add member to role.", "Remove member from role")
+      | where Result =~ "success"
+      | extend TargetUpn = tolower(tostring(TargetResources[0].userPrincipalName))
+      | where TargetUpn in (BreakGlassAccounts)
+      | mv-expand ModProp = TargetResources[0].modifiedProperties
+      | where tostring(ModProp.displayName) =~ "Role.DisplayName"
+      | extend ChangedObject = trim('"', tostring(coalesce(ModProp.newValue, ModProp.oldValue)))
+      | extend ChangeType = iff(OperationName has "Add", "RoleAdded", "RoleRemoved")
+      | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+      | extend ActorApp = tostring(InitiatedBy.app.displayName)
+      | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+      | extend ActorIp  = iff(
+            isnotempty(tostring(InitiatedBy.user.ipAddress)),
+            tostring(InitiatedBy.user.ipAddress),
+            tostring(InitiatedBy.app.ipAddress))
+      | project TimeGenerated, OperationName, ChangeType, ChangedObject, TargetUpn, Actor, ActorIp, CorrelationId;
+  let GroupChanges =
+      AuditLogs
+      | where TimeGenerated between (starttime .. endtime)
+      | where Category =~ "GroupManagement"
+      | where OperationName in~ ("Add member to group", "Add owner to group", "Remove member from group", "Remove owner from group")
+      | where Result =~ "success"
+      | extend ActorUpn = tostring(InitiatedBy.user.userPrincipalName)
+      | extend ActorApp = tostring(InitiatedBy.app.displayName)
+      | extend Actor    = iff(isnotempty(ActorUpn), ActorUpn, ActorApp)
+      | extend ActorIp  = iff(
+            isnotempty(tostring(InitiatedBy.user.ipAddress)),
+            tostring(InitiatedBy.user.ipAddress),
+            tostring(InitiatedBy.app.ipAddress))
+      | mv-apply TargetResource = TargetResources on (
+            where TargetResource.type =~ "User"
+            | extend TargetUpn  = tolower(tostring(TargetResource.userPrincipalName)),
+                     Properties = TargetResource.modifiedProperties
+        )
+      | where TargetUpn in (BreakGlassAccounts)
+      | mv-apply Property = Properties on (
+            where Property.displayName =~ "Group.DisplayName"
+            | extend ChangedObject = trim('"', tostring(Property.newValue))
+        )
+      | extend ChangeType = case(
+            OperationName has_cs "Add" and OperationName has_cs "owner", "GroupOwnerAdded",
+            OperationName has_cs "Add", "GroupMemberAdded",
+            OperationName has_cs "owner", "GroupOwnerRemoved",
+            "GroupMemberRemoved")
+      | project TimeGenerated, OperationName, ChangeType, ChangedObject, TargetUpn, Actor, ActorIp, CorrelationId;
+  union RoleChanges, GroupChanges
+  | extend AccountName      = tostring(split(TargetUpn, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(TargetUpn, "@")[1])
+  | project
+      TimeGenerated,
+      OperationName,
+      ChangeType,
+      ChangedObject,
+      TargetUpn,
+      AccountName,
+      AccountUPNSuffix,
+      Actor,
+      ActorIp,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: TargetUpn
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActorIp
+customDetails:
+  ChangeType: ChangeType
+  ChangedObject: ChangedObject
+  Actor: Actor
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/SigninLogs/BreakGlassAccountSignIn.yaml
+++ b/Hunting Queries/SigninLogs/BreakGlassAccountSignIn.yaml
@@ -1,0 +1,92 @@
+id: 1685c69b-d03b-4e71-8171-879d6fefad2d
+name: Break-glass account sign-in detected
+description: |
+  Identifies any sign-in from an account designated as an emergency break-glass account. These
+  accounts exist purely as a last-resort fallback and should show no sign-in activity outside a
+  scheduled quarterly test or a genuine tenant-wide lockout.
+description-detailed: |
+  Break-glass (emergency access) accounts are cloud-only, highly privileged accounts that
+  organizations deliberately exclude from Conditional Access policies and day-to-day MFA
+  enforcement so they remain usable if every other authentication path fails. Because of that
+  exclusion, a successful sign-in to one of these accounts bypasses the same controls that
+  protect every other identity in the tenant, and Microsoft's own guidance is that sign-in and
+  credential-change activity on them should be monitored continuously.
+  This query depends on a watchlist named `BreakGlassAccounts` with a single column,
+  `AccountUPN`, listing the user principal names of the tenant's designated emergency access
+  accounts. Populate it once from the tenant's documented break-glass account inventory; there
+  is no reliable way to infer these accounts from sign-in data alone.
+  Any match here should be validated against the change calendar for a planned access-recovery
+  test. Sign-ins that fall outside a documented test window, that originate from an unexpected
+  IP address or country, or that are followed by scope changes on the account (see the companion
+  hunting query for credential and security-info modifications) warrant immediate escalation.
+  References:
+  - https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access
+  - https://attack.mitre.org/techniques/T1078/004/
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - SigninLogs
+tactics:
+  - InitialAccess
+  - Persistence
+relevantTechniques:
+  - T1078.004
+query: |
+  let starttime = todatetime('{{StartTimeISO}}');
+  let endtime = todatetime('{{EndTimeISO}}');
+  let BreakGlassAccounts = (
+      _GetWatchlist('BreakGlassAccounts')
+      | project AccountUPN = tolower(tostring(AccountUPN))
+  );
+  SigninLogs
+  | where TimeGenerated between (starttime .. endtime)
+  | where tolower(UserPrincipalName) in (BreakGlassAccounts)
+  | extend City = tostring(LocationDetails.city)
+  | extend Country = tostring(LocationDetails.countryOrRegion)
+  | extend AccountName      = tostring(split(UserPrincipalName, "@")[0])
+  | extend AccountUPNSuffix = tostring(split(UserPrincipalName, "@")[1])
+  | project
+      TimeGenerated,
+      UserPrincipalName,
+      AccountName,
+      AccountUPNSuffix,
+      UserId,
+      IPAddress,
+      City,
+      Country,
+      AppDisplayName,
+      ResourceDisplayName,
+      ResultType,
+      ResultDescription,
+      ConditionalAccessStatus,
+      AuthenticationRequirement,
+      CorrelationId
+  | sort by TimeGenerated desc
+entityMappings:
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: UserPrincipalName
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: AccountUPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: IPAddress
+customDetails:
+  ResultType: ResultType
+  AppDisplayName: AppDisplayName
+  Country: Country
+  ConditionalAccessStatus: ConditionalAccessStatus
+version: 1.0.0
+metadata:
+    source:
+        kind: Community
+    author:
+        name: descambiado
+    support:
+        tier: Community
+    categories:
+        domains: [ "Security - Threat Protection", "Identity" ]

--- a/Hunting Queries/SigninLogs/BreakGlassAccountSignIn.yaml
+++ b/Hunting Queries/SigninLogs/BreakGlassAccountSignIn.yaml
@@ -17,8 +17,10 @@ description-detailed: |
   is no reliable way to infer these accounts from sign-in data alone.
   Any match here should be validated against the change calendar for a planned access-recovery
   test. Sign-ins that fall outside a documented test window, that originate from an unexpected
-  IP address or country, or that are followed by scope changes on the account (see the companion
-  hunting query for credential and security-info modifications) warrant immediate escalation.
+  IP address or country, or that are closely followed by a credential change or a privilege
+  change on the same account (see the two companion hunting queries in this pack, covering
+  credential and security-info modifications and role or group membership changes) warrant
+  immediate escalation.
   References:
   - https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access
   - https://attack.mitre.org/techniques/T1078/004/

--- a/Hunting Queries/SigninLogs/BreakGlassAccountSignIn.yaml
+++ b/Hunting Queries/SigninLogs/BreakGlassAccountSignIn.yaml
@@ -11,10 +11,10 @@ description-detailed: |
   exclusion, a successful sign-in to one of these accounts bypasses the same controls that
   protect every other identity in the tenant, and Microsoft's own guidance is that sign-in and
   credential-change activity on them should be monitored continuously.
-  This query depends on a watchlist named `BreakGlassAccounts` with a single column,
-  `AccountUPN`, listing the user principal names of the tenant's designated emergency access
-  accounts. Populate it once from the tenant's documented break-glass account inventory; there
-  is no reliable way to infer these accounts from sign-in data alone.
+  This query depends on a watchlist named `BreakGlassAccounts` whose `SearchKey` column holds
+  the user principal names of the tenant's designated emergency access accounts. Populate it
+  once from the tenant's documented break-glass account inventory; there is no reliable way to
+  infer these accounts from sign-in data alone.
   Any match here should be validated against the change calendar for a planned access-recovery
   test. Sign-ins that fall outside a documented test window, that originate from an unexpected
   IP address or country, or that are closely followed by a credential change or a privilege
@@ -38,7 +38,7 @@ query: |
   let endtime = todatetime('{{EndTimeISO}}');
   let BreakGlassAccounts = (
       _GetWatchlist('BreakGlassAccounts')
-      | project AccountUPN = tolower(tostring(AccountUPN))
+      | project AccountUPN = tolower(tostring(SearchKey))
   );
   SigninLogs
   | where TimeGenerated between (starttime .. endtime)


### PR DESCRIPTION
## Summary

Three hunting queries for monitoring designated emergency break-glass accounts, which should show no sign-in, credential, or membership activity outside a documented recovery test.

### BreakGlassAccountSignIn (SigninLogs)

Identifies any sign-in from a designated break-glass account. These accounts are deliberately excluded from Conditional Access and day-to-day MFA, so a successful sign-in bypasses the same controls protecting every other identity in the tenant.

MITRE: T1078.004, InitialAccess, Persistence

### BreakGlassAccountCredentialsModified (AuditLogs)

Identifies password resets, security-info registrations, and MFA changes on a break-glass account. Matches official Microsoft phrasing for password-reset detection (noun+verb match) rather than an exact-string list, since operation names vary across tenants and service versions.

MITRE: T1098, T1556.006, Persistence, DefenseEvasion

### BreakGlassAccountRoleOrGroupMembershipChanged (AuditLogs)

Identifies direct role assignment and group-mediated privilege changes on a break-glass account. Covers both paths since a group-mediated addition to a role-assignable group grants the inherited role without ever generating a direct role-assignment event.

MITRE: T1098.003, PrivilegeEscalation, Persistence

## Validation

- All three descriptions under 255 characters (204, 245, 214)
- Names sentence case, under the 100-char hard limit
- No non-ASCII characters
- GUIDs unique (verified against existing queries in the repo)
- All three share and document the `BreakGlassAccounts` watchlist dependency
- MITRE tactics/techniques verified against ATT&CK v16