### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/AddLabel.yaml
+++ b/.github/workflows/AddLabel.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         with:
           app-id: ${{ env.GITHUB_APPS_ID }}
           private-key: ${{ env.GITHUB_APPS_KEY }}

--- a/.github/workflows/IssueComment.yml
+++ b/.github/workflows/IssueComment.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Generate a token
       id: generate_token
-      uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+      uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
       with:
         app-id: ${{ env.GITHUB_APPS_ID }}
         private-key: ${{ env.GITHUB_APPS_KEY }}

--- a/.github/workflows/ScanSecrets.yaml
+++ b/.github/workflows/ScanSecrets.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 10
       - name: Secret Scanning

--- a/.github/workflows/addComment.yaml
+++ b/.github/workflows/addComment.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         with:
           app-id: ${{ env.GITHUB_APPS_ID }}
           private-key: ${{ env.GITHUB_APPS_KEY }}

--- a/.github/workflows/addLabelOnPr.yaml
+++ b/.github/workflows/addLabelOnPr.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         with:
           app-id: ${{ env.GITHUB_APPS_ID }}
           private-key: ${{ env.GITHUB_APPS_KEY }}

--- a/.github/workflows/aws-s3-bundle-update.yaml
+++ b/.github/workflows/aws-s3-bundle-update.yaml
@@ -33,13 +33,13 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
 
       - name: Checkout PR branch with sparse checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/checkPRContentChange.yaml
+++ b/.github/workflows/checkPRContentChange.yaml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       hasContentPackageChange: ${{ steps.changesInPR.outputs.hasContentPackageChange }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 2
           ref: "${{ env.BRANCH_NAME }}"

--- a/.github/workflows/checkSkipPackagingInfo.yaml
+++ b/.github/workflows/checkSkipPackagingInfo.yaml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       isPackagingRequired: ${{ steps.getPackagingSkipStatus.outputs.isPackagingRequired }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 2
           ref: "${{ env.BRANCH_NAME }}"

--- a/.github/workflows/cleanup-stale-branch.yaml
+++ b/.github/workflows/cleanup-stale-branch.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup Stale Branches
-        uses: fpicalausa/remove-stale-branches@7c4f2afe88a36c0f9114cd958380979b9d7323fb
+        uses: fpicalausa/remove-stale-branches@7c4f2afe88a36c0f9114cd958380979b9d7323fb # v2.4.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           days-before-branch-stale: 90

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
 
     # ℹ️ Setup DotNet Versions to building C# projects
     - name: Setup DotNet Versions
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: | 
           6.0.x
@@ -64,7 +64,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -78,4 +78,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9

--- a/.github/workflows/content-validations.yaml
+++ b/.github/workflows/content-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/convertKqlFunctionYamlToArmTemplate.yaml
+++ b/.github/workflows/convertKqlFunctionYamlToArmTemplate.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         env:
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
         with:
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout pull request branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         env:
           GeneratedToken: ${{ steps.generate_token.outputs.token }}
         with:
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Install python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
         with:
           python-version: "3.x"
           architecture: "x64"
@@ -94,7 +94,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           branch: ${{ github.head_ref }}
       - name: Add comment
-        uses: mshick/add-pr-comment@3b5edaaa32fd0272ba44e0eb2d9070b55110e0b9
+        uses: mshick/add-pr-comment@3b5edaaa32fd0272ba44e0eb2d9070b55110e0b9 # v3.1.0
         if: ${{ env.armTemplatesChanged == 'true' }}
         with:
           message: |

--- a/.github/workflows/data-connector-validations.yaml
+++ b/.github/workflows/data-connector-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/detection-template-schema-validations.yaml
+++ b/.github/workflows/detection-template-schema-validations.yaml
@@ -17,11 +17,11 @@ jobs:
       dotnetSdkVersion: 3.1.401
       PRNUM: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Need HEAD and parent for git diff
       - name: Use .NET Core SDK ${{ env.dotnetSdkVersion }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnetSdkVersion }}
       - name: Run Detection template structure validation tests

--- a/.github/workflows/detection-validations.yaml
+++ b/.github/workflows/detection-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/documents-link-validation.yaml
+++ b/.github/workflows/documents-link-validation.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/getSolutionName.yaml
+++ b/.github/workflows/getSolutionName.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       sName: "${{ steps.getSolutionName.outputs.solutionName }}"
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 2
           ref: "${{ env.BRANCH_NAME }}"

--- a/.github/workflows/hyperlinkValidator.yaml
+++ b/.github/workflows/hyperlinkValidator.yaml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         with:
           app-id: ${{ env.GITHUB_APPS_ID }}
           private-key: ${{ env.GITHUB_APPS_KEY }}
 
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         env:
           GeneratedToken: ${{ steps.generate_token.outputs.token }}
         with:

--- a/.github/workflows/json-syntax-validation.yaml
+++ b/.github/workflows/json-syntax-validation.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/kql-validations.yaml
+++ b/.github/workflows/kql-validations.yaml
@@ -17,11 +17,11 @@ jobs:
       dotnetSdkVersion: 6.0.x
       PRNUM: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Need HEAD and parent for git diff
       - name: Use .NET Core SDK ${{ env.dotnetSdkVersion }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnetSdkVersion }}
       - name: Run KQL Validation tests

--- a/.github/workflows/logo-validation.yaml
+++ b/.github/workflows/logo-validation.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/neworexistingsolution.yaml
+++ b/.github/workflows/neworexistingsolution.yaml
@@ -31,7 +31,7 @@ jobs:
       solutionOfferId: "${{ steps.IdentifyNewOrExistingSolution.outputs.solutionOfferId }}"
       solutionPublisherId: "${{ steps.IdentifyNewOrExistingSolution.outputs.solutionPublisherId }}"
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 2
           ref: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/non-ascii-validations.yaml
+++ b/.github/workflows/non-ascii-validations.yaml
@@ -17,11 +17,11 @@ jobs:
       buildConfiguration: Release
       dotnetSdkVersion: 3.1.401
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Need HEAD and parent for git diff
       - name: Use .NET Core SDK ${{ env.dotnetSdkVersion }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnetSdkVersion }}
       - name: Run Non-Ascii validation tests

--- a/.github/workflows/playbook-validations.yaml
+++ b/.github/workflows/playbook-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/runAsimSchemaAndDataTesters.yaml
+++ b/.github/workflows/runAsimSchemaAndDataTesters.yaml
@@ -69,7 +69,7 @@ jobs:
           github.event.pull_request.head.repo.fork == true &&
           github.event.action == 'labeled' &&
           github.event.label.name == 'SafeToRun'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const log = (level, message) => {
@@ -163,7 +163,7 @@ jobs:
           github.event.pull_request.head.repo.fork == true &&
           github.event.action == 'synchronize' &&
           steps.check-approval.outputs.should_remove_label == 'true'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const log = (level, message) => {
@@ -205,7 +205,7 @@ jobs:
 
       - name: Prevent fork modifications to test infrastructure
         if: github.event.pull_request.head.repo.fork == true
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const log = (level, message) => {
@@ -241,7 +241,7 @@ jobs:
           always() && 
           github.event.pull_request.head.repo.fork == true && 
           steps.check-approval.outputs.comment_needed == 'true'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             // Helper function for consistent logging
@@ -353,7 +353,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pull request branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: ${{github.event.pull_request.head.sha}}
           repository: ${{ github.repository }}
@@ -374,7 +374,7 @@ jobs:
             exit 1
           fi
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -415,7 +415,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout pull request branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{github.event.pull_request.head.sha}}
           repository: ${{ github.repository }}
@@ -436,7 +436,7 @@ jobs:
             exit 1
           fi
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -453,7 +453,7 @@ jobs:
         # - Resource Group: asim-schemadatatester-githubshared-canary
         # - Deny read access to other workspaces/subscriptions
         # - Deny write access outside canary RG
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_ASIM_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -492,7 +492,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout pull request branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.repository }}
@@ -506,7 +506,7 @@ jobs:
         # - Resource Group: asim-schemadatatester-githubshared-canary
         # - Deny read access to other workspaces/subscriptions
         # - Deny write access outside canary RG
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_ASIM_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -528,7 +528,7 @@ jobs:
             exit 1
           fi
       - name: Run ASIM Schema and Data tests PowerShell script
-        uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709
+        uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2.0.0
         with:
           inlineScript: |
             $filePath = ".script/tests/asimParsersTest/runAsimTesters.ps1"
@@ -567,7 +567,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout pull request branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.repository }}
@@ -588,7 +588,7 @@ jobs:
             exit 1
           fi
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -603,7 +603,7 @@ jobs:
         # - Resource Group: asim-schemadatatester-githubshared-canary
         # - Deny read access to other workspaces/subscriptions
         # - Deny write access outside canary RG
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_ASIM_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/sample-data-validation.yaml
+++ b/.github/workflows/sample-data-validation.yaml
@@ -21,10 +21,10 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/slash-command-armttk.yaml
+++ b/.github/workflows/slash-command-armttk.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR details and validate
         id: get-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({

--- a/.github/workflows/solution-validations.yaml
+++ b/.github/workflows/solution-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/solutionIntegration.yaml
+++ b/.github/workflows/solutionIntegration.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout pull request branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -33,7 +33,7 @@ jobs:
         git config --local user.email "<>"
 
     - name: Azure Login to Dev Account 
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
       with:
         client-id: ${{ secrets.AZURE_SOLUTIONTESTING_DEV_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_SOLUTIONTESTING_DEV_TENANT_ID }}
@@ -64,7 +64,7 @@ jobs:
         "https://dev.azure.com/msazure/One/_apis/git/repositories/Sentinel-CATUtilities/items?path=/SolutionIntegrationTesting/config.json&api-version=6.0"
 
     - name: Setup Python Environment
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: '3.x'
           
@@ -79,7 +79,7 @@ jobs:
         echo "AZURE_TEST_TENANT_ID=$(az keyvault secret show --name TenantId-Test --vault-name e2e-solIntegTesting-KV --query value -o tsv)" >> $GITHUB_ENV
 
     - name: Azure Login to Test Tenant Account
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
       with:
         client-id: ${{ env.AZURE_TEST_CLIENT_ID }}
         tenant-id: ${{ env.AZURE_TEST_TENANT_ID }}
@@ -96,7 +96,7 @@ jobs:
         python $filePath
     
     - name: Azure Login to Dev Account 
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
       if: '!cancelled()'
       with:
         client-id: ${{ secrets.AZURE_SOLUTIONTESTING_DEV_CLIENT_ID }}

--- a/.github/workflows/validateClassicAppInsights.yaml
+++ b/.github/workflows/validateClassicAppInsights.yaml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         with:
           app-id: ${{ env.GITHUB_APPS_ID }}
           private-key: ${{ env.GITHUB_APPS_KEY }}
 
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validateFieldTypes.yaml
+++ b/.github/workflows/validateFieldTypes.yaml
@@ -25,12 +25,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9
+        uses: actions/create-github-app-token@46e4a501e119d39574a54e53a06c9a705efc55c9 # v1.6.1
         with:
           app-id: ${{ env.GITHUB_APPS_ID }}
           private-key: ${{ env.GITHUB_APPS_KEY }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         env:
           GeneratedToken: ${{ steps.generate_token.outputs.token }}
         with:

--- a/.github/workflows/validateVersionChangedInDetections.yml
+++ b/.github/workflows/validateVersionChangedInDetections.yml
@@ -20,7 +20,7 @@ jobs:
     # check out and run the script
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
 
       - name: Check that template version was updated
         run: bash .script/checkThatTemplatesVersionWasChanged.sh

--- a/.github/workflows/workbook-metadata-validations.yaml
+++ b/.github/workflows/workbook-metadata-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/workbook-template-validations.yaml
+++ b/.github/workflows/workbook-template-validations.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2 # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v

--- a/.github/workflows/yaml-syntax-validation.yaml
+++ b/.github/workflows/yaml-syntax-validation.yaml
@@ -21,7 +21,7 @@ jobs:
         GITHUBAPPPRIVATEKEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
         SYSTEM_PULLREQUEST_ISFORK: ${{ github.event.pull_request.head.repo.fork }}
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 2  # Only need HEAD and parent for git diff
       - run: npm install -g npm@6.14.18;which npm;npm -v


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
