### PR TITLE
Fix AWS CloudTrail false positives in Malformed user agent analytic

### DIFF
--- a/Detections/MultipleDataSources/MalformedUserAgents.yaml
+++ b/Detections/MultipleDataSources/MalformedUserAgents.yaml
@@ -73,7 +73,7 @@ query: |
   )
   )
   // Likely artefact of hardcoding
-  | where UserAgent startswith "User" or UserAgent startswith '\"'
+  | where (UserAgent startswith "User" or UserAgent startswith '\"'
   // Incorrect casing
   or (UserAgent startswith "Mozilla" and not(UserAgent contains_cs "Mozilla"))
   // Incorrect casing
@@ -81,7 +81,9 @@ query: |
   // Missing MSIE version
   or UserAgent matches regex @"MSIE\s?;"
   // Incorrect spacing around MSIE version
-  or UserAgent matches regex  @"MSIE(?:\d|.{1,5}?\d\s;)"
+  or UserAgent matches regex  @"MSIE(?:\d|.{1,5}?\d\s;)")
+  // Exclude legitimate AWS service user agents (e.g. user-subscriptions.amazonaws.com) - CloudTrail logs the calling service as the user agent
+  and not (Type == "AWSCloudTrail" and UserAgent endswith ".amazonaws.com")
   | extend AccountName = split(Account, "@")[0], UPNSuffix = split(Account, "@")[1]
 entityMappings:
   - entityType: Account
@@ -96,7 +98,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: SourceIP
-version: 1.0.6
+version: 1.0.7
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/MalformedUserAgents.yaml
+++ b/Detections/MultipleDataSources/MalformedUserAgents.yaml
@@ -83,7 +83,7 @@ query: |
   // Incorrect spacing around MSIE version
   or UserAgent matches regex  @"MSIE(?:\d|.{1,5}?\d\s;)")
   // Exclude legitimate AWS service user agents (e.g. user-subscriptions.amazonaws.com) - CloudTrail logs the calling service as the user agent
-  and not (Type == "AWSCloudTrail" and UserAgent endswith ".amazonaws.com")
+  and not (Type == "AWSCloudTrail" and (UserAgent endswith ".amazonaws.com" or UserAgent endswith ".amazonaws.com.cn"))
   | extend AccountName = split(Account, "@")[0], UPNSuffix = split(Account, "@")[1]
 entityMappings:
   - entityType: Account
@@ -98,7 +98,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: SourceIP
-version: 1.0.7
+version: 1.0.8
 kind: Scheduled
 metadata:
     source:

--- a/Detections/MultipleDataSources/MalformedUserAgents.yaml
+++ b/Detections/MultipleDataSources/MalformedUserAgents.yaml
@@ -61,7 +61,7 @@ query: |
   (
   AWSCloudTrail
   | where isnotempty(UserAgent)
-  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent, SourceIP = SourceIpAddress, Account = UserIdentityUserName, Type, EventSource, EventName
+  | summarize StartTime = min(TimeGenerated), EndTime = max(TimeGenerated) by UserAgent, SourceIP = SourceIpAddress, Account = UserIdentityUserName, Type, EventSource, EventName, AwsServiceInvokedBy = tostring(UserIdentityInvokedBy)
   ),
   (SigninLogs
   | where isnotempty(UserAgent)
@@ -82,8 +82,11 @@ query: |
   or UserAgent matches regex @"MSIE\s?;"
   // Incorrect spacing around MSIE version
   or UserAgent matches regex  @"MSIE(?:\d|.{1,5}?\d\s;)")
-  // Exclude legitimate AWS service user agents (e.g. user-subscriptions.amazonaws.com) - CloudTrail logs the calling service as the user agent
-  and not (Type == "AWSCloudTrail" and (UserAgent endswith ".amazonaws.com" or UserAgent endswith ".amazonaws.com.cn"))
+  // Exclude legitimate AWS service user agents (e.g. user-subscriptions.amazonaws.com) only when CloudTrail
+  // confirms the API call was made by an AWS service (userIdentity.invokedBy is populated exclusively for
+  // AWS-service-originated calls). Requiring this service-identity evidence prevents an external caller from
+  // suppressing the alert simply by spoofing an .amazonaws.com user agent suffix.
+  and not (Type == "AWSCloudTrail" and isnotempty(AwsServiceInvokedBy) and (UserAgent endswith ".amazonaws.com" or UserAgent endswith ".amazonaws.com.cn"))
   | extend AccountName = split(Account, "@")[0], UPNSuffix = split(Account, "@")[1]
 entityMappings:
   - entityType: Account
@@ -98,7 +101,7 @@ entityMappings:
     fieldMappings:
       - identifier: Address
         columnName: SourceIP
-version: 1.0.8
+version: 1.0.9
 kind: Scheduled
 metadata:
     source:


### PR DESCRIPTION
## Summary
- Fixes false positives in `Detections/MultipleDataSources/MalformedUserAgents.yaml` when AWS CloudTrail logs a **service** as `UserAgent` (for example `user-subscriptions.amazonaws.com`).
- CloudTrail documents this as expected `userAgent` content for calls made by AWS services.
- Existing malformed-UA heuristics for Office, Signin, IIS, and WAF are unchanged (`startswith "User"`, leading quote, Mozilla casing, `(Compatible;`, MSIE regexes).
- AWS exclusion is scoped: `Type == "AWSCloudTrail"` and `UserAgent endswith ".amazonaws.com"`.
- Version `1.0.6` → `1.0.7`.

Closes #14686

## Test Plan
- [ ] Review the parenthesized `where` predicate so the AWS exclusion applies to the whole heuristic `or` chain
- [ ] Confirm non-CloudTrail sources still match the original `startswith "User"` / quote / Mozilla / Compatible / MSIE checks
- [ ] If CloudTrail is available: `AWSCloudTrail | where UserAgent startswith "User" and UserAgent endswith ".amazonaws.com"` should no longer alert after this change
