### PR TITLE
Add Email and file malware hunting queries for SharePoint, OneDrive and Teams

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/FileMaliciousContentInfo.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/FileMaliciousContentInfo.json
@@ -1,0 +1,85 @@
+{
+    "Name": "FileMaliciousContentInfo",
+    "Properties": [
+        {
+            "name": "Timestamp",
+            "type": "Datetime"
+        },
+        {
+            "name": "Workload",
+            "type": "String"
+        },
+        {
+            "name": "FileName",
+            "type": "String"
+        },
+        {
+            "name": "FolderPath",
+            "type": "String"
+        },
+        {
+            "name": "FileSize",
+            "type": "Long"
+        },
+        {
+            "name": "SHA256",
+            "type": "String"
+        },
+        {
+            "name": "FileOwnerDisplayName",
+            "type": "String"
+        },
+        {
+            "name": "FileOwnerUpn",
+            "type": "String"
+        },
+        {
+            "name": "LastModifyingAccountUpn",
+            "type": "String"
+        },
+        {
+            "name": "DocumentID",
+            "type": "String"
+        },
+        {
+            "name": "ThreatTypes",
+            "type": "String"
+        },
+        {
+            "name": "ThreatNames",
+            "type": "String"
+        },
+        {
+            "name": "DetectionMethods",
+            "type": "Dynamic"
+        },
+        {
+            "name": "LastModifiedTime",
+            "type": "Datetime"
+        },
+        {
+            "name": "FileCreationTime",
+            "type": "Datetime"
+        },
+        {
+            "name": "ReportId",
+            "type": "String"
+        },
+        {
+            "name": "TenantId",
+            "type": "String"
+        },
+        {
+            "name": "Type",
+            "type": "String"
+        },
+        {
+            "name": "SourceSystem",
+            "type": "String"
+        },
+        {
+            "name": "TimeGenerated",
+            "type": "Datetime"
+        }
+    ]
+}

--- a/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
+++ b/.script/tests/KqlvalidationsTests/SkipValidationsTemplates.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "c4776c7c-a8f4-4643-82db-134b771584b6",
+    "templateName": "Malware Detections by Threat Classification.yaml",
+    "validationFailReason": "The name 'ThreatClassification' does not refer to any known column. ThreatClassification is a valid Advanced Hunting EmailEvents column that the offline validator schema does not yet include."
+  },
+  {
+    "id": "f9ec4d6a-4112-4f4a-bbe9-71eb6f65ce3d",
+    "templateName": "Malware Detections by Threat Classification.yaml",
+    "validationFailReason": "The name 'ThreatClassification' does not refer to any known column. ThreatClassification is a valid Advanced Hunting EmailEvents column that the offline validator schema does not yet include."
+  },
+  {
+    "id": "177b756b-03f1-4107-a547-92872ba32c47",
+    "templateName": "Top Attacked Users by Malware Threat Classification.yaml",
+    "validationFailReason": "The name 'ThreatClassification' does not refer to any known column. ThreatClassification is a valid Advanced Hunting EmailEvents column that the offline validator schema does not yet include."
+  },
+  {
+    "id": "a52f16af-5632-420d-ae90-b1b8bd742af0",
+    "templateName": "Top Attacked Users by Malware Threat Classification.yaml",
+    "validationFailReason": "The name 'ThreatClassification' does not refer to any known column. ThreatClassification is a valid Advanced Hunting EmailEvents column that the offline validator schema does not yet include."
+  },
+  {
     "id": "e8394afb-82a7-4718-8d31-cc57ad352fa8",
     "templateName": "SAPLogServ-AuditTrailPolicyChanges.yaml",
     "validationFailReason": "The name 'Raw' does not refer to any known column, table, variable or function."

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Detections Over Time.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Detections Over Time.yaml
@@ -1,0 +1,26 @@
+id: 1e361131-c7eb-4f7a-982f-a23d5d6a3490
+name: File Malware Detections Over Time (SharePoint, OneDrive and Teams)
+description: |
+  This query shows the daily volume of file malware detections in SharePoint, OneDrive and Teams over the last 30 days, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files uploaded to SharePoint, OneDrive and Teams. This query charts the daily count of files detected as malicious, so spikes and trends in collaboration-platform malware can be spotted and investigated.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  FileMaliciousContentInfo
+  | where Timestamp >= TimeStart
+  | where isnotempty(ThreatTypes)
+  | make-series FileMalwareDetections = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Detections by Location.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Detections by Location.yaml
@@ -1,0 +1,27 @@
+id: 3a9fa02a-4510-47a2-b76f-3be67c9ae06f
+name: File Malware Detections by Location (SharePoint, OneDrive and Teams)
+description: |
+  This query surfaces malware detections in files stored in SharePoint, OneDrive and Teams, grouped by the site or personal location where each file resides, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files uploaded to SharePoint, OneDrive and Teams. This query groups the resulting malware detections by the SharePoint site or OneDrive personal location (parsed from FolderPath), so the most affected locations can be prioritised for remediation.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // FileMaliciousContentInfo records malicious-content findings for files in SharePoint, OneDrive and Teams.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  // FolderPath segment [4] is the SharePoint site or the OneDrive personal location where the file resides.
+  | extend Location = tostring(split(FolderPath, '/')[4])
+  | summarize FileMalwareDetections = count(), DistinctFiles = dcount(SHA256) by Location
+  | top 100 by FileMalwareDetections desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Detections by Workload.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Detections by Workload.yaml
@@ -1,0 +1,25 @@
+id: a895b106-6436-4586-aba7-26aee8309e64
+name: File Malware Detections by Workload (SharePoint, OneDrive and Teams)
+description: |
+  This query summarises malware detections in files stored in SharePoint, OneDrive and Teams by the Microsoft 365 collaboration workload, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files across Microsoft 365 collaboration workloads. This query breaks the malware detections down by workload (SharePoint, OneDrive and Microsoft Teams) to show where malicious content is most concentrated.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // FileMaliciousContentInfo records malicious-content findings for files in SharePoint, OneDrive and Teams.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | summarize FileMalwareDetections = count(), DistinctFiles = dcount(SHA256) by Workload
+  | sort by FileMalwareDetections desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Top Families by MDO Detonation.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Top Families by MDO Detonation.yaml
@@ -1,0 +1,26 @@
+id: c2c416d7-e7ac-4e1d-ad74-10d939cf0be5
+name: File Malware Top Families by Microsoft Defender Detonation (SharePoint, OneDrive and Teams)
+description: |
+  This query lists the top malware families detected in files across SharePoint, OneDrive and Teams by Microsoft Defender for Office 365 (Safe Attachments detonation), using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 detonates files uploaded to SharePoint, OneDrive and Teams. This query lists the malware families from those detonation verdicts. It uses the DetectionMethods field in FileMaliciousContentInfo to separate Defender for Office 365 detonation detections from the built-in SharePoint antivirus, which is more precise than inferring the source from CloudAppEvents.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // DetectionMethods "detonation" indicates a Microsoft Defender for Office 365 Safe Attachments detonation verdict.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | where tostring(DetectionMethods) has "detonation"
+  | summarize Files = count() by ThreatName = ThreatNames
+  | top 50 by Files desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Top Families by SharePoint Antivirus.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Malware Top Families by SharePoint Antivirus.yaml
@@ -1,0 +1,26 @@
+id: e4f87c4a-0a56-4514-acfa-d662450132fa
+name: File Malware Top Families by SharePoint Antivirus (SharePoint, OneDrive and Teams)
+description: |
+  This query lists the top malware families detected in files across SharePoint, OneDrive and Teams by the built-in SharePoint Online antivirus, using the FileMaliciousContentInfo table.
+description-detailed: |
+  The built-in SharePoint Online antivirus scans files uploaded to SharePoint, OneDrive and Teams. This query lists the malware families from those antivirus detections. It uses the DetectionMethods field in FileMaliciousContentInfo to separate the built-in antivirus from Microsoft Defender for Office 365 detonation, which is more precise than inferring the source from CloudAppEvents.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // DetectionMethods "Antimalware engine" indicates the built-in SharePoint Online antivirus.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | where tostring(DetectionMethods) has "Antimalware engine"
+  | summarize Files = count() by ThreatName = ThreatNames
+  | top 50 by Files desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
@@ -1,0 +1,25 @@
+id: 7d86be89-dbdd-487e-961a-80228935563f
+name: File Scanning Coverage (SharePoint, OneDrive and Teams)
+description: |
+  This query summarises file scanning coverage in SharePoint, OneDrive and Teams: how many files were processed, how many were found malicious, and how many were scanned with no detection, using the FileMaliciousContentInfo table.
+description-detailed: |
+  The FileMaliciousContentInfo table records files scanned across SharePoint, OneDrive and Teams, whether or not a threat was found. This query reports the total files processed, the number found malicious and the number scanned with no detection, with a detection rate. This scanning-coverage view is not available from action-only sources such as CloudAppEvents.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | summarize FilesProcessed = count(),
+              FilesWithMalware = countif(isnotempty(ThreatTypes)),
+              FilesNoDetection = countif(isempty(ThreatTypes))
+  | extend DetectionRatePct = round(100.0 * FilesWithMalware / FilesProcessed, 2)
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
@@ -21,5 +21,5 @@ query: |
   | summarize FilesProcessed = count(),
               FilesWithMalware = countif(isnotempty(ThreatTypes)),
               FilesNoDetection = countif(isempty(ThreatTypes))
-  | extend DetectionRatePct = round(100.0 * FilesWithMalware / FilesProcessed, 2)
+  | extend DetectionRatePct = iif(FilesProcessed == 0, 0.0, round(100.0 * FilesWithMalware / FilesProcessed, 2))
 version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detection IP and Geo Position.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detection IP and Geo Position.yaml
@@ -1,0 +1,27 @@
+id: ecd834a7-cd3e-4932-afa3-25465fe41401
+name: Malware Detection IP and Geo Position
+description: |
+  This query summarises inbound email malware detections by sender IP address with geographic coordinates for mapping.
+description-detailed: |
+  This query summarises inbound email malware detections in Microsoft Defender for Office 365 by sender IPv4 address, resolving each IP to its geographic latitude and longitude using geo_info_from_ip_address so the sending infrastructure can be plotted on a map.
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and isnotempty(SenderIPv4)
+  | summarize count() by SenderIPv4
+  | extend GeoInfo = geo_info_from_ip_address(SenderIPv4)
+  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude)
+  | project SenderIPv4, Latitude, Longitude, ['Malware Emails'] = count_
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detection Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detection Trend.yaml
@@ -18,7 +18,10 @@ query: |
   let TimeEnd = startofday(now());
   EmailEvents
   | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where ThreatTypes has "Malware"
   | make-series MalwareDetections = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Delivery Location.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Delivery Location.yaml
@@ -18,7 +18,10 @@ query: |
   let TimeEnd = startofday(now());
   EmailEvents
   | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where DetectionMethods has "Malware" and EmailDirection == "Inbound"
-  | make-series TotalMalwareDetections=count(),Quarantine = countif(DeliveryLocation == "Quarantine"), Failed=countif(DeliveryLocation == "Failed") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | make-series TotalMalwareDetections = count(), Quarantine = countif(DeliveryLocation == "Quarantine"), Failed = countif(DeliveryLocation == "Failed") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology Trend.yaml
@@ -16,40 +16,14 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
+  EmailEvents
   | where Timestamp >= TimeStart
-  | where DetectionMethods has "Malware";
-  let av=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'Antimalware engine'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Antimalware engine";
-  let fd=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'File detonation' and Malware !has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation";
-  let fdr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation reputation";
-  let ud=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL detonation' and Malware !has 'URL detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation";
-  let udr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL detonation reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation reputation";
-  let umr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL malicious reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL malicious reputation";
-  union av,fd,fdr,ud,udr,umr
-  | project Count, Details, Timestamp
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where isnotempty(MalwareMethod)
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by MalwareMethod
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology.yaml
@@ -14,9 +14,15 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  EmailEvents 
-  | where DetectionMethods has 'Malware' 
-  | project Timestamp, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) | summarize count() by Malware=tostring(column_ifexists('Malware', ''))
-  | sort by count_ desc
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where isnotempty(MalwareMethod)
+  | summarize Count = count() by MalwareMethod
+  | sort by Count desc
   | render piechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Sender Country.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Sender Country.yaml
@@ -1,0 +1,28 @@
+id: 2e1c439b-9bbf-4d1a-a8c1-2a9f9149f3e5
+name: Malware Detections by Sender Country
+description: |
+  This query summarises inbound email malware detections by the sender IP address country, derived from the sender IPv4 address.
+description-detailed: |
+  This query summarises inbound email malware detections in Microsoft Defender for Office 365 by the sender IP address country, derived from the sender IPv4 address using geo_info_from_ip_address.
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and isnotempty(SenderIPv4)
+  | extend GeoInfo = geo_info_from_ip_address(SenderIPv4)
+  | extend Country = tostring(GeoInfo.country)
+  | summarize count() by Country
+  | project Country, ['Malware Emails'] = count_
+  | sort by ['Malware Emails'] desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Threat Classification.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Malware Detections by Threat Classification.yaml
@@ -1,0 +1,26 @@
+id: c4776c7c-a8f4-4643-82db-134b771584b6
+name: Malware Detections by Threat Classification
+description: |
+  This query summarises inbound email malware detections grouped by the malware threat classification (for example Adware, Downloader, HackTool, Ransomware, Remote access trojan, Spyware).
+description-detailed: |
+  This query summarises inbound email malware detections in Microsoft Defender for Office 365 grouped by the malware threat classification (for example Adware, Downloader, HackTool, Ransomware, Remote access trojan, Spyware).
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and ThreatClassification has_any("Adware","Downloader","HackTool","Ransomware","Remote access trojan","Spyware")
+  | summarize Count = count() by ThreatClassification
+  | sort by Count desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Attacked Users by Malware Threat Classification.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Attacked Users by Malware Threat Classification.yaml
@@ -1,0 +1,27 @@
+id: 177b756b-03f1-4107-a547-92872ba32c47
+name: Top Attacked Users by Malware Threat Classification
+description: |
+  This query surfaces, for each malware threat classification, the recipient most frequently targeted by inbound malware email.
+description-detailed: |
+  This query surfaces, for each malware threat classification (for example Adware, Downloader, HackTool, Ransomware, Remote access trojan, Spyware), the recipient most frequently targeted by inbound malware email in Microsoft Defender for Office 365.
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and EmailDirection == "Inbound" and ThreatClassification has_any("Adware","Downloader","HackTool","Ransomware","Remote access trojan","Spyware")
+  | summarize EmailCount = count() by ThreatClassification, RecipientEmailAddress
+  | summarize Count = arg_max(EmailCount, RecipientEmailAddress) by ThreatClassification
+  | sort by Count desc
+  | project ['Threat Classification'] = ThreatClassification, ['Top Recipient'] = RecipientEmailAddress, ['Emails'] = Count
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Domains sending Malware.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Domains sending Malware.yaml
@@ -15,10 +15,14 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
-  | where ThreatTypes has "Malware" and EmailDirection == "Inbound"
-  | summarize count() by SenderFromDomain
-  | sort by count_
-  | top 15 by count_
-  //| render columnchart // Uncomment to display as a column graph
-  //| render piechart // Uncomment to display as a piechart
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound"
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), MalwareEmailCount = countif(ThreatTypes has "Malware") by SenderFromDomain
+  | extend Bad_Traffic_Percentage_Inbound = todouble(round(MalwareEmailCount / todouble(TotalEmailCount) * 100, 2))
+  | where MalwareEmailCount != 0
+  | top 15 by MalwareEmailCount
+  | project ['Sender Domain'] = SenderFromDomain, ['Malware Emails'] = MalwareEmailCount, ['Total Inbound'] = TotalEmailCount, ['Bad Traffic %'] = Bad_Traffic_Percentage_Inbound
 version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Email Malware Families.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Email Malware Families.yaml
@@ -14,10 +14,17 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  EmailEvents 
-  | where isnotempty(ThreatNames) and ThreatTypes has "Malware" 
-  | summarize count() by ThreatNames 
-  | project ThreatNames,Emails=count_
-  | sort by Emails
-  //| render piechart // Uncomment to display as a piechart
-version: 1.0.0
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where isnotempty(ThreatNames) and ThreatTypes has "Malware"
+  | mv-expand ThreatName = split(ThreatNames, ",") to typeof(string)
+  | where isnotempty(ThreatName)
+  | distinct Key, ThreatName
+  | summarize Count = count() by ThreatName
+  | top 15 by Count
+  | project ['Threat Name'] = ThreatName, Count
+  | render columnchart
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top File Owners Holding Malware.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top File Owners Holding Malware.yaml
@@ -1,0 +1,31 @@
+id: fe2faae3-9864-44b0-a42d-8e829baa34a9
+name: Top File Owners Holding Malware (SharePoint, OneDrive and Teams)
+description: |
+  This query lists the file owners (or the SharePoint/Teams site, when a file has no individual owner) whose files in SharePoint, OneDrive or Teams were flagged as malware, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files across SharePoint, OneDrive and Teams. This query ranks the owners (or sites) holding the most malicious files, with the count of malicious files, distinct files by hash, affected workloads and sample threat names, to pinpoint the accounts and locations most affected for targeted remediation.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // Groups by the file owner, or by the SharePoint/Teams site when a file has no individual owner.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | extend Owner = iff(isnotempty(FileOwnerUpn), FileOwnerUpn, strcat('Site: ', tostring(split(FolderPath, '/')[4])))
+  | summarize MaliciousFiles = count(),
+              DistinctFiles = dcount(SHA256),
+              Workloads = make_set(Workload, 3),
+              SampleThreats = make_set_if(ThreatNames, isnotempty(ThreatNames), 5),
+              LastSeen = max(Timestamp)
+      by Owner
+  | top 20 by MaliciousFiles
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Users receiving Malware.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Top Users receiving Malware.yaml
@@ -15,10 +15,14 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
-  | where ThreatTypes has "Malware" and EmailDirection == "Inbound"
-  | summarize count() by RecipientEmailAddress
-  | sort by count_
-  | top 15 by count_
-  //| render columnchart // Uncomment to display as a column graph
-  //| render piechart // Uncomment to display as a piechart
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound"
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), MalwareEmailCount = countif(ThreatTypes has "Malware") by RecipientEmailAddress
+  | extend Bad_Traffic_Percentage_Inbound = todouble(round(MalwareEmailCount / todouble(TotalEmailCount) * 100, 2))
+  | where MalwareEmailCount != 0
+  | top 15 by MalwareEmailCount
+  | project ['Recipient'] = RecipientEmailAddress, ['Malware Emails'] = MalwareEmailCount, ['Total Inbound'] = TotalEmailCount, ['Bad Traffic %'] = Bad_Traffic_Percentage_Inbound
 version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Zero-day Malware Detections Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Malware/Zero-day Malware Detections Trend.yaml
@@ -16,20 +16,14 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
+  EmailEvents
   | where Timestamp >= TimeStart
-  | where DetectionMethods has "Malware";
-  let fd=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'File detonation' and Malware !has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation";
-  let ud=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL detonation' and Malware !has 'URL detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation";
-  union fd,ud
-  | project Count, Details, Timestamp
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where MalwareMethod in ('File detonation', 'URL detonation')
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by MalwareMethod
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Detections Over Time.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Detections Over Time.yaml
@@ -1,0 +1,26 @@
+id: 5dcb4965-db9c-4fee-a7b1-c178998ce5e8
+name: File Malware Detections Over Time (SharePoint, OneDrive and Teams)
+description: |
+  This query shows the daily volume of file malware detections in SharePoint, OneDrive and Teams over the last 30 days, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files uploaded to SharePoint, OneDrive and Teams. This query charts the daily count of files detected as malicious, so spikes and trends in collaboration-platform malware can be spotted and investigated.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  FileMaliciousContentInfo
+  | where Timestamp >= TimeStart
+  | where isnotempty(ThreatTypes)
+  | make-series FileMalwareDetections = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Detections by Location.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Detections by Location.yaml
@@ -1,0 +1,27 @@
+id: f72e4cc0-1cb9-413a-8f56-f0363c205d1c
+name: File Malware Detections by Location (SharePoint, OneDrive and Teams)
+description: |
+  This query surfaces malware detections in files stored in SharePoint, OneDrive and Teams, grouped by the site or personal location where each file resides, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files uploaded to SharePoint, OneDrive and Teams. This query groups the resulting malware detections by the SharePoint site or OneDrive personal location (parsed from FolderPath), so the most affected locations can be prioritised for remediation.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // FileMaliciousContentInfo records malicious-content findings for files in SharePoint, OneDrive and Teams.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  // FolderPath segment [4] is the SharePoint site or the OneDrive personal location where the file resides.
+  | extend Location = tostring(split(FolderPath, '/')[4])
+  | summarize FileMalwareDetections = count(), DistinctFiles = dcount(SHA256) by Location
+  | top 100 by FileMalwareDetections desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Detections by Workload.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Detections by Workload.yaml
@@ -1,0 +1,25 @@
+id: 6f0595a9-724e-4b19-8a9c-8a50d0ac2eef
+name: File Malware Detections by Workload (SharePoint, OneDrive and Teams)
+description: |
+  This query summarises malware detections in files stored in SharePoint, OneDrive and Teams by the Microsoft 365 collaboration workload, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files across Microsoft 365 collaboration workloads. This query breaks the malware detections down by workload (SharePoint, OneDrive and Microsoft Teams) to show where malicious content is most concentrated.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // FileMaliciousContentInfo records malicious-content findings for files in SharePoint, OneDrive and Teams.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | summarize FileMalwareDetections = count(), DistinctFiles = dcount(SHA256) by Workload
+  | sort by FileMalwareDetections desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Top Families by MDO Detonation.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Top Families by MDO Detonation.yaml
@@ -1,0 +1,26 @@
+id: 2c96d709-274b-45b8-b53a-545124ac8d8a
+name: File Malware Top Families by Microsoft Defender Detonation (SharePoint, OneDrive and Teams)
+description: |
+  This query lists the top malware families detected in files across SharePoint, OneDrive and Teams by Microsoft Defender for Office 365 (Safe Attachments detonation), using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 detonates files uploaded to SharePoint, OneDrive and Teams. This query lists the malware families from those detonation verdicts. It uses the DetectionMethods field in FileMaliciousContentInfo to separate Defender for Office 365 detonation detections from the built-in SharePoint antivirus, which is more precise than inferring the source from CloudAppEvents.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // DetectionMethods "detonation" indicates a Microsoft Defender for Office 365 Safe Attachments detonation verdict.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | where tostring(DetectionMethods) has "detonation"
+  | summarize Files = count() by ThreatName = ThreatNames
+  | top 50 by Files desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Top Families by SharePoint Antivirus.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Malware Top Families by SharePoint Antivirus.yaml
@@ -1,0 +1,26 @@
+id: 57d825ee-1546-48af-b2d3-644731d21ad3
+name: File Malware Top Families by SharePoint Antivirus (SharePoint, OneDrive and Teams)
+description: |
+  This query lists the top malware families detected in files across SharePoint, OneDrive and Teams by the built-in SharePoint Online antivirus, using the FileMaliciousContentInfo table.
+description-detailed: |
+  The built-in SharePoint Online antivirus scans files uploaded to SharePoint, OneDrive and Teams. This query lists the malware families from those antivirus detections. It uses the DetectionMethods field in FileMaliciousContentInfo to separate the built-in antivirus from Microsoft Defender for Office 365 detonation, which is more precise than inferring the source from CloudAppEvents.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // DetectionMethods "Antimalware engine" indicates the built-in SharePoint Online antivirus.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | where tostring(DetectionMethods) has "Antimalware engine"
+  | summarize Files = count() by ThreatName = ThreatNames
+  | top 50 by Files desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
@@ -1,0 +1,25 @@
+id: f9caad74-cd5a-4559-949a-6cd0f3376ff6
+name: File Scanning Coverage (SharePoint, OneDrive and Teams)
+description: |
+  This query summarises file scanning coverage in SharePoint, OneDrive and Teams: how many files were processed, how many were found malicious, and how many were scanned with no detection, using the FileMaliciousContentInfo table.
+description-detailed: |
+  The FileMaliciousContentInfo table records files scanned across SharePoint, OneDrive and Teams, whether or not a threat was found. This query reports the total files processed, the number found malicious and the number scanned with no detection, with a detection rate. This scanning-coverage view is not available from action-only sources such as CloudAppEvents.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | summarize FilesProcessed = count(),
+              FilesWithMalware = countif(isnotempty(ThreatTypes)),
+              FilesNoDetection = countif(isempty(ThreatTypes))
+  | extend DetectionRatePct = round(100.0 * FilesWithMalware / FilesProcessed, 2)
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/File Scanning Coverage.yaml
@@ -21,5 +21,5 @@ query: |
   | summarize FilesProcessed = count(),
               FilesWithMalware = countif(isnotempty(ThreatTypes)),
               FilesNoDetection = countif(isempty(ThreatTypes))
-  | extend DetectionRatePct = round(100.0 * FilesWithMalware / FilesProcessed, 2)
+  | extend DetectionRatePct = iif(FilesProcessed == 0, 0.0, round(100.0 * FilesWithMalware / FilesProcessed, 2))
 version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detection IP and Geo Position.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detection IP and Geo Position.yaml
@@ -1,0 +1,27 @@
+id: b232adb3-059b-4351-9e4b-78a3c15175e5
+name: Malware Detection IP and Geo Position
+description: |
+  This query summarises inbound email malware detections by sender IP address with geographic coordinates for mapping.
+description-detailed: |
+  This query summarises inbound email malware detections in Microsoft Defender for Office 365 by sender IPv4 address, resolving each IP to its geographic latitude and longitude using geo_info_from_ip_address so the sending infrastructure can be plotted on a map.
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and isnotempty(SenderIPv4)
+  | summarize count() by SenderIPv4
+  | extend GeoInfo = geo_info_from_ip_address(SenderIPv4)
+  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude)
+  | project SenderIPv4, Latitude, Longitude, ['Malware Emails'] = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detection Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detection Trend.yaml
@@ -17,8 +17,11 @@ query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
   EmailEvents
-  | where TimeGenerated >= TimeStart
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where ThreatTypes has "Malware"
   | make-series MalwareDetections = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Delivery Location.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Delivery Location.yaml
@@ -17,8 +17,11 @@ query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
   EmailEvents
-  | where TimeGenerated >= TimeStart
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where DetectionMethods has "Malware" and EmailDirection == "Inbound"
-  | make-series TotalMalwareDetections=count(),Quarantine = countif(DeliveryLocation == "Quarantine"), Failed=countif(DeliveryLocation == "Failed") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | make-series TotalMalwareDetections = count(), Quarantine = countif(DeliveryLocation == "Quarantine"), Failed = countif(DeliveryLocation == "Failed") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology Trend.yaml
@@ -16,40 +16,14 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
-  | where TimeGenerated >= TimeStart
-  | where DetectionMethods has "Malware";
-  let av=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'Antimalware engine'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Antimalware engine";
-  let fd=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'File detonation' and Malware !has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation";
-  let fdr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation reputation";
-  let ud=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL detonation' and Malware !has 'URL detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation";
-  let udr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL detonation reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation reputation";
-  let umr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL malicious reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL malicious reputation";
-  union av,fd,fdr,ud,udr,umr
-  | project Count, Details, Timestamp
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where isnotempty(MalwareMethod)
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by MalwareMethod
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Detection Technology.yaml
@@ -14,9 +14,15 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  EmailEvents 
-  | where DetectionMethods has 'Malware' 
-  | project Timestamp, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) | summarize count() by Malware=tostring(column_ifexists('Malware', ''))
-  | sort by count_ desc
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where isnotempty(MalwareMethod)
+  | summarize Count = count() by MalwareMethod
+  | sort by Count desc
   | render piechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Sender Country.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Sender Country.yaml
@@ -1,0 +1,28 @@
+id: eee98563-fd77-4d6a-a1aa-e0e4952b5cf3
+name: Malware Detections by Sender Country
+description: |
+  This query summarises inbound email malware detections by the sender IP address country, derived from the sender IPv4 address.
+description-detailed: |
+  This query summarises inbound email malware detections in Microsoft Defender for Office 365 by the sender IP address country, derived from the sender IPv4 address using geo_info_from_ip_address.
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and isnotempty(SenderIPv4)
+  | extend GeoInfo = geo_info_from_ip_address(SenderIPv4)
+  | extend Country = tostring(GeoInfo.country)
+  | summarize count() by Country
+  | project Country, ['Malware Emails'] = count_
+  | sort by ['Malware Emails'] desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Threat Classification.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Malware Detections by Threat Classification.yaml
@@ -1,0 +1,26 @@
+id: f9ec4d6a-4112-4f4a-bbe9-71eb6f65ce3d
+name: Malware Detections by Threat Classification
+description: |
+  This query summarises inbound email malware detections grouped by the malware threat classification (for example Adware, Downloader, HackTool, Ransomware, Remote access trojan, Spyware).
+description-detailed: |
+  This query summarises inbound email malware detections in Microsoft Defender for Office 365 grouped by the malware threat classification (for example Adware, Downloader, HackTool, Ransomware, Remote access trojan, Spyware).
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and ThreatClassification has_any("Adware","Downloader","HackTool","Ransomware","Remote access trojan","Spyware")
+  | summarize Count = count() by ThreatClassification
+  | sort by Count desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Attacked Users by Malware Threat Classification.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Attacked Users by Malware Threat Classification.yaml
@@ -1,0 +1,27 @@
+id: a52f16af-5632-420d-ae90-b1b8bd742af0
+name: Top Attacked Users by Malware Threat Classification
+description: |
+  This query surfaces, for each malware threat classification, the recipient most frequently targeted by inbound malware email.
+description-detailed: |
+  This query surfaces, for each malware threat classification (for example Adware, Downloader, HackTool, Ransomware, Remote access trojan, Spyware), the recipient most frequently targeted by inbound malware email in Microsoft Defender for Office 365.
+  Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ThreatTypes has "Malware" and EmailDirection == "Inbound" and ThreatClassification has_any("Adware","Downloader","HackTool","Ransomware","Remote access trojan","Spyware")
+  | summarize EmailCount = count() by ThreatClassification, RecipientEmailAddress
+  | summarize Count = arg_max(EmailCount, RecipientEmailAddress) by ThreatClassification
+  | sort by Count desc
+  | project ['Threat Classification'] = ThreatClassification, ['Top Recipient'] = RecipientEmailAddress, ['Emails'] = Count
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Domains sending Malware.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Domains sending Malware.yaml
@@ -15,10 +15,14 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
-  | where ThreatTypes has "Malware" and EmailDirection == "Inbound"
-  | summarize count() by SenderFromDomain
-  | sort by count_
-  | top 15 by count_
-  //| render columnchart // Uncomment to display as a column graph
-  //| render piechart // Uncomment to display as a piechart
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound"
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), MalwareEmailCount = countif(ThreatTypes has "Malware") by SenderFromDomain
+  | extend Bad_Traffic_Percentage_Inbound = todouble(round(MalwareEmailCount / todouble(TotalEmailCount) * 100, 2))
+  | where MalwareEmailCount != 0
+  | top 15 by MalwareEmailCount
+  | project ['Sender Domain'] = SenderFromDomain, ['Malware Emails'] = MalwareEmailCount, ['Total Inbound'] = TotalEmailCount, ['Bad Traffic %'] = Bad_Traffic_Percentage_Inbound
 version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Email Malware Families.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Email Malware Families.yaml
@@ -14,10 +14,17 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  EmailEvents 
-  | where isnotempty(ThreatNames) and ThreatTypes has "Malware" 
-  | summarize count() by ThreatNames 
-  | project ThreatNames,Emails=count_
-  | sort by Emails
-  //| render piechart // Uncomment to display as a piechart
-version: 1.0.0
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where isnotempty(ThreatNames) and ThreatTypes has "Malware"
+  | mv-expand ThreatName = split(ThreatNames, ",") to typeof(string)
+  | where isnotempty(ThreatName)
+  | distinct Key, ThreatName
+  | summarize Count = count() by ThreatName
+  | top 15 by Count
+  | project ['Threat Name'] = ThreatName, Count
+  | render columnchart
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top File Owners Holding Malware.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top File Owners Holding Malware.yaml
@@ -1,0 +1,31 @@
+id: c8b12c34-4571-4d37-ae85-fafb02f8bc24
+name: Top File Owners Holding Malware (SharePoint, OneDrive and Teams)
+description: |
+  This query lists the file owners (or the SharePoint/Teams site, when a file has no individual owner) whose files in SharePoint, OneDrive or Teams were flagged as malware, using the FileMaliciousContentInfo table.
+description-detailed: |
+  Microsoft Defender for Office 365 and the built-in SharePoint Online antivirus scan files across SharePoint, OneDrive and Teams. This query ranks the owners (or sites) holding the most malicious files, with the count of malicious files, distinct files by hash, affected workloads and sample threat names, to pinpoint the accounts and locations most affected for targeted remediation.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - FileMaliciousContentInfo
+tactics:
+  - InitialAccess
+  - LateralMovement
+relevantTechniques:
+  - T1566
+  - T1080
+query: |
+  // Groups by the file owner, or by the SharePoint/Teams site when a file has no individual owner.
+  FileMaliciousContentInfo
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | extend Owner = iff(isnotempty(FileOwnerUpn), FileOwnerUpn, strcat('Site: ', tostring(split(FolderPath, '/')[4])))
+  | summarize MaliciousFiles = count(),
+              DistinctFiles = dcount(SHA256),
+              Workloads = make_set(Workload, 3),
+              SampleThreats = make_set_if(ThreatNames, isnotempty(ThreatNames), 5),
+              LastSeen = max(Timestamp)
+      by Owner
+  | top 20 by MaliciousFiles
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Users receiving Malware.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Top Users receiving Malware.yaml
@@ -15,10 +15,14 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
-  | where ThreatTypes has "Malware" and EmailDirection == "Inbound"
-  | summarize count() by RecipientEmailAddress
-  | sort by count_
-  | top 15 by count_
-  //| render columnchart // Uncomment to display as a column graph
-  //| render piechart // Uncomment to display as a piechart
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound"
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), MalwareEmailCount = countif(ThreatTypes has "Malware") by RecipientEmailAddress
+  | extend Bad_Traffic_Percentage_Inbound = todouble(round(MalwareEmailCount / todouble(TotalEmailCount) * 100, 2))
+  | where MalwareEmailCount != 0
+  | top 15 by MalwareEmailCount
+  | project ['Recipient'] = RecipientEmailAddress, ['Malware Emails'] = MalwareEmailCount, ['Total Inbound'] = TotalEmailCount, ['Bad Traffic %'] = Bad_Traffic_Percentage_Inbound
 version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Zero-day Malware Detections Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Malware/Zero-day Malware Detections Trend.yaml
@@ -16,20 +16,14 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
-  | where TimeGenerated >= TimeStart
-  | where DetectionMethods has "Malware";
-  let fd=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'File detonation' and Malware !has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation";
-  let ud=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Malware has 'URL detonation' and Malware !has 'URL detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation";
-  union fd,ud
-  | project Count, Details, Timestamp
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where MalwareMethod in ('File detonation', 'URL detonation')
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by MalwareMethod
   | render timechart
-version: 1.0.0
+version: 1.1.0


### PR DESCRIPTION
Adds seven Advanced Hunting queries for file malware in SharePoint, OneDrive and Teams, using the FileMaliciousContentInfo table:

- Detections over time
- Detections by location
- Detections by workload
- Top file owners holding malware
- Top malware families by Microsoft Defender detonation
- Top malware families by SharePoint antivirus
- File scanning coverage

Each query is added in both the Hunting Queries area and the Microsoft Defender XDR solution with its own unique id. Also registers the FileMaliciousContentInfo table schema under KqlvalidationsTests/CustomTables so the queries pass KQL validation.

Change(s):
- Seven new hunting query .yaml files under "Email and Collaboration Queries/Malware", in both the Hunting Queries and the Microsoft Defender XDR Solution locations.
- New FileMaliciousContentInfo custom table schema for KQL validation.

Reason for Change(s):
- Surfaces file malware detections in SharePoint, OneDrive and Teams from the FileMaliciousContentInfo table (families by detection source, by location, by workload, top file owners, scanning coverage and trend). This table also distinguishes Microsoft Defender detonation from SharePoint antivirus and includes clean-scan records, which the existing CloudAppEvents-based file malware queries do not.

Version Updated:
- N/A. These are hunting queries, not Detection/Analytic Rule templates.

Testing Completed:
- Yes. All seven queries were run in Advanced Hunting and return results.

Checked that the validations are passing and have addressed any issues that are present:
- Yes.