### PR TITLE
Remove GitHub App secrets from KQL validation

### DIFF
--- a/.azure-pipelines/kqlValidations.yaml
+++ b/.azure-pipelines/kqlValidations.yaml
@@ -14,10 +14,6 @@ jobs:
         version: '$(dotnetSdkVersion)'
     - task: DotNetCoreCLI@2
       displayName: 'Run kql validation tests'
-      env:
-        GITHUBAPPID: $(GitHubAppID)
-        GITHUBAPPINSTALLATIONID: $(GitHubAppInstallationID)
-        GITHUBAPPPRIVATEKEY: $(GitHubAppPrivateKey)
       inputs:
         command: 'test'
         arguments: '--configuration $(buildConfiguration)'

--- a/.github/workflows/kql-validations.yaml
+++ b/.github/workflows/kql-validations.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 jobs:
   KqlValidations:
     runs-on: ubuntu-22.04
@@ -26,8 +26,3 @@ jobs:
           dotnet-version: ${{ env.dotnetSdkVersion }}
       - name: Run KQL Validation tests
         run: dotnet test .script/tests/KqlvalidationsTests/Kqlvalidations.Tests.csproj --configuration ${{ env.buildConfiguration }}
-        env:
-          GITHUBAPPID: ${{ secrets.APPLICATION_ID }}
-          GITHUBAPPINSTALLATIONID: ${{ secrets.APPLICATION_INSTALLATION_ID }}
-          GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-          SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}

--- a/.script/tests/KqlvalidationsTests/GitHubApiClient.cs
+++ b/.script/tests/KqlvalidationsTests/GitHubApiClient.cs
@@ -46,7 +46,6 @@ namespace Kqlvalidations.Tests
         /// Creates singleton instance of <see cref="GitHubApiClient"/>
         /// </summary>
         /// <returns>singleton instance of GitHub Client</returns>
-        /// <exception cref="InvalidOperationException">Throws an exception if there is an issue with app id, installation id, private key.</exception>
         public static GitHubApiClient Create()
         {
             if (_instance == null)
@@ -66,18 +65,20 @@ namespace Kqlvalidations.Tests
                             var privateKey = Environment.GetEnvironmentVariable("GITHUBAPPPRIVATEKEY");
                             if (string.IsNullOrEmpty(appId) || string.IsNullOrEmpty(installationId) || string.IsNullOrEmpty(privateKey))
                             {
-                                throw new InvalidOperationException("GitHub App ID, Installation ID, or Private Key is missing.");
+                                _instance = new GitHubApiClient();
                             }
-
-                            try
+                            else
                             {
-                                var jwtToken = GenerateJwtToken(appId, RemovePemHeaderAndFooter(privateKey));
-                                var accessToken = GetInstallationAccessToken(installationId, jwtToken).Result;
-                                _instance = new GitHubApiClient(accessToken);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw new InvalidOperationException("Error occurred while creating GitHubApiClient instance.", ex);
+                                try
+                                {
+                                    var jwtToken = GenerateJwtToken(appId, RemovePemHeaderAndFooter(privateKey));
+                                    var accessToken = GetInstallationAccessToken(installationId, jwtToken).Result;
+                                    _instance = new GitHubApiClient(accessToken);
+                                }
+                                catch (Exception ex)
+                                {
+                                    throw new InvalidOperationException("Error occurred while creating GitHubApiClient instance.", ex);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- removes GitHub App credentials from Azure Pipelines and GitHub Actions KQL test environments
- uses the anonymous GitHub client when credentials are unavailable
- reduces GitHub Actions pull-request permissions to read-only

## AI scan item

- https://dev.azure.com/MSecProductSecurity/AI%20Vuln%20Scanning/_workitems/edit/130362

## Validation

- parsed both workflow YAML files
- built `Kqlvalidations.Tests.csproj` successfully with no warnings or errors