### PR TITLE
[Oracle Cloud Infrastructure] - Add 3.0.11 upgrade notice

### DIFF
--- a/Solutions/Oracle Cloud Infrastructure/Data Connectors/README.md
+++ b/Solutions/Oracle Cloud Infrastructure/Data Connectors/README.md
@@ -1,0 +1,13 @@
+# Oracle Cloud Infrastructure data connector update
+
+Customers using the **Oracle Cloud Infrastructure (via Codeless Connector Framework)** data connector should update the Oracle Cloud Infrastructure solution to version **3.0.11 or later**.
+
+This release includes an important update to the connector's data processing behavior. Updating helps ensure that the connector continues to collect the intended OCI log data.
+
+## Update the solution
+
+1. In Microsoft Sentinel, open **Content hub**.
+2. Find the **Oracle Cloud Infrastructure** solution.
+3. Select **Update** and install version **3.0.11** or a later available version.
+4. After the update completes, review the data connector page and confirm that existing connections remain connected and data collection continues as expected.
+


### PR DESCRIPTION
Change(s):
   - Providing an update for upgrading to version `3.0.11` of the connector or later.

   Reason for Change(s):
   - This version addresses a data processing issue.

   Version Updated: N/A

   Testing Completed: N/A

   Checked that the validations are passing and have addressed any issues that are present: N/A