### PR TITLE
Update AzureBuiltInRole.csv with latest Azure built-in roles

### DIFF
--- a/Sample Data/Feeds/AzureBuiltInRole.csv
+++ b/Sample Data/Feeds/AzureBuiltInRole.csv
@@ -1,246 +1,949 @@
 ﻿Role,RoleDescription,ID
-Contributor,"Grants full access to manage all resources, but does not allow you to assign roles in Azure RBAC, manage assignments in Azure Blueprints, or share image galleries.",b24988ac-6180-42a0-ab88-20f7382dd24c
-Owner,"Grants full access to manage all resources, including the ability to assign roles in Azure RBAC.",8e3af657-a8ff-443c-a75c-2fe8c4bcb635
-Reader,"View all resources, but does not allow you to make any changes.",acdd72a7-3385-48ef-bd42-f606fba81ae7
-User Access Administrator,Lets you manage user access to Azure resources.,18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
-Classic Virtual Machine Contributor,"Lets you manage classic virtual machines, but not access to them, and not the virtual network or storage account they're connected to.",d73bb868-a0df-4d4d-bd69-98a00b01fccb
-Data Operator for Managed Disks,"Provides permissions to upload data to empty managed disks, read, or export data of managed disks (not attached to running VMs) and snapshots using SAS URIs and Azure AD authentication.",959f8984-c045-4866-89c7-12bf9737be2e
-Disk Backup Reader,Provides permission to backup vault to perform disk backup.,3e5e47e6-65f7-47ef-90b5-e5dd4d455f24
-Disk Pool Operator,Provide permission to StoragePool Resource Provider to manage disks added to a disk pool.,60fc6e62-5479-42d4-8bf4-67625fcc2840
-Disk Restore Operator,Provides permission to backup vault to perform disk restore.,b50d9833-a0cb-478e-945f-707fcc997c13
-Disk Snapshot Contributor,Provides permission to backup vault to manage disk snapshots.,7efff54f-a5b4-42b5-a1c5-5411624893ce
-Virtual Machine Administrator Login,View Virtual Machines in the portal and login as administrator,1c0163c0-47e6-4577-8991-ea5c82e286e4
-Virtual Machine Contributor,"Create and manage virtual machines, manage disks, install and run software, reset password of the root user of the virtual machine using VM extensions, and manage local user accounts using VM extensions. This role does not grant you management access to the virtual network or storage account the virtual machines are connected to. This role does not allow you to assign roles in Azure RBAC.",9980e02c-c2be-4d73-94e8-173b1dc7cf3c
-Virtual Machine User Login,View Virtual Machines in the portal and login as a regular user.,fb879df8-f326-4884-b1cf-06f3ad86be52
-CDN Endpoint Contributor,"Can manage CDN endpoints, but can't grant access to other users.",426e0c7f-0c7e-4658-b36f-ff54d6c29b45
-CDN Endpoint Reader,"Can view CDN endpoints, but can't make changes.",871e35f6-b5c1-49cc-a043-bde969a0f2cd
-CDN Profile Contributor,"Can manage CDN profiles and their endpoints, but can't grant access to other users.",ec156ff8-a8d1-4d15-830c-5b80698ca432
-CDN Profile Reader,"Can view CDN profiles and their endpoints, but can't make changes.",8f96442b-4075-438f-813d-ad51ab4019af
-Classic Network Contributor,"Lets you manage classic networks, but not access to them.",b34d265f-36f7-4a0d-a4d4-e158ca92e90f
-DNS Zone Contributor,"Lets you manage DNS zones and record sets in Azure DNS, but does not let you control who has access to them.",befefa01-2a29-4197-83a8-272ff33ce314
-Network Contributor,"Lets you manage networks, but not access to them.",4d97b98b-1d4f-4787-a291-c67834d212e7
-Private DNS Zone Contributor,"Lets you manage private DNS zone resources, but not the virtual networks they are linked to.",b12aa53e-6015-4669-85d0-8515ebb3ae7f
-Traffic Manager Contributor,"Lets you manage Traffic Manager profiles, but does not let you control who has access to them.",a4b10055-b0c7-44c2-b00f-c7b5b3550cf7
+AI Model Scanner Operator,Grants Microsoft Defender for AI access to AI services and resources.,8b9beb50-e28c-4879-8472-24c9d328085f
+API Management Developer Portal Content Editor,"Can customize the developer portal, edit its content, and publish it.",c031e6a8-4391-4de0-8d69-4706a7ed3729
+API Management Service Contributor,Can manage service and the APIs,312a565d-c81f-4fd8-895a-4e21e48d571c
+API Management Service Operator Role,Can manage service but not the APIs,e022efe7-f5ba-4159-bbe4-b44f577e9b61
+API Management Service Reader Role,Read-only access to service and APIs,71522526-b88f-4d52-b57f-d31fc3546d0d
+API Management Service Workspace API Developer,"Has read access to tags and products and write access to allow: assigning APIs to products, assigning tags to products and APIs. This role should be assigned on the service scope.",9565a273-41b9-4368-97d2-aeb0c976a9b3
+API Management Service Workspace API Product Manager,Has the same access as API Management Service Workspace API Developer as well as read access to users and write access to allow assigning users to groups. This role should be assigned on the service scope.,d59a3e9c-6d52-4a5a-aeed-6bf3cf0e31da
+API Management Workspace API Developer,Has read access to entities in the workspace and read and write access to entities for editing APIs. This role should be assigned on the workspace scope.,56328988-075d-4c6a-8766-d93edd6725b6
+API Management Workspace API Product Manager,Has read access to entities in the workspace and read and write access to entities for publishing APIs. This role should be assigned on the workspace scope.,73c2c328-d004-4c5e-938c-35c6f5679a1f
+API Management Workspace Contributor,"Can manage the workspace and view, but not modify its members. This role should be assigned on the workspace scope.",0c34c906-8d99-4cb7-8bb7-33f5b0a1a799
+API Management Workspace Reader,Has read-only access to entities in the workspace. This role should be assigned on the workspace scope.,ef1c2c96-4a77-49e8-b9a4-6179fe1d2fd2
+ARN Service Event Grid Subscriber Role,Allows ARN to subscribe to partner event grid topics,dc0882cc-bc27-4d21-9ea2-f821aaa10fb1
+AVS Orchestrator Role,"Do not remove this role from your resource group because it is critical to enable your AVS private cloud to operate. If the role is removed, it will cause your AVS private cloud control plane to no longer operate correctly. The role is used to enable the AVS private cloud control plane to create the supporting resources in the resource group of the private clouds attached virtual network and bind them to the attached virtual network. This role is not intended for use cases outside of assignment to the associated AVS identity in your entra-id tenant.",d715fb95-a0f0-4f1c-8be6-5ad2d2767f67
+AVS on Fleet VIS Role,"Do not remove this role from your resource because it is critical to enable your AVS private cloud to operate. If the role is removed, it will cause your AVS private cloud control plane to no longer operate correctly. The role is used to enable the AVS private cloud control plane to inject address prefix changes of the private clouds attached virtual network to SDN and support peering sync feature. This role is not intended for use cases outside of assignment to the associated AVS identity in your entra-id tenant.",49fc33c1-886f-4b21-a00e-1d9993234734
+Access Review Operator Service Role,Lets you grant Access Review System app permissions to discover and revoke access as needed by the access review process.,76cc9ee4-d5d3-4a45-a930-26add3d73475
+AcrDelete,acr delete,c2f4ef07-c644-48eb-af81-4b1b4947fb11
+AcrImageSigner,"Planned DEPRECATION on March 31, 2028. Grant the signing permission for content trust. As content trust is being deprecated and will be completely removed on March 31, 2028, this role will also be removed. Refer to https://aka.ms/acr/dctdeprecation for details and transition guidance.",6cef56e8-d556-48e5-a04f-b8e64114680f
+AcrPull,acr pull,7f951dda-4ed3-4680-a7ca-43fe172d538d
+AcrPush,acr push,8311e382-0749-4cb8-b61a-304f252e45ec
+AcrQuarantineReader,acr quarantine data reader,cdda3590-29a3-44f6-95f2-9f980659eb04
+AcrQuarantineWriter,acr quarantine data writer,c8d4ff99-41c3-41a8-9f60-21dfdad59608
+Advisor Recommendations Contributor,"View assessment recommendations, accepted review recommendations, and manage the recommendations lifecycle (mark recommendations as completed, postponed or dismissed, in progress, or not started).",f680209a-a2a2-4e0d-aa81-5d2a65c13604
+Advisor Recommendations Contributor (Assessments and Reviews),"View assessment recommendations, accepted review recommendations, and manage the recommendations lifecycle (mark recommendations as completed, postponed or dismissed, in progress, or not started).",6b534d80-e337-47c4-864f-140f5c7f593d
+Advisor Reviews Contributor,View reviews for a workload and triage recommendations linked to them.,8aac15f0-d885-4138-8afa-bfb5872f7d13
+Advisor Reviews Reader,View reviews for a workload and recommendations linked to them.,c64499e0-74c3-47ad-921c-13865957895c
+AgFood Platform Dataset Admin,Provides access to Dataset APIs,a8d4b70f-0fb9-4f72-b267-b87b2f990aec
+AgFood Platform Sensor Partner Contributor,Provides contribute access to manage sensor related entities in AgFood Platform Service,6b77f0a0-0d89-41cc-acd1-579c22c17a67
+AgFood Platform Service Admin,Provides admin access to AgFood Platform Service,f8da80de-1ff9-4747-ad80-a19b7f6079e3
+AgFood Platform Service Contributor,Provides contribute access to AgFood Platform Service,8508508a-4469-4e45-963b-2518ee0bb728
+AgFood Platform Service Reader,Provides read access to AgFood Platform Service,7ec7ccdc-f61e-41fe-9aaf-980df0a44eba
+AnyBuild Builder,Basic user role for AnyBuild. This role allows listing of agent information and execution of remote build capabilities.,a2138dac-4907-4679-a376-736901ed8ad8
+Anyscale Platform Administrator Role,Provides full access to Anyscale Cloud and resources as well as admin features such as usage and resource notifications.,3e9f3756-203e-4734-a0b8-4b68691ffae3
+Anyscale Platform Contributor Role,Grants read/write access to Anyscale Cloud and resources,6d461258-d39c-46cc-8ca1-cab4120979d8
+Anyscale Platform Reader Role,Read access to Anyscale Cloud and resources,ab24b16e-fd5d-41b5-839e-6c6d2ad32363
+App Compliance Automation Administrator,Allows managing App Compliance Automation tool for Microsoft 365,0f37683f-2463-46b6-9ce7-9b788b988ba2
+App Compliance Automation Reader,Allows read-only access to App Compliance Automation tool for Microsoft 365,ffc6bbe0-e443-4c3b-bf54-26581bb2f78e
+App Configuration Contributor,"Grants permission for all management operations, except purge, for App Configuration resources. This role does not grant access to data plane resources such as key-values, snapshots, and feature flags.",fe86443c-f201-4fc4-9d2a-ac61149fbda0
+App Configuration Data Owner,Allows full access to App Configuration data.,5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b
+App Configuration Data Reader,Allows read access to App Configuration data.,516239f1-63e1-4d78-a4de-a74fb236a071
+App Configuration Reader,"Grants permission for read operations for App Configuration resources. This role does not grant access to data plane resources such as key-values, snapshots, and feature flags.",175b81b9-6e0d-490a-85e4-0d422273c10c
+App Service Environment Contributor,Manage App Service Environments but not the App Service Plans or Websites that it hosts.,8ea85a25-eb16-4e29-ab4d-6f2a26c711a2
+AppGw for Containers Configuration Manager,Allows access and configuration updates to Application Gateway for Containers resource.,fbc52c3f-28ad-4303-a892-8a056630b8f1
+Application Group Contributor,Contributor of the Application Group.,ca6382a4-1721-4bcf-a114-ff0c70227b6b
+Application Insights Component Contributor,Can manage Application Insights components,ae349356-3a1b-4a5e-921d-050484c6347e
+Application Insights Snapshot Debugger,Gives user permission to use Application Insights Snapshot Debugger features,08954f03-6346-4c2e-81c0-ec3a5cfae23b
+Arc Container Storage Contributor,"Create, read, modify, and delete Arc Container Storage resources on connected clusters. This role is in preview and subject to change.",ee99642a-225b-4fe8-a771-9d9036053e87
+Arc Gateway Manager,Manage Arc Gateway Resources,f6e92014-8af2-414d-9948-9b1abf559285
+ArizeAi.ObservabilityEval Contributor Role,Provides access to all ArizeAi.ObservabilityEval related operations,dca88c6f-5090-44cd-a0ff-a88f337b12a5
+Artifact Signing Certificate Profile Signer,Sign files with a certificate profile.,2837e146-70d7-4cfd-ad55-7efa6464f958
+Artifact Signing Identity Verifier,Manage identity or business verification requests.,4339b7cf-9826-4e41-b4ed-c7f4505dac08
+Associated Billing Accounts Reader,Allows users to list all the associated billing accounts for their tenant.,d6c7ff7d-dd03-45a8-af9c-2a825e11bf9f
+Astronomer Astro Contributor,Provides access to Astronomer.Astro Control Plane Operations,a6a9a135-9048-45df-b559-a90bb025e92f
+Attestation Contributor,Can read write or delete the attestation provider instance,bbf86eb8-f7b4-4cce-96e4-18cddf81d86e
+Attestation Reader,Can read the attestation provider properties,fd1bd22b-8476-40bc-a0bc-69b95687b9f3
+Auto Actions Contributor,Allows users to manage Auto Actions resources.,a8d01690-9418-4783-8ca2-9f0f1791783d
+Automation Contributor,Manage azure automation resources and other resources using azure automation.,f353d9bd-d4a6-484e-a77a-8050b599b867
+Automation Job Operator,Create and Manage Jobs using Automation Runbooks.,4fe576fe-1146-4730-92eb-48519fa6bf9f
+Automation Operator,"Automation Operators are able to start, stop, suspend, and resume jobs",d3881f73-407a-4167-8283-e981cbba0404
+Automation Runbook Operator,Read Runbook properties - to be able to create Jobs of the runbook.,5fb5aef8-1081-4b8e-bb16-9d5d0385bab5
+Autonomous Development Platform Data Contributor (Preview),Grants permissions to upload and manage new Autonomous Development Platform measurements.,b8b15564-4fa6-4a59-ab12-03e1d9594795
+Autonomous Development Platform Data Owner (Preview),Grants full access to Autonomous Development Platform data.,27f8b550-c507-4db9-86f2-f4b8e816d59d
+Autonomous Development Platform Data Reader (Preview),Grants read access to Autonomous Development Platform data.,d63b75f7-47ea-4f27-92ac-e0d173aaf093
 Avere Contributor,Can create and manage an Avere vFXT cluster.,4f8fab4f-1852-4a58-a46a-8eaf358af14a
 Avere Operator,Used by the Avere vFXT cluster to manage the cluster,c025889f-8102-4ebf-b32c-fc0c6f0c6bd9
-Backup Contributor,"Lets you manage backup service, but can't create vaults and give access to others",5e467623-bb1f-42f4-a55d-6e525e11384b
-Backup Operator,"Lets you manage backup services, except removal of backup, vault creation and giving access to others",00c29273-979b-4161-815c-10b084fb9324
-Backup Reader,"Can view backup services, but can't make changes",a795c7a0-d4a2-40c1-ae25-d81f01202912
-Classic Storage Account Contributor,"Lets you manage classic storage accounts, but not access to them.",86e8f5dc-a6e9-4c67-9d15-de283e8eac25
-Classic Storage Account Key Operator Service Role,Classic Storage Account Key Operators are allowed to list and regenerate keys on Classic Storage Accounts,985d6b00-f706-48f5-a6fe-d0ca12fb668d
-Data Box Contributor,Lets you manage everything under Data Box Service except giving access to others.,add466c9-e687-43fc-8d98-dfcf8d720be5
-Data Box Reader,Lets you manage Data Box Service except creating order or editing order details and giving access to others.,028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027
-Data Lake Analytics Developer,"Lets you submit, monitor, and manage your own jobs but not create or delete Data Lake Analytics accounts.",47b7735b-770e-4598-a7da-8b91488b4c88
-Reader and Data Access,Lets you view everything but will not let you delete or create a storage account or contained resource. It will also allow read/write access to all data contained in a storage account via access to storage account keys.,c12c1c16-33a1-487b-954d-41c89c60f349
-Storage Account Backup Contributor,Lets you perform backup and restore operations using Azure Backup on the storage account.,e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1
-Storage Account Contributor,"Permits management of storage accounts. Provides access to the account key, which can be used to access data via Shared Key authorization.",17d1049b-9a84-46fb-8f53-869881c3d3ab
-Storage Account Key Operator Service Role,Permits listing and regenerating storage account access keys.,81a9662b-bebf-436f-a333-f67b29880f12
-Storage Blob Data Contributor,"Read, write, and delete Azure Storage containers and blobs. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",ba92f5b4-2d11-453d-a403-e96b0029c9fe
-Storage Blob Data Owner,"Provides full access to Azure Storage blob containers and data, including assigning POSIX access control. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",b7e6dc6d-f1e8-4753-8033-0f276bb0955b
-Storage Blob Data Reader,"Read and list Azure Storage containers and blobs. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",2a2b9908-6ea1-4ae2-8e65-a410df84e7d1
-Storage Blob Delegator,"Get a user delegation key, which can then be used to create a shared access signature for a container or blob that is signed with Azure AD credentials. For more information, see Create a user delegation SAS.",db58b8e5-c6ad-4a2a-8342-4190687cbf4a
-Storage File Data SMB Share Contributor,"Allows for read, write, and delete access on files/directories in Azure file shares. This role has no built-in equivalent on Windows file servers.",0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb
-Storage File Data SMB Share Elevated Contributor,"Allows for read, write, delete, and modify ACLs on files/directories in Azure file shares. This role is equivalent to a file share ACL of change on Windows file servers.",a7264617-510b-434b-a828-9731dc254ea7
-Storage File Data SMB Share Reader,Allows for read access on files/directories in Azure file shares. This role is equivalent to a file share ACL of read on Windows file servers.,aba4ae5f-2193-4029-9191-0cb91df5e314
-Storage Queue Data Contributor,"Read, write, and delete Azure Storage queues and queue messages. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",974c5e8b-45b9-4653-ba55-5f855dd0fb88
-Storage Queue Data Message Processor,"Peek, retrieve, and delete a message from an Azure Storage queue. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",8a0f0c08-91a1-4084-bc3d-661d67233fed
-Storage Queue Data Message Sender,"Add messages to an Azure Storage queue. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",c6a89b2d-59bc-44d0-9896-0f6e12d7b80a
-Storage Queue Data Reader,"Read and list Azure Storage queues and queue messages. To learn which actions are required for a given data operation, see Permissions for calling blob and queue data operations.",19e7f393-937e-4f77-808e-94535e297925
-Storage Table Data Contributor,"Allows for read, write and delete access to Azure Storage tables and entities",0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3
-Storage Table Data Reader,Allows for read access to Azure Storage tables and entities,76199698-9eea-4c19-bc75-cec21354c6b6
+Aws Connector contributor role,Microsoft.AwsConnector contributor role,98c206fe-ea1b-4578-93f8-83a99a5628fc
+Azure AI Administrator,A Built-In Role that has all control plane permissions to work with Azure AI and its dependencies.,b78c5d69-af96-48a3-bf8d-a8b4d589de94
+Azure AI Developer,"Can perform all actions within an Azure Machine Learning workspace besides managing the workspace itself. For Foundry project access, use the Foundry User or Foundry Owner roles instead.",64702f94-c441-49e6-a78b-ef80e0188fee
+Azure AI Enterprise Network Connection Approver,Can approve private endpoint connections to Azure AI common dependency resources,b556d68e-0be0-4f35-a333-ad7ee1ce17ea
+Azure AI Enterprise Networking Outbound Rules Operator,A Built-in role that can authorize users to access and update the managed network settings of a machine learning workspace.,25cabde7-1a6c-4350-8877-cb6fe59f1399
+Azure AI Inference Deployment Operator,Can perform all actions required to create a resource deployment within a resource group.,3afb7f49-54cb-416e-8c09-6dc049efa503
+Azure AI Manager and Namespace RBAC Inference Operator,"Allows read access to all objects in an Azure AI Manager namespace, plus the ability to read Secrets and invoke inference against AI models deployed in that namespace. This role does not allow modifying objects, roles, or role bindings. However, the ability to read Secrets allows the holder to obtain ServiceAccount tokens in the namespace. Applying this role at the AI Manager scope will give access across all namespaces.",82b2f1a9-9593-4498-a824-c209343a28ec
+Azure AI Safety Evaluator,This role can perform all actions under workspace evaluations and simulations.,11102f94-c441-49e6-a78b-ef80e0188abc
+Azure AIManager Contributor,"Grants read/write access to Azure resources provided by Kubernetes AI Manager, including aimanagers, deployments, namespace, etc.",413f2675-4911-4010-be3b-c720b43a3c59
+Azure AIManager User,"Grants read access to Azure resources provided by Kubernetes AI Manager, including aimanagers, deployments, namespace, etc.",223653d0-bf85-419e-ac7a-a67edf5fc44b
+Azure AIManager and namespace RBAC Reader,"Allows read-only access to all objects in an Azure AI Manager namespace, except Secrets, roles, and role bindings. Applying this role at the AI Manager scope will give access across all namespaces.",9c77f8a7-b0b9-4462-844c-de6e66add8ba
+Azure API Center Compliance Manager,Allows managing API compliance in Azure API Center service.,ede9aaa3-4627-494e-be13-4aa7c256148d
+Azure API Center Credential Access Reader,Allows for access to Azure API Center data plane get credentials operations.,1df7cd83-1d3f-41df-95b0-53b30d963369
+Azure API Center Data Reader,Allows for access to Azure API Center data plane read operations.,c7244dfb-f447-457d-b2ba-3999044d1706
+Azure API Center Service Contributor,Allows managing Azure API Center service.,dd24193f-ef65-44e5-8a7e-6fa6e03f7713
+Azure API Center Service Reader,Allows read-only access to Azure API Center service.,6cba8790-29c5-48e5-bab1-c7541b01cb04
+Azure Advisor Service Role,"Grants permission to delete and write access for suppressions, configurations and assmessments",69a41f41-6dce-4ea7-8a34-8e095ddba55c
+Azure Arc Enabled Kubernetes Cluster User Role,List cluster user credentials action.,00493d72-78f6-4148-b6c5-d3ce8e4799dd
+Azure Arc Kubernetes Admin,"Lets you manage all resources under cluster/namespace, except update or delete resource quotas and namespaces.",dffb1e0c-446f-4dde-a09f-99eb5cc68b96
+Azure Arc Kubernetes Cluster Admin,Lets you manage all resources in the cluster.,8393591c-06b9-48a2-a542-1bd6b377f6a2
+Azure Arc Kubernetes Viewer,"Lets you view all resources in cluster/namespace, except secrets.",63f0a09d-1495-4db4-a681-037d84835eb4
+Azure Arc Kubernetes Writer,"Lets you update everything in cluster/namespace, except (cluster)roles and (cluster)role bindings.",5b999177-9696-4545-85c7-50de3797e5a1
+Azure Arc ScVmm Administrator role,Arc ScVmm VM Administrator has permissions to perform all ScVmm actions.,a92dfd61-77f9-4aec-a531-19858b406c87
+Azure Arc ScVmm Private Cloud User,Azure Arc ScVmm Private Cloud User has permissions to use the ScVmm resources to deploy VMs.,c0781e91-8102-4553-8951-97c6d4243cda
+Azure Arc ScVmm Private Clouds Onboarding,Azure Arc ScVmm Private Clouds Onboarding role has permissions to provision all the required resources for onboard and deboard vmm server instances to Azure.,6aac74c4-6311-40d2-bbdd-7d01e7c6e3a9
+Azure Arc ScVmm VM Contributor,Arc ScVmm VM Contributor has permissions to perform all VM actions.,e582369a-e17b-42a5-b10c-874c387c530b
+Azure Arc VMware Administrator role ,Arc VMware VM Contributor has permissions to perform all connected VMwarevSphere actions.,ddc140ed-e463-4246-9145-7c664192013f
+Azure Arc VMware Private Cloud User,Azure Arc VMware Private Cloud User has permissions to use the VMware cloud resources to deploy VMs.,ce551c02-7c42-47e0-9deb-e3b6fc3a9a83
+Azure Arc VMware Private Clouds Onboarding,Azure Arc VMware Private Clouds Onboarding role has permissions to provision all the required resources for onboard and deboard vCenter instances to Azure.,67d33e57-3129-45e6-bb0b-7cc522f762fa
+Azure Arc VMware VM Contributor,Arc VMware VM Contributor has permissions to perform all VM actions.,b748a06d-6150-4f8a-aaa9-ce3940cd96cb
+Azure Automanage Contributor,Azure Automanage Contributor,8d6517c1-e434-405c-9f3f-e0ae65085d76
+Azure Backup Snapshot Contributor,Provide permissions to backup identity to manage RPC snapshots,afc680e2-a938-412d-b213-9a49efa7fb83
+Azure Batch Account Contributor,"Grants full access to manage all Batch resources, including Batch accounts, pools and jobs.",29fe4964-1e60-436b-bd3a-77fd4c178b3c
+Azure Batch Account Reader,Lets you view all resources including pools and jobs in the Batch account.,11076f67-66f6-4be0-8f6b-f0609fd05cc9
+Azure Batch Data Contributor,Grants permissions to manage Batch pools and jobs but not to modify accounts.,6aaa78f1-f7de-44ca-8722-c64a23943cae
+Azure Batch Job Submitter,Lets you submit and manage jobs in the Batch account.,48e5e92e-a480-4e71-aa9c-2778f4c13781
+Azure Batch Service Orchestration Role,Grants the required permissions to Azure Batch Resource Provider to manage compute and other backing resources in the subscription.,a35466a1-cfd6-450a-b35e-683fcdf30363
+Azure Bot Service Contributor Role,To perform actions on the bots by copilot studio platform and extensibility team,9fc6112f-f48e-4e27-8b09-72a5c94e4ae9
+Azure Business Continuity DUPI Reader,Lets you view Deleted Unified Protected items in Azure Business Continuity Center.,f4eb044f-76b9-47af-92f9-1d95c4c14ab5
+Azure Business Continuity UPI Reader,Lets you view Unified Protected items in Azure Business Continuity Center.,3b5a0aa9-eccd-48dc-9011-f2fd03b5e5f9
+Azure Center for SAP solutions Management role,"This role has permissions which allow users to register existing systems, view and manage systems.",6d949e1d-41e2-46e3-8920-c6e4f31a8310
+Azure Center for SAP solutions Service role for management,This role has permissions that the user assigned managed identity must have to enable registration for the existing systems.,0105a6b0-4bb9-43d2-982a-12806f9faddb
+Azure Center for SAP solutions administrator,This role provides read and write access to all capabilities of Azure Center for SAP solutions.,7b0c7e81-271f-4c71-90bf-e30bdfdbc2f7
+Azure Center for SAP solutions reader,This role provides read access to all capabilities of Azure Center for SAP solutions.,05352d14-a920-4328-a0de-4cbe7430e26b
+Azure Center for SAP solutions service role,Azure Center for SAP solutions service role - This role is intended to be used for providing the permissions to user assigned managed identity. Azure Center for SAP solutions will use this identity to deploy and manage SAP systems.,aabbc5dd-1af0-458b-a942-81af88f9c138
+Azure Connected Machine Onboarding,Can onboard Azure Connected Machines.,b64e21ea-ac4e-4cdf-9dc9-5b892992bee7
+Azure Connected Machine Resource Administrator,"Can read, write, delete and re-onboard Azure Connected Machines.",cd570a14-e51a-42ad-bac8-bafd67325302
+Azure Connected Machine Resource Manager,Custom Role for AzureStackHCI RP to manage hybrid compute machines and hybrid connectivity endpoints in a resource group,f5819b54-e033-4d82-ac66-4fec3cbf3f4c
+Azure Connected SQL Server Onboarding,Microsoft.AzureArcData service role to access the resources of Microsoft.AzureArcData stored with RPSAAS.,e8113dce-c529-4d33-91fa-e9b972617508
+Azure Container Instances Contributor Role,Grants read/write access to container groups provided by Azure Container Instances,5d977122-f97e-4b4d-a52f-6b43003ddb4d
+Azure Container Storage Contributor,Lets you install Azure Container Storage and manage its storage resources,95dd08a6-00bd-4661-84bf-f6726f83a4d0
+Azure Container Storage Operator,Role required by a Managed Identity for Azure Container Storage operations,08d4c71a-cc63-4ce4-a9c8-5dd251b4d619
+Azure Container Storage Owner,Lets you install Azure Container Storage and grants access to its storage resources,95de85bd-744d-4664-9dde-11430bc34793
+Azure ContainerApps Session Executor,Create and execute sessions in a sessionPool,0fb8eba5-a2bb-4abe-b1c1-49dfad359bb0
+Azure Customer Lockbox Approver for Subscription,"Can approve Microsoft support requests to access specific resources contained within a subscription, or the subscription itself, when Customer Lockbox for Microsoft Azure is enabled on the tenant where the subscription resides.",4dae6930-7baf-46f5-909e-0383bc931c46
+Azure Data Transfer Owner,"Create, read, modify, and delete pipelines, connections, and flows in Azure Data Transfer. Also perform any appropriate control plane operations for managing Azure Data Transfer resources.",eded264d-1796-4e25-8500-a78427f8a316
+Azure Deployment Stack Contributor,"Allows a user to manage deployment stacks, but cannot create or delete deny assignments within the deployment stack.",bf7f8882-3383-422a-806a-6526c631a88a
+Azure Deployment Stack Owner,"Allows a user to manage deployment stacks, including those with deny assignments.",adb29209-aa1d-457b-a786-c913953d2891
+Azure Device Onboarding Contributor,"Can read, write, or delete resources for onboarding services, policies, and device states.",a954a0e0-f57f-4606-8421-fd7bd4e54b0f
+Azure Device Onboarding Discovery Contributor,"Can read, write or delete the discovery and it's child resources.",a227fb39-f479-404b-96fd-0176f5d88ab4
+Azure Device Registry Administrator,Azure Device Registry Administrator,12675fd7-7f59-493f-9201-f7944860a2f1
+Azure Device Registry Contributor,Allows for full access to IoT devices within Azure Device Registry Namespace.,a5c3590a-3a1a-4cd4-9648-ea0a32b15137
+Azure Device Registry Credentials Contributor,Allows for full access to manage credentials and policies within Azure Device Registry Namespace.,09267e11-2e06-40b5-8fe4-68cea20794c9
+Azure Device Registry Onboarding,Allows for full access to Azure Device Registry Namespace and X.509 certificate provisioning.,547f7f0a-69c0-4807-bd9e-0321dfb66a84
+Azure Device Update Agent,Provide full access to all Azure Device Update agent operations,2a740172-0fc2-4039-972c-b31864cd47d6
+Azure Digital Twins Data Owner,Full access role for Digital Twins data-plane,bcd981a7-7f74-457b-83e1-cceb9e632ffe
+Azure Digital Twins Data Reader,Read-only role for Digital Twins data-plane properties,d57506d4-4c8d-48b1-8587-93c323f6a5a3
+Azure Edge Hardware Center Administrator,Grants you access to take actions as an edge order administrator,9295f069-25d0-4f44-bb6a-3da70d11aa00
+Azure Edge On-Site Deployment Engineer,Grants you access to take actions as an on-site person to assist in the provisioning of an edge device,207bcc4b-86a6-4487-9141-d6c1f4c238aa
+Azure Edge On-Site Deployment Manager,Grants you access to take actions as an on-site person to assist in the provisioning of an edge device,78739afa-3ece-4d6b-90ba-762fdccd7438
+Azure Event Hubs Data Owner,Allows for full access to Azure Event Hubs resources.,f526a384-b230-433a-b45c-95f59c4a2dec
+Azure Event Hubs Data Receiver,Allows receive access to Azure Event Hubs resources.,a638d3c7-ab3a-418d-83e6-5f17a39d4fde
+Azure Event Hubs Data Sender,Allows send access to Azure Event Hubs resources.,2b629674-e913-4c01-ae53-ef4638d8f975
+Azure Extension for SQL Server Deployment,Microsoft.AzureArcData service role to enable deployment of Azure Extension for SQL Server,7392c568-9289-4bde-aaaa-b7131215889d
+Azure File Sync Administrator,Provides full access to manage all Azure File Sync (Storage Sync Service) resources.,92b92042-07d9-4307-87f7-36a593fc5850
+Azure File Sync Reader,Provides read access to Azure File Sync service (Storage Sync Service).,754c1a27-40dc-4708-8ad4-2bffdeee09e8
+Azure Front Door Domain Contributor,"For internal use within Azure. Can manage Azure Front Door domains, but can't grant access to other users.",0ab34830-df19-4f8c-b84e-aa85b8afa6e8
+Azure Front Door Domain Reader,"For internal use within Azure. Can view Azure Front Door domains, but can't make changes.",0f99d363-226e-4dca-9920-b807cf8e1a5f
+Azure Front Door Profile Reader,"Can view AFD standard and premium profiles and their endpoints, but can't make changes.",662802e2-50f6-46b0-aed2-e834bacc6d12
+Azure Front Door Secret Contributor,"For internal use within Azure. Can manage Azure Front Door secrets, but can't grant access to other users.",3f2eb865-5811-4578-b90a-6fc6fa0df8e5
+Azure Front Door Secret Reader,"For internal use within Azure. Can view Azure Front Door secrets, but can't make changes.",0db238c4-885e-4c4f-a933-aa2cef684fca
+Azure Hybrid Database Administrator - Read Only Service Role,Read only access to Azure hybrid database services resources.,5d9c6a55-fc0e-4e21-ae6f-f7b095497342
+Azure IoT Operations Administrator,"View, create, edit and delete AIO resources. Manage all resources, including instance and its downstream resources.",5bc02df6-6cd5-43fe-ad3d-4c93cf56cc16
+Azure IoT Operations Onboarding,User can Azure arc connect and deploy Azure IoT Operations securely.,7b7c71ed-33fa-4ed2-a91a-e56d5da260b5
+Azure Kubernetes Application Network Contributor Role,"Grant read, write and delete access to Azure Kubernetes Application Network",852e55ca-96ce-48b0-abca-2cd74d9042ca
+Azure Kubernetes Fleet Manager ABAC Custom Resources Reader,"Allows read-only access to view Kubernetes custom resources on Azure Kubernetes Fleet Manager fleets. This role enables viewing custom resources without the ability to create, modify, or delete them. Applying this role at cluster scope will give read access to custom resources across all namespaces. More information on supported attributes for Attribute-Based Access Control (ABAC) conditions can be found under documentation at aka.ms/aks/abac/custom-resources/docs",20cf746c-c765-402a-885e-c389c64478ce
+Azure Kubernetes Fleet Manager ABAC Custom Resources Reader for Member Clusters,"Allows read-only access to view Kubernetes custom resources on Azure Kubernetes Fleet Manager member clusters. This role enables viewing custom resources without the ability to create, modify, or delete them. Applying this role at cluster scope will give read access to custom resources across all namespaces. More information on supported attributes for Attribute-Based Access Control (ABAC) conditions can be found under documentation at aka.ms/aks/abac/custom-resources/docs",e1663658-d5f7-4383-9afb-af9fdc9c5eae
+Azure Kubernetes Fleet Manager ABAC Custom Resources Writer,"Allows write and delete access to manage Kubernetes custom resources on Azure Kubernetes Fleet Manager fleets. This role enables creating, modifying, and deleting custom resources. Applying this role at cluster scope will give access to custom resources across all namespaces. More information on supported attributes for Attribute-Based Access Control (ABAC) conditions can be found under documentation at aka.ms/aks/abac/custom-resources/docs",ff8eb232-5069-437e-94e5-31112ef30539
+Azure Kubernetes Fleet Manager ABAC Custom Resources Writer for Member Clusters,"Allows write and delete access to manage Kubernetes custom resources on Azure Kubernetes Fleet Manager member clusters. This role enables creating, modifying, and deleting custom resources. Applying this role at cluster scope will give access to custom resources across all namespaces. More information on supported attributes for Attribute-Based Access Control (ABAC) conditions can be found under documentation at aka.ms/aks/abac/custom-resources/docs",673366d4-9664-4020-b03b-b0093366bff9
+Azure Kubernetes Fleet Manager Contributor Role,"Grants read/write access to Azure resources provided by Azure Kubernetes Fleet Manager, including fleets, fleet members, fleet update strategies, fleet update runs, etc.",63bb64ad-9799-4770-b5c3-24ed299a07bf
+Azure Kubernetes Fleet Manager Hub Agent Role,Grants access to Azure resources needed by Azure Kubernetes Fleet Manager hub agents.,de2b316d-7a2c-4143-b4cd-c148f6a355a1
+Azure Kubernetes Fleet Manager Hub Cluster User Role,Grants read access to Azure Kubernetes Fleet Manager as well as the Kubernetes config file to connect to the fleet-managed hub cluster.,850c5848-fc51-4a9a-8823-f220370626e3
+Azure Kubernetes Fleet Manager RBAC Admin,"Grants read/write access to Kubernetes resources within a namespace in the fleet-managed hub cluster - provides write permissions on most objects within a a namespace, with the exception of ResourceQuota object and the namespace object itself. Applying this role at cluster scope will give access across all namespaces.",434fb43a-c01c-447e-9f67-c3ad923cfaba
+Azure Kubernetes Fleet Manager RBAC Admin for Member Clusters,"This role grants admin access - provides write permissions on most objects within a namespace, with the exception of ResourceQuota object and the namespace object itself. Applying this role at cluster scope will give access across all namespaces.",d1f699ed-700a-4c77-a22f-29890ac7b115
+Azure Kubernetes Fleet Manager RBAC Cluster Admin,Grants read/write access to all Kubernetes resources in the fleet-managed hub cluster.,18ab4d3d-a1bf-4477-8ad9-8359bc988f69
+Azure Kubernetes Fleet Manager RBAC Cluster Admin for Member Clusters,Lets you manage all resources in the member clusters in the fleet.,79a36d98-eb96-4a76-ae1d-481dc98d2c23
+Azure Kubernetes Fleet Manager RBAC Cluster Reader,Grants read-only access to most Kubernetes cluster-scoped resources in the fleet-managed hub cluster.,bd80684d-2f5f-4130-892a-0955546282de
+Azure Kubernetes Fleet Manager RBAC Cluster Writer,Grants read/write access to most Kubernetes cluster-scoped resources in the fleet-managed hub cluster.,1dc4cd5a-de51-4ee4-bc8e-b40e9c17e320
+Azure Kubernetes Fleet Manager RBAC Reader,"Grants read-only access to most Kubernetes resources within a namespace in the fleet-managed hub cluster. It does not allow viewing roles or role bindings. This role does not allow viewing Secrets, since reading the contents of Secrets enables access to ServiceAccount credentials in the namespace, which would allow API access as any ServiceAccount in the namespace (a form of privilege escalation).  Applying this role at cluster scope will give access across all namespaces.",30b27cfc-9c84-438e-b0ce-70e35255df80
+Azure Kubernetes Fleet Manager RBAC Reader for Member Clusters,"Allows read-only access to see most objects in a namespace. It does not allow viewing roles or role bindings. This role does not allow viewing Secrets, since reading the contents of Secrets enables access to ServiceAccount credentials in the namespace, which would allow API access as any ServiceAccount in the namespace (a form of privilege escalation).  Applying this role at cluster scope will give access across all namespaces.",463ad26c-fcce-4469-9c7f-5653d8acbab5
+Azure Kubernetes Fleet Manager RBAC Writer,"Grants read/write access to most Kubernetes resources within a namespace in the fleet-managed hub cluster. This role does not allow viewing or modifying roles or role bindings. However, this role allows accessing Secrets as any ServiceAccount in the namespace, so it can be used to gain the API access levels of any ServiceAccount in the namespace.  Applying this role at cluster scope will give access across all namespaces.",5af6afb3-c06c-4fa4-8848-71a8aee05683
+Azure Kubernetes Fleet Manager RBAC Writer for Member Clusters,"Allows read/write access to most objects in a namespace. This role does not allow viewing or modifying roles or role bindings. However, this role allows accessing Secrets and running Pods as any ServiceAccount in the namespace, so it can be used to gain the API access levels of any ServiceAccount in the namespace.  Applying this role at cluster scope will give access across all namespaces.",50346970-0998-40f2-b47d-f3b8809840f8
+Azure Kubernetes Service Agent Pool Manager Role,Role for agentpool related actions,1b7f3653-4324-473a-9165-bc55e4d04ba8
+Azure Kubernetes Service Arc Cluster Admin Role,List cluster admin credential action.,b29efa5f-7782-4dc3-9537-4d5bc70a5e9f
+Azure Kubernetes Service Arc Cluster User Role,List cluster user credential action.,233ca253-b031-42ff-9fba-87ef12d6b55f
+Azure Kubernetes Service Arc Contributor Role,Grants access to read and write Azure Kubernetes Services hybrid clusters,5d3f1697-4507-4d08-bb4a-477695db5f82
+Azure Kubernetes Service Cluster Admin Role,List cluster admin credential action.,0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8
+Azure Kubernetes Service Cluster Monitoring User,List cluster monitoring user credential action.,1afdec4b-e479-420e-99e7-f82237c7c5e6
+Azure Kubernetes Service Cluster User Role,List cluster user credential action.,4abbcc35-e782-43d8-92c5-2d3f1bd2253f
+Azure Kubernetes Service Contributor Role,Grants access to read and write Azure Kubernetes Service clusters,ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8
+Azure Kubernetes Service Hybrid Cluster Admin Role,List cluster admin credential action.,b5092dac-c796-4349-8681-1a322a31c3f9
+Azure Kubernetes Service Hybrid Cluster User Role,List cluster user credential action.,fc3f91a1-40bf-4439-8c46-45edbd83563a
+Azure Kubernetes Service Hybrid Contributor Role,Grants access to read and write Azure Kubernetes Services hybrid clusters,e7037d40-443a-4434-a3fb-8cd202011e1d
+Azure Kubernetes Service Machine Manager Role,Role for machine related actions,8e253927-1f29-4d89-baa2-c3a549eff423
+Azure Kubernetes Service Namespace Contributor,Allows users to create and manage Azure Kubernetes Service namespace resources.,289d8817-ee69-43f1-a0af-43a45505b488
+Azure Kubernetes Service Namespace User,Allows users to read Azure Kubernetes Service namespace resources. In-cluster namespace access further requires assignment of Azure Kubernetes Service RBAC roles to the namespace resource for an Entra ID enabled cluster.,c9f76ca8-b262-4b10-8ed2-09cf0948aa35
+Azure Kubernetes Service Policy Add-on Deployment,Deploy the Azure Policy add-on on Azure Kubernetes Service clusters,18ed5180-3e48-46fd-8541-4ea054d57064
+Azure Kubernetes Service Prepared Image Specification Contributor,Allows users to create and manage Prepared Image Specification resources.,4f772c11-8026-4833-859c-5c23e84b5c30
+Azure Kubernetes Service Prepared Image Specification Reader,Allows read-only access to Prepared Image Specification resources.,ed915fdf-c373-4707-988e-fb5d15a5a9ec
+Azure Kubernetes Service RBAC Admin,"Lets you manage all resources under cluster/namespace, except update or delete resource quotas and namespaces.",3498e952-d568-435e-9b2c-8d77e338d7f7
+Azure Kubernetes Service RBAC Cluster Admin,Lets you manage all resources in the cluster.,b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
+Azure Kubernetes Service RBAC Reader,"Allows read-only access to see most objects in a namespace. It does not allow viewing roles or role bindings. This role does not allow viewing Secrets, since reading the contents of Secrets enables access to ServiceAccount credentials in the namespace, which would allow API access as any ServiceAccount in the namespace (a form of privilege escalation). Applying this role at cluster scope will give access across all namespaces.",7f6c6a51-bcf8-42ba-9220-52d62157d7db
+Azure Kubernetes Service RBAC Writer,"Allows read/write access to most objects in a namespace.This role does not allow viewing or modifying roles or role bindings. However, this role allows accessing Secrets and running Pods as any ServiceAccount in the namespace, so it can be used to gain the API access levels of any ServiceAccount in the namespace. Applying this role at cluster scope will give access across all namespaces.",a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb
+Azure Local Disconnected Operations Role,Azure Local Disconnected Operations Role,478d20ba-a53e-4946-b33c-8078a92f2d0a
+Azure Local Infrastructure Contributor,"Grants permission to manage GPUs, network, disks, and volumes on Azure Local clusters.",3e43f27e-8f98-43b0-9036-e5ae540c968a
+Azure Local Infrastructure Reader,"Grants read-only access to GPUs, network, disks, and volumes on Azure Local clusters.",345f07df-7946-4fa9-9edd-80e603e89ea1
+Azure Local Migrate Execute Expert,"Grants restricted access on an Azure Local based Azure Migrate project to only perform migration related operations, including replication, execution of migrations, tracking and monitoring of migration progress, and initiation of agentless migrations.",1cfa4eac-9a23-481c-a793-bfb6958e836c
+Azure Local Migrate Owner,Grants full access to create and manage Azure Local based Azure Migrate projects including appliance-based discovery and execution of migrations; Also grants ability to assign Azure Migrate Local specific roles in Azure RBAC,fd8ea4d5-6509-4db0-bada-356ab233b4fb
+Azure Machine Learning Workspace Connection Secrets Reader,Can list workspace connection secrets,ea01e6af-a1c1-4350-9563-ad00f8c72ec5
+Azure Managed Grafana Workspace Contributor,"Can manage Azure Managed Grafana resources, without providing access to the workspaces themselves.",5c2d7e57-b7c2-4d8a-be4f-82afa42c6e95
+Azure Managed Redis Contributor,"Lets you manage Azure Managed Redis resources, but not access the data stored in them.",3015e5ed-6856-4ab3-b2f0-b8492aa30ca6
+Azure Managed Redis Reader,"Read Azure Managed Redis resources and their configuration. Cannot modify resources, retrieve access keys, or read data stored in the cache.",f287ba2f-f923-4464-a5bd-721c3951d32d
+Azure Maps Contributor,Grants access all Azure Maps resource management.,dba33070-676a-4fb0-87fa-064dc56ff7fb
 Azure Maps Data Contributor,"Grants access to read, write, and delete access to map related data from an Azure maps account.",8f5e0ce6-4f7b-4dcf-bddf-e6f48634a204
+Azure Maps Data Read and Batch Role,This role can be used to assign read and batch actions on Azure Maps.,d6470a16-71bd-43ab-86b3-6f3a73f4e787
 Azure Maps Data Reader,Grants access to read map related data from an Azure maps account.,423170ca-a8f6-4b0f-8487-9e4eb8f49bfa
+Azure Maps Search and Render Data Reader,"Grants access to very limited set of data APIs for common visual web SDK scenarios. Specifically, render and search data APIs.",6be48352-4f82-47c9-ad5e-0acacefdb005
+Azure Messaging Catalog Data Owner,Allows for full access to Azure Messaging Catalog resources.,f27b7598-bc64-41f7-8a44-855ff16326c2
+Azure Messaging Connectors Owner,Allows for full access to Azure Messaging Connectors resources.,ff478a4e-8633-416e-91bc-ec33ce7c9516
+Azure Migrate Decide and Plan Expert,"Grants restricted access on Azure Migrate project to only perform planning operations including appliance-based discovery, managing inventory, identifying server dependencies, creation of business case & assessment reports.",7859c0b0-0bb9-4994-bd12-cd529af7d646
+Azure Migrate Execute Expert,"Grants restricted access on an Azure Migrate project to only perform migration related operations, including replication, execution of test migrations, tracking and monitoring of migration progress, and initiation of agentless and agent-based migrations.",1cfa4eac-9a23-481c-a793-bfb6958e836b
+Azure Migrate Management Role,This role will let users grant permission to HybridOnboarding RP to manage extensions on their infrastructure.,c20ab07d-648c-4fed-977e-f917d8095dfc
+Azure Migrate Owner,"Grants full access to create and manage Azure Migrate projects including appliance-based discovery, creation of business case & assessment report and execution of migrations; Also grants ability to assign Azure Migrate specific roles in Azure RBAC.",fd8ea4d5-6509-4db0-bada-356ab233b4fa
+Azure Migrate Service Reader,Grants required access to the system assigned managed identity of Azure Migrate project resource.,ba480ccd-6499-4709-b581-8f38bb215c63
+Azure Monitor Dashboards with Grafana Contributor,Can manage dashboards with Grafana.,0618ae3d-2930-4bb7-aa00-718db34ee9f9
+Azure Monitor Pipeline Contributor,"Manage Azure Monitor Pipeline resources, providing full read and write access to pipeline configurations and monitoring features.",679dc20a-52e8-4ac0-a23c-3b557dfb1e24
+Azure Monitor Pipeline Reader,"Read Azure Monitor Pipeline resources, including pipeline configurations and monitoring features.",2d50f159-7b96-4f1e-8fc7-fee6957ab7cc
+Azure Native Dynatrace Agent Management Role,Grants access to manage Dynatrace Agent on compute resources,55077723-1b30-4603-a70b-68de134cfa20
+Azure NetApp Files Administrator,Allows full administrative access to Azure NetApp Files operations,f5db7409-a2c6-4d0c-8cf4-412ac01a38df
+Azure NetApp Files Reader,Allows read-only discovery operations for Azure NetApp Files resources,bafa5965-3211-483c-a7b7-027648c789e9
+Azure Notebooks NotebookProxy Contributor,"Can create, read, update, delete NotebookProxy resources and manage their credentials under Microsoft.Notebooks.",063e4498-230d-40a9-be9b-037f35f982b5
+Azure Programmable Connectivity Gateway Dataplane User,Allows access to all Gateway dataplane APIs.,c20923c5-b089-47a5-bf67-fd89569c4ad9
+Azure Programmable Connectivity Gateway User,Allows access to all Gateway dataplane APIs.,609c0c20-e0a0-4a71-b99f-e7e755ac493d
+Azure Red Hat OpenShift Cloud Controller Manager,Manage and update the cloud controller manager deployed on top of OpenShift.,a1f96423-95ce-4224-ab27-4e3dc72facd4
+Azure Red Hat OpenShift Cluster Ingress Operator,Manage and configure the OpenShift router.,0336e1d3-7a87-462b-b6db-342b63f7802c
+Azure Red Hat OpenShift Disk Storage Operator,Install Container Storage Interface (CSI) drivers that enable your cluster to use Azure Disks. Set OpenShift cluster-wide storage defaults to ensure a default storageclass exists for clusters.,5b7237c5-45e1-49d6-bc18-a1f62f400748
+Azure Red Hat OpenShift Federated Credential,"Create, update and delete federated credentials on user assigned managed identities in order to build a trust relationship between the managed identity, OpenID Connect (OIDC), and the service account.",ef318e2a-8334-4a05-9e4a-295a196c6a6e
+Azure Red Hat OpenShift File Storage Operator,Install Container Storage Interface (CSI) drivers that enable your cluster to use Azure Files. Set OpenShift cluster-wide storage defaults to ensure a default storageclass exists for clusters.,0d7aedc0-15fd-4a67-a412-efad370c947e
+Azure Red Hat OpenShift First Party Network,Grant ARO Classic First Party Service Principal or managed identity required network permissions.,42f3c60f-e7b1-46d7-ba56-6de681664342
+Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider,"Enables permissions to allow cluster API to manage nodes, networks and disks for OpenShift cluster.",88366f10-ed47-4cc0-9fab-c8a06148393e
+Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator,Enables the control plane operator to read resources necessary for OpenShift cluster.,fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+Azure Red Hat OpenShift Hosted Control Planes Service Managed Identity,Azure Red Hat OpenShift Hosted Control Planes Service Managed Identity,c0ff367d-66d8-445e-917c-583feb0ef0d4
+Azure Red Hat OpenShift Image Registry Operator,"Enables permissions for the operator to manage a singleton instance of the OpenShift image registry. It manages all configuration of the registry, including creating storage.",8b32b316-c2f5-4ddf-b05b-83dacd2d08b5
+Azure Red Hat OpenShift Machine API Operator,"Manage the lifecycle of specific-purpose custom resource definitions (CRD), controllers, and Azure RBAC objects that extend the Kubernetes API to declares the desired state of machines in a cluster.",0358943c-7e01-48ba-8889-02cc51d78637
+Azure Red Hat OpenShift Network Operator,Install and upgrade the networking components on an OpenShift cluster.,be7a6435-15ae-4171-8f30-4a343eff9e8f
+Azure Red Hat OpenShift Service Operator,"Maintain machine health, network configuration, monitoring, and other features that are specific to an OpenShift cluster's continued functionality as a managed service.",4436bae4-7702-4c84-919b-c4069ff25ee2
+Azure Relay Listener,Allows for listen access to Azure Relay resources.,26e0b698-aa6d-4085-9386-aadae190014d
+Azure Relay Owner,Allows for full access to Azure Relay resources.,2787bf04-f1f5-4bfe-8383-c8a24483ee38
+Azure Relay Sender,Allows for send access to Azure Relay resources.,26baccc8-eea7-41f1-98f4-1762cc7f685d
+Azure Resilience Management Drills Administrator,Administrator Role of Azure Resilience Management Drills Service,c914561b-1575-4601-af9c-a1356bf59818
+Azure Resilience Management Drills Assets Administrator,"This Role grants permissions on the Chaos Subscription to create, read, and delete Resource Groups, Automation Accounts, and Chaos Experiments, and assigns necessary roles to Drill and Chaos MSIs for executing post actions required by Azure Resilience Management Drills.",5a2ec2f1-2375-4950-9906-59ec1d979249
+Azure Resilience Management Drills Assets Contributor,"This Role grants permissions on the Chaos Subscription to create, read, and delete Resource Groups, Automation Accounts, and Chaos Experiments for managing chaos engineering workflows required by Azure Resilience Management Drills",344b740c-5e7c-4d32-89b2-ee3b51cb89bc
+Azure Resilience Management Drills Contributor,Contributor Role of Azure Resilience Management Drills Service,e131102b-11a5-4ff4-8508-ed922132b74c
+Azure Resilience Management Drills Operator,Operator Role of Azure Resilience Management Drills Service,ff09793b-be48-49f6-ad96-70d32039c0b9
+Azure Resilience Management Drills Reader,Reader Role of Azure Resilience Management Drills Service,d2e8fe82-9212-490f-af3e-34bb52d87d3d
+Azure Resilience Management Drills Target Resource Administrator,"This role should be assigned at the Service Group Members scope to enable resource read access, manage role assignments, and configure chaos targets and capabilities for fault injection, failover, and other post-fault actions",e4c7f620-39b8-4688-bba2-70dd82ef367b
+Azure Resilience Management Drills Target Resource Contributor,"This role should be assigned at the Service Group Members scope to enable resource read access and configure chaos targets and capabilities for fault injection, failover, and other post-fault actions",82c6a823-ae9c-4b90-b5c5-bff581c45896
+Azure Resilience Management Goals Administrator,"This role allows users to view, assign and delete resiliency goals for the service group, as well as modify the list of service group members that get evaluated against the goal. This role also allows a user to assign goal related permissions to other users.",a2b7cc47-30ec-462f-a2f4-9ac6e1c266af
+Azure Resilience Management Goals Contributor,"This role allows users to view, assign and delete resiliency goals for the service group, as well as modify the list of service group members that get evaluated against the goal.",3910633d-19d0-4d31-b5e6-4f3101b137b9
+Azure Resilience Management Goals Reader,"This role allows users to view the resiliency goals for the service group, as well as view the list of service group members that are being evaluated against the goal.",39ea2c4e-798a-4469-b81d-65dc7c54cbdb
+Azure Resilience Management Recovery Administrator,Administrator Role of Azure Resilience Management Recovery Service,481d9636-d9f0-468b-b93d-6056318e6f36
+Azure Resilience Management Recovery Contributor,Contributor Role of Azure Resilience Management Recovery Service,4c7fd853-7345-4453-babd-e9481e9b460b
+Azure Resilience Management Recovery Operator,Operator Role of Azure Resilience Management Recovery Service,517781b0-5ad4-4418-94d5-f2421834b586
+Azure Resilience Management Recovery Reader,Reader Role of Azure Resilience Management Recovery Service,8210e6a3-4e4c-4e1a-bd83-ef8bac788a45
+Azure Resilience Management Usage Administrator,Administrator Role of Azure Resilience Management Usage,b66c1f7c-c685-40d6-b8b8-64b8230febf4
+Azure Resilience Management Usage Contributor,Contributor Role of Azure Resilience Management Usage,5ca51376-e049-4302-abcc-64c588049c59
+Azure Resilience Management Usage Reader,Reader Role of Azure Resilience Management Usage,b130f7de-5374-4e3d-ada8-bae6e49114b9
+Azure Resource Bridge Deployment Role,Azure Resource Bridge Deployment Role,7b1f81f9-4196-4058-8aae-762e593270df
+Azure Resource Notifications System Topics Subscriber,Lets you create system topics and event subscriptions on all system topics exposed currently and in the future by Azure Resource Notifications,0b962ed2-6d56-471c-bd5f-3477d83a7ba4
+Azure Service Bus Data Owner,Allows for full access to Azure Service Bus resources.,090c5cfd-751d-490a-894a-3ce6f1109419
+Azure Service Bus Data Receiver,Allows for receive access to Azure Service Bus resources.,4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0
+Azure Service Bus Data Sender,Allows for send access to Azure Service Bus resources.,69a216fc-b8fb-44d8-bc22-1f3c2cd27a39
+Azure Sphere Contributor,Allows user read and write access to Azure Sphere resources.,8b9dfcab-4b77-4632-a6df-94bd07820648
+Azure Sphere Owner,"Allows user read and write access to Azure Sphere resources and RBAC configuration, includes an ABAC condition to constrain role assignments.",5a382001-fe36-41ff-bba4-8bf06bd54da9
+Azure Sphere Publisher,Allows user to read and download Azure Sphere resources and upload images.,6d994134-994b-4a59-9974-f479f0b227fb
+Azure Sphere Reader,Allows user to read Azure Sphere resources.,c8ae6279-5a0b-4cb2-b3f0-d4d62845742c
+Azure Spring Apps Application Configuration Service Config File Pattern Reader Role,Read content of config file pattern for Application Configuration Service in Azure Spring Apps,25211fc6-dc78-40b6-b205-e4ac934fd9fd
+Azure Spring Apps Application Configuration Service Log Reader Role,Read real-time logs for Application Configuration Service in Azure Spring Apps,6593e776-2a30-40f9-8a32-4fe28b77655d
+Azure Spring Apps Connect Role,Azure Spring Apps Connect Role,80558df3-64f9-4c0f-b32d-e5094b036b0b
+Azure Spring Apps Job Execution Instance List Role,List instances for job executions in Azure Spring Apps,91422e52-bb88-4415-bb4a-90f5b71f6dcb
+Azure Spring Apps Job Log Reader Role,Read real-time logs for jobs in Azure Spring Apps,b459aa1d-e3c8-436f-ae21-c0531140f43e
+Azure Spring Apps Managed Components Log Reader Role,Read real-time logs for all managed components in Azure Spring Apps,52fd16bd-6ed5-46af-9c40-29cbd7952a29
+Azure Spring Apps Remote Debugging Role,Azure Spring Apps Remote Debugging Role,a99b0159-1064-4c22-a57b-c9b3caa1c054
+Azure Spring Apps Service Owner,Full access to Azure Spring Apps Service REST APIs,4037dd68-1cc7-4a64-8765-3a79963a9940
+Azure Spring Apps Spring Cloud Config Server Log Reader Role,Read real-time logs for Spring Cloud Config Server in Azure Spring Apps,74252426-c508-480e-9345-4607bbebead4
+Azure Spring Apps Spring Cloud Gateway Log Reader Role,Read real-time logs for Spring Cloud Gateway in Azure Spring Apps,4301dc2a-25a9-44b0-ae63-3636cf7f2bd2
 Azure Spring Cloud Config Server Contributor,"Allow read, write and delete access to Azure Spring Cloud Config Server",a06f5c24-21a7-4e1a-aa2b-f19eb6684f5b
 Azure Spring Cloud Config Server Reader,Allow read access to Azure Spring Cloud Config Server,d04c6db6-4947-4782-9e91-30a88feb7be7
 Azure Spring Cloud Data Reader,Allow read access to Azure Spring Cloud Data,b5537268-8956-4941-a8f0-646150406f0c
 Azure Spring Cloud Service Registry Contributor,"Allow read, write and delete access to Azure Spring Cloud Service Registry",f5880b48-c26d-48be-b172-7927bfa1c8f1
 Azure Spring Cloud Service Registry Reader,Allow read access to Azure Spring Cloud Service Registry,cff1b556-2399-4e7e-856d-a8f754be7b65
-Media Services Account Administrator,"Create, read, modify, and delete Media Services accounts; read-only access to other Media Services resources.",054126f8-9a2b-4f1c-a9ad-eca461f08466
-Media Services Live Events Administrator,"Create, read, modify, and delete Live Events, Assets, Asset Filters, and Streaming Locators; read-only access to other Media Services resources.",532bc159-b25e-42c0-969e-a1d439f60d77
-Media Services Media Operator,"Create, read, modify, and delete Assets, Asset Filters, Streaming Locators, and Jobs; read-only access to other Media Services resources.",e4395492-1534-4db2-bedf-88c14621589c
-Media Services Policy Administrator,"Create, read, modify, and delete Account Filters, Streaming Policies, Content Key Policies, and Transforms; read-only access to other Media Services resources. Cannot create Jobs, Assets or Streaming resources.",c4bba371-dacd-4a26-b320-7250bca963ae
-Media Services Streaming Endpoints Administrator,"Create, read, modify, and delete Streaming Endpoints; read-only access to other Media Services resources.",99dba123-b5fe-44d5-874c-ced7199a5804
+Azure Stack Edge Operations Role,Built in role for managing operations in azure stack edge,12b8206a-0216-4469-908d-a3e2025fe085
+Azure Stack HCI Administrator,"Grants full access to the cluster and its resources, including the ability to register Azure Stack HCI and assign others as Azure Arc HCI VM Contributor and/or Azure Arc HCI VM Reader",bda0d508-adf1-4af0-9c28-88919fc3ae06
+Azure Stack HCI Connected InfraVMs,Role of Arc Integration for Azure Stack HCI Infrastructure Virtual Machines.,c99c945f-8bd1-4fb1-a903-01460aae6068
+Azure Stack HCI Device Management Role,Microsoft.AzureStackHCI Device Management Role,865ae368-6a45-4bd1-8fbf-0d5151f56fc1
+Azure Stack HCI Edge Machine Contributor Role,Microsoft.AzureStackHCI Edge Machine Contributor Role,1a6f9009-515c-4455-b170-143e4c9ce229
+Azure Stack HCI VM Contributor,Grants permissions to perform all VM actions,874d1c73-6003-4e60-a13a-cb31ea190a85
+Azure Stack HCI VM Reader,Grants permissions to view VMs,4b3fe76c-f777-4d24-a2d7-b027b0f7b273
+Azure Stack Hub Linked Subscriptions role,Microsoft.AzureStack Linked Subscriptions role.,17e4de9d-139f-4531-b521-20804c310cf8
+Azure Stack Hub registration role,Microsoft.AzureStack registration role.,9a0e5da3-6c70-4a35-b13a-715cd5a7919a
+Azure Stack Registration Owner,Lets you manage Azure Stack registrations.,6f12a6df-dd06-4f3e-bcb1-ce8be600526a
+Azure Usage Billing Data Sender,Azure Usage Billing shared BuiltIn role to be used for all Customer Account Authentication,f0310ce6-e953-4cf8-b892-fb1c87eaf7f6
+Azure VM Managed identities restore Contributor,Azure VM Managed identities restore Contributors are allowed to perform Azure VM Restores with managed identities both user and system,6ae96244-5829-4925-a7d3-5975537d91dd
+Azure impact Reporter role,built-in role for azure impact write access,36e80216-a7e8-4f42-a7e1-f12c98cbaf8a
+Azure impact-insight reader,built-in role for azure impact-insight read access,dfb2f09d-25f8-4558-8986-497084006d7a
+AzureML Compute Operator,Can access and perform CRUD operations on Machine Learning Services managed compute resources (including Notebook VMs).,e503ece1-11d0-4e8e-8e2c-7a6c3bf38815
+AzureML Data Scientist,"Can perform all actions within an Azure Machine Learning workspace, except for creating or deleting compute resources and modifying the workspace itself.",f6c7c914-8db3-469d-8ca1-694a8f32e121
+AzureML Metrics Writer (preview),Lets you write metrics to AzureML workspace,635dd51f-9968-44d3-b7fb-6d9a6bd613ae
+AzureML Registry User,Can perform all actions on Machine Learning Services Registry assets as well as get Registry resources.,1823dd4f-9b8c-4ab6-ab4e-7397a3684615
+Backup Contributor,"Lets you manage backups, but can't delete vaults and give access to others",5e467623-bb1f-42f4-a55d-6e525e11384b
+Backup MUA Admin,Backup MultiUser-Authorization. Can create/delete ResourceGuard,c2a970b4-16a7-4a51-8c84-8a8ea6ee0bb8
+Backup MUA Operator,Backup MultiUser-Authorization. Allows user to perform critical operation protected by resourceguard,f54b6d04-23c6-443e-b462-9c16ab7b4a52
+Backup Operator,"Lets you manage backup services, except removal of backup, vault creation and giving access to others",00c29273-979b-4161-815c-10b084fb9324
+Backup Reader,"Can view backup services, but can't make changes",a795c7a0-d4a2-40c1-ae25-d81f01202912
+Bayer Ag Powered Services CWUM Solution,Provide access to CWUM Solution by Bayer Ag Powered Services,a9b99099-ead7-47db-8fcf-072597a61dfa
+Bayer Ag Powered Services Crop Id Solution User Role,Provide access to Crop Id Solution by Bayer Ag Powered Services,39138f76-04e6-41f0-ba6b-c411b59081a9
+Bayer Ag Powered Services Field Imagery Solution Service Role,Provide access to Field Imagery Solution by Bayer Ag Powered Services,1af232de-e806-426f-8ca1-c36142449755
+Bayer Ag Powered Services GDU Solution,Provide access to GDU Solution by Bayer Ag Powered Services,c4bc862a-3b64-4a35-a021-a380c159b042
+Bayer Ag Powered Services Historical Weather Data Solution User Role,Provide access to Historical Weather Data Solution by Bayer Ag Powered Services,b5b192c1-773c-4543-bfb0-6c59254b74a9
+Bayer Ag Powered Services Imagery Solution,Provide access to Imagery Solution by Bayer Ag Powered Services,ef29765d-0d37-4119-a4f8-f9f9902c9588
+Bayer Ag Powered Services Smart Boundary Solution User Role,Provide access to Smart Boundary Solution by Bayer Ag Powered Services,539283cd-c185-4a9a-9503-d35217a1db7b
+Billing Reader,Allows read access to billing data,fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64
+BizTalk Contributor,"Lets you manage BizTalk services, but not access to them.",5e3c6656-6cfa-4708-81fe-0de47ac73342
+Blockchain Member Node Access (Preview),Allows for access to Blockchain Member nodes,31a002a1-acaf-453e-8a5b-297c9ca1ea24
+Blueprint Contributor,"Can manage blueprint definitions, but not assign them.",41077137-e803-4205-871c-5a86e6a753b4
+Blueprint Operator,"Can assign existing published blueprints, but cannot create new blueprints. NOTE: this only works if the assignment is done with a user-assigned managed identity.",437d2ced-4a38-4302-8479-ed2bcb43d090
+CDN Endpoint Contributor,"Can manage CDN endpoints, but can't grant access to other users.",426e0c7f-0c7e-4658-b36f-ff54d6c29b45
+CDN Endpoint Reader,"Can view CDN endpoints, but can't make changes.",871e35f6-b5c1-49cc-a043-bde969a0f2cd
+CDN Profile Contributor,"Can manage CDN and Azure Front Door standard and premium profiles and their endpoints, but can't grant access to other users.",ec156ff8-a8d1-4d15-830c-5b80698ca432
+CDN Profile Reader,"Can view CDN profiles and their endpoints, but can't make changes.",8f96442b-4075-438f-813d-ad51ab4019af
+Carbon Optimization Reader,Allow read access to Azure Carbon Optimization data,fa0d39e6-28e5-40cf-8521-1eb320653a4c
+Change Safety Contributor,Grants access to manage all Microsoft.ChangeSafety resources.,fdb3df26-8dd6-49ff-9a74-e95dbfadcad3
+Chaos Studio Experiment Contributor,"Can create, run, and see details for experiments, onboard targets, and manage capabilities.",7c2e40b7-25eb-482a-82cb-78ba06cb46d5
+Chaos Studio Operator,Can run and see details for experiments but cannot create experiments or manage targets and capabilities.,1a40e87e-6645-48e0-b27a-0b115d849a20
+Chaos Studio Reader,"Can view targets, capabilities, experiments, and experiment details.",29e2da8a-229c-4157-8ae8-cc72fc506b74
+Chaos Studio Target Contributor,"Can onboard targets and manage capabilities but cannot create, run, or see details for experiments",59a618e3-3c9a-406e-9f03-1a20dd1c55f1
+Classic Network Contributor,"Lets you manage classic networks, but not access to them.",b34d265f-36f7-4a0d-a4d4-e158ca92e90f
+Classic Storage Account Contributor,"Lets you manage classic storage accounts, but not access to them.",86e8f5dc-a6e9-4c67-9d15-de283e8eac25
+Classic Storage Account Key Operator Service Role,Classic Storage Account Key Operators are allowed to list and regenerate keys on Classic Storage Accounts,985d6b00-f706-48f5-a6fe-d0ca12fb668d
+Classic Virtual Machine Contributor,"Lets you manage classic virtual machines, but not access to them, and not the virtual network or storage account they’re connected to.",d73bb868-a0df-4d4d-bd69-98a00b01fccb
+ClearDB MySQL DB Contributor,"Lets you manage ClearDB MySQL databases, but not access to them.",9106cda0-8a86-4e81-b686-29a22c54effe
+Clinical Coder Data User,Allows processing of health data in Clinical Coder,d0a94e7a-d791-4571-b2e0-8bdd8f867544
+CloudTest Contributor Role,"Read, write, delete and perform actions on CloudTest Accounts, CloudTest Pools, 1ES Hosted Pools, 1ES Build Caches and 1ES Images.",4e9d0bd4-5aab-4f91-92df-9def33fe287c
+CloudTest Leased VM Reader,Can view CloudTest leased VM's credentials,b1e6a0dd-ea0f-4108-8925-7047693f2cfe
+Cognitive Search Serverless Data Contributor (Deprecated),This role has been deprecated,7ac06ca7-21ca-47e3-a67b-cbd6e6223baf
+Cognitive Search Serverless Data Reader (Deprecated),This role has been deprecated,79b01272-bf9f-4f4c-9517-5506269cf524
+Cognitive Services Content Understanding Contributor,"Has access to read, create, update, analyze, and test operations for Azure AI Content Understanding. Can manage analyzers, classifiers, labeling projects, and person directories, but cannot delete analyzers or classifiers, manage role assignments, or list account keys.",59a2dba3-6303-4fd8-9a2e-8cbb4bdda972
+Cognitive Services Content Understanding Owner,"Has full access to all Azure AI Content Understanding operations including read, create, update, delete, analyze, and test. Can manage all analyzers, classifiers, labeling projects, and person directories.",4b42bd01-da42-4c92-9b07-15ea5bd6a602
+Cognitive Services Content Understanding Reader,"Has access to read, list, and analyze operations for Azure AI Content Understanding. Can list and view analyzers, classifiers, and person directories, and run analysis and classification jobs, but cannot create, update, or delete resources.",379c52cb-64de-498c-8b5b-c6170d6c49d4
+Cognitive Services Contributor,"Lets you create, read, update, delete and manage keys of Cognitive Services.",25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68
+Cognitive Services Custom Vision Contributor,"Full access to the project, including the ability to view, create, edit, or delete projects.",c1ff6cc2-c111-46fe-8896-e0ef812ad9f3
+Cognitive Services Custom Vision Deployment,"Publish, unpublish or export models. Deployment can view the project but can’t update.",5c4089e1-6d96-4d2f-b296-c1bc7137275f
+Cognitive Services Custom Vision Labeler,"View, edit training images and create, add, remove, or delete the image tags. Labelers can view the project but can’t update anything other than training images and tags.",88424f51-ebe7-446f-bc41-7fa16989e96c
+Cognitive Services Custom Vision Reader,Read-only actions in the project. Readers can’t create or update the project.,93586559-c37d-4a6b-ba08-b9f0940c2d73
+Cognitive Services Custom Vision Trainer,"View, edit projects and train the models, including the ability to publish, unpublish, export the models. Trainers can’t create or delete the project.",0a5ae4ab-0d65-4eeb-be61-29fc9b54394b
+Cognitive Services Data Contributor (Preview),"Allows to call data plane APIs, but not any control plane APIs for Microsoft Cognitive Services. This role is in preview and subject to change.",19c28022-e58e-450d-a464-0b2a53034789
+Cognitive Services Data Reader,Lets you read Cognitive Services data.,b59867f0-fa02-499b-be73-45a86b5b3e1c
+Cognitive Services Face Contributor,Full access to perform all Face APIs,b5b0c71d-aca9-4081-aee2-9b1bb335fc1a
+Cognitive Services Face Recognizer,"Lets you perform detect, verify, identify, group, and find similar operations on Face API. This role does not allow create or delete operations, which makes it well suited for endpoints that only need inferencing capabilities, following 'least privilege' best practices.",9894cab4-e18a-44aa-828b-cb588cd6f2d7
+Cognitive Services Immersive Reader User,Provides access to create Immersive Reader sessions and call APIs,b2de6794-95db-4659-8781-7e080d3f2b9d
+Cognitive Services LUIS Owner,"Has access to all Read, Test, Write, Deploy and Delete functions under LUIS",f72c8140-2111-481c-87ff-72b910f6e3f8
+Cognitive Services LUIS Reader,Has access to Read and Test functions under LUIS.,18e81cdc-4e98-4e29-a639-e7d10c5a6226
+Cognitive Services LUIS Writer,"Has access to all Read, Test, and Write functions under LUIS",6322a993-d5c9-4bed-b113-e49bbea25b27
+Cognitive Services Language Owner,"Has access to all Read, Test, Write, Deploy and Delete functions under Language portal",f07febfe-79bc-46b1-8b37-790e26e6e498
+Cognitive Services Language Reader,Has access to Read and Test functions under Language portal,7628b7b8-a8b2-4cdc-b46f-e9b35248918e
+Cognitive Services Language Writer,"Has access to all Read, Test, and Write functions under Language Portal",f2310ca1-dc64-4889-bb49-c8e0fa3d47a8
+Cognitive Services Metrics Advisor Administrator,"Full access to the project, including the system level configuration.",cb43c632-a144-4ec5-977c-e80c4affc34a
+Cognitive Services Metrics Advisor User,Access to the project.,3b20f47b-3825-43cb-8114-4bd2201156a8
+Cognitive Services OpenAI Contributor,"Full access including the ability to fine-tune, deploy and generate text",a001fd3d-188f-4b5d-821b-7da978bf7442
+Cognitive Services OpenAI User,"Ability to view files, models, deployments. Readers can't make any changes They can inference and create images",5e0bd9bd-7b93-4f28-af87-19fc36ad61bd
+Cognitive Services QnA Maker Editor,"Let’s you create, edit, import and export a KB. You cannot publish or delete a KB.",f4cc2bf9-21be-47a1-bdf1-5c5804381025
+Cognitive Services QnA Maker Reader,Let’s you read and test a KB only.,466ccd10-b268-4a11-b098-b4849f024126
+Cognitive Services Security Integration Admin,Lets you manage safety providers for Cognitive Services.,14f26b53-9d80-4924-8141-f664426a48f6
+Cognitive Services Speech Contributor,"Full access to Speech projects, including read, write and delete all entities, for real-time speech recognition and batch transcription tasks, real-time speech synthesis and long audio tasks, custom speech and custom voice.",0e75ca1e-0464-4b4d-8b93-68208a576181
+Cognitive Services Speech User,"Access to the real-time speech recognition and batch transcription APIs, real-time speech synthesis and long audio APIs, as well as to read the data/test/model/endpoint for custom models, but can’t create, delete or modify the data/test/model/endpoint for custom models.",f2dc8367-1007-4938-bd23-fe263f013447
+Cognitive Services Usages Reader,Minimal permission to view Cognitive Services usages.,bba48692-92b0-4667-a9ad-c31c7b334ac2
+Cognitive Services User,Lets you read and list keys of Cognitive Services.,a97b65f3-24c7-4388-baec-2e87135dc908
+Collaborative Data Contributor,Can manage data packages of a collaborative.,daa9e50b-21df-454c-94a6-a8050adab352
+Collaborative Runtime Operator,Can manage resources created by AICS at runtime,7a6f0e70-c033-4fb1-828c-08514e5f4102
+Common Edge Admin,Common Edge Admin Role,b256d512-9a3a-4a96-9366-9f54f900e58b
+Communication and Email Service Owner,"Create, read, modify, and delete Communications and Email Service resources.",09976791-48a7-449e-bb21-39d1a415f350
+Community Contributor Role,Community Contributor Role to access the resources of Microsoft.Mission stored with RPSAAS.,49435da6-99fe-48a5-a235-fc668b9dc04a
+Community Owner Role,Community Owner Role to access the resources of Microsoft.Mission stored with RPSAAS.,5e28a61e-8040-49db-b175-bb5b88af6239
+Community Reader Role,Community Reader Role to access the resources of Microsoft.Mission stored with RPSAAS.,e6aadb6b-e64f-41c0-9392-d2bba3bc3ebc
+Commvault Contributor,Provides access to Commvault ContentStore Control Plane Operations,222f0527-8571-4054-955d-aae12f1d09d6
+Compute Diagnostics Role,Grants permissions to execute diagnostics provided by Compute Diagnostic Service for Compute Resources.,df2711a6-406d-41cf-b366-b0250bff9ad1
+Compute Fleet Contributor,Allows users to manage Compute Fleet resources.,2bed379c-9fba-455b-99e4-6b911073bcf2
+Compute Gallery Artifacts Publisher,This is the role for publishing gallery artifacts.,85a2d0d9-2eba-4c9c-b355-11c2cc0788ab
+Compute Gallery Image Reader,This is the role for reading gallery images.,cf7c76d2-98a3-4358-a134-615aa78bf44d
+Compute Gallery Sharing Admin,This role allows user to share gallery to another subscription/tenant or share it to the public.,1ef6a3be-d0ac-425d-8c01-acb62866290b
+Compute Limit Operator,Read and manage compute limits using compute limit operations.,980cf6f7-edec-4fd1-8e9e-28f70b1d5258
+Compute Recommendations Role,Grants permissions to call Compute Recommendations APIs provided by Compute Diagnostic Resource Provider service.,e82342c9-ac7f-422b-af64-e426d2e12b2d
+Confidential Ledger Contributor,"Allows full management of Confidential Ledger resources, including create, read, update, delete, backup and private endpoint connection management.",9cf8853f-1e61-4999-915d-3e018bfc8a71
+Confidential Ledger Data Contributor,"Allows read and write access to Confidential Ledger transactions, including reading entries, receipts, and transaction status, and creating new ledger entries.",f1641a58-a144-402b-baf9-39d1a4c10119
+Confidential Ledger Data Reader,"Allows read access to Confidential Ledger transactions, including reading entries, receipts, and transaction status.",4f1e6fca-3fde-4291-961e-642def6d5e1d
+Connected Cluster Managed Identity CheckAccess Reader,Built-in role that allows a Connected Cluster managed identity to call the checkAccess API,65a14201-8f6c-4c28-bec4-12619c5a9aaa
+Connector Namespace Contributor,You can manage all aspects of a Connector Namespace and its sub-resources. You can't change access or ownership.,e7560e73-ee25-4ed7-94f9-666cca24b501
+Connector Namespace Developer,"You can create and manage connections, custom connectors, MCP server configurations, and trigger configurations within an existing Connector Namespace. You can't create, modify, or delete the Connector Namespace itself.",93ef01d8-7600-4956-9f82-b924cb66bfc6
+Connector Namespace Reader,"You have read-only access to all resources in a Connector Namespace and its sub-resources, including their configurations.",5d0402fa-1042-4603-9e01-7fea218a05af
+Connector Reader,"Read connectors and their associated resources, such as impacts and insights.",6cdbb904-5ff3-429d-8169-7d7818b91bd8
+Connector Writer,"Write connectors and have basic customer permissions like reading authorizations, alert rules and resourceGroups",c459b115-f629-486b-b359-35feb5568b83
+Container Apps Artifact Data Pull,"Grants content pull permission for Container Apps Artifacts, allowing callers to pull the contents of Artifact versions.",2aea396c-91f9-444f-a367-6bd94ab9a5cf
+Container Apps ConnectedEnvironments Contributor,"Full management of Container Apps ConnectedEnvironments, including creation, deletion, and updates.",6f4fe6fc-f04f-4d97-8528-8bc18c848dca
+Container Apps ConnectedEnvironments Reader,Read access to Container Apps ConnectedEnvironments.,d5adeb5b-107f-4aca-99ea-4e3f4fc008d5
+Container Apps Contributor,"Full management of Container Apps, including creation, deletion, and updates.",358470bc-b998-42bd-ab17-a7e34c199c0f
+Container Apps Jobs Contributor,"Full management of Container Apps jobs, including creation, deletion, and updates.",4e3d2b60-56ae-4dc6-a233-09c8e5a82e68
+Container Apps Jobs Operator,"Read, start, and stop Container Apps jobs.",b9a307c4-5aa3-4b52-ba60-2b17c136cd7b
+Container Apps Jobs Reader,Read access to ContainerApps jobs,edd66693-d32a-450b-997d-0158c03976b0
+Container Apps ManagedEnvironments Contributor,"Full management of Container Apps ManagedEnvironments, including creation, deletion, and updates.",57cc5028-e6a7-4284-868d-0611c5923f8d
+Container Apps ManagedEnvironments Reader,Read access to ContainerApps managedenvironments.,1b32c00b-7eff-4c22-93e6-93d11d72d2d8
+Container Apps Operator,"Read, logstream and exec into Container Apps.",f3bd1b5c-91fa-40e7-afe7-0c11d331232c
+Container Apps SandboxGroup Contributor,"Full management of Container Apps Sandbox Groups, including creation, deletion, and updates.",11b23f7a-6229-4518-88db-0576f10dd2a0
+Container Apps SandboxGroup Data Owner,"Grants ownership of Container Apps Sandbox Group data in the group, including sandboxes, disk images, volumes, secrets, and all associated operations.",c24cf47c-5077-412d-a19c-45202126392c
+Container Apps SessionPools Contributor,"Full management of Container Apps SessionPools, including creation, deletion, and updates.",f7669afb-68b2-44b4-9c5f-6d2a47fddda0
+Container Apps SessionPools Reader,Read access to ContainerApps sessionpools.,af61e8fc-2633-4b95-bed3-421ad6826515
+Container Registry Cache Rule Administrator,"Create, Read, Update, and Delete Cache Rules in Container Registry. This role doesn't grant permissions to manage Credential Sets.",df87f177-bb12-4db1-9793-a413691eff94
+Container Registry Cache Rule Reader,Read the configuration of Cache Rules in Container Registry. This permission doesn't grant permission to read Credential Sets.,c357b964-0002-4b64-a50d-7a28f02edc52
+Container Registry Configuration Reader and Data Access Configuration Reader,"Provides permissions to list container registries and registry configuration properties. Provides permissions to list data access configuration such as admin user credentials, scope maps, and tokens, which can be used to read, write or delete repositories and images. Does not provide direct permissions to read, list, or write registry contents including repositories and images. Does not provide permissions to modify data plane content such as imports, Artifact Cache or Sync, and Transfer Pipelines. Does not provide permissions for managing Tasks.",69b07be0-09bf-439a-b9a6-e73de851bd59
+Container Registry Connected Registry Administrator,"Can manage connected registries in a container registry, including the scope maps and tokens required to provision and operate them.",281928aa-9782-4d9a-954a-3f34c1ed9f95
+Container Registry Connected Registry Reader,Can view connected registries and their associated scope maps and tokens in a container registry.,93f83a62-9a8b-4821-9827-5b3ee513aec3
+Container Registry Contributor and Data Access Configuration Administrator,"Provides permissions to create, list, and update container registries and registry configuration properties. Provides permissions to configure data access such as admin user credentials, scope maps, and tokens, which can be used to read, write or delete repositories and images. Does not provide direct permissions to read, list, or write registry contents including repositories and images. Does not provide permissions to modify data plane content such as imports, Artifact Cache or Sync, and Transfer Pipelines. Does not provide permissions for managing Tasks.",3bc748fc-213d-45c1-8d91-9da5725539b9
+Container Registry Credential Set Administrator,"Create, Read, Update, and Delete Credential Sets in Container Registry. This role doesn't affect the needed permissions for storing content inside Azure Key Vault. This role also doesn't grant permissions to manage Cache Rules.",f094fb07-0703-4400-ad6a-e16dd8000e14
+Container Registry Credential Set Reader,Read the configuration of Credential Sets in Container Registry. This permission doesn't allow permission to see content inside Azure Key vault only the content inside Container Registry. This permission doesn't grant permission to read Cache Rules.,29093635-9924-4f2c-913b-650a12949526
+Container Registry Data Importer and Data Reader,"Provides the ability to import images into a registry through the registry import operation. Provides the ability to list repositories, view images and tags, get manifests, and pull images. Does not provide permissions for importing images through configuring registry transfer pipelines such as import and export pipelines. Does not provide permissions for importing through configuring Artifact Cache or Sync rules.",577a9874-89fd-4f24-9dbd-b5034d0ad23a
+Container Registry Repository Catalog Lister,Allows for listing all repositories in an Azure Container Registry.,bfdb9389-c9a5-478a-bb2f-ba9ca092c3c7
+Container Registry Repository Contributor,"Allows for read, write, and delete access to Azure Container Registry repositories, but excluding catalog listing.",2efddaa5-3f1f-4df3-97df-af3f13818f4c
+Container Registry Repository Reader,"Allows for read access to Azure Container Registry repositories, but excluding catalog listing.",b93aa761-3e63-49ed-ac28-beffa264f7ac
+Container Registry Repository Writer,"Allows for read and write access to Azure Container Registry repositories, but excluding catalog listing.",2a1e307c-b015-4ebd-883e-5b7698a07328
+Container Registry Tasks Contributor,"Provides permissions to configure, read, list, trigger, or cancel Container Registry Tasks, Task Runs, Task Logs, Quick Runs, Quick Builds, and Task Agent Pools. Permissions granted for Tasks management can be used for full registry data plane permissions including reading/writing/deleting container images in registries. Permissions granted for Tasks management can also be used to run customer authored build directives and run scripts to build software artifacts.",fb382eab-e894-4461-af04-94435c366c3f
+Container Registry Transfer Pipeline Contributor,"Provides the ability to transfer, import, and export artifacts through configuring registry transfer pipelines that involve intermediary storage accounts and key vaults. Does not provide permissions to push or pull images. Does not provide permissions to create, manage, or list storage accounts or key vaults. Does not provide permissions to perform role assignments.",bf94e731-3a51-4a7c-8c54-a1ab9971dfc1
+ContainerApp Reader,"View all containerapp resources, but does not allow you to make any changes.",ad2dd5fb-cd4b-4fd4-a9b6-4fed3630980b
+Context Cache Administrator,Provides full to manage all Azure Context Cache resources. This role is in preview and subject to change.,b0ffeab8-d678-4570-b532-ce96bf97b032
+Context Cache Container Contributor,Allows creating and managing Azure Context Cache Container resource. This role is in preview and subject to change.,646a9378-973f-42fd-927f-62d1c4381f50
+Contributor,"Grants full access to manage all resources, but does not allow you to assign roles in Azure RBAC, manage assignments in Azure Blueprints, or share image galleries.",b24988ac-6180-42a0-ab88-20f7382dd24c
+Conversation Session User,"Allows sending a message to the agent and receive a response, using the conversation session API",b3eb788f-5426-48bd-821d-561701ede368
+Cosmos DB Account Reader Role,Can read Azure Cosmos DB Accounts data,fbdf93bf-df7d-467e-a4d2-9458aa1360c8
+Cosmos DB Data Contributor - Preview,(Preview) Allows Cosmos DB Data Plane read and write access,fd5a8ad5-38c7-4428-a6d3-ed202e467ff0
+Cosmos DB Data Reader - Preview,(Preview) Allows Cosmos DB Data Plane read access,356d02cb-3f43-4b52-8ac4-85065178b1a0
+Cosmos DB Long Term Retention Backup Role,Allows performing long term retention backup operations for Cosmos DB,fc896ebc-f9a8-484d-a5ff-bd6a8c36289f
+Cosmos DB Long Term Retention Restore Role,Allows performing long term retention restore operations for Cosmos DB,955d0cb2-de4e-43ed-819a-14220e079ba7
+Cosmos DB Operator,"Lets you manage Azure Cosmos DB accounts, but not access data in them. Prevents access to account keys and connection strings.",230815da-be43-4aae-9cb4-875f7bd000aa
+CosmosBackupOperator,Can submit restore request for a Cosmos DB database or a container for an account,db7b14f2-5adf-42da-9f96-f2ee17bab5cb
+CosmosDB Fleet Analytics Storage Data Writer,Write telemetry data from the Fleet Analytics Synapse workspace to customer-provided storage accounts or Fabric Lakehouses.,bf41e52e-617f-4981-8b7a-47431bd4e011
+CosmosDB Fleet Operator Role,Lets you manage Azure CosmosDB Fleets and related child resources,35ffec73-9cb8-4593-8718-40d5bc4b7f6f
+CosmosRestoreOperator,Can perform restore action for Cosmos DB database account with continuous backup mode,5432c526-bc82-444a-b7ba-57c5b0b5b34f
+Cost Management Contributor,"Can view costs and manage cost configuration (e.g. budgets, exports)",434105ed-43f6-45c7-a02f-909b2ba83430
+Cost Management Reader,"Can view cost data and configuration (e.g. budgets, exports)",72fafb9e-0641-4937-9268-a91bfd8191a3
+CrossConnectionManager,"Allows for read, write access to ExpressRoute CrossConnections",399c3b2b-64c2-4ff1-af34-571db925b068
+CrossConnectionReader,Allows for read access to ExpressRoute CrossConnections,b6ee44de-fe58-4ddc-b5c2-ab174eb23f05
+DICOM Data Owner,Full access to DICOM data.,58a3b984-7adf-4c20-983a-32417c86fbc8
+DICOM Data Reader,Read and search DICOM data.,e89c7a3c-2f64-4fa1-a847-3e4c9ba4283a
+DNS Resolver Contributor,Lets you manage DNS resolver resources.,0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d
+DNS Zone Contributor,"Lets you manage DNS zones and record sets in Azure DNS, but does not let you control who has access to them.",befefa01-2a29-4197-83a8-272ff33ce314
+Data Boundary Tenant Administrator,Allows tenant level administration for data boundaries.,d1a38570-4b05-4d70-b8e4-1100bcf76d12
+Data Box Contributor,Lets you manage everything under Data Box Service except giving access to others.,add466c9-e687-43fc-8d98-dfcf8d720be5
+Data Box Reader,Lets you manage Data Box Service except creating order or editing order details and giving access to others.,028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027
+Data Factory Contributor,"Create and manage data factories, as well as child resources within them.",673868aa-7521-48a0-acc6-0f60742d39f5
+Data Labeling - Labeler,Can label data in Labeling.,c6decf44-fd0a-444c-a844-d653c394e7ab
+Data Lake Analytics Developer,"Lets you submit, monitor, and manage your own jobs but not create or delete Data Lake Analytics accounts.",47b7735b-770e-4598-a7da-8b91488b4c88
+Data Operator for Managed Disks,"Provides permissions to upload data to empty managed disks, read, or export data of managed disks (not attached to running VMs) and snapshots using SAS URIs and Azure AD authentication.",959f8984-c045-4866-89c7-12bf9737be2e
+Data Purger,Can purge analytics data,150f5e0c-0603-4f03-8c7f-cf70034c4e90
+DeID Batch Data Owner,Create and manage DeID batch jobs. This role is in preview and subject to change.,8a90fa6b-6997-4a07-8a95-30633a7c97b9
+DeID Batch Data Reader,Read DeID batch jobs. This role is in preview and subject to change.,b73a14ee-91f5-41b7-bd81-920e12466be9
+DeID Data Owner,Full access to DeID data. This role is in preview and subject to change,78e4b983-1a0b-472e-8b7d-8d770f7c5890
+DeID Realtime Data User,Execute requests against DeID realtime endpoint. This role is in preview and subject to change.,bb6577c4-ea0a-40b2-8962-ea18cb8ecd4e
+Dedicated Host Contributor Role,This is the role created for DedicatedHosts Contributor,96ebd254-ecc7-4590-aff5-e9af3ff5f3b3
+Defender AI,Service role that provides permissions for Microsoft Defender for AI,6fe711ec-654d-4ef7-8e32-eb7de3d94774
+Defender API Security,Grants Microsoft Defender for Cloud access to computes to provide API security,6f91a4f9-10ee-4b95-b8cd-96ee73c5968d
+Defender Agentless VM Scan,Role that provides access to disk snapshot for security analysis.,d24ecba3-c1f4-40fa-a7bb-4588a071e8fd
+Defender Azure Cosmos DB,Microsoft Defender for Azure Cosmos DB role. Grant permissions for enablement.,d2acaa63-2a62-4c01-998a-cdbe7a00d709
+Defender Azure SQL Databases,Microsoft Defender for Azure SQL Databases role. Grant permissions for enablement.,eef9d654-743f-4e2c-ad0f-9ed243177663
+Defender CSPM,Grants permissions for Microsoft Defender for Cloud CSPM base plan features,46023a6a-0702-4cbf-956c-d8c3ac27bc2b
+Defender CSPM Storage Scanner Operator,Lets you enable and configure Microsoft Defender CSPM's sensitive data discovery feature on your storage accounts. Includes an ABAC condition to limit role assignments.,8480c0f0-4509-4229-9339-7c10018cb8c4
+Defender Cloud Secrets Posture,Service role that provides permissions for Microsoft Defender Cloud Secrets Posture,512ef07a-840c-48d2-9be4-9a30a75a5c70
+Defender Containers Sensor,Grants Microsoft Defender for Cloud access to Azure Kubernetes Services,5e93ba01-8f92-4c7a-b12a-801e3df23824
+Defender Databricks Operator,Grants permissions for Microsoft Defender for Cloud feature on Databricks.,0e2ecf2a-0574-4b08-89e2-be133aa6303f
+Defender For Container Registries Operator,Grants Microsoft Defender for Cloud access to Azure Container Registries,c5c82243-e78e-43f9-8428-793bba85b28e
+Defender Kubernetes API Access,Grants Microsoft Defender for Cloud access to Azure Kubernetes Services,d5a2ae44-610b-4500-93be-660a0c5f5ca6
+Defender Kubernetes Agent Operator,Grants Microsoft Defender for Cloud permissions to provision the Kubernetes defender security agent,8bb6f106-b146-4ee6-a3f9-b9c5a96e0ae5
+Defender Open Source Relational Databases,Microsoft Defender for Open Source Relational Databases role. Grant permissions for enablement.,99626c15-0799-47ad-96ab-f298031f69d6
+Defender Registry Access,Grants Microsoft Defender for Cloud access to Azure Container Registry for security assessment of container images,96062cf7-95ca-4f89-9b9d-2a2aa47356af
+Defender SQL Servers On Machines,Microsoft Defender for SQL Servers On Machines role. Grant permissions for enablement.,d9468a2b-1820-47e1-a40e-d2b7fba1879a
+Defender Sensitive Data Discovery,Grants permissions for Microsoft Defender for Cloud Sensitive Data Discovery plan features,0b6ca2e8-2cdc-4bd6-b896-aa3d8c21fc35
+Defender Serverless Scanner,Grants access to Serverless resources and thier connections,68ac31b4-936a-4046-a6d2-ba6f8a757bf6
+Defender Servers P1,Defender Servers P1,78b19ac9-582c-44d8-9e11-733ae424ad83
+Defender Servers P2,Defender Servers P2,1dc24dd8-b00e-4344-837c-58b193cd23c7
+Defender Settings Contributor,Grants Microsoft Defender for Cloud access to Defender Settings,7d0c0268-1199-449b-a52e-75c20879f46b
+Defender Storage Automated Malware Remediation,Grants additional permissions for Microsoft Defender for Storage automated remediation operations including soft-delete management and blob deletion.,c6c9b2d8-9a5e-4122-85e1-81612a046ab2
+Defender Storage Malware Data Scanner,"Grants data plane permissions for Microsoft Defender for Storage scanning operations — blob/file read, index tag updates.",cd50fd1f-0421-46f2-8cce-afc587dbcc77
+Defender Storage Malware Operator,"Grants permissions for Microsoft Defender for Storage malware scanning operations including blob/file read, index tag updates, EventGrid management, and network bypass.",971cce9f-2680-4357-9678-c947847a9425
+Defender Unified RBAC Authorization Manager,"Defender Unified RBAC Authorization Manager. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",1fd5d8bf-9037-4ede-89bf-680f798e2765
+Defender Unified RBAC Authorization Reader,"Defender Unified RBAC Authorization Reader. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",ca62263b-07d5-4b48-b437-088803f5c2ff
+Defender Unified RBAC Contributor and Responder,"Defender Unified RBAC Contributor and Responder. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",625a1cea-653b-4a19-bd3a-df1d66ab6637
+Defender Unified RBAC Data Manager,"Defender Unified RBAC Data Manager. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",40ead2a5-466e-4039-8a80-325542d9d2dd
+Defender Unified RBAC Reader,"Defender Unified RBAC Reader. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",78b7345a-1e1b-483a-ac62-62228c6ea89d
+Defender Unified RBAC Responder,"Defender Unified RBAC Responder. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",1bacae94-6c0f-4d2d-8dfa-408d5a28e6ec
+Defender Unified RBAC Scoped Reader,"Defender Unified RBAC Scoped Reader. This role is managed and assigned automatically by the Defender Unified RBAC system. Manual assignment of this role is not recommended, as the Defender Unified RBAC system may modify or remove it at any time based on system requirements.",d56b031f-8d90-4376-9231-b5c94fce88ef
+Defender for Storage Data Scanner,Grants access to read blobs and update index tags. This role is used by the data scanner of Defender for Storage.,1e7ca9b1-60d1-4db8-a914-f2ca1ff27c40
+Defender for Storage Scanner Operator,Lets you enable and configure Microsoft Defender for Storage's malware scanning and sensitive data discovery features on your storage accounts. Includes an ABAC condition to limit role assignments.,0f641de8-0b88-4198-bdef-bd8b45ceba96
+Defender for Storage Threat Protection,Microsoft Defender for Storage Threat Protection role - grants the permissions needed to enable/disable Defender for Storage Advanced Threat Protection at resource level.,a366d631-94bf-46bf-b4af-b38f28c80774
+Deployment Environments Reader,Provides read access to environment resources.,eb960402-bf75-4cc3-8d68-35b34f960f72
+Deployment Environments User,Provides access to manage environment resources.,18e40d4e-8d2e-438d-97e1-9528336e149c
+Desktop Virtualization App Attach Contributor,Provide permission to manage app attach resources,97dfb3ce-e936-462c-9425-9cdb67e66d45
+Desktop Virtualization Application Group Contributor,Contributor of the Desktop Virtualization Application Group.,86240b0e-9422-4c43-887b-b61143f32ba8
+Desktop Virtualization Application Group Reader,Reader of the Desktop Virtualization Application Group.,aebf23d0-b568-4e86-b8f9-fe83a2c6ab55
+Desktop Virtualization Contributor,Contributor of Desktop Virtualization.,082f0a83-3be5-4ba1-904c-961cca79b387
+Desktop Virtualization Host Pool Contributor,Contributor of the Desktop Virtualization Host Pool.,e307426c-f9b6-4e81-87de-d99efb3c32bc
+Desktop Virtualization Host Pool Reader,Reader of the Desktop Virtualization Host Pool.,ceadfde2-b300-400a-ab7b-6143895aa822
+Desktop Virtualization Power On Contributor,Provide permission to the Azure Virtual Desktop Resource Provider to start virtual machines.,489581de-a3bd-480d-9518-53dea7416b33
+Desktop Virtualization Power On Off Contributor,Provide permission to the Azure Virtual Desktop Resource Provider to start and stop virtual machines.,40c5ff49-9181-41f8-ae61-143b0e78555e
+Desktop Virtualization Reader,Reader of Desktop Virtualization.,49a72310-ab8d-41df-bbb0-79b649203868
+Desktop Virtualization Session Host Operator,Operator of the Desktop Virtualization Session Host.,2ad6aaab-ead9-4eaa-8ac5-da422f562408
+Desktop Virtualization User,Allows user to use the applications in an application group.,1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63
+Desktop Virtualization User Session Operator,Operator of the Desktop Virtualization User Session.,ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6
+Desktop Virtualization Virtual Machine Contributor,"This role is in preview and subject to change. Provide permission to the Azure Virtual Desktop Resource Provider to create, delete, update, start, and stop virtual machines.",a959dbd1-f747-45e3-8ba6-dd80f235f97c
+Desktop Virtualization Workspace Contributor,Contributor of the Desktop Virtualization Workspace.,21efdde3-836f-432b-bf3d-3e8e734d4b2b
+Desktop Virtualization Workspace Reader,Reader of the Desktop Virtualization Workspace.,0fa44ee9-7a7d-466b-9bb2-2bf446b1204d
+DevCenter Dev Box User,Provides access to create and manage dev boxes.,45d50f46-0b78-4001-a660-4198cbe8cd05
+DevCenter Owner,"Provides access to manage all Microsoft.DevCenter resources, and to manage access to Microsoft.DevCenter resources by adding or removing role assignments for the DevCenter Project Admin and DevCenter Dev Box roles.",4c6569b6-f23e-4295-9b90-bd4cc4ff3292
+DevCenter Project Admin,Provides access to manage project resources.,331c37c6-af14-46d9-b9f4-e1909e1b95a0
+DevOps Infrastructure Contributor,"Read, write, delete and perform actions on Managed DevOps Pools",76153a9e-0edb-49bc-8e01-93c47e6b5180
+DevTest Labs User,"Lets you connect, start, restart, and shutdown your virtual machines in your Azure DevTest Labs.",76283e04-6283-4c54-8f91-bcf1374a3c64
+Device Provisioning Service Data Contributor,Allows for full access to Device Provisioning Service data-plane operations.,dfce44e4-17b7-4bd1-a6d1-04996ec95633
+Device Provisioning Service Data Reader,Allows for full read access to Device Provisioning Service data-plane properties.,10745317-c249-44a1-a5ce-3a4353c0bbd8
+Device Update Administrator,"Gives you full access to Device Update content and device management operations, with read access to Device Update resources",02ca0879-e8e4-47a5-a61e-5c618b76e64a
+Device Update Content Administrator,Gives you full access to content operations,0378884a-3af5-44ab-8323-f5b22f9f3c98
+Device Update Content Reader,"Gives you read access to content operations, but does not allow making changes",d1ee9a80-8b14-47f0-bdc2-f4a351625a7b
+Device Update Contributor,"Gives you full access to manage Device Update accounts, instances, linked accounts, linking operations, and private endpoint connections",f82fbe13-0f98-4809-af81-b82c343db82f
+Device Update Deployments Administrator,Gives you full access to management operations,e4237640-0e3d-4a46-8fda-70bc94856432
+Device Update Deployments Reader,"Gives you read access to management operations, but does not allow making changes",49e2f5d2-7741-4835-8efa-19e1fe35e47f
+Device Update Reader,"Gives you read access to management and content operations, but does not allow making changes",e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f
+Diagnostics Operator,Collect diagnostic information regarding Virtual Machine and Virtual Machine Scale Sets,64375caa-ac3e-48b3-9492-da4d60aba7bb
+Disk Backup Reader,Provides permission to backup vault to perform disk backup.,3e5e47e6-65f7-47ef-90b5-e5dd4d455f24
+Disk Encryption Set Operator for Managed Disks,"Provides permissions to read, write or delete disk encryption sets which are used for encrypting managed disks with customer managed keys",136d308c-0937-4a49-9bd7-edfb42adbffc
+Disk Pool Operator,Used by the StoragePool Resource Provider to manage Disks added to a Disk Pool.,60fc6e62-5479-42d4-8bf4-67625fcc2840
+Disk Restore Operator,Provides permission to backup vault to perform disk restore.,b50d9833-a0cb-478e-945f-707fcc997c13
+Disk Snapshot Contributor,Provides permission to backup vault to manage disk snapshots.,7efff54f-a5b4-42b5-a1c5-5411624893ce
+DocumentDB Account Contributor,"Lets you manage DocumentDB accounts, but not access to them.",5bd9cd88-fe45-4216-938b-f97437e15450
+Domain Services Contributor,Can manage Azure AD Domain Services and related network configurations,eeaeda52-9324-47f6-8069-5d5bade478b2
+Domain Services Reader,Can view Azure AD Domain Services and related network configurations,361898ef-9ed1-48c2-849c-a832951106bb
+Durable Task Data Contributor,Durable Task role for all data access operations.,0ad04412-c4d5-4796-b79c-f76d14c8d402
+Durable Task Data Reader,Read all Durable Task Scheduler data.,d6a5505f-6ebb-45a4-896e-ac8274cfc0ac
+Durable Task Worker,Used by worker applications to interact with the Durable Task service,80d0d6b0-f522-40a4-8886-a5a11720c375
+Dynamics 365 Customer Insights Service Role,Enables Diagnostic Logging setup for Customer Insights instances.,89f7a3ec-e9d0-40eb-9b96-c016a5c2a53f
+Edge Management Copilot User,Enables users access to Edge Management Copilot.,53e48117-a530-4075-bcbe-d91913e3bdb8
+Edge Order Partner Inventory Manager Service Role,Manage inventory metadata and inventory links associated with Edge Order Partner scenarios. Enables configuration and control of inventory resources for tracking and fulfillment purposes,f24a559b-c2fc-4409-b96e-9af4b0c28ad6
+EdgeMarketPlace role,Microsoft.EdgeMarketPlace role.,4b2b8358-764b-4884-85c6-f4b7946d95ad
+Elastic Autopilot Contributor,Lets you manage 1p EAP resources,753ceed7-553b-434b-a2e5-78da1a8379d9
+Elastic SAN Network Admin,"Allows access to create Private Endpoints on SAN resources, and to read SAN resources",fa6cecf6-5db3-4c43-8470-c540bcb4eafa
+Elastic SAN Owner,Allows for full access to all resources under Azure Elastic SAN including changing network security policies to unblock data path access,80dcbedb-47ef-405d-95bd-188a1b4ac406
+Elastic SAN Reader,Allows for control path read access to Azure Elastic SAN,af6a70f8-3c9f-4105-acf1-d719e9fca4ca
+Elastic SAN Snapshot Exporter,Allows for creating and exporting Snapshot of Elastic San Volume,1c4770c0-34f7-4110-a1ea-a5855cc7a939
+Elastic SAN Volume Data Contributor,Allows for read and write access to a volume data on Azure Elastic SAN,8da79822-b118-42bc-83c9-789fdbdcd77b
+Elastic SAN Volume Group Owner,Allows for full access to a volume group in Azure Elastic SAN including changing network security policies to unblock data path access,a8281131-f312-4f34-8d98-ae12be9f0d23
+Elastic SAN Volume Importer,Allows for Importing Elastic San Volume,90e8b822-3e73-47b5-868a-787dc80c008f
+Enclave Approver Role,Read all resources in Azure Virtual Enclaves and Approve approval requests within the Enclave,2142ea27-02ad-4094-bfea-2dbac6d24934
+Enclave Contributor Role,Enclave Contributor Role to access the resources of Microsoft.Mission stored with RPSAAS.,19feefae-eacc-4106-81fd-ac34c0671f14
+Enclave Owner Role,Enclave Owner Role to access the resources of Microsoft.Mission stored with RPSAAS.,3d5f3eff-eb94-473d-91e3-7aac74d6c0bb
+Enclave Reader Role,Enclave Reader Role to access the resources of Microsoft.Mission stored with RPSAAS.,86fede04-b259-4277-8c3e-e26b9865abd8
+Essential Machine Management Administrator,Can managed Essential Machine Management resources for subscriptions,34013b0a-565b-43aa-8755-1b7c286f6cf7
+EventGrid Contributor,Lets you manage EventGrid operations.,1e241071-0855-49ea-94dc-649edcd759de
+EventGrid Data Contributor,Allows send and receive access to event grid events.,1d8c3fe3-8864-474b-8749-01e3783e8157
+EventGrid Data Receiver,Allows receive access to event grid events.,78cbd9e7-9798-4e2e-9b5a-547d9ebb31fb
+EventGrid Data Sender,Allows send access to event grid events.,d5a91429-5739-47e2-a06b-3470a27159e7
+EventGrid EventSubscription Contributor,Lets you manage EventGrid event subscription operations.,428e0ff0-5e57-4d9c-a221-2c70d0e0a443
+EventGrid EventSubscription Reader,Lets you read EventGrid event subscriptions.,2414bbcf-6497-4faf-8c65-045460748405
+EventGrid TopicSpaces Publisher,Lets you publish messages on topicspaces.,a12b0b94-b317-4dcd-84a8-502ce99884c6
+EventGrid TopicSpaces Subscriber,Lets you subscribe messages on topicspaces.,4b0f2fd7-60b4-4eca-896f-4435034f8bf5
+Experimentation Administrator,Experimentation Administrator,7f646f1b-fa08-80eb-a33b-edd6ce5c915c
+Experimentation Contributor,Experimentation Contributor,7f646f1b-fa08-80eb-a22b-edd6ce5c915c
+Experimentation Metric Contributor,"Allows for creation, writes and reads to the metric set via the metrics service APIs.",6188b7c9-7d01-4f99-a59f-c88b630326c0
+Experimentation Reader,Experimentation Reader,49632ef5-d9ac-41f4-b8e7-bbe587fa74a1
+Experimentation Resource Admin,Experimentation Resource Admin,548d7e7c-65ee-412b-ae37-2dbb419d4207
+FHIR Data Bulk Operator,Role allows user or principal to perform bulk operations,804db8d3-32c7-4ad4-a975-3f6f90d5f5f5
+FHIR Data Contributor,Role allows user or principal full access to FHIR Data,5a1fc7df-4bf1-4951-a576-89034ee01acd
+FHIR Data Converter,Role allows user or principal to convert data from legacy format to FHIR,a1705bd2-3a8f-45a5-8683-466fcfd5cc24
+FHIR Data Exporter,Role allows user or principal to read and export FHIR Data,3db33094-8700-4567-8da5-1501d4e7e843
+FHIR Data Importer,Role allows user or principal to read and import FHIR Data,4465e953-8ced-4406-a58e-0f6e3f3b530b
+FHIR Data Reader,Role allows user or principal to read FHIR Data,4c8d0bbc-75d3-4935-991f-5f3c56d81508
+FHIR Data Writer,Role allows user or principal to read and write FHIR Data,3f88fce4-5892-4214-ae73-ba5294559913
+FHIR SMART User,Role allows user to access FHIR Service according to SMART on FHIR specification,4ba50f17-9666-485c-a643-ff00808643f0
+Fabric Resource Management Administrator,"Used by TIPS and FRM MSIs to create, update, delete and manage Fabric resources",337a31c1-4e14-4ef9-83ed-584bb8d2b70a
+Firmware Analysis Admin,Administrative user that can upload/view firmwares & configure firmware workspaces,9c1607d1-791d-4c68-885d-c7b7aaff7c8a
+Firmware Analysis Reader,View firmware images but not upload them or perform any workspace configuration,2a94a2fd-3c4f-45d1-847d-6585ba88af94
+Firmware Analysis User,Upload and analyze firmware images but not perform any workspace configuration,53b2724d-1e51-44fa-b586-bcace0c82609
+Flux Configurations Contributor,"Can create, update, get, list and delete Flux Configurations",61eb6405-5f4a-440b-ad03-fe06c5c85e44
+Foundational RP Contributor,Role for FRP customers to provision ARM resource types,c840cbbc-8508-4228-b700-ec6522a74314
+Foundry Account Owner,Grants full access to manage Foundry projects and accounts. Grants conditional assignment of the Foundry User role to other user principles.,e47c6f54-e4a2-4754-9501-8e0985b135e1
+Foundry Agent Consumer,Allows interacting with Foundry agents at runtime.,eed3b665-ab3a-47b6-8f48-c9382fb1dad6
+Foundry Owner,"Grants full to manage Foundry project and accounts. Grants reader access to Foundry projects, reader access to Foundry accounts, and data actions for a Foundry project.",c883944f-8b7b-4483-af10-35834be79c4a
+Foundry Project Manager,"Lets you perform developer actions and management actions on Microsoft Foundry Projects. Allows for making role assignments, but limited to Cognitive Service User role.",eadc314b-1a2d-4efa-be10-5d325db5065e
+Foundry Project Runtime User,Allows interacting with Foundry agents at runtime with minimal required permissions.,142bfaed-a13f-4c2d-bed2-6db62c4a1009
+Foundry User,"Grants reader access to Foundry projects, reader access to Foundry accounts, and data actions for an Foundry project.",53ca6127-db72-4b80-b1b0-d745d6d5456d
+Garnet Data Contributor,Allows read and write access to all keys within the Garnet resource,1694e55a-2496-4d07-b005-7259aa3fcbe8
+Garnet Data Owner,"Allows read, write, destructive and scripting actions on the Garnet resource",04f6c337-ffae-414c-b00f-3e80c9ab8a2c
+Garnet Data Reader,Allows read access to all keys within the Garnet resource,d9cd91b9-dada-4fa9-9406-454c4659c137
+Garnet PubSub Data Contributor,Allows read and write access to all channels within the Garnet resource,56e95fdc-3337-468d-b964-30d07f2a2018
+Garnet PubSub Data Reader,Allows read access to all channels within the Garnet resource,da9adf61-39cd-41d5-87a0-30b21f7270d8
+Garnet Script Data Contributor,Allows execution and management of scripts on the Garnet resource,7021ea36-e168-4bc0-af53-88de51d20665
+Gcp Connector contributor role,Microsoft.GcpConnector contributor role,a51d5f27-deba-47d1-9ccd-8589014b2e28
+Genome Admin,Full access to Genome control plane operations only,ef3729d8-2861-401e-95ae-c7d4845a6097
+Genome EndUser,Full access to Genome control plane and data plane operations,0e91b552-ae32-49ea-9898-317af306aa4b
+Genome SuperAdmin,Full access to Genome control plane and data plane operations,27ddfca1-add5-422d-9817-ab0d2d13dc6c
+GeoCatalog Administrator,"Grants full access to manage GeoCatalogs, but does not allow you to assign roles in Azure RBAC.",c9c97b9c-105d-4bb5-a2a7-7d15666c2484
+GeoCatalog Reader,"View GeoCatalogs, but does not allow you to make any changes.",b7b8f583-43d0-40ae-b147-6b46f53661c1
+Grafana Admin,"Manage server-wide settings and manage access to resources such as organizations, users, and licenses.",22926164-76b3-42b3-bc55-97df8dab3e41
+Grafana Editor,"Create, edit, delete, or view dashboards; create, edit, or delete folders; and edit or view playlists.",a79a5197-3a5c-4973-a920-486035ffd60f
+Grafana Limited Viewer,View home page.,41e04612-9dac-4699-a02b-c82ff2cc3fb5
+Grafana Viewer,"View dashboards, playlists, and query data sources.",60921a7e-fef1-4a43-9b16-a26c52ad4769
+Graph Owner,"Create and manage all aspects of the Enterprise Graph - Ontology, Schema mapping, Conflation and Conversational AI and Ingestions",b60367af-1334-4454-b71e-769d9a4f83d9
+Grounding with Bing User,Enable Approved Microsoft Applications to connect to Bing to retrieve and ground responses using real-time data,2016c9ed-c18d-4120-93d7-178e583efe92
+GroupQuota Reader,"Read GroupQuota requests, get GroupQuota request status, and get groupQuotaLimits.",d0f495dc-44ef-4140-aeb0-b89110e6a7c1
+GroupQuota Request Operator,"Read and create GroupQuota requests, get GroupQuota request status, and get groupQuotaLimits.",e2217c0e-04bb-4724-9580-91cf9871bc01
+Guest Configuration Resource Contributor,"Lets you read, write Guest Configuration Resource.",088ab73d-1256-47ae-bea9-9de8e7131f31
+HDInsight Cluster Admin,"Can read, create, modify and delete HDInsight clusters, configuration, extensions, etc.",0847e196-2fd2-4c2f-a48c-fca6fd030f44
+HDInsight Cluster Operator,Lets you read and modify HDInsight cluster configurations.,61ed4efc-fab3-44fd-b111-e24485cc132a
+HDInsight Domain Services Contributor,"Can Read, Create, Modify and Delete Domain Services related operations needed for HDInsight Enterprise Security Package",8d8d5a11-05d3-4bda-a417-a08778121c7c
+HDInsight on AKS Cluster Admin,"Grants a user/group the ability to create, delete and manage clusters within a given cluster pool. Cluster Admin can also run workloads, monitor, and manage all user activity on these clusters.",fd036e6b-1266-47a0-b0bb-a05d04831731
+HDInsight on AKS Cluster Operator,"Grants a user/group the ability to read cluster configurations, resize clusters and run jobs",bcf28286-af25-4c81-bb6f-351fcab5dbe9
+HDInsight on AKS Cluster Pool Admin,"Can read, create, modify and delete HDInsight on AKS cluster pools and create clusters",7656b436-37d4-490a-a4ab-d39f838f0042
+Health Safeguards Data User,Allows processing of health data in all available Health Safeguards,566f0da3-e2a5-4393-9089-763f8bab8fb6
+Healthcare Agent Admin,"Users with admin access can sign in, view and edit all of the bot resources, scenarios and configuration setting including the bot instance keys & secrets.",f1082fec-a70f-419f-9230-885d2550fb38
+Healthcare Agent Contributer,"Manage Helathcare Agent resources - list, view details, edit and delete resources.",13d06eae-ec82-4345-bcd6-c38625ddffbc
+Healthcare Agent Editor,"Users with editor access can sign in, view and edit all the bot resources, scenarios and configuration setting except for the bot instance keys & secrets and the end-user inputs (including Feedback, Unrecognized utterances and Conversation logs). A read-only access to the bot skills and channels.",af854a69-80ce-4ff7-8447-f1118a2e0ca8
+Healthcare Agent Reader,"Users with reader access can sign in, have read-only access to the bot resources, scenarios and configuration setting except for the bot instance keys & secrets (including Authentication, Data Connection and Channels keys) and the end-user inputs (including Feedback, Unrecognized utterances and Conversation logs).",eb5a76d5-50e7-4c33-a449-070e7c9c4cf2
+Healthcare Apis contributor,Allows all actions on healthcareapis provider resources,29f61507-bdfb-4987-b629-20033be2d6c3
+Healthcare Interop Contributor,Allows all actions on healthcare interop provider resources,585db2ed-219e-4821-a06a-c6c14b602afa
+Hierarchy Settings Administrator,Allows users to edit and delete Hierarchy Settings,350f8d15-c687-4448-8ae1-157740a3936d
+Hybrid Connectivity contributor role,Microsoft.HybridConnectivity contributor role,f0f57965-de58-41bc-ba76-2aaab4d09f30
+Hybrid Network Owner,Provides owner access to Hybrid Network Resources,9d3ef640-3c86-4e0a-8907-8d361559c012
+Hybrid Server Onboarding,Can onboard new Hybrid servers to the Hybrid Resource Provider.,5d1e5ee4-7c68-4a71-ac8b-0739630a3dfb
+Hybrid Server Resource Administrator,"Can read, write, delete, and re-onboard Hybrid servers to the Hybrid Resource Provider.",48b40c6e-82e0-4eb3-90d5-19e40f49b624
+HybridCompute Machine ListAccessDetails Action In-Built Role,In-Built Role definition that grants permissions to execute the listAccessDetails action on HybridCompute Machines,e9701b4d-e6e7-4657-91cd-360a0881d224
+IPAM Pool User,Read IPAM Pools and child resources. Create and remove associations. This role is in preview and subject to change.,7b3e853f-ad5d-4fb5-a7b8-56a3581c7037
+Impact Reader,Allows read-only access to reported impacts and impact categories,68ff5d27-c7f5-4fa9-a21c-785d0df7bd9e
+Inference Account Operator,"Create, read, modify, and delete inference accounts. This role should be assigned to users who can only manage inference accounts but can't perform inference operations.",360cab3d-4340-4c96-816d-682fbd52b3e2
+Inference Account Owner,"Create, read, modify, and delete inference accounts; as well as running inference workloads against those accounts. This role should be assigned to users who need full management capabilities over inference accounts, including the ability to run workloads.",76315a85-9e6b-4514-9780-868b1977b64e
+Informatica DataManagement Contributor role,Informatica DataManagement Provider role to manage organizations and child resource.,2e481b5d-5af3-463b-8b01-f9c948aaf0c5
+Integration Service Environment Contributor,"Lets you manage integration service environments, but not access to them.",a41e2c5b-bd99-4a07-88f4-9bf657a760b8
+Integration Service Environment Developer,"Allows developers to create and update workflows, integration accounts and API connections in integration service environments.",c7aa55d3-1abb-444a-a5ca-5e51e485d6ec
+Intelligent Systems Account Contributor,"Lets you manage Intelligent Systems accounts, but not access to them.",03a6d094-3444-4b3d-88af-7477090a9e5e
+IoT Hub Data Contributor,Allows for full access to IoT Hub data plane operations.,4fc6c259-987e-4a07-842e-c321cc9d413f
+IoT Hub Data Reader,Allows for full read access to IoT Hub data-plane properties,b447c946-2db7-41ec-983d-d8bf3b1c77e3
+IoT Hub Registry Contributor,Allows for full access to IoT Hub device registry.,4ea46cd5-c1b2-4a8e-910b-273211f9ce47
+IoT Hub Twin Contributor,Allows for read and write access to all IoT Hub device and module twins.,494bdba2-168f-4f31-a0a1-191d2f7c028c
+Issue Contributor,Can read all issues data and update issues settings.,8d7ecc5c-f27b-43cf-883f-46409d445502
+Key Vault Administrator,"Perform all data plane operations on a key vault and all objects in it, including certificates, keys, and secrets. Cannot manage key vault resources or manage role assignments. Only works for key vaults that use the 'Azure role-based access control' permission model.",00482a5a-887f-4fb3-b363-3b7fe8e74483
+Key Vault Certificate User,Read certificate contents. Only works for key vaults that use the 'Azure role-based access control' permission model.,db79e9a7-68ee-4b58-9aeb-b90e7c24fcba
+Key Vault Certificates Officer,"Perform any action on the certificates of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model.",a4417e6f-fecd-4de8-b567-7b0420556985
+Key Vault Contributor,"Lets you manage key vaults, but not access to them.",f25e0fa2-a7c8-4377-a976-54943a77a395
+Key Vault Crypto Officer,"Perform any action on the keys of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model.",14b46e9e-c2b7-41b4-b07b-48a6ebf60603
+Key Vault Crypto Service Encryption User,Read metadata of keys and perform wrap/unwrap operations. Only works for key vaults that use the 'Azure role-based access control' permission model.,e147488a-f6f5-4113-8e2d-b22465e65bf6
+Key Vault Crypto Service Release User,Release keys. Only works for key vaults that use the 'Azure role-based access control' permission model.,08bbd89e-9f13-488c-ac41-acfcb10c90ab
+Key Vault Crypto User,Perform cryptographic operations using keys. Only works for key vaults that use the 'Azure role-based access control' permission model.,12338af0-0e69-4776-bea7-57ae8d297424
+Key Vault Data Access Administrator,"Manage access to Azure Key Vault by adding or removing role assignments for the Key Vault Administrator, Key Vault Certificates Officer, Key Vault Crypto Officer, Key Vault Crypto Service Encryption User, Key Vault Crypto User, Key Vault Reader, Key Vault Secrets Officer, or Key Vault Secrets User roles. Includes an ABAC condition to constrain role assignments.",8b54135c-b56d-4d72-a534-26097cfdc8d8
+Key Vault Purge Operator,Allows permanent deletion of soft-deleted vaults.,a68e7c17-0ab2-4c09-9a58-125dae29748c
+Key Vault Reader,"Read metadata of key vaults and its certificates, keys, and secrets. Cannot read sensitive values such as secret contents or key material. Only works for key vaults that use the 'Azure role-based access control' permission model.",21090545-7ca7-4776-b22c-e363652d74d2
+Key Vault Secrets Officer,"Perform any action on the secrets of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model.",b86a8fe4-44ce-4948-aee5-eccb2c155cd7
+Key Vault Secrets User,Read secret contents. Only works for key vaults that use the 'Azure role-based access control' permission model.,4633458b-17de-408a-b874-0445c86b69e6
+Knowledge Consumer,Knowledge Read permission to consume Enterprise Graph Knowledge using entity search and graph query,ee361c5d-f7b5-4119-b4b6-892157c8f64c
+Kubernetes Agent Subscription Level Operator,Grants Microsoft Defender for Cloud subscription level permissions needed to activate Containers plan,ada52afe-776a-4b4d-a8f2-55670d3d8178
+Kubernetes Cluster - Azure Arc Onboarding,Role definition to authorize any user/service to create connectedClusters resource,34e09817-6cbe-4d01-b1a2-e0eac5743d41
+Kubernetes Extension Contributor,"Can create, update, get, list and delete Kubernetes Extensions, and get extension async operations",85cb6faf-e071-4c9b-8136-154b5a04f717
+Kubernetes Namespace User,Allows a user to read namespace resources and retrieve kubeconfig for the cluster,ba79058c-0414-4a34-9e42-c3399d80cd5a
+Kubernetes Runtime Storage Class Contributor Role,"Read, write, and delete Kubernetes Runtime storage classes in an Arc connected Kubernetes cluster",0cd9749a-3aaf-4ae5-8803-bd217705bf3b
+KubernetesRuntime Load Balancer Contributor Role,"Read, write, and delete load balancers in an Arc connected Kubernetes cluster",1a5682fc-4f12-4b25-927e-e8cfed0c539e
+Kusto Contributor,Can Manage Kusto Operations.,8ca4f98b-e38b-4784-9fc0-7aefa970cc5b
+Lab Assistant,The lab assistant role,ce40b423-cede-4313-a93f-9b28290b72e1
+Lab Contributor,The lab contributor role,5daaa2af-1fe8-407c-9122-bba179798270
+Lab Creator,Lets you create new labs under your Azure Lab Accounts.,b97fb8bc-a8b2-4522-a38b-dd33c7e65ead
+Lab Operator,The lab operator role,a36e6959-b6be-4b12-8e9f-ef4b474d304d
+Lab Services Contributor,The lab services contributor role,f69b8690-cc87-41d6-b77a-a4bc3c0a966f
+Lab Services Reader,The lab services reader role,2a5c394f-5eb7-4d4f-9c8e-e8eae39faebc
+LambdaTest.HyperExecute Contributor Role,Provides access to all LambdaTest.HyperExecute related operations,44a00263-b2a0-45d5-a618-5d8d11709349
+Landing Zone Account Owner,"Microsoft.Sovereign Landing Zone Account Owner allowing to review and modify Landing Zone Account, Landing Zone Configurations, as well as reading and adding Landing Zone Registrations. Also enables read-access to policies and management groups for enabling the full user experience of the Sovereign Services RP in the Azure Portal (as otherwise some elements might not be accessible to end users).",bf2b6809-e9a5-4aea-a6e1-40a9dc8c43a7
+Landing Zone Account Reader,"Microsoft.Sovereign Landing Zone Account Reader allowing to read Landing Zone Account, Landing Zone Configurations and Landing Zone Registrations. Also enables read-access to policies and management groups for enabling the full user experience of the Sovereign Services RP in the Azure Portal (as otherwise some elements might not be accessible to end users).",2718b1f7-eb07-424e-8868-0137541392a1
+Landing Zone Management Owner,Microsoft.Sovereign Landing Zone Management Owner allowing to review and modify Landing Zone Configurations as well as reading and adding Landing Zone Registrations. Also enables read-access to policies and management groups for enabling the full user experience of the Sovereign Services RP in the Azure Portal (as otherwise some elements might not be accessible to end users).,38863829-c2a4-4f8d-b1d2-2e325973ebc7
+Landing Zone Management Reader,Microsoft.Sovereign Landing Zone Management Reader allowing to review Landing Zone Configurations and corresponding Registrations without the ability to modify. Also enables read-access to policies and management groups for enabling the full user experience of the Sovereign Services RP in the Azure Portal (as otherwise some elements might not be accessible to end users).,8fe6e843-6d9e-417b-9073-106b048f50bb
+Liftr Datadog Contributor,Provides access to Datadog Control Plane Operations,81b67e46-ef5b-4404-bddd-090985bb4a28
+Liftr Dell Owner role,Provides access to all Dell related operations,d683b71b-2b91-4fc1-a43e-b53b3d85bed9
+Liftr Dynatrace Contributor,Provides access to Dynatrace Control Plane Operations,fa96a588-3fac-4adb-bfb2-f8404ece07e0
+Liftr Elastic Contributor,Provides access to Elastic Control Plane Operations,d68eeb8d-afae-4932-a331-203b7957e509
+Liftr Elastic Owner,Grants full access to manage Elastic resources,225efd4d-4ca0-42a1-ae53-5f233ba23c73
+Liftr Newrelic Contributor,Provides access to Newrelic Control Plane Operations,a60da355-bdec-443f-8d42-a03f0422f04d
+Liftr PureStorage Owner role,Provides access to all PureStorage related operations,85546f1f-f28b-4cb3-b852-73e422a96897
+Load Test Contributor,"View, create, update, delete and execute load tests. View and list load test resources but can not make any changes.",749a398d-560b-491b-bb21-08924219302e
+Load Test Owner,Execute all operations on load test resources and load tests,45bb0b16-2f0c-4e78-afaa-a07599b003f6
+Load Test Reader,View and list all load tests and load test resources but can not make any changes,3ae3fb29-0000-4ccd-bf80-542e7b26e081
+LocalNGFirewallAdministrator role,"Allows user to create, modify, describe, or delete NGFirewalls.",a8835c7d-b5cb-47fa-b6f0-65ea10ce07a2
+LocalRulestacksAdministrator role,"Allows users to create, modify, describe, or delete Rulestacks.",bfc3b73d-c6ff-45eb-9a5f-40298295bf20
+Locks Contributor,Can Manage Locks Operations.,28bf596f-4eb7-45ce-b5bc-6cf482fec137
+Log Analytics Contributor,Log Analytics Contributor can read all monitoring data and edit monitoring settings. Editing monitoring settings includes adding the VM extension to VMs; reading storage account keys to be able to configure collection of logs from Azure Storage; adding solutions; and configuring Azure diagnostics on all Azure resources.,92aaf0da-9dab-42b6-94a3-d43ce8d16293
+Log Analytics Data Reader,Log Analytics Data Reader can query and search the logs it is allowed to view over Log Analytics workspaces and tables,3b03c2da-16b3-4a49-8834-0f8130efdd3b
+Log Analytics Reader,"Log Analytics Reader can view and search all monitoring data as well as and view monitoring settings, including viewing the configuration of Azure diagnostics on all Azure resources.",73c42c96-874c-492b-b04d-ab87d138a893
+Logic App Contributor,"Lets you manage logic app, but not access to them.",87a39d53-fc1b-424a-814c-f7e04687dc9e
+Logic App Operator,"Lets you read, enable and disable logic app.",515c2055-d9d4-4321-b1b9-bd0c9a0f79fe
+Logic Apps Hybrid Contributor,"Full management of Logic Apps Hybrid, including creation, deletion, and updates.",32109304-a0e2-4d64-bd07-b23ac5efbe43
+Logic Apps Standard Contributor,You can manage all aspects of a Standard logic app and workflows. You can't change access or ownership.,ad710c24-b039-4e85-a019-deb4a06e8570
+Logic Apps Standard Developer,"You can create and edit workflows, connections, and settings for a Standard logic app. You can't make changes outside the workflow scope.",523776ba-4eb2-4600-a3c8-f2dc93da4bdb
+Logic Apps Standard Operator,"You can enable and disable the logic app, resubmit workflow runs, as well as create connections. You can't edit workflows or settings.",b70c96e9-66fe-4c09-b6e7-c98e69c98555
+Logic Apps Standard Reader,"You have read-only access to all resources in a Standard logic app and workflows, including the workflow runs and their history.",4accf36b-2c05-432f-91c8-5c532dff4c73
+Managed Application Contributor Role,Allows for creating managed application resources.,641177b8-a67a-45b9-a033-47bc880bb21e
+Managed Application Operator Role,Lets you read and perform actions on Managed Application resources,c7393b34-138c-406f-901b-d8cf2b17e6ae
+Managed Application Publisher Operator,Allows the publisher to read resources in the managed resource group for Managed Application and request JIT access for additional operations. This role is only used by the Managed Application service to provide access to publishers.,b9331d33-8a36-4f8c-b097-4f54124fdb44
+Managed HSM contributor,"Lets you manage managed HSM pools, but not access to them.",18500a29-7fe2-46b2-a342-b16a415e101d
+Managed Identity Contributor,"Create, Read, Update, and Delete User Assigned Identity",e40ec5ca-96e0-45a2-b4ff-59039f2c2b59
+Managed Identity Federated Identity Credential Contributor,"Create, Read, Update, and Delete User Assigned Identity Federated Identity Credentials(FIC)",7e559ce2-48d7-4b27-9128-fa1b247f1308
+Managed Identity Operator,Read and Assign User Assigned Identity,f1a07417-d97a-45cb-824c-7a7467783830
+Managed Services Registration assignment Delete Role,Managed Services Registration Assignment Delete Role allows the managing tenant users to delete the registration assignment assigned to their tenant.,91c1777a-f3dc-4fae-b103-61d183457e46
+Management Group Contributor,Management Group Contributor Role,5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c
+Management Group Reader,Management Group Reader Role,ac63b705-f282-497d-ac71-919bf39d939d
+Microsoft Approvals Request User,Requests approval workflow execution for resource changes.,0343f3e8-01ac-4bb8-8f93-78b1d31ba64b
+Microsoft Approvals Service Operator,Performs Approvals service-level management operations including service onboarding and configuration.,98d40527-c073-4096-943a-dd593105ca9c
+Microsoft Approvals Workflow Contributor,"Performs approval workflow management operations including workflow creation, execution and deletion.",92318126-08be-45d0-a1b2-532e6c7d52ce
+Microsoft Cloud Security Arc Machine Operator,"Allows Microsoft Cloud Security to manage Azure Arc-enabled machines and their extensions, helping to secure connected workloads.",53ad7cb7-33cc-4509-b36b-03d40643c499
+Microsoft Confluent Contributor role,Microsoft Confluent Provider role to manage organizations and child resource.,5052f0f9-7e27-4570-bc13-9ee1cf442526
+Microsoft Discovery Bookshelf Index Data Reader - Preview,"Grants query access to search and retrieve data from Microsoft Discovery Bookshelf knowledge bases, and read-only access to list Bookshelves and their knowledge bases. This is the minimum role required to use the retrieve action when linking a knowledge base to an agent. This role is in preview and subject to change.",8ec773c5-7ce6-4b78-91d1-182f8faa536d
+Microsoft Discovery Chat Model Reader - Preview,"Read-only access to Discovery chat model deployments: allows listing chat model deployments and reading their details. Does not allow creating, modifying, or deleting deployments. Intended to be assigned alongside Discovery project roles so users can view and select the models available to them (e.g. in the agent-create model picker). This role is in preview and subject to change.",5e523d62-66de-4912-99be-6b009b7839cc
+Microsoft Discovery Platform Administrator (Preview),Grants full access to manage Microsoft.Discovery resources. This role is in preview and subject to change.,7a2b6e6c-472e-4b39-8878-a26eb63d75c6
+Microsoft Discovery Platform Contributor (Preview),"Grants permissions to view and operate on most Discovery platform resources, including workspaces, supercomputers, storages, agents, bookshelves, data containers, models, tools, workflows, and investigations, as well as perform data plane actions, but does not allow creating, updating, or deleting core resources such as workspaces, supercomputers, storages, bookshelves, node pools, or projects. This role is in preview and subject to change.",01288891-85ee-45a7-b367-9db3b752fc65
+Microsoft Discovery Platform Reader (Preview),Grants readonly permissions to view Microsoft.Discovery resources. This role in preview and subject to change.,3bb7c424-af4e-436b-bfcc-8779c8934c31
+Microsoft Discovery Project Contributor - Preview,"Full operational control over an existing Discovery project: investigations and conversations (read/write/delete) plus project settings update and deletion. Does not allow creating new projects, assigning roles, or managing tools or knowledge bases. This role is in preview and subject to change.",c883607b-5c40-4930-b09a-19f58ae1c538
+Microsoft Discovery Project Reader - Preview,"Read-only access to an existing Discovery project and its contents, including its investigations and conversations. Does not allow creating, modifying, or deleting any resources, nor assigning roles. This role is in preview and subject to change.",ac7d1e6d-3070-4d7d-9cd9-7adbf5cdd579
+Microsoft Discovery Storage Container Contributor - Preview,"Grants management of storage assets within Microsoft.Discovery storage containers: allows reading a storage container and creating, reading, updating, and deleting the storage assets within it, including checking the status of asynchronous storage asset operations. Cannot create, update, or delete the storage container itself, and does not grant access to the underlying Azure Storage blob data. Intended to be assigned alongside Discovery project roles. This role is in preview and subject to change.",9697f39a-3a08-4fc8-ab07-674a0d5cacdd
+Microsoft Discovery Storage Container Reader - Preview,"Read-only access to Microsoft.Discovery storage containers and the storage assets within them: allows reading a storage container and listing/reading its storage assets. Does not allow creating, modifying, or deleting storage assets or containers, and does not grant access to the underlying Azure Storage blob data. Intended to be assigned alongside Discovery project roles. This role is in preview and subject to change.",a51eacd1-6976-43ce-b6b6-83585e3639f0
+Microsoft Discovery Tools Reader - Preview,"Read-only access to Discovery tool definitions: allows listing tools and reading their definitions. Does not allow creating, modifying, deleting, or running tools. Intended to be assigned alongside Discovery project roles so users can view the tools available to them. This role is in preview and subject to change.",84c36cf8-7fcd-4453-af30-5f5b52b86732
+Microsoft PowerBI Tenant Operations Role,Allows management of tenant operations,8c87871d-6201-42da-abb1-1c0c985ff71c
+Microsoft Sentinel Automation Contributor,Microsoft Sentinel Automation Contributor,f4c81013-99ee-4d62-a7ee-b3f1f648599a
+Microsoft Sentinel Business Applications Agent Operator,List and update actions on a business applications system. This role is in preview and subject to change.,c18f9900-27b8-47c7-a8f0-5b3b3d4c2bc2
+Microsoft Sentinel Contributor,Microsoft Sentinel Contributor,ab8e14d6-4a74-4a29-9ba8-549422addade
+Microsoft Sentinel Playbook Operator,Microsoft Sentinel Playbook Operator,51d6186e-6489-4900-b93f-92e23144cca5
+Microsoft Sentinel Reader,Microsoft Sentinel Reader,8d289c81-5878-46d4-8554-54e1e3d8b5cb
+Microsoft Sentinel Responder,Microsoft Sentinel Responder,3e150937-b8fe-4cfb-8069-0eaf05ecd056
+Microsoft.AzureStackHCI Device Pool Machine Manager,Microsoft.AzureStackHCI Device Pool Machine Manager,b6d9c0f6-d69f-472b-91b4-7a6838c6d1cb
+Microsoft.AzureStackHCI Device Pool Manager,Microsoft.AzureStackHCI Device Pool Manager,adc3c795-c41e-4a89-a478-0b321783324c
+Microsoft.AzureStackHCI EdgeMachine Reader,Microsoft.AzureStackHCI EdgeMachine Reader,5f569efd-4da5-4123-99cd-d42fbb2a836e
+Microsoft.Edge Winfields federated subscription read access role,Microsoft.Edge Winfields role for read access on federated subscriptions,83ee7727-862c-4213-8ed8-2ce6c5d69a40
+Microsoft.Kubernetes connected cluster role,Microsoft.Kubernetes connected cluster role.,5548b2cf-c94c-4228-90ba-30851930a12f
+Microsoft.OffAzureSpringBoot Service Owner,Full access to Azure Microsoft.OffAzureSpringBoot Service REST APIs,79732128-7761-4733-aebf-35590da9f29b
+Microsoft.WeightsAndBiases Contributor Role,Provides access to all Microsoft.WeightsAndBiases related operations,246fffca-69ee-4945-bbf1-2a867dce4fda
+Microsoft.Windows365.CloudPcDelegatedMsis Writer User,Built in role to perform Write operations on CloudPcDelegatedMsis resources.,21bffb94-04c0-4ed0-b676-68bb926e832b
+Migrate Arc Discovery Reader - Preview,"Read metadata of Azure Arc enabled server resources and metadata, performance and migration suitability of Arc enabled SQL server resources. Users creating Azure Migrate project that uses Arc resource discovery require this role on Arc scope of the project. To enable periodic sync, Azure Migrate project managed identity must be assigned this role. This role is in preview and subject to change.",5d5dddae-e124-4753-972d-aae60b37deb4
+MongoDB Atlas Contributor,Provides access to MongoDB.Atlas Control Plane Operations,045b6ee5-0c68-42c4-9be0-7389794309f5
+Monitoring Contributor,Can read all monitoring data and update monitoring settings.,749f88d5-cbae-40b8-bcfc-e573ddc772fa
+Monitoring Data Reader,Can access the data in an Azure Monitor Workspace.,b0d8363b-8ddd-447d-831f-62ca05bff136
+Monitoring Metrics Publisher,Enables publishing metrics against Azure resources,3913510d-42f4-4e42-8a64-420c390055eb
+Monitoring Policy Contributor,"Allows read access to all monitoring data, update permissions for monitoring settings and permissions to deploy and remediate Azure Monitor alert policies.",47be4a87-7950-4631-9daf-b664a405f074
+Monitoring Reader,Can read all monitoring data.,43d0d8ad-25c7-4714-9337-8ba259a9fe05
+MySQL Backup And Export Operator,Grants full access to manage backup and export resources,d18ad5f3-1baf-4119-b49b-d944edb1f9d0
+MySQL Control Plane,The permission set to use on mysql control plane,b5207fd7-42d3-40fa-8cc6-a7e189aef39e
+MySQL User Data Reader,User data reader for MySQL service.,abed7cd4-f358-4384-9d17-def9303b3b53
+MySQL User Data Writer,User data writer for MySQL service.,8894c184-eeb6-45cc-868a-1be782055af3
+Network Contributor,"Lets you manage networks, but not access to them.",4d97b98b-1d4f-4787-a291-c67834d212e7
+New Relic APM Account Contributor,"Lets you manage New Relic Application Performance Management accounts and applications, but not access to them.",5d28c62d-5b37-4476-8438-e587778df237
+Nexus Identity Owner,Provides owner access to nexusidentity resources,374a1cc6-96cb-4946-8d8b-a41054c8ae97
+Nexus Network Fabric Owner,Provides owner access to nexus network fabric resources,46c70067-0f50-457f-8137-2449c90de518
+Nexus Network Fabric Service Reader,Read-only access to Nexus Network Fabric Service,05fdd44c-adc6-4aff-981c-61041f0c929a
+Nexus Network Fabric Service Writer,Read-write access to Nexus Network Fabric Service,a5eb8433-97a5-4a06-80b2-a877e1622c31
+NginxPlus Contributor service role,Provides access to all Nginx.NginxPlus Control Plane operations,61aed14c-6c9a-4ed5-aa44-49fc5e96a167
+Object Anchors Account Owner,Provides user with ingestion capabilities for an object anchors account.,ca0835dd-bacc-42dd-8ed2-ed5e7230d15b
+Object Anchors Account Reader,Lets you read ingestion jobs for an object anchors account.,4a167cdf-cb95-4554-9203-2347fe489bd9
+Object Understanding Account Owner,Provides user with ingestion capabilities for Azure Object Understanding.,4dd61c23-6743-42fe-a388-d8bdd41cb745
+Object Understanding Account Reader,Lets you read ingestion jobs for an object understanding account.,d18777c0-1514-4662-8490-608db7d334b6
+Online Experimentation Contributor,Grants permissions for all management operations to Online Experimentation resources.,2c7a01fe-5518-4a42-93c2-658e45441691
+Online Experimentation Data Owner,Allows full access to Online Experimentation data.,53747cdd-e97c-477a-948c-b587d0e514b2
+Online Experimentation Data Reader,Allows read access to Online Experimentation data.,1363e94d-546f-4fe9-8434-b0eefb292d59
+Online Experimentation Reader,Grants permission for read operations to Online Experimentation resources.,58b80de8-4b34-424c-9e47-23faf0f7cfe2
+Operator Nexus Compute Contributor Role (Preview),(Preview) Manage and configure Azure Operator Nexus infrastructure resources. This role is in preview and subject to change.,4aa368ec-fba9-4e93-81ed-396b3d461cc5
+Operator Nexus Key Vault Writer Service Role (Preview),(Preview) Provides Azure Operator Nexus services the ability to write to a Key Vault. This role is in preview and subject to change.,44f0a1a8-6fea-4b35-980a-8ff50c487c97
+Operator Nexus Owner (Preview),(Preview) This role allows full access to Azure Operator Nexus Network Cloud resources. This role is in preview and subject to change.,77be276d-fb44-4f3b-beb5-9bf03c4cd2d3
+Oracle Database DbSystems Administrator,Grants full access to manage DbSystems resources,63342533-d951-495d-a3c3-a459aa02362b
+Oracle Subscriptions Manager Built-in Role,Grants full access to manage all Oracle Subscriptions resources,4caf51ec-f9f5-413f-8a94-b9f5fddba66b
+Oracle.Database Autonomous Database Administrator,Grants full access to manage all Autonomous Database resources,59c05558-2358-462d-ba19-afbd7118936d
+Oracle.Database Exadata Infrastructure Administrator Built-in Role,Grants full access to manage all Exadata Infrastructure resources,4cfdd23b-aece-4fd1-b614-ad3a06c53453
+Oracle.Database Exascale Storage Vault Administrator,Grants full access to manage Exascale Storage Vaults,a00ed373-f085-4b75-a950-53eacdc52ac0
+Oracle.Database Exascale VmCluster Administrator,Grants full access to manage Exascale VmClusters,0869d06d-e3d1-4472-8764-1bb71b2bdaf7
+Oracle.Database Owner Built-in Role,Grants full access to manage all Oracle.Database resources,4562aac9-b209-4bd7-a144-6d7f3bb516f4
+Oracle.Database Reader Built-in Role,Grants read access to all Oracle.Database resources,d623d097-b882-4e1e-a26f-ac60e31065a1
+Oracle.Database VmCluster Administrator Built-in Role,Grants full access to manage all VmCluster resources,e9ce8739-6fa2-4123-a0a2-0ef41a67806f
+Owner,"Grants full access to manage all resources, including the ability to assign roles in Azure RBAC.",8e3af657-a8ff-443c-a75c-2fe8c4bcb635
+Pinecone.VectorDb Contributor Role,Provides access to all Pinecone.VectorDb related operations,dd799a69-ffc8-4aa8-9701-b51f686857d9
+PlayFab Contributor,Provides contributor access to PlayFab resources,0c8b84dc-067c-4039-9615-fa1a4b77c726
+PlayFab Reader,Provides read access to PlayFab resources,a9a19cc5-31f4-447c-901f-56c0bb18fcaf
+Playwright Workspace Contributor,View and list Playwright Workspace resources but can not make any changes. Can manage service access tokens and execute Playwright tests.,78cf819f-0969-4ebe-8759-015c6efcd5bf
+Playwright Workspace Owner,Perform all operations on Playwright Workspace resources. Can manage service access tokens and execute Playwright tests.,45265627-32f7-4da4-9ab0-b1cb0e9ec70b
+Playwright Workspace Reader,View and list all Playwright Workspace resources and tests but can not make any changes.,19d36063-d00b-4ea5-a1ac-a7c4926a0b78
+Policy Enrollments Contributor,Allows the creation and modification of policy enrollments,285ce6d6-fa11-43bd-94ef-42a9b3740bfd
+Policy Insights Data Writer (Preview),Allows read access to resource policies and write access to resource component policy events.,66bb4e9e-b016-4a94-8249-4c0511c2be84
+Portal Dashboard Writer Role,Can write an Azure Portal Dashboard,78eacb5e-e318-4560-85a9-e6a724ca60c9
+PostgreSQL Flexible Management Contributor,"Create, read, modify, and delete required resources objects to be used by Azure PostgreSQL Flexible servers.",cc3c084f-9a2e-4664-b2bc-47a6685a5f99
+PostgreSQL Flexible Management Service Contributor (Deprecated),This role is deprecated.,a60b64c0-1adf-4051-956a-78f3ae578c7d
+PostgreSQL Flexible Server Long Term Retention Backup Role,Role to allow backup vault to access PostgreSQL Flexible Server Resource APIs for Long Term Retention Backup.,c088a766-074b-43ba-90d4-1fb21feae531
+Power Platform Account Contributor,"Create, Read, Update, and Delete Power Platform Account resources",2593f4c7-8bf4-4fff-9804-2ee069b41902
+Power Platform Enterprise Policy Contributor,"Create, Read, Update, and Delete Power Platform Enterprise Policy resources",babe7770-cdbc-4f46-9bd7-b90b34842946
+PowerBI Dedicated Contributor,Grants full access to manage all resources within Power BI Dedicated RP,10550c65-218e-4de9-9e52-0200c8ed4748
+Private DNS Zone Contributor,"Lets you manage private DNS zone resources, but not the virtual networks they are linked to.",b12aa53e-6015-4669-85d0-8515ebb3ae7f
+Privileged Monitoring Data Reader,"Privileged Monitoring Data Reader can query and search the logs it is allowed to view over Log Analytics workspaces and tables, including protected tables",dbc9c667-e97f-4491-aee6-90b9cf960190
+Pro Active Coding Data User,Allows processing of health data in Pro Active Coding,d622af9a-030e-4f32-8267-419abfd54702
+Procurement Contributor,Lets you manage the procurement of products and services.,be1a1ac2-09d3-4261-9e57-a73a6e227f53
+Procurement Contributor with Resource Group Permissions,"Manage procurement of products and services, and create, update, and delete resource groups.",469a0cf0-3794-4627-838e-39d04f27b306
+Project Babylon Data Curator,"The Microsoft.ProjectBabylon data curator can create, read, modify and delete catalog data objects and establish relationships between objects. This role is in preview and subject to change.",9ef4ef9c-a049-46b0-82ab-dd8ac094c889
+Project Babylon Data Reader,The Microsoft.ProjectBabylon data reader can read catalog data objects. This role is in preview and subject to change.,c8d896ba-346d-4f50-bc1d-7d1c84130446
+Project Babylon Data Source Administrator,The Microsoft.ProjectBabylon data source administrator can manage data sources and data scans. This role is in preview and subject to change.,05b7651b-dc44-475e-b74d-df3db49fae0f
+ProviderHub Contributor,Allows you to create and manage Microsoft.ProviderHub resources through the Resource Provider Platform. Does not allow you to assign roles in Azure RBAC.,a3ab03bc-5350-42ff-b0d5-00207672db55
+ProviderHub Reader,"Allows you to view all Microsoft.ProviderHub resources created through the Resource Provider Platform, but does not allow you to make any changes to the resources.",4d8c6f2e-3fd6-4d40-826e-93e3dc4c3fc1
+Provisioned Machine Admin,"Grants full access to Azure Stack HCI Provisioned Machine resources, including disk management, device reset, deletion, and the ability to assign others as Provisioned Machine Reader and/or Contributor",97922edc-56af-49a9-8996-4679a6e10e68
+Provisioned Machine Contributor,"Grants permissions to manage Azure Stack HCI Provisioned Machine resources, excluding disk management, device reset, and resource deletion",dab09fbf-28d0-4b30-b97e-d2a0f680847a
+Provisioned Machine Reader,Grants read-only access to Azure Stack HCI Provisioned Machine resources,cc733c34-b633-4850-8d77-77aa26638325
+Pure Storage Cloud VM Volume Group Mount Reader,A special role for mount operation (e.g VM extension) only - enables to read connection endpoints.,a2425b74-61f3-4bff-97cb-d0e3bc906777
+Pure Storage Cloud VM Volume Group Owner,To manage anything within the volume group resource.,c9ba051b-aad6-42fd-92dc-e48780abee75
+Purview role 1 (Deprecated),Deprecated role.,8a3c2885-9b38-4fd2-9d99-91af537c1347
+Purview role 2 (Deprecated),Deprecated role.,200bba9e-f0c8-430f-892b-6f0794863803
+Purview role 3 (Deprecated),Deprecated role.,ff100721-1b9d-43d8-af52-42b69c1272db
+Quantum Workspace Data Contributor,"Create, read, and modify jobs and other Workspace data.",c1410b24-3e69-4857-8f86-4d0a2e603250
+Quantum Workspace Data Reader,Read jobs and other Workspace data.,27af9d98-85b7-4dad-bc1b-df53a7fc8877
+Quantum Workspace Owner,"Create, read, and modify Workspace and job data. Make Workspace Data Contributor role assignments.",30b3bcf2-670a-4bdc-8669-7e0ae0c0dfda
+Quota Request Operator,"Read and create quota requests, get quota request status, and create support tickets.",0e5f05e5-9ab9-446b-b98d-1e2157c94125
+Reader,"View all resources, but does not allow you to make any changes.",acdd72a7-3385-48ef-bd42-f606fba81ae7
+Reader and Data Access,Lets you view everything but will not let you delete or create a storage account or contained resource. It will also allow read/write access to all data contained in a storage account via access to storage account keys.,c12c1c16-33a1-487b-954d-41c89c60f349
+Recurring Scheduled Actions Contributor,Allows users to use Recurring Scheduled Actions offered by Microsoft.ComputeSchedule,376d0802-aca8-4c2d-83a5-c88630f396fe
+Redis Cache Contributor,Create and manage Azure Cache for Redis resources. Cannot read or write data stored in the cache.,e0f68234-74aa-48ed-b826-c38b57376e17
+Register Contributor,Lets you Register / Unregister any Azure service,1cbe04d4-3fa3-4559-a406-71584a32cacb
+Relationship Administrator,"Role definition allowing read, write and delete access to all relationship types",b54df9c1-53dc-45cc-a86d-7a83cced2ed0
+Relationship Reader,Role definition allowing read access to all relationship types,5eaf7b81-a48f-45ed-b6b4-c64bfe86d523
+Remote Rendering Administrator,"Provides user with conversion, manage session, rendering and diagnostics capabilities for Azure Remote Rendering",3df8b902-2a6f-47c7-8cc5-360e9b272a7e
+Remote Rendering Client,"Provides user with manage session, rendering and diagnostics capabilities for Azure Remote Rendering.",d39065c4-c120-43c9-ab0a-63eed9795f0a
+Reservation Purchaser,Lets you purchase reservations,f7b75c60-3036-4b75-91c3-6b41c27c1689
+Resource Group Contributor,Can Manage Resource Group Operations.,94877a25-7520-40c5-9c42-68e02e4758bd
+Resource Policy Contributor,"Users with rights to create/modify resource policy, create support ticket and read resources/hierarchy.",36243c78-bf99-498c-9df9-86d9f8d28608
+Role Based Access Control Administrator,"Manage access to Azure resources by assigning roles using Azure RBAC. This role does not allow you to manage access using other ways, such as Azure Policy.",f58310d9-a9f6-439a-9e8d-f62e7b41a168
+SQL DB Contributor,"Lets you manage SQL databases, but not access to them. Also, you can't manage their security-related policies or their parent SQL servers.",9b7fa17d-e63e-47b0-bb0a-15c516ac86ec
+SQL Data Reader - Preview,Allows reading data stored in databases in Azure SQL Database - this will only work for allow listed tenants,9d4c0abd-119b-475f-853b-31f56289076f
+SQL Data Writer - Preview,Allows writing data to databases in Azure SQL Database - this will only work for allow listed tenants,9b6940eb-1937-49e0-9557-58a69cdd4ef4
+SQL Managed Instance Contributor,"Lets you manage SQL Managed Instances and required network configuration, but can’t give access to others.",4939a1f6-9ae0-4e48-a1e0-f2cbe897382d
+SQL Security Manager,"Lets you manage the security-related policies of SQL servers and databases, but not access to them.",056cd41c-7e88-42e1-933e-88ba6a50c9c3
+SQL Server Contributor,"Lets you manage SQL servers and databases, but not access to them, and not their security -related policies.",6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437
+SRE Agent Administrator,"Full control of the agent—manage chats, incident response plans, and agent run modes; approve and execute commands.",e79298df-d852-4c6d-84f9-5d13249d1e55
+SRE Agent Author,Allows users to add custom features to the SRE Agent using incident handlers and extended agents.,eb64ab4c-23eb-4f63-a9c2-27da365f04e7
+SRE Agent Reader,"Grants read-only access to all SRE Agent data, including chats, incidents, logs, and configurations. Does not permit interaction with the agent.",a4b156ac-253f-4a1a-9851-96d62b71b047
+SRE Agent Standard User,Grants access to interact with the SRE Agent to triage incidents and run diagnostics.,2d84a65a-63b2-4343-bbb6-31105d857bc1
+SSH PublicKeys Contributor Role,This is the role created for SSH PublicKeys Contributor,fc6e3395-6a8c-4527-bb4c-d0abd41e8e74
+SSH PublicKeys Reader Role,This is the role created for SSH PublicKeys Reader,31ef6312-5b0c-4ce9-8c5d-587a91344fe7
+SaaS Hub Contributor,SaaS Hub contributor can manage SaaS Hub resource,e9b8712a-cbcf-4ea7-b0f7-e71b803401e6
+Savings plan Purchaser,Lets you purchase savings plans,3d24a3a0-c154-4f6f-a5ed-adc8e01ddb74
+Scheduled Actions Contributor,Allows users to use Scheduled Actions offered by Microsoft.ComputeSchedule,6fbca9a8-3561-41fd-8b20-6576043c1076
+Scheduled Events Contributor,Provides access to scheduled event actions,b67fe603-310e-4889-b9ee-8257d09d353d
+Scheduled Patching Contributor,Provides access to manage maintenance configurations with maintenance scope InGuestPatch and corresponding configuration assignments,cd08ab90-6b14-449c-ad9a-8f8e549482c6
+Scheduler Job Collections Contributor,"Lets you manage Scheduler job collections, but not access to them.",188a0f2f-5c9e-469b-ae67-2aa5ce574b94
+Schema Registry Contributor,"Read, write, and delete Schema Registry groups and schemas.",5dffeca3-4936-4216-b2bc-10343a5abb25
+Schema Registry Reader,Read and list Schema Registry groups and schemas.,2c56ea50-c6b3-40a6-83c0-9d98858bc7d2
 Search Index Data Contributor,Grants full access to Azure Cognitive Search index data.,8ebe5a00-799e-43f5-93ac-243d3dce84a7
 Search Index Data Reader,Grants read access to Azure Cognitive Search index data.,1407120a-92aa-4202-b7e9-c0e197c71c8f
+Search Parameter Manager,Role allows user or principal access to $status and $reindex to update search parameters,a02f7c31-354d-4106-865a-deedf37fa038
 Search Service Contributor,"Lets you manage Search services, but not access to them.",7ca78c08-252a-4471-8644-bb5ff32d4ba0
+Secrets Store Extension Owner,"Read, create and modify secretsync and secretproviderclass objects. Register and deregister the provider from the subscription.",5c227a58-cff3-4b51-9fa3-51bdafb6ca55
+Security Admin,Security Admin Role,fb1c8493-542b-48eb-b624-b4c8fea62acd
+Security Assessment Contributor,Lets you push assessments to Security Center,612c2aa1-cb24-443b-ac28-3ab7272de6f5
+Security Detonation Chamber Publisher,"Allowed to publish and modify platforms, workflows and toolsets to Security Detonation Chamber",352470b3-6a9c-4686-b503-35deb827e500
+Security Detonation Chamber Reader,Allowed to query submission info and files from Security Detonation Chamber,28241645-39f8-410b-ad48-87863e2951d5
+Security Detonation Chamber Submission Manager,Allowed to create and manage submissions to Security Detonation Chamber,a37b566d-3efa-4beb-a2f2-698963fa42ce
+Security Detonation Chamber Submitter,Allowed to create submissions to Security Detonation Chamber,0b555d9b-b4a7-4f43-b330-627f0e5be8f0
+Security Manager (Legacy),This is a legacy role. Please use Security Administrator instead,e3d13bf0-dd5a-482e-ba6b-9b8433878d10
+Security Reader,Security Reader Role,39bc4728-0917-49c7-9d2c-d95423bc2eb4
+Semantic Reranker User,Execute semantic reranking operations against registered inference accounts. This role should be assigned to users who need to run semantic reranking workloads but do not need to manage the accounts themselves.,6c74a7c5-4a87-40f9-bb03-61e49aecbc78
+Service Connector Contributor,Can Manage Service Connector.,db7003cd-07a9-490c-bfa5-23e40314f8d7
+Service Fabric Cluster Contributor,"Manage your Service Fabric Cluster resources. Includes clusters, application types, application type versions, applications, and services. You will need additional permissions to deploy and manage the cluster's underlying resources such as virtual machine scale sets, storage accounts, networks, etc.",b6efc156-f0da-4e90-a50a-8c000140b017
+Service Fabric Managed Cluster Contributor,"Deploy and manage your Service Fabric Managed Cluster resources. Includes managed clusters, node types, application types, application type versions, applications, and services.",83f80186-3729-438c-ad2d-39e94d718838
+Service Group Member Relationship Contributor,"Role definition allowing read, write and delete access to Service Group Member relationship types",05b1aaf9-00c9-477b-b0e8-2da660b78c51
+Service Health Billing Reader,Grants permissions to view billing information present in service health events,32c34659-0f83-4a4c-80f2-63a244f8ae0b
+Service Health Security Reader,Grants permissions to view sensitive security information present in service health events,1a928ab0-1fee-43cf-9266-f9d8c22a8ddb
+Services Hub Operator,"Services Hub Operator allows you to perform all read, write, and deletion operations related to Services Hub Connectors.",82200a5b-e217-47a5-b665-6d8765ee745b
+Services Hub User,"Services Hub User allows you to perform all read, write, and deletion operations related to Services Hub Connectors except create/delete connector and managing law.",4417a88f-3e58-4cf2-a4e9-112cf414254c
 SignalR AccessKey Reader,Read SignalR Service Access Keys,04165923-9d83-45d5-8227-78b77b0a687e
 SignalR App Server,Lets your app server access SignalR Service with AAD auth options.,420fcaa2-552c-430f-98ca-3264be4806c7
 SignalR REST API Owner,Full access to Azure SignalR Service REST APIs,fd53cd77-2268-407a-8f46-7e7863d0f521
 SignalR REST API Reader,Read-only access to Azure SignalR Service REST APIs,ddde6b66-c0df-4114-a159-3618637b3035
 SignalR Service Owner,Full access to Azure SignalR Service REST APIs,7e4f1700-ea5a-4f59-8f37-079cfe29dce3
 SignalR/Web PubSub Contributor,"Create, Read, Update, and Delete SignalR service resources",8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761
-Web Plan Contributor,Manage the web plans for websites. Does not allow you to assign roles in Azure RBAC.,2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b
-Website Contributor,"Manage websites, but not web plans. Does not allow you to assign roles in Azure RBAC.",de139f84-1756-47ae-9be6-808fbbe84772
-AcrDelete,"Delete repositories, tags, or manifests from a container registry.",c2f4ef07-c644-48eb-af81-4b1b4947fb11
-AcrImageSigner,Push trusted images to or pull trusted images from a container registry enabled for content trust.,6cef56e8-d556-48e5-a04f-b8e64114680f
-AcrPull,Pull artifacts from a container registry.,7f951dda-4ed3-4680-a7ca-43fe172d538d
-AcrPush,Push artifacts to or pull artifacts from a container registry.,8311e382-0749-4cb8-b61a-304f252e45ec
-AcrQuarantineReader,Pull quarantined images from a container registry.,cdda3590-29a3-44f6-95f2-9f980659eb04
-AcrQuarantineWriter,Push quarantined images to or pull quarantined images from a container registry.,c8d4ff99-41c3-41a8-9f60-21dfdad59608
-Azure Kubernetes Service Cluster Admin Role,List cluster admin credential action.,0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8
-Azure Kubernetes Service Cluster User Role,List cluster user credential action.,4abbcc35-e782-43d8-92c5-2d3f1bd2253f
-Azure Kubernetes Service Contributor Role,Grants access to read and write Azure Kubernetes Service clusters,ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8
-Azure Kubernetes Service RBAC Admin,"Lets you manage all resources under cluster/namespace, except update or delete resource quotas and namespaces.",3498e952-d568-435e-9b2c-8d77e338d7f7
-Azure Kubernetes Service RBAC Cluster Admin,Lets you manage all resources in the cluster.,b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
-Azure Kubernetes Service RBAC Reader,"Allows read-only access to see most objects in a namespace. It does not allow viewing roles or role bindings. This role does not allow viewing Secrets, since reading the contents of Secrets enables access to ServiceAccount credentials in the namespace, which would allow API access as any ServiceAccount in the namespace (a form of privilege escalation). Applying this role at cluster scope will give access across all namespaces.",7f6c6a51-bcf8-42ba-9220-52d62157d7db
-Azure Kubernetes Service RBAC Writer,"Allows read/write access to most objects in a namespace.This role does not allow viewing or modifying roles or role bindings. However, this role allows accessing Secrets and running Pods as any ServiceAccount in the namespace, so it can be used to gain the API access levels of any ServiceAccount in the namespace. Applying this role at cluster scope will give access across all namespaces.",a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb
-Azure Connected SQL Server Onboarding,Allows for read and write access to Azure resources for SQL Server on Arc-enabled servers.,e8113dce-c529-4d33-91fa-e9b972617508
-Cosmos DB Account Reader Role,Can read Azure Cosmos DB account data. See DocumentDB Account Contributor for managing Azure Cosmos DB accounts.,fbdf93bf-df7d-467e-a4d2-9458aa1360c8
-Cosmos DB Operator,"Lets you manage Azure Cosmos DB accounts, but not access data in them. Prevents access to account keys and connection strings.",230815da-be43-4aae-9cb4-875f7bd000aa
-CosmosBackupOperator,Can submit restore request for a Cosmos DB database or a container for an account,db7b14f2-5adf-42da-9f96-f2ee17bab5cb
-CosmosRestoreOperator,Can perform restore action for Cosmos DB database account with continuous backup mode,5432c526-bc82-444a-b7ba-57c5b0b5b34f
-DocumentDB Account Contributor,Can manage Azure Cosmos DB accounts. Azure Cosmos DB is formerly known as DocumentDB.,5bd9cd88-fe45-4216-938b-f97437e15450
-Redis Cache Contributor,"Lets you manage Redis caches, but not access to them.",e0f68234-74aa-48ed-b826-c38b57376e17
-SQL DB Contributor,"Lets you manage SQL databases, but not access to them. Also, you can't manage their security-related policies or their parent SQL servers.",9b7fa17d-e63e-47b0-bb0a-15c516ac86ec
-SQL Managed Instance Contributor,"Lets you manage SQL Managed Instances and required network configuration, but can't give access to others.",4939a1f6-9ae0-4e48-a1e0-f2cbe897382d
-SQL Security Manager,"Lets you manage the security-related policies of SQL servers and databases, but not access to them.",056cd41c-7e88-42e1-933e-88ba6a50c9c3
-SQL Server Contributor,"Lets you manage SQL servers and databases, but not access to them, and not their security-related policies.",6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437
-Azure Event Hubs Data Owner,Allows for full access to Azure Event Hubs resources.,f526a384-b230-433a-b45c-95f59c4a2dec
-Azure Event Hubs Data Receiver,Allows receive access to Azure Event Hubs resources.,a638d3c7-ab3a-418d-83e6-5f17a39d4fde
-Azure Event Hubs Data Sender,Allows send access to Azure Event Hubs resources.,2b629674-e913-4c01-ae53-ef4638d8f975
-Data Factory Contributor,"Create and manage data factories, as well as child resources within them.",673868aa-7521-48a0-acc6-0f60742d39f5
-Data Purger,Delete private data from a Log Analytics workspace.,150f5e0c-0603-4f03-8c7f-cf70034c4e90
-HDInsight Cluster Operator,Lets you read and modify HDInsight cluster configurations.,61ed4efc-fab3-44fd-b111-e24485cc132a
-HDInsight Domain Services Contributor,"Can Read, Create, Modify and Delete Domain Services related operations needed for HDInsight Enterprise Security Package",8d8d5a11-05d3-4bda-a417-a08778121c7c
-Log Analytics Contributor,Log Analytics Contributor can read all monitoring data and edit monitoring settings. Editing monitoring settings includes adding the VM extension to VMs; reading storage account keys to be able to configure collection of logs from Azure Storage; adding solutions; and configuring Azure diagnostics on all Azure resources.,92aaf0da-9dab-42b6-94a3-d43ce8d16293
-Log Analytics Reader,"Log Analytics Reader can view and search all monitoring data as well as and view monitoring settings, including viewing the configuration of Azure diagnostics on all Azure resources.",73c42c96-874c-492b-b04d-ab87d138a893
-Schema Registry Contributor (Preview),"Read, write, and delete Schema Registry groups and schemas.",5dffeca3-4936-4216-b2bc-10343a5abb25
-Schema Registry Reader (Preview),Read and list Schema Registry groups and schemas.,2c56ea50-c6b3-40a6-83c0-9d98858bc7d2
-Stream Analytics Query Tester,Lets you perform query testing without creating a stream analytics job first,1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf
-AzureML Data Scientist,"Can perform all actions within an Azure Machine Learning workspace, except for creating or deleting compute resources and modifying the workspace itself.",f6c7c914-8db3-469d-8ca1-694a8f32e121
-Cognitive Services Contributor,"Lets you create, read, update, delete and manage keys of Cognitive Services.",25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68
-Cognitive Services Custom Vision Contributor,"Full access to the project, including the ability to view, create, edit, or delete projects.",c1ff6cc2-c111-46fe-8896-e0ef812ad9f3
-Cognitive Services Custom Vision Deployment,"Publish, unpublish or export models. Deployment can view the project but can't update.",5c4089e1-6d96-4d2f-b296-c1bc7137275f
-Cognitive Services Custom Vision Labeler,"View, edit training images and create, add, remove, or delete the image tags. Labelers can view the project but can't update anything other than training images and tags.",88424f51-ebe7-446f-bc41-7fa16989e96c
-Cognitive Services Custom Vision Reader,Read-only actions in the project. Readers can't create or update the project.,93586559-c37d-4a6b-ba08-b9f0940c2d73
-Cognitive Services Custom Vision Trainer,"View, edit projects and train the models, including the ability to publish, unpublish, export the models. Trainers can't create or delete the project.",0a5ae4ab-0d65-4eeb-be61-29fc9b54394b
-Cognitive Services Data Reader (Preview),Lets you read Cognitive Services data.,b59867f0-fa02-499b-be73-45a86b5b3e1c
-Cognitive Services Face Recognizer,"Lets you perform detect, verify, identify, group, and find similar operations on Face API. This role does not allow create or delete operations, which makes it well suited for endpoints that only need inferencing capabilities, following 'least privilege' best practices.",9894cab4-e18a-44aa-828b-cb588cd6f2d7
-Cognitive Services Metrics Advisor Administrator,"Full access to the project, including the system level configuration.",cb43c632-a144-4ec5-977c-e80c4affc34a
-Cognitive Services QnA Maker Editor,"Let's you create, edit, import and export a KB. You cannot publish or delete a KB.",f4cc2bf9-21be-47a1-bdf1-5c5804381025
-Cognitive Services QnA Maker Reader,Let's you read and test a KB only.,466ccd10-b268-4a11-b098-b4849f024126
-Cognitive Services User,Lets you read and list keys of Cognitive Services.,a97b65f3-24c7-4388-baec-2e87135dc908
-Device Update Administrator,Gives you full access to management and content operations,02ca0879-e8e4-47a5-a61e-5c618b76e64a
-Device Update Content Administrator,Gives you full access to content operations,0378884a-3af5-44ab-8323-f5b22f9f3c98
-Device Update Content Reader,"Gives you read access to content operations, but does not allow making changes",d1ee9a80-8b14-47f0-bdc2-f4a351625a7b
-Device Update Deployments Administrator,Gives you full access to management operations,e4237640-0e3d-4a46-8fda-70bc94856432
-Device Update Deployments Reader,"Gives you read access to management operations, but does not allow making changes",49e2f5d2-7741-4835-8efa-19e1fe35e47f
-Device Update Reader,"Gives you read access to management and content operations, but does not allow making changes",e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f
-IoT Hub Data Contributor,Allows for full access to IoT Hub data plane operations.,4fc6c259-987e-4a07-842e-c321cc9d413f
-IoT Hub Data Reader,Allows for full read access to IoT Hub data-plane properties,b447c946-2db7-41ec-983d-d8bf3b1c77e3
-IoT Hub Registry Contributor,Allows for full access to IoT Hub device registry.,4ea46cd5-c1b2-4a8e-910b-273211f9ce47
-IoT Hub Twin Contributor,Allows for read and write access to all IoT Hub device and module twins.,494bdba2-168f-4f31-a0a1-191d2f7c028c
-Remote Rendering Administrator,"Provides user with conversion, manage session, rendering and diagnostics capabilities for Azure Remote Rendering",3df8b902-2a6f-47c7-8cc5-360e9b272a7e
-Remote Rendering Client,"Provides user with manage session, rendering and diagnostics capabilities for Azure Remote Rendering.",d39065c4-c120-43c9-ab0a-63eed9795f0a
-Spatial Anchors Account Contributor,"Lets you manage spatial anchors in your account, but not delete them",8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827
-Spatial Anchors Account Owner,"Lets you manage spatial anchors in your account, including deleting them",70bbe301-9835-447d-afdd-19eb3167307c
-Spatial Anchors Account Reader,Lets you locate and read properties of spatial anchors in your account,5d51204f-eb77-4b1c-b86a-2ec626c49413
-API Management Service Contributor,Can manage service and the APIs,312a565d-c81f-4fd8-895a-4e21e48d571c
-API Management Service Operator Role,Can manage service but not the APIs,e022efe7-f5ba-4159-bbe4-b44f577e9b61
-API Management Service Reader Role,Read-only access to service and APIs,71522526-b88f-4d52-b57f-d31fc3546d0d
-App Configuration Data Owner,Allows full access to App Configuration data.,5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b
-App Configuration Data Reader,Allows read access to App Configuration data.,516239f1-63e1-4d78-a4de-a74fb236a071
-Azure Relay Listener,Allows for listen access to Azure Relay resources.,26e0b698-aa6d-4085-9386-aadae190014d
-Azure Relay Owner,Allows for full access to Azure Relay resources.,2787bf04-f1f5-4bfe-8383-c8a24483ee38
-Azure Relay Sender,Allows for send access to Azure Relay resources.,26baccc8-eea7-41f1-98f4-1762cc7f685d
-Azure Service Bus Data Owner,Allows for full access to Azure Service Bus resources.,090c5cfd-751d-490a-894a-3ce6f1109419
-Azure Service Bus Data Receiver,Allows for receive access to Azure Service Bus resources.,4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0
-Azure Service Bus Data Sender,Allows for send access to Azure Service Bus resources.,69a216fc-b8fb-44d8-bc22-1f3c2cd27a39
-Azure Stack Registration Owner,Lets you manage Azure Stack registrations.,6f12a6df-dd06-4f3e-bcb1-ce8be600526a
-EventGrid Contributor,Lets you manage EventGrid operations.,1e241071-0855-49ea-94dc-649edcd759de
-EventGrid Data Sender,Allows send access to event grid events.,d5a91429-5739-47e2-a06b-3470a27159e7
-EventGrid EventSubscription Contributor,Lets you manage EventGrid event subscription operations.,428e0ff0-5e57-4d9c-a221-2c70d0e0a443
-EventGrid EventSubscription Reader,Lets you read EventGrid event subscriptions.,2414bbcf-6497-4faf-8c65-045460748405
-FHIR Data Contributor,Role allows user or principal full access to FHIR Data,5a1fc7df-4bf1-4951-a576-89034ee01acd
-FHIR Data Exporter,Role allows user or principal to read and export FHIR Data,3db33094-8700-4567-8da5-1501d4e7e843
-FHIR Data Reader,Role allows user or principal to read FHIR Data,4c8d0bbc-75d3-4935-991f-5f3c56d81508
-FHIR Data Writer,Role allows user or principal to read and write FHIR Data,3f88fce4-5892-4214-ae73-ba5294559913
-Integration Service Environment Contributor,"Lets you manage integration service environments, but not access to them.",a41e2c5b-bd99-4a07-88f4-9bf657a760b8
-Integration Service Environment Developer,"Allows developers to create and update workflows, integration accounts and API connections in integration service environments.",c7aa55d3-1abb-444a-a5ca-5e51e485d6ec
-Intelligent Systems Account Contributor,"Lets you manage Intelligent Systems accounts, but not access to them.",03a6d094-3444-4b3d-88af-7477090a9e5e
-Logic App Contributor,"Lets you manage logic apps, but not change access to them.",87a39d53-fc1b-424a-814c-f7e04687dc9e
-Logic App Operator,"Lets you read, enable, and disable logic apps, but not edit or update them.",515c2055-d9d4-4321-b1b9-bd0c9a0f79fe
-Domain Services Contributor,Can manage Azure AD Domain Services and related network configurations,eeaeda52-9324-47f6-8069-5d5bade478b2
-Domain Services Reader,Can view Azure AD Domain Services and related network configurations,361898ef-9ed1-48c2-849c-a832951106bb
-Managed Identity Contributor,"Create, Read, Update, and Delete User Assigned Identity",e40ec5ca-96e0-45a2-b4ff-59039f2c2b59
-Managed Identity Operator,Read and Assign User Assigned Identity,f1a07417-d97a-45cb-824c-7a7467783830
-Attestation Contributor,Can read write or delete the attestation provider instance,bbf86eb8-f7b4-4cce-96e4-18cddf81d86e
-Attestation Reader,Can read the attestation provider properties,fd1bd22b-8476-40bc-a0bc-69b95687b9f3
-Key Vault Administrator,"Perform all data plane operations on a key vault and all objects in it, including certificates, keys, and secrets. Cannot manage key vault resources or manage role assignments. Only works for key vaults that use the 'Azure role-based access control' permission model.",00482a5a-887f-4fb3-b363-3b7fe8e74483
-Key Vault Certificates Officer,"Perform any action on the certificates of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model.",a4417e6f-fecd-4de8-b567-7b0420556985
-Key Vault Contributor,"Manage key vaults, but does not allow you to assign roles in Azure RBAC, and does not allow you to access secrets, keys, or certificates.",f25e0fa2-a7c8-4377-a976-54943a77a395
-Key Vault Crypto Officer,"Perform any action on the keys of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model.",14b46e9e-c2b7-41b4-b07b-48a6ebf60603
-Key Vault Crypto Service Encryption User,Read metadata of keys and perform wrap/unwrap operations. Only works for key vaults that use the 'Azure role-based access control' permission model.,e147488a-f6f5-4113-8e2d-b22465e65bf6
-Key Vault Crypto User,Perform cryptographic operations using keys. Only works for key vaults that use the 'Azure role-based access control' permission model.,12338af0-0e69-4776-bea7-57ae8d297424
-Key Vault Reader,"Read metadata of key vaults and its certificates, keys, and secrets. Cannot read sensitive values such as secret contents or key material. Only works for key vaults that use the 'Azure role-based access control' permission model.",21090545-7ca7-4776-b22c-e363652d74d2
-Key Vault Secrets Officer,"Perform any action on the secrets of a key vault, except manage permissions. Only works for key vaults that use the 'Azure role-based access control' permission model.",b86a8fe4-44ce-4948-aee5-eccb2c155cd7
-Key Vault Secrets User,Read secret contents. Only works for key vaults that use the 'Azure role-based access control' permission model.,4633458b-17de-408a-b874-0445c86b69e6
-Managed HSM contributor,"Lets you manage managed HSM pools, but not access to them.",18500a29-7fe2-46b2-a342-b16a415e101d
-Microsoft Sentinel Automation Contributor,Microsoft Sentinel Automation Contributor,f4c81013-99ee-4d62-a7ee-b3f1f648599a
-Microsoft Sentinel Contributor,Microsoft Sentinel Contributor,ab8e14d6-4a74-4a29-9ba8-549422addade
-Microsoft Sentinel Reader,Microsoft Sentinel Reader,8d289c81-5878-46d4-8554-54e1e3d8b5cb
-Microsoft Sentinel Responder,Microsoft Sentinel Responder,3e150937-b8fe-4cfb-8069-0eaf05ecd056
-Security Admin,View and update permissions for Microsoft Defender for Cloud. Same permissions as the Security Reader role and can also update the security policy and dismiss alerts and recommendations.,fb1c8493-542b-48eb-b624-b4c8fea62acd
-Security Assessment Contributor,Lets you push assessments to Microsoft Defender for Cloud,612c2aa1-cb24-443b-ac28-3ab7272de6f5
-Security Manager (Legacy),This is a legacy role. Please use Security Admin instead.,e3d13bf0-dd5a-482e-ba6b-9b8433878d10
-Security Reader,"View permissions for Microsoft Defender for Cloud. Can view recommendations, alerts, a security policy, and security states, but cannot make changes.",39bc4728-0917-49c7-9d2c-d95423bc2eb4
-DevTest Labs User,"Lets you connect, start, restart, and shutdown your virtual machines in your Azure DevTest Labs.",76283e04-6283-4c54-8f91-bcf1374a3c64
-Lab Creator,Lets you create new labs under your Azure Lab Accounts.,b97fb8bc-a8b2-4522-a38b-dd33c7e65ead
-Application Insights Component Contributor,Can manage Application Insights components,ae349356-3a1b-4a5e-921d-050484c6347e
-Application Insights Snapshot Debugger,"Gives user permission to view and download debug snapshots collected with the Application Insights Snapshot Debugger. Note that these permissions are not included in the Owner or Contributor roles. When giving users the Application Insights Snapshot Debugger role, you must grant the role directly to the user. The role is not recognized when it is added to a custom role.",08954f03-6346-4c2e-81c0-ec3a5cfae23b
-Monitoring Contributor,"Can read all monitoring data and edit monitoring settings. See also Get started with roles, permissions, and security with Azure Monitor.",749f88d5-cbae-40b8-bcfc-e573ddc772fa
-Monitoring Metrics Publisher,Enables publishing metrics against Azure resources,3913510d-42f4-4e42-8a64-420c390055eb
-Monitoring Reader,"Can read all monitoring data (metrics, logs, etc.). See also Get started with roles, permissions, and security with Azure Monitor.",43d0d8ad-25c7-4714-9337-8ba259a9fe05
-Workbook Contributor,Can save shared workbooks.,e8ddcd69-c73f-4f9f-9844-4100522f16ad
-Workbook Reader,Can read workbooks.,b279062a-9be3-42a0-92ae-8b3cf002ec4d
-Automation Contributor,Manage azure automation resources and other resources using azure automation.,f353d9bd-d4a6-484e-a77a-8050b599b867
-Automation Job Operator,Create and Manage Jobs using Automation Runbooks.,4fe576fe-1146-4730-92eb-48519fa6bf9f
-Automation Operator,"Automation Operators are able to start, stop, suspend, and resume jobs",d3881f73-407a-4167-8283-e981cbba0404
-Automation Runbook Operator,Read Runbook properties - to be able to create Jobs of the runbook.,5fb5aef8-1081-4b8e-bb16-9d5d0385bab5
-Azure Arc Enabled Kubernetes Cluster User Role,List cluster user credentials action.,00493d72-78f6-4148-b6c5-d3ce8e4799dd
-Azure Arc Kubernetes Admin,"Lets you manage all resources under cluster/namespace, except update or delete resource quotas and namespaces.",dffb1e0c-446f-4dde-a09f-99eb5cc68b96
-Azure Arc Kubernetes Cluster Admin,Lets you manage all resources in the cluster.,8393591c-06b9-48a2-a542-1bd6b377f6a2
-Azure Arc Kubernetes Viewer,"Lets you view all resources in cluster/namespace, except secrets.",63f0a09d-1495-4db4-a681-037d84835eb4
-Azure Arc Kubernetes Writer,"Lets you update everything in cluster/namespace, except (cluster)roles and (cluster)role bindings.",5b999177-9696-4545-85c7-50de3797e5a1
-Azure Connected Machine Onboarding,Can onboard Azure Connected Machines.,b64e21ea-ac4e-4cdf-9dc9-5b892992bee7
-Azure Connected Machine Resource Administrator,"Can read, write, delete and re-onboard Azure Connected Machines.",cd570a14-e51a-42ad-bac8-bafd67325302
-Billing Reader,Allows read access to billing data,fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64
-Blueprint Contributor,"Can manage blueprint definitions, but not assign them.",41077137-e803-4205-871c-5a86e6a753b4
-Blueprint Operator,"Can assign existing published blueprints, but cannot create new blueprints. Note that this only works if the assignment is done with a user-assigned managed identity.",437d2ced-4a38-4302-8479-ed2bcb43d090
-Cost Management Contributor,"Can view costs and manage cost configuration (e.g. budgets, exports)",434105ed-43f6-45c7-a02f-909b2ba83430
-Cost Management Reader,"Can view cost data and configuration (e.g. budgets, exports)",72fafb9e-0641-4937-9268-a91bfd8191a3
-Hierarchy Settings Administrator,Allows users to edit and delete Hierarchy Settings,350f8d15-c687-4448-8ae1-157740a3936d
-Kubernetes Cluster - Azure Arc Onboarding,Role definition to authorize any user/service to create connectedClusters resource,34e09817-6cbe-4d01-b1a2-e0eac5743d41
-Kubernetes Extension Contributor,"Can create, update, get, list and delete Kubernetes Extensions, and get extension async operations",85cb6faf-e071-4c9b-8136-154b5a04f717
-Managed Application Contributor Role,Allows for creating managed application resources.,641177b8-a67a-45b9-a033-47bc880bb21e
-Managed Application Operator Role,Lets you read and perform actions on Managed Application resources,c7393b34-138c-406f-901b-d8cf2b17e6ae
-Managed Applications Reader,Lets you read resources in a managed app and request JIT access.,b9331d33-8a36-4f8c-b097-4f54124fdb44
-Managed Services Registration assignment Delete Role,Managed Services Registration Assignment Delete Role allows the managing tenant users to delete the registration assignment assigned to their tenant.,91c1777a-f3dc-4fae-b103-61d183457e46
-Management Group Contributor,Management Group Contributor Role,5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c
-Management Group Reader,Management Group Reader Role,ac63b705-f282-497d-ac71-919bf39d939d
-New Relic APM Account Contributor,"Lets you manage New Relic Application Performance Management accounts and applications, but not access to them.",5d28c62d-5b37-4476-8438-e587778df237
-Policy Insights Data Writer (Preview),Allows read access to resource policies and write access to resource component policy events.,66bb4e9e-b016-4a94-8249-4c0511c2be84
-Quota Request Operator,"Read and create quota requests, get quota request status, and create support tickets.",0e5f05e5-9ab9-446b-b98d-1e2157c94125
-Reservation Purchaser,Lets you purchase reservations,f7b75c60-3036-4b75-91c3-6b41c27c1689
-Resource Policy Contributor,"Users with rights to create/modify resource policy, create support ticket and read resources/hierarchy.",36243c78-bf99-498c-9df9-86d9f8d28608
 Site Recovery Contributor,Lets you manage Site Recovery service except vault creation and role assignment,6670b86e-a3f7-4917-ac9b-5d6ab1be4567
 Site Recovery Operator,Lets you failover and failback but not perform other Site Recovery management operations,494ae006-db33-4328-bf46-533a6560a3ca
 Site Recovery Reader,Lets you view Site Recovery status but not perform other management operations,dbaa88c4-0c30-4179-9fb3-46319faa6149
+Sites Owner,"Microsoft Edge Sites Owner role - Grants full access to manage all resources, including the ability to assign roles in Azure RBAC.",1cd7e4da-2789-457f-adbe-3e9e84037a93
+Sites Reader,View all Sites related resources but does not allow you to make any changes.,59f98be6-0817-488b-831e-36a353c8000b
+Spatial Anchors Account Contributor,"Lets you manage spatial anchors in your account, but not delete them",8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827
+Spatial Anchors Account Owner,"Lets you manage spatial anchors in your account, including deleting them",70bbe301-9835-447d-afdd-19eb3167307c
+Spatial Anchors Account Reader,Lets you locate and read properties of spatial anchors in your account,5d51204f-eb77-4b1c-b86a-2ec626c49413
+SpatialMapsAccounts Account Owner,"Lets you manage data in your account, including deleting them",e9c9ed2b-2a99-4071-b2ff-5b113ebf73a1
+SqlDb Migration Role,Role for SqlDb migration,189207d4-bb67-4208-a635-b06afe8b2c57
+SqlMI Migration Role,Role for SqlMI migration,1d335eef-eee1-47fe-a9e0-53214eba8872
+SqlVM Migration Role,Role for SqlVM migration,ae8036db-e102-405b-a1b9-bae082ea436d
+Standby Container Group Pool Contributor,Allows users to manage standby container group pool resources.,39fcb0de-8844-4706-b050-c28ddbe3ff83
+Storage Account Backup Contributor,Lets you perform backup and restore operations using Azure Backup on the storage account.,e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1
+Storage Account Contributor,"Lets you manage storage accounts, including accessing storage account keys which provide full access to storage account data.",17d1049b-9a84-46fb-8f53-869881c3d3ab
+Storage Account Encryption Scope Contributor Role,Allows management of Encryption Scopes on a Storage Account,a316ed6d-1efe-48ac-ac08-f7995a9c26fb
+Storage Account Key Operator Service Role,Storage Account Key Operators are allowed to list and regenerate keys on Storage Accounts,81a9662b-bebf-436f-a333-f67b29880f12
+Storage Actions Blob Data Operator,Used by the Storage Actions - Storage Task to list & perform operations on the Storage Account blobs,4bad4d9e-2a13-4888-94bb-c8432f6f3040
+Storage Actions Contributor,"Used by the Storage Actions author to create, read, update, and delete Storage Actions",bd8acdb0-202c-4493-a7fe-ef98eefbfbc4
+Storage Actions Task Assignment Contributor,"Used by the Storage Actions assigner to create a Task Assignment on their target Storage Account, with RBAC privileges for Managed Identity",77789c21-1643-48a2-8f27-47f858540b51
+Storage Blob Data Contributor,"Allows for read, write and delete access to Azure Storage blob containers and data",ba92f5b4-2d11-453d-a403-e96b0029c9fe
+Storage Blob Data Owner,"Allows for full access to Azure Storage blob containers and data, including assigning POSIX access control.",b7e6dc6d-f1e8-4753-8033-0f276bb0955b
+Storage Blob Data Reader,Allows for read access to Azure Storage blob containers and data,2a2b9908-6ea1-4ae2-8e65-a410df84e7d1
+Storage Blob Delegator,Allows for generation of a user delegation key which can be used to sign SAS tokens,db58b8e5-c6ad-4a2a-8342-4190687cbf4a
+Storage Connector Contributor,Allows creating and managing storage connectors to access remote data sources in-place in a storage account. This role is in preview and subject to change.,9d819e60-1b9f-4871-b492-4e6cdee0b50a
+Storage DataShare Contributor,Allows creating and managing storage dataShares to share data from storage accounts in-place. This role is in preview and subject to change.,35c49d44-ccc1-4b18-8267-cfb3bacdd396
+Storage File Backup Contributor,Lets you perform file share backup operations using Azure Backup on the storage account,c8a487a2-c85b-4487-83a1-9f04cde10293
+Storage File Data Privileged Contributor,"Customer has read, write, delete and modify NTFS permission access on Azure Storage file shares.",69566ab7-960f-475b-8e7c-b3118f30c6bd
+Storage File Data Privileged Reader,Customer has read access on Azure Storage file shares.,b8eda974-7b85-4f76-af95-65846b26df6d
+Storage File Data SMB Admin,Allows for admin access equivalent to storage account key for end users over SMB.,bbf004e3-0e4b-4f86-ae4f-1f8fb47b357b
+Storage File Data SMB MI Admin,Allows for admin-level access for managed identities on files/directories in Azure file shares.,a235d3ee-5935-4cfb-8cc5-a3303ad5995e
+Storage File Data SMB Share Contributor,"Allows for read, write, and delete access in Azure Storage file shares over SMB",0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb
+Storage File Data SMB Share Elevated Contributor,"Allows for read, write, delete and modify NTFS permission access in Azure Storage file shares over SMB",a7264617-510b-434b-a828-9731dc254ea7
+Storage File Data SMB Share Reader,Allows for read access to Azure File Share over SMB,aba4ae5f-2193-4029-9191-0cb91df5e314
+Storage File Data SMB Take Ownership,Allows end user to assume ownership of a file/directory,5d9bac3f-34b2-432f-bde5-78aa8e73ce6b
+Storage File Delegator,"Allows for generation of a user delegation key, which can then be used to create a shared access signature for a file or Azure file share that is signed with Entra ID credentials.",765a04e0-5de8-4bb2-9bf6-b2a30bc03e91
+Storage File Restore Contributor,Lets you perform file share restore operations using Azure Backup on the storage account,e7a9e73d-4397-41f2-a282-af8b65aaa2dc
+Storage Queue Data Contributor,"Allows for read, write, and delete access to Azure Storage queues and queue messages",974c5e8b-45b9-4653-ba55-5f855dd0fb88
+Storage Queue Data Message Processor,"Allows for peek, receive, and delete access to Azure Storage queue messages",8a0f0c08-91a1-4084-bc3d-661d67233fed
+Storage Queue Data Message Sender,Allows for sending of Azure Storage queue messages,c6a89b2d-59bc-44d0-9896-0f6e12d7b80a
+Storage Queue Data Reader,Allows for read access to Azure Storage queues and queue messages,19e7f393-937e-4f77-808e-94535e297925
+Storage Queue Delegator,"Allows for generation of a user delegation key, which can then be used to create a shared access signature for an Azure Storage queue that is signed with Entra ID credentials.",7ee386e9-84f0-448e-80a6-f185f6533131
+Storage Table Data Contributor,"Allows for read, write and delete access to Azure Storage tables and entities",0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3
+Storage Table Data Reader,Allows for read access to Azure Storage tables and entities,76199698-9eea-4c19-bc75-cec21354c6b6
+Storage Table Delegator,"Allows for generation of a user delegation key, which can then be used to create a shared access signature for an Azure Storage table that is signed with Entra ID credentials.",965033a5-c8eb-4f35-b82f-fef460a3606d
+Stream Analytics Contributor,Contributor access to Clusters and Streaming Jobs,6e0c8711-85a0-4490-8365-8ec13c4560b4
+Stream Analytics Query Tester,Lets you perform query testing without creating a stream analytics job first,1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf
+Stream Analytics Reader,Read-only access to Clusters and Streaming Jobs,1dfc38e8-6ce7-447f-807c-029c65262c5f
+Subscription Migrator,Can perform operations related to the transfer of managed identities and their associated authorization policies from one Entra ID tenant to another,cd7709b9-d129-4dc4-ac27-d215a1be1e07
+Supercomputer Infrastructure Contributor,"Lets you manage Supercomputer Infrastructure resources, but not access to them.",68899692-f960-4247-af28-82f55b357997
 Support Request Contributor,Lets you create and manage Support requests,cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e
+SupportPlan Contributor,Contributor role for Enterprise Support Resource Provider,6d6f52ba-a7de-4c56-a58f-522154514fba
 Tag Contributor,"Lets you manage tags on entities, without providing access to the entities themselves.",4a9ae827-6dc8-4573-8ac7-8239d42aa03f
-Desktop Virtualization Application Group Contributor,Contributor of the Desktop Virtualization Application Group.,86240b0e-9422-4c43-887b-b61143f32ba8
-Desktop Virtualization Application Group Reader,Reader of the Desktop Virtualization Application Group.,aebf23d0-b568-4e86-b8f9-fe83a2c6ab55
-Desktop Virtualization Contributor,Contributor of Desktop Virtualization.,082f0a83-3be5-4ba1-904c-961cca79b387
-Desktop Virtualization Host Pool Contributor,Contributor of the Desktop Virtualization Host Pool.,e307426c-f9b6-4e81-87de-d99efb3c32bc
-Desktop Virtualization Host Pool Reader,Reader of the Desktop Virtualization Host Pool.,ceadfde2-b300-400a-ab7b-6143895aa822
-Desktop Virtualization Reader,Reader of Desktop Virtualization.,49a72310-ab8d-41df-bbb0-79b649203868
-Desktop Virtualization Session Host Operator,Operator of the Desktop Virtualization Session Host.,2ad6aaab-ead9-4eaa-8ac5-da422f562408
-Desktop Virtualization User,Allows user to use the applications in an application group.,1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63
-Desktop Virtualization User Session Operator,Operator of the Desktop Virtualization User Session.,ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6
-Desktop Virtualization Workspace Contributor,Contributor of the Desktop Virtualization Workspace.,21efdde3-836f-432b-bf3d-3e8e734d4b2b
-Desktop Virtualization Workspace Reader,Reader of the Desktop Virtualization Workspace.,0fa44ee9-7a7d-466b-9bb2-2bf446b1204d
-Azure Digital Twins Data Owner,Full access role for Digital Twins data-plane,bcd981a7-7f74-457b-83e1-cceb9e632ffe
-Azure Digital Twins Data Reader,Read-only role for Digital Twins data-plane properties,d57506d4-4c8d-48b1-8587-93c323f6a5a3
-BizTalk Contributor,"Lets you manage BizTalk services, but not access to them.",5e3c6656-6cfa-4708-81fe-0de47ac73342
-Scheduler Job Collections Contributor,"Lets you manage Scheduler job collections, but not access to them.",188a0f2f-5c9e-469b-ae67-2aa5ce574b94
-Services Hub Operator,"Services Hub Operator allows you to perform all read, write, and deletion operations related to Services Hub Connectors.",82200a5b-e217-47a5-b665-6d8765ee745b
+Template Spec Contributor,Allows full access to Template Spec operations at the assigned scope.,1c9b6475-caf0-4164-b5a1-2142a7116f4b
+Template Spec Reader,Allows read access to Template Specs at the assigned scope.,392ae280-861d-42bd-9ea5-08ee6d83b80e
+Tenant Contributor,Allows users to create and manage Entra ID Tenants.,0a7c2fa1-6f28-41a4-86b8-e74937c63222
+Test Base Reader,Let you view and download packages and test results.,15e0f5a1-3450-4248-8e25-e2afe88a9e85
+ToolchainOrchestrator Admin Role,Grant full access to manage all Toolchain orchestrator resources.,2ccf8795-8983-4912-8036-1c45212c95e8
+ToolchainOrchestrator Viewer Role,Grant access to view all Toolchain orchestrator resources.,c5826735-177b-4a0d-a9a3-d0e4b4bda107
+Traffic Manager Contributor,"Lets you manage Traffic Manager profiles, but does not let you control who has access to them.",a4b10055-b0c7-44c2-b00f-c7b5b3550cf7
+Transparency Logs Owner,Grants full access to manage Transparency Log resources.,8ad4d0ee-9bfb-49e8-93fc-01abb8db6240
+Usage Billing Contributor,Contributor access to Accounts,33cdeeac-0940-4f85-9317-7e2432c17289
+User Access Administrator,Lets you manage user access to Azure resources.,18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
+VM Restore Operator,Create and Delete resources during VM Restore. This role is in preview and subject to change.,dfce8971-25e3-42e3-ba33-6055438e3080
+Video Indexer Account Contributor,Can manage Video Indexer Account resources and generate access tokens for data plane operations.,3f99eaab-6f59-4877-adf5-1cacd22e20b0
+Video Indexer Restricted Viewer,"Has access to view and search through all video's insights and transcription in the Video Indexer portal. No access to model customization, embedding of widget, downloading videos, or sharing the account.",a2c4a527-7dc0-4ee3-897b-403ade70fafb
+Virtual Enclave Owner Role,Virtual Enclave Owner Role to access the resources of Microsoft.Mission stored with RPSAAS.,1abf4029-2200-4343-800c-e4c4c01eddbd
+Virtual Machine Administrator Login,View Virtual Machines in the portal and login as administrator,1c0163c0-47e6-4577-8991-ea5c82e286e4
+Virtual Machine Contributor,"Lets you manage virtual machines, but not access to them, and not the virtual network or storage account they're connected to.",9980e02c-c2be-4d73-94e8-173b1dc7cf3c
+Virtual Machine Data Access Administrator (preview),Manage access to Virtual Machines by adding or removing role assignments for the Virtual Machine Administrator Login and Virtual Machine User Login roles. Includes an ABAC condition to constrain role assignments.,66f75aeb-eabe-4b70-9f1e-c350c4c9ad04
+Virtual Machine Local User Login,View Virtual Machines in the portal and login as a local user configured on the arc server,602da2ba-a5c2-41da-b01d-5360126ab525
+Virtual Machine User Login,View Virtual Machines in the portal and login as a regular user.,fb879df8-f326-4884-b1cf-06f3ad86be52
+Web Plan Contributor,"Lets you manage the web plans for websites, but not access to them.",2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b
+Web PubSub Service Owner,Full access to Azure Web PubSub Service REST APIs,12cf5a90-567b-43ae-8102-96cf46c7d9b4
+Web PubSub Service Reader,Read-only access to Azure Web PubSub Service REST APIs,bfb1c7d2-fb1a-466b-b2ba-aee63b92deaf
+Website Contributor,"Lets you manage websites (not web plans), but not access to them.",de139f84-1756-47ae-9be6-808fbbe84772
+Windows 365 Network Interface Contributor,This role is used by Windows 365 to provision required network resources and join Microsoft-hosted VMs to network interfaces.,1f135831-5bbe-4924-9016-264044c00788
+Windows 365 Network User,This role is used by Windows 365 to read virtual networks and join the designated virtual networks.,7eabc9a4-85f7-4f71-b8ab-75daaccc1033
+Windows Admin Center Administrator Login,Let's you manage the OS of your resource via Windows Admin Center as an administrator.,a6333a3e-0164-44c3-b281-7a577aff287f
+Windows365SubscriptionReader,"Read subscriptions, images, azure firewalls. This role is used in Windows365 scenarios.",3d55a8f6-4133-418d-8051-facdb1735758
+Workbook Contributor,Can save shared workbooks.,e8ddcd69-c73f-4f9f-9844-4100522f16ad
+Workbook Reader,Can read workbooks.,b279062a-9be3-42a0-92ae-8b3cf002ec4d
+Workload Orchestration Administrator,Workload Orchestration Administrator Role,cbb820e9-e561-45bb-84c2-ef45d0a13f7d
+Workload Orchestration IT Admin,Grants you access to manage the IT Admin operations for Workload Orchestration,63304235-eaf4-4c15-8e93-46c483611231
+Workload Orchestration Solution External Validator,"Grants you access to fetch targets, solution templates, solutions and update the external validation status",db9875ba-bd2b-4e98-934d-0daa549a07f0
+WorkloadBuilder Migration Agent Role,WorkloadBuilder Migration Agent Role.,d17ce0a2-0697-43bc-aac5-9113337ab61c


### PR DESCRIPTION
## Summary
Updated `Sample Data/Feeds/AzureBuiltInRole.csv` with the current list of Azure RBAC built-in roles. The file was last updated in July 2022 and was significantly outdated.

## Changes
- **Added:** 708 new roles (e.g., AI, Agent, Fabric, Entra, Copilot-related roles)
- **Removed:** 5 retired Media Services roles
- **Updated:** 55 roles with refreshed names or descriptions
- **Total:** 245 → 948 roles

## Why

Fixes #14935
