### PR TITLE
Fix broken Azure Gov deploy badge and workbook image link in readme for Cybersecurity Maturity Model Certification (CMMC) 2.0

### DIFF
--- a/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/Data/Solution_CybersecurityMaturityModelCertification(CMMC)2.0.json
+++ b/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/Data/Solution_CybersecurityMaturityModelCertification(CMMC)2.0.json
@@ -17,6 +17,6 @@
   ],
   "Metadata": "SolutionMetadata.json",
   "BasePath": "C:\\Github\\Azure-Sentinel\\Solutions\\CybersecurityMaturityModelCertification(CMMC)2.0",
-  "Version": "3.1.0",
+  "Version": "3.1.1",
   "TemplateSpec": true
 }

--- a/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/readme.md
+++ b/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/readme.md
@@ -8,7 +8,7 @@ You can deploy the solution by clicking on the buttons below:
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FSolutions%2FCybersecurityMaturityModelCertification(CMMC)2.0%2FPackage%2FmainTemplate.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/></a>
 <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FSolutions%2FCybersecurityMaturityModelCertification(CMMC)2.0%2FPackage%2FmainTemplate.json" target="_blank"><img src="https://aka.ms/deploytoazuregovernbutton"/></a>
 
-![Workbook Overview](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/Workbooks/Images/CybersecurityMaturityModelCertification(CMMC)Black.png?raw=true)
+![Workbook Overview](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/Workbooks/Images/CybersecurityMaturityModelCertification(CMMC)Workbook.png?raw=true)
 
 ## [Recommended Microsoft Sentinel Roles](https://docs.microsoft.com/azure/sentinel/roles) / [Recommended Microsoft Defender for Cloud Roles](https://docs.microsoft.com/azure/defender-for-cloud/permissions#roles-and-allowed-actions)
 | <strong> Roles </strong> | <strong> Rights </strong> | 

--- a/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/readme.md
+++ b/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/readme.md
@@ -6,9 +6,9 @@ Welcome to the Microsoft Sentinel: Cybersecurity Maturity Model Certification (C
 You can deploy the solution by clicking on the buttons below:
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FSolutions%2FCybersecurityMaturityModelCertification(CMMC)2.0%2FPackage%2FmainTemplate.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/></a>
-<a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FSolutions%2FCybersecurityMaturityModelCertification(CMMC)2.0%2FPackage%2FmainTemplate.json" target="_blank"><img src="https://aka.ms/deploytoazuregovbutton"/></a>
+<a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAzure-Sentinel%2Fmaster%2FSolutions%2FCybersecurityMaturityModelCertification(CMMC)2.0%2FPackage%2FmainTemplate.json" target="_blank"><img src="https://aka.ms/deploytoazuregovernbutton"/></a>
 
-![Workbook Overview](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/Workbooks/Images/CybersecurityMaturityModelCertification(CMMC)Black1.png?raw=true)
+![Workbook Overview](https://github.com/Azure/Azure-Sentinel/blob/master/Solutions/CybersecurityMaturityModelCertification(CMMC)2.0/Workbooks/Images/CybersecurityMaturityModelCertification(CMMC)Black.png?raw=true)
 
 ## [Recommended Microsoft Sentinel Roles](https://docs.microsoft.com/azure/sentinel/roles) / [Recommended Microsoft Defender for Cloud Roles](https://docs.microsoft.com/azure/defender-for-cloud/permissions#roles-and-allowed-actions)
 | <strong> Roles </strong> | <strong> Rights </strong> | 


### PR DESCRIPTION
### Change(s)
- Bumped the **Cybersecurity Maturity Model Certification (CMMC) 2.0** solution version from
  **3.1.0 → 3.1.1** in `Data/Solution_CybersecurityMaturityModelCertification(CMMC)2.0.json`
- `readme.md`: replaced the dead **Deploy to Azure Gov** badge alias
  `https://aka.ms/deploytoazuregovbutton` with `https://aka.ms/deploytoazuregovernbutton`
- `readme.md`: corrected the broken **Workbook Overview** image reference

### Reason for Change(s)
- The `aka.ms/deploytoazuregovbutton` short link no longer resolves to the Azure Government deploy
  badge (it falls back to a search page), so the "Deploy to Azure Gov" button rendered as a broken
  image in the solution readme. `aka.ms/deploytoazuregovernbutton` resolves to the correct badge SVG.
  Only the badge image URL changed — the underlying `portal.azure.us` deployment target link is
  untouched, so deployment behavior is unaffected.
- The Workbook Overview image URL pointed at a filename that does not exist in
  `Workbooks/Images/`, leaving a broken image in the readme.

### Version updated
Yes — solution version 3.1.0 → 3.1.1. No analytic rule / detection logic was modified.

### Testing Completed
Yes — documentation and metadata only; no KQL, workbook, connector or playbook logic changed.
Verified that the new badge URL resolves to the Azure Gov deploy badge, that the deployment target
URL is unchanged, and that the referenced workbook image resolves.

### Checked that the validations are passing and have addressed any issues that are present
Yes
