### PR TITLE
Skip additional ASIM union parsers during validation

### DIFF
--- a/.github/workflows/runAsimSchemaAndDataTesters.yaml
+++ b/.github/workflows/runAsimSchemaAndDataTesters.yaml
@@ -385,6 +385,13 @@ jobs:
           pip install tabulate
       - name: Run ASim parsers template validations python script
         run: |
+          helperPath=".script/tests/asimParsersTest/asim_parser_file_utils.py"
+          helperUrl="https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/.script/tests/asimParsersTest/asim_parser_file_utils.py"
+          if [ -f "$helperPath" ]; then
+            rm -f "$helperPath"
+          fi
+          echo "Downloading helper from the master: $helperUrl"
+          curl --fail --location --output "$helperPath" "$helperUrl"
           filePath=".script/tests/asimParsersTest/VerifyASimParserTemplate.py"
           url="https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/.script/tests/asimParsersTest/VerifyASimParserTemplate.py" 
           # Check if file exists and delete if it does
@@ -454,6 +461,13 @@ jobs:
       - name: Asim Sample Log Ingestion
         id: Ingestlogs
         run: |
+          helperPath=".script/tests/asimParsersTest/asim_parser_file_utils.py"
+          helperUrl="https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/.script/tests/asimParsersTest/asim_parser_file_utils.py"
+          if [ -f "$helperPath" ]; then
+            rm -f "$helperPath"
+          fi
+          echo "Downloading helper from the master: $helperUrl"
+          curl --fail --location --output "$helperPath" "$helperUrl"
           filePath=".script/tests/asimParsersTest/ingestASimSampleData.py"
           url="https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/.script/tests/asimParsersTest/ingestASimSampleData.py" 
           # Check if file exists and delete if it does
@@ -596,6 +610,13 @@ jobs:
           allow-no-subscriptions: true
       - name: Run ASim parsers filtering tests python script
         run: |
+          helperPath=".script/tests/asimParsersTest/asim_parser_file_utils.py"
+          helperUrl="https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/.script/tests/asimParsersTest/asim_parser_file_utils.py"
+          if [ -f "$helperPath" ]; then
+            rm -f "$helperPath"
+          fi
+          echo "Downloading helper from the master: $helperUrl"
+          curl --fail --location --output "$helperPath" "$helperUrl"
           filePath=".script/tests/asimParsersTest/ASimFilteringTest.py"
           url="https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/.script/tests/asimParsersTest/ASimFilteringTest.py"
           # Check if file exists and delete if it does

--- a/.script/tests/asimParsersTest/ASimFilteringTest.py
+++ b/.script/tests/asimParsersTest/ASimFilteringTest.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 import os
 
@@ -7,6 +8,15 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 # Remove the script's directory from sys.path to avoid importing local malicious modules. 
 if script_dir in sys.path:
     sys.path.remove(script_dir)
+
+spec = importlib.util.spec_from_file_location(
+    'asim_parser_file_utils', os.path.join(script_dir, 'asim_parser_file_utils.py')
+)
+parser_file_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parser_file_utils)
+extract_schema_name = parser_file_utils.extract_schema_name
+is_empty_parser = parser_file_utils.is_empty_parser
+is_union_parser = parser_file_utils.is_union_parser
 
 __unittest = True #prevents stacktrace during most assertions
 
@@ -61,15 +71,6 @@ failure_messages = {
     'Authentication': "This single failure is because only two values exist in 'EventType' field in 'Authentication' schema. 'Authentication' is a special case where 'EventType' validations could be partial as only 'Logon' or 'Logoff' events may exists. Ignoring this error.",
     'Dns': "This single failure is because only one value exist in 'EventType' field in 'Dns' schema. 'Dns' is a special case where 'EventType' validations could be 'Query' only. Ignoring this error."
 }
-ADDITIONAL_UNION_PARSERS = {
-    "ProcessEvent": (
-        "ASimProcessEventCreate.yaml",
-        "ASimProcessEventTerminate.yaml",
-        "imProcessCreate.yaml",
-        "imProcessTerminate.yaml",
-    )
-}
-
 def attempt_to_connect():
     try:
             credential = DefaultAzureCredential()
@@ -301,19 +302,10 @@ def main():
         sys.stdout.flush()  # Explicitly flush stdout
 
     for PARSER_FILE_NAME in modified_yaml_files:
-        # Use regular expression to extract SchemaName from the parser filename
-        SchemaNameMatch = re.search(r'ASim(\w+)/', PARSER_FILE_NAME)
-        if SchemaNameMatch:
-            SchemaName = SchemaNameMatch.group(1)
-        else:
-            SchemaName = None
+        SchemaName = extract_schema_name(PARSER_FILE_NAME)
+        parser_filename = os.path.basename(PARSER_FILE_NAME)
         # Check if changed file is a union parser. If Yes, skip the file
-        is_union_parser = (
-            PARSER_FILE_NAME.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml'))
-            or os.path.basename(PARSER_FILE_NAME) in ADDITIONAL_UNION_PARSERS.get(SchemaName, ())
-        )
-        is_empty_parser = os.path.basename(PARSER_FILE_NAME).startswith('vim') and PARSER_FILE_NAME.endswith('Empty.yaml')
-        if is_union_parser or is_empty_parser:
+        if is_union_parser(parser_filename, SchemaName) or is_empty_parser(parser_filename):
             continue
         parser_file_path = PARSER_FILE_NAME
         sys.stdout.flush()  # Explicitly flush stdout

--- a/.script/tests/asimParsersTest/ASimFilteringTest.py
+++ b/.script/tests/asimParsersTest/ASimFilteringTest.py
@@ -61,6 +61,14 @@ failure_messages = {
     'Authentication': "This single failure is because only two values exist in 'EventType' field in 'Authentication' schema. 'Authentication' is a special case where 'EventType' validations could be partial as only 'Logon' or 'Logoff' events may exists. Ignoring this error.",
     'Dns': "This single failure is because only one value exist in 'EventType' field in 'Dns' schema. 'Dns' is a special case where 'EventType' validations could be 'Query' only. Ignoring this error."
 }
+ADDITIONAL_UNION_PARSERS = {
+    "ProcessEvent": (
+        "ASimProcessEventCreate.yaml",
+        "ASimProcessEventTerminate.yaml",
+        "imProcessCreate.yaml",
+        "imProcessTerminate.yaml",
+    )
+}
 
 def attempt_to_connect():
     try:
@@ -300,8 +308,12 @@ def main():
         else:
             SchemaName = None
         # Check if changed file is a union parser. If Yes, skip the file
+        is_union_parser = (
+            PARSER_FILE_NAME.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml'))
+            or os.path.basename(PARSER_FILE_NAME) in ADDITIONAL_UNION_PARSERS.get(SchemaName, ())
+        )
         is_empty_parser = os.path.basename(PARSER_FILE_NAME).startswith('vim') and PARSER_FILE_NAME.endswith('Empty.yaml')
-        if PARSER_FILE_NAME.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml')) or is_empty_parser:
+        if is_union_parser or is_empty_parser:
             continue
         parser_file_path = PARSER_FILE_NAME
         sys.stdout.flush()  # Explicitly flush stdout

--- a/.script/tests/asimParsersTest/VerifyASimParserTemplate.py
+++ b/.script/tests/asimParsersTest/VerifyASimParserTemplate.py
@@ -60,6 +60,14 @@ SCHEMA_INFO = [
     {"SchemaName": "WebSession", "SchemaVersion": "0.2.7", "SchemaTitle":"ASIM Web Session Schema","SchemaLink": "https://aka.ms/ASimWebSessionDoc"}
     # Add more schemas as needed
 ]
+ADDITIONAL_UNION_PARSERS = {
+    "ProcessEvent": (
+        "ASimProcessEventCreate.yaml",
+        "ASimProcessEventTerminate.yaml",
+        "imProcessCreate.yaml",
+        "imProcessTerminate.yaml",
+    )
+}
 
 # Global array to store results
 results = []
@@ -87,8 +95,12 @@ def run():
     for parser in parser_yaml_files:
         
         schema_name = extract_schema_name(parser)
+        is_union_parser = (
+            parser.endswith((f'ASim{schema_name}.yaml', f'im{schema_name}.yaml'))
+            or os.path.basename(parser) in ADDITIONAL_UNION_PARSERS.get(schema_name, ())
+        )
         is_empty_parser = os.path.basename(parser).startswith('vim') and parser.endswith('Empty.yaml')
-        if parser.endswith((f'ASim{schema_name}.yaml', f'im{schema_name}.yaml')) or is_empty_parser:
+        if is_union_parser or is_empty_parser:
             print(f"{YELLOW}Skipping '{parser}' as this is a union or empty parser file. This file won't be tested.{RESET}")
             continue
         # Skip vim parser file if the corresponding ASim parser file is not present

--- a/.script/tests/asimParsersTest/VerifyASimParserTemplate.py
+++ b/.script/tests/asimParsersTest/VerifyASimParserTemplate.py
@@ -20,6 +20,7 @@
 #
 # Parsers listed in ExclusionListForASimTests.csv are allowed to fail without blocking the workflow.
 
+import importlib.util
 import sys
 import os
 
@@ -29,6 +30,15 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 # Remove the script's directory from sys.path to avoid importing local malicious modules
 if script_dir in sys.path:
     sys.path.remove(script_dir)
+
+spec = importlib.util.spec_from_file_location(
+    'asim_parser_file_utils', os.path.join(script_dir, 'asim_parser_file_utils.py')
+)
+parser_file_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parser_file_utils)
+extract_schema_name = parser_file_utils.extract_schema_name
+is_empty_parser = parser_file_utils.is_empty_parser
+is_union_parser = parser_file_utils.is_union_parser
 
 import yaml
 import re
@@ -60,15 +70,6 @@ SCHEMA_INFO = [
     {"SchemaName": "WebSession", "SchemaVersion": "0.2.7", "SchemaTitle":"ASIM Web Session Schema","SchemaLink": "https://aka.ms/ASimWebSessionDoc"}
     # Add more schemas as needed
 ]
-ADDITIONAL_UNION_PARSERS = {
-    "ProcessEvent": (
-        "ASimProcessEventCreate.yaml",
-        "ASimProcessEventTerminate.yaml",
-        "imProcessCreate.yaml",
-        "imProcessTerminate.yaml",
-    )
-}
-
 # Global array to store results
 results = []
 # Global variable to store if test failed
@@ -95,12 +96,8 @@ def run():
     for parser in parser_yaml_files:
         
         schema_name = extract_schema_name(parser)
-        is_union_parser = (
-            parser.endswith((f'ASim{schema_name}.yaml', f'im{schema_name}.yaml'))
-            or os.path.basename(parser) in ADDITIONAL_UNION_PARSERS.get(schema_name, ())
-        )
-        is_empty_parser = os.path.basename(parser).startswith('vim') and parser.endswith('Empty.yaml')
-        if is_union_parser or is_empty_parser:
+        parser_filename = os.path.basename(parser)
+        if is_union_parser(parser_filename, schema_name) or is_empty_parser(parser_filename):
             print(f"{YELLOW}Skipping '{parser}' as this is a union or empty parser file. This file won't be tested.{RESET}")
             continue
         # Skip vim parser file if the corresponding ASim parser file is not present
@@ -358,10 +355,6 @@ def get_current_commit_number():
     except subprocess.CalledProcessError as e:
         print(f"::error::Error occurred while executing the command: {e}")
         return None
-
-def extract_schema_name(parser):
-    match = re.search(r'ASim(\w+)/', parser)
-    return match.group(1) if match else None
 
 def read_local_yaml(filepath):
     try:

--- a/.script/tests/asimParsersTest/asim_parser_file_utils.py
+++ b/.script/tests/asimParsersTest/asim_parser_file_utils.py
@@ -1,0 +1,30 @@
+import re
+
+
+ADDITIONAL_UNION_PARSERS = {
+    "ProcessEvent": (
+        "ASimProcessEventCreate.yaml",
+        "ASimProcessEventTerminate.yaml",
+        "imProcessCreate.yaml",
+        "imProcessTerminate.yaml",
+    )
+}
+
+
+def extract_schema_name(parser_path):
+    match = re.search(r'ASim(\w+)[/\\]', parser_path)
+    return match.group(1) if match else None
+
+
+def is_union_parser(parser_filename, schema_name):
+    if not schema_name:
+        return False
+
+    return (
+        parser_filename in (f'ASim{schema_name}.yaml', f'im{schema_name}.yaml')
+        or parser_filename in ADDITIONAL_UNION_PARSERS.get(schema_name, ())
+    )
+
+
+def is_empty_parser(parser_filename):
+    return parser_filename.startswith('vim') and parser_filename.endswith('Empty.yaml')

--- a/.script/tests/asimParsersTest/asim_parser_file_utils.py
+++ b/.script/tests/asimParsersTest/asim_parser_file_utils.py
@@ -1,6 +1,5 @@
 import re
 
-
 ADDITIONAL_UNION_PARSERS = {
     "ProcessEvent": (
         "ASimProcessEventCreate.yaml",
@@ -10,11 +9,9 @@ ADDITIONAL_UNION_PARSERS = {
     )
 }
 
-
 def extract_schema_name(parser_path):
     match = re.search(r'ASim(\w+)[/\\]', parser_path)
     return match.group(1) if match else None
-
 
 def is_union_parser(parser_filename, schema_name):
     if not schema_name:
@@ -24,7 +21,6 @@ def is_union_parser(parser_filename, schema_name):
         parser_filename in (f'ASim{schema_name}.yaml', f'im{schema_name}.yaml')
         or parser_filename in ADDITIONAL_UNION_PARSERS.get(schema_name, ())
     )
-
 
 def is_empty_parser(parser_filename):
     return parser_filename.startswith('vim') and parser_filename.endswith('Empty.yaml')

--- a/.script/tests/asimParsersTest/ingestASimSampleData.py
+++ b/.script/tests/asimParsersTest/ingestASimSampleData.py
@@ -472,6 +472,14 @@ dcr_directory=[]
 
 lia_supported_builtin_table = ['ADAssessmentRecommendation','ADSecurityAssessmentRecommendation','Anomalies','ASimAuditEventLogs','ASimAuthenticationEventLogs','ASimDhcpEventLogs','ASimDnsActivityLogs','ASimDnsAuditLogs','ASimFileEventLogs','ASimNetworkSessionLogs','ASimProcessEventLogs','ASimRegistryEventLogs','ASimUserManagementActivityLogs','ASimWebSessionLogs','AWSCloudTrail','AWSCloudWatch','AWSGuardDuty','AWSVPCFlow','AzureAssessmentRecommendation','CommonSecurityLog','DeviceTvmSecureConfigurationAssessmentKB','DeviceTvmSoftwareVulnerabilitiesKB','ExchangeAssessmentRecommendation','ExchangeOnlineAssessmentRecommendation','GCPAuditLogs','GoogleCloudSCC','SCCMAssessmentRecommendation','SCOMAssessmentRecommendation','SecurityEvent','SfBAssessmentRecommendation','SharePointOnlineAssessmentRecommendation','SQLAssessmentRecommendation','StorageInsightsAccountPropertiesDaily','StorageInsightsDailyMetrics','StorageInsightsHourlyMetrics','StorageInsightsMonthlyMetrics','StorageInsightsWeeklyMetrics','Syslog','UCClient','UCClientReadinessStatus','UCClientUpdateStatus','UCDeviceAlert','UCDOAggregatedStatus','UCServiceUpdateStatus','UCUpdateAlert','WindowsEvent','WindowsServerAssessmentRecommendation','NTANetAnalytics', 'AZFWNetworkRule', 'AZFWNatRule', 'AZFWApplicationRule', 'AZFWDnsQuery', 'AZFWIdspSignature', 'AZFWThreatIntel']
 reserved_columns = ["_ResourceId", "id", "_SubscriptionId", "TenantId", "Type", "UniqueId", "Title","_ItemId","verbose_b","verbose","MG","_ResourceId_s"]
+ADDITIONAL_UNION_PARSERS = {
+    "ProcessEvent": (
+        "ASimProcessEventCreate.yaml",
+        "ASimProcessEventTerminate.yaml",
+        "imProcessCreate.yaml",
+        "imProcessTerminate.yaml",
+    )
+}
 
 SentinelRepoUrl = "https://github.com/Azure/Azure-Sentinel"
 current_directory = os.path.dirname(os.path.abspath(__file__))
@@ -488,8 +496,12 @@ for file in parser_yaml_files:
     else:
         SchemaName = None
     # Check if changed file is a union or empty parser. If Yes, skip the file
+    is_union_parser = (
+        file.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml'))
+        or os.path.basename(file) in ADDITIONAL_UNION_PARSERS.get(SchemaName, ())
+    )
     is_empty_parser = os.path.basename(file).startswith('vim') and file.endswith('Empty.yaml')
-    if file.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml')) or is_empty_parser:
+    if is_union_parser or is_empty_parser:
         print(f"Ignoring this {file} because it is a union or empty parser file")
         continue        
     print(f"Starting ingestion for sample data present in {file}")

--- a/.script/tests/asimParsersTest/ingestASimSampleData.py
+++ b/.script/tests/asimParsersTest/ingestASimSampleData.py
@@ -11,6 +11,7 @@
 #
 # Usage: python ingestASimSampleData.py <pr_number>
 
+import importlib.util
 import sys
 import os
 
@@ -20,6 +21,15 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 # Remove the script's directory from sys.path to avoid importing local malicious modules
 if script_dir in sys.path:
     sys.path.remove(script_dir)
+
+spec = importlib.util.spec_from_file_location(
+    'asim_parser_file_utils', os.path.join(script_dir, 'asim_parser_file_utils.py')
+)
+parser_file_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parser_file_utils)
+extract_schema_name = parser_file_utils.extract_schema_name
+is_empty_parser = parser_file_utils.is_empty_parser
+is_union_parser = parser_file_utils.is_union_parser
 
 import requests
 import yaml
@@ -472,14 +482,6 @@ dcr_directory=[]
 
 lia_supported_builtin_table = ['ADAssessmentRecommendation','ADSecurityAssessmentRecommendation','Anomalies','ASimAuditEventLogs','ASimAuthenticationEventLogs','ASimDhcpEventLogs','ASimDnsActivityLogs','ASimDnsAuditLogs','ASimFileEventLogs','ASimNetworkSessionLogs','ASimProcessEventLogs','ASimRegistryEventLogs','ASimUserManagementActivityLogs','ASimWebSessionLogs','AWSCloudTrail','AWSCloudWatch','AWSGuardDuty','AWSVPCFlow','AzureAssessmentRecommendation','CommonSecurityLog','DeviceTvmSecureConfigurationAssessmentKB','DeviceTvmSoftwareVulnerabilitiesKB','ExchangeAssessmentRecommendation','ExchangeOnlineAssessmentRecommendation','GCPAuditLogs','GoogleCloudSCC','SCCMAssessmentRecommendation','SCOMAssessmentRecommendation','SecurityEvent','SfBAssessmentRecommendation','SharePointOnlineAssessmentRecommendation','SQLAssessmentRecommendation','StorageInsightsAccountPropertiesDaily','StorageInsightsDailyMetrics','StorageInsightsHourlyMetrics','StorageInsightsMonthlyMetrics','StorageInsightsWeeklyMetrics','Syslog','UCClient','UCClientReadinessStatus','UCClientUpdateStatus','UCDeviceAlert','UCDOAggregatedStatus','UCServiceUpdateStatus','UCUpdateAlert','WindowsEvent','WindowsServerAssessmentRecommendation','NTANetAnalytics', 'AZFWNetworkRule', 'AZFWNatRule', 'AZFWApplicationRule', 'AZFWDnsQuery', 'AZFWIdspSignature', 'AZFWThreatIntel']
 reserved_columns = ["_ResourceId", "id", "_SubscriptionId", "TenantId", "Type", "UniqueId", "Title","_ItemId","verbose_b","verbose","MG","_ResourceId_s"]
-ADDITIONAL_UNION_PARSERS = {
-    "ProcessEvent": (
-        "ASimProcessEventCreate.yaml",
-        "ASimProcessEventTerminate.yaml",
-        "imProcessCreate.yaml",
-        "imProcessTerminate.yaml",
-    )
-}
 
 SentinelRepoUrl = "https://github.com/Azure/Azure-Sentinel"
 current_directory = os.path.dirname(os.path.abspath(__file__))
@@ -490,18 +492,10 @@ parser_yaml_files = filter_yaml_files(modified_files)
 prnumber = sys.argv[1]
 
 for file in parser_yaml_files:
-    SchemaNameMatch = re.search(r'ASim(\w+)/', file)
-    if SchemaNameMatch:
-        SchemaName = SchemaNameMatch.group(1)
-    else:
-        SchemaName = None
+    SchemaName = extract_schema_name(file)
+    parser_filename = os.path.basename(file)
     # Check if changed file is a union or empty parser. If Yes, skip the file
-    is_union_parser = (
-        file.endswith((f'ASim{SchemaName}.yaml', f'im{SchemaName}.yaml'))
-        or os.path.basename(file) in ADDITIONAL_UNION_PARSERS.get(SchemaName, ())
-    )
-    is_empty_parser = os.path.basename(file).startswith('vim') and file.endswith('Empty.yaml')
-    if is_union_parser or is_empty_parser:
+    if is_union_parser(parser_filename, SchemaName) or is_empty_parser(parser_filename):
         print(f"Ignoring this {file} because it is a union or empty parser file")
         continue        
     print(f"Starting ingestion for sample data present in {file}")


### PR DESCRIPTION
Required items, please complete

Change(s):
- Add a shared, dependency-free helper for ASIM schema extraction and union/empty parser classification.
- Reuse the helper during template validation, filtering tests, and sample-data ingestion.
- Download the helper from `master` alongside each trusted validation script to preserve the `pull_request_target` security boundary.

Reason for Change(s):
- Secondary ProcessEvent unions were treated as source-specific parsers, causing validation failures when files such as `ASimProcessEventCreate.yaml` and `ASimProcessEventTerminate.yaml` were updated.
- Centralizing parser classification prevents the three workflow scripts from drifting over time.

Version Updated:
- N/A - no detection or analytic rule templates changed.

Testing Completed:
- Yes - compiled the helper and all three consumers, validated 14 schema/union/empty cases across POSIX and Windows paths, and confirmed the template validator skips union and empty parsers before YAML validation.

Checked that the validations are passing and have addressed any issues that are present:
- Yes - the updated workflow YAML parses successfully and `git diff --check` passes.