### PR TITLE
Add and improve URL-click, spam and override email hunting queries

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/SecOps Mailbox Override Count.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/SecOps Mailbox Override Count.yaml
@@ -1,0 +1,22 @@
+id: d4a0f7f4-1c9b-4c2f-9644-2c53cfd7af0f
+name: SecOps Mailbox Override Count
+description: |
+  This query counts inbound emails delivered to the SecOps mailbox by an organisation-level allow override.
+description-detailed: |
+  This query counts inbound emails delivered to the SecOps mailbox in Microsoft Defender for Office 365 as a result of an organisation-level allow override (OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"), so the volume of deliberately-allowed SecOps deliveries can be isolated from other admin overrides. Messages are de-duplicated to the latest record per NetworkMessageId and recipient.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"
+  | summarize ['SecOps Mailbox Deliveries'] = count()
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/SecOps Mailbox Overrides by Threat Type.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/SecOps Mailbox Overrides by Threat Type.yaml
@@ -1,0 +1,25 @@
+id: d234d85d-1dd5-433b-a984-0fd764f25363
+name: SecOps Mailbox Overrides by Threat Type
+description: |
+  This query breaks down inbound emails delivered to the SecOps mailbox by an organisation-level allow override, grouped by threat type.
+description-detailed: |
+  This query breaks down inbound emails delivered to the SecOps mailbox in Microsoft Defender for Office 365 as a result of an organisation-level allow override (OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"), grouped by threat type (Malware, Phish, Spam). Messages are de-duplicated to the latest record per NetworkMessageId and recipient.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"
+  | extend ThreatType = case(ThreatTypes has "Malware", "Malware", ThreatTypes has "Phish", "Phish", ThreatTypes has "Spam", "Spam", ThreatTypes)
+  | summarize TotalEmails = count() by OrgLevelAction, OrgLevelPolicy, ThreatType
+  | sort by TotalEmails desc
+  | project ['Override Action'] = OrgLevelAction, ['Override Policy'] = OrgLevelPolicy, ['Threat Type'] = ThreatType, ['Total Emails'] = TotalEmails
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Top Recipients Receiving Threats Delivered by Override.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Top Recipients Receiving Threats Delivered by Override.yaml
@@ -1,0 +1,36 @@
+id: 6b92522d-8e82-4fd2-ae70-3f1bc4846909
+name: Top Recipients Receiving Threats Delivered by Override
+description: |
+  This query lists the recipients who received the most threats that were delivered because of an admin or user override, with the share overridden and a breakdown of override types, using the EmailEvents table.
+description-detailed: |
+  Threats delivered because of an admin or user override (allow policies, safe-sender lists, Exchange transport rules, quarantine release) bypass Microsoft Defender for Office 365 protection and reach the user. This query ranks the recipients with the most overridden threats, showing the total threats they received, how many were delivered via an override, the override percentage, and which override types were responsible. A high override rate on a mailbox warrants a policy review.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Recipients with the most threats delivered via an admin or user override, with the override share and type breakdown.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | extend OverrideType = case(
+      OrgLevelAction == "Allow" and OrgLevelPolicy != "" and OrgLevelPolicy != "SecOps Mailbox", OrgLevelPolicy,
+      UserLevelAction == "Allow", strcat("User: ", UserLevelPolicy),
+      "(none)")
+  | summarize PerType = count() by RecipientEmailAddress, OverrideType
+  | summarize TotalThreats = sum(PerType),
+              OverriddenThreats = sumif(PerType, OverrideType != "(none)"),
+              OverrideTypes = strcat_array(make_set_if(strcat(OverrideType, " (", PerType, ")"), OverrideType != "(none)"), "; ")
+          by RecipientEmailAddress
+  | where OverriddenThreats > 0
+  | extend OverridePercent = round(OverriddenThreats * 100.0 / TotalThreats, 1)
+  | top 15 by OverriddenThreats
+  | project Recipient = RecipientEmailAddress, TotalThreats, OverriddenThreats, OverridePercent, OverrideTypes
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Top Sender Domains Delivering Threats via Override.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Top Sender Domains Delivering Threats via Override.yaml
@@ -1,0 +1,36 @@
+id: 8c2aeb94-ecd0-4b14-ad8c-a6e2986f6b50
+name: Top Sender Domains Delivering Threats via Override
+description: |
+  This query lists the sender domains whose threats were most often delivered because of an admin or user override, with the share overridden and a breakdown of override types, using the EmailEvents table.
+description-detailed: |
+  A sender domain with a high share of its threats delivered because of an admin or user override (allow policies, safe-sender lists, Exchange transport rules, quarantine release) is bypassing Microsoft Defender for Office 365 protection. This query ranks sender domains by the number of threats delivered via an override, showing the total threats, the overridden count, the override percentage, and which override types were responsible. High override rates are strong candidates for policy review or a Tenant Allow/Block List (TABL) block.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Sender domains with the most threats delivered via an admin or user override, with the override share and type breakdown.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | extend OverrideType = case(
+      OrgLevelAction == "Allow" and OrgLevelPolicy != "" and OrgLevelPolicy != "SecOps Mailbox", OrgLevelPolicy,
+      UserLevelAction == "Allow", strcat("User: ", UserLevelPolicy),
+      "(none)")
+  | summarize PerType = count() by SenderFromDomain, OverrideType
+  | summarize TotalThreats = sum(PerType),
+              OverriddenThreats = sumif(PerType, OverrideType != "(none)"),
+              OverrideTypes = strcat_array(make_set_if(strcat(OverrideType, " (", PerType, ")"), OverrideType != "(none)"), "; ")
+          by SenderFromDomain
+  | where OverriddenThreats > 0
+  | extend OverridePercent = round(OverriddenThreats * 100.0 / TotalThreats, 1)
+  | top 10 by OverriddenThreats
+  | project SenderDomain = SenderFromDomain, TotalThreats, OverriddenThreats, OverridePercent, OverrideTypes
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Allow.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Allow.yaml
@@ -16,8 +16,11 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  EmailEvents 
-  | where OrgLevelPolicy != "" and OrgLevelAction == "Allow" // and OrgLevelPolicy != "SecOps Mailbox" // Remove to filter SecOps mailbox
-  | make-series Count= count() on Timestamp from TimeStart to TimeEnd step 1d by OrgLevelPolicy
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where OrgLevelPolicy != "" and OrgLevelAction == "Allow"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by OrgLevelPolicy
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Block.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Block.yaml
@@ -14,9 +14,14 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
   EmailEvents
+  | where Timestamp >= TimeStart
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where OrgLevelPolicy != "" and OrgLevelAction == "Block"
-  | make-series TotalAdminOverrides = count() default = 0 on Timestamp step 1d
-  // | render columnchart // Uncomment this line to render as a graph
-version: 1.0.0
+  | make-series TotalAdminOverrides = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.1.0
 

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Allow.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Allow.yaml
@@ -15,8 +15,10 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where UserLevelPolicy != "" and UserLevelAction == "Allow"
-  | summarize Emails=count() by UserLevelAction,UserLevelPolicy,ThreatTypes
-  | sort by Emails
-  // | render columnchart // Uncomment this line to render as a graph
-version: 1.0.0
+  | summarize Emails = count() by UserLevelAction, UserLevelPolicy, ThreatTypes
+  | sort by Emails desc
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Block.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Block.yaml
@@ -14,8 +14,13 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
   EmailEvents
+  | where Timestamp >= TimeStart
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where UserLevelPolicy != "" and UserLevelAction == "Block"
-  | make-series TotalUserOverrides = count() default = 0 on Timestamp step 1d
-  // | render columnchart // Uncomment this line to render as a graph
-version: 1.0.0
+  | make-series TotalUserOverrides = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Bulk Detection Top10 Domains.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Bulk Detection Top10 Domains.yaml
@@ -17,10 +17,12 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails which has any Bulk complaint level. It is summarizing the data by the various Bulk Complaint levels and SenderFromDomain of the email sender. It provides insights how many messages are detected with each Bulk Complaint level for each sender domain.
   EmailEvents
-  | where EmailDirection == "Inbound" and BulkComplaintLevel !=""
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where EmailDirection == "Inbound" and isnotempty(BulkComplaintLevel)
   | summarize count() by BulkComplaintLevel, SenderFromDomain
-  | sort by count_ desc
-  | project SenderFromDomain,BulkComplaintLevel,Emails=count_
-  | take 10
-version: 1.0.0
+  | top 10 by count_
+  | project SenderFromDomain, BulkComplaintLevel, Emails = count_
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Delivery Location.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Delivery Location.yaml
@@ -16,8 +16,11 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where DetectionMethods has "Spam" and EmailDirection == "Inbound"
-  | make-series TotalSpamDetections=count(),Quarantine = countif(DeliveryLocation == "Quarantine"),Junkfolder=countif(DeliveryLocation == "Junk folder") ,Inbox=countif(DeliveryLocation == "Inbox/folder"),Failed=countif(DeliveryLocation == "Failed"),Dropped=countif(DeliveryLocation == "Dropped") default = 0 on Timestamp step 1d 
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | make-series TotalSpamDetections=count(),Quarantine = countif(DeliveryLocation == "Quarantine"),Junkfolder=countif(DeliveryLocation == "Junk folder"),Inbox=countif(DeliveryLocation == "Inbox/folder"),Failed=countif(DeliveryLocation == "Failed"),Dropped=countif(DeliveryLocation == "Dropped") default = 0 on Timestamp step 1d
   // | render timechart // Uncomment this line to render as a graph
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection IP and Geo Position.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection IP and Geo Position.yaml
@@ -18,22 +18,26 @@ relevantTechniques:
 query: |
   //This query visualises total emails with Spam detections summarizing the data by email sender IP address (SenderIPv4, SenderIPv6).
   let ipv4position = EmailEvents
-  | where ThreatTypes has "Spam" 
-  | where TimeGenerated > ago(90d) // last 30 days by default, replace 30d with the desired period
-  | where SenderIPv4 != ""
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and SenderIPv4 != ""
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderIPv4
   | extend GeoInfo = geo_info_from_ip_address(SenderIPv4)
-  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude)
-  | project SenderIPv4, Latitude, Longitude, count_;
+  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude), Country = tostring(GeoInfo.country)
+  | project SenderIPv4, Country, Latitude, Longitude, count_;
   let ipv6position = EmailEvents
-  | where ThreatTypes has "Spam" 
-  | where TimeGenerated > ago(90d) // last 30 days by default, replace 30d with the desired period
-  | where SenderIPv6 != ""
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and SenderIPv6 != ""
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderIPv6
   | extend GeoInfo = geo_info_from_ip_address(SenderIPv6)
-  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude)
-  | project SenderIPv6, Latitude, Longitude, count_;
+  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude), Country = tostring(GeoInfo.country)
+  | project SenderIPv6, Country, Latitude, Longitude, count_;
   ipv4position
   | union ipv6position
-  | project SenderIPv6, SenderIPv4, Latitude, Longitude, count_;
-version: 1.0.0
+  | project SenderIPv6, SenderIPv4, Country, Latitude, Longitude, count_
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Mails with BCL.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Mails with BCL.yaml
@@ -17,9 +17,12 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails which has any Bulk complaint level. It is summarizing the data by the various Bulk Complaint levels to understand how many messages are detected with each Bulk Complaint level.
   EmailEvents
-  | where EmailDirection == "Inbound" and BulkComplaintLevel !=""
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where EmailDirection == "Inbound" and isnotempty(BulkComplaintLevel)
   | summarize count() by BulkComplaintLevel
   | sort by BulkComplaintLevel desc
-  | project BulkComplaintLevel,Emails=count_
-version: 1.0.0
+  | project BulkComplaintLevel, Emails = count_
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Tech.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Tech.yaml
@@ -16,10 +16,13 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total emails with Spam detections summarizing the data by various Spam detection technologies/controls in Microsoft Defender for Office 365.
-  EmailEvents 
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where DetectionMethods has 'Spam'
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | project Timestamp, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) | summarize count() by Spam=tostring(column_ifexists('Spam', ''))
   | sort by count_
   // | render piechart  // Uncomment this line to render as a graph
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top10 Domains.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top10 Domains.yaml
@@ -16,11 +16,15 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain).
-  EmailEvents 
-  | where ThreatTypes has "Spam" and EmailDirection =="Inbound"
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
-  | summarize count() by SenderFromDomain
-  | sort by count_ desc 
-  | take 10
-  // | render piechart // Uncomment this line to render as a graph
-version: 1.0.0
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where EmailDirection == "Inbound"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), SpamEmailCount = countif(ThreatTypes has "Spam") by SenderFromDomain
+  | extend Bad_Traffic_Percentage_Inbound = round(100.0 * SpamEmailCount / TotalEmailCount, 2)
+  | where SpamEmailCount != 0
+  | top 10 by SpamEmailCount
+  | project SenderFromDomain, SpamEmailCount, TotalEmailCount, Bad_Traffic_Percentage_Inbound
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top10 Users.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top10 Users.yaml
@@ -16,11 +16,12 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 10 recipient email address (RecipientEmailAddress).
-  EmailEvents 
-  | where ThreatTypes has "Spam" and EmailDirection =="Inbound" 
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
-  | summarize count() by RecipientEmailAddress 
-  | sort by count_ desc
-  | take 10
-  | render piechart // Uncomment this line to render as a graph
-version: 1.0.0
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and EmailDirection == "Inbound"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by RecipientEmailAddress
+  | top 10 by count_
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top15 Domains Details.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top15 Domains Details.yaml
@@ -17,13 +17,15 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 15 email sender P2 domain (SenderFromDomain). Adding additional insights for total inbound emails and bad traffic percentage for each sender domain.
   EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where EmailDirection == "Inbound"
-  | where Timestamp > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | summarize TotalEmailCount = count(),
-            SpamEmailCount = countif(ThreatTypes has "Spam") by SenderFromDomain
+              SpamEmailCount = countif(ThreatTypes has "Spam") by SenderFromDomain
   | extend Bad_Traffic_Percentage_Inbound = todouble(round(SpamEmailCount / todouble(TotalEmailCount) * 100, 2))
-  | where SpamEmailCount !=0
-  | sort by SpamEmailCount desc 
-  | project SenderFromDomain,SpamEmailCount,TotalEmailCount,Bad_Traffic_Percentage_Inbound
+  | where SpamEmailCount != 0
   | top 15 by SpamEmailCount
-version: 1.0.0
+  | project SenderFromDomain, SpamEmailCount, TotalEmailCount, Bad_Traffic_Percentage_Inbound
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top15 Users Details.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Top15 Users Details.yaml
@@ -17,10 +17,14 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 15 recipient email address (RecipientEmailAddress).
   EmailEvents
-  | where ThreatTypes has "Spam" and EmailDirection =="Inbound"
-  | where Timestamp > ago(90d) // last 30 days by default, replace 30d with the desired period
-  | summarize count() by RecipientEmailAddress
-  | sort by count_ desc
-  | take 15
-  | project RecipientEmailAddress,Emails=count_
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where EmailDirection == "Inbound"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), SpamEmailCount = countif(ThreatTypes has "Spam") by RecipientEmailAddress
+  | extend Bad_Traffic_Percentage_Inbound = round(100.0 * SpamEmailCount / TotalEmailCount, 2)
+  | where SpamEmailCount != 0
+  | top 15 by SpamEmailCount
+  | project RecipientEmailAddress, SpamEmailCount, TotalEmailCount, Bad_Traffic_Percentage_Inbound
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detection Trend.yaml
@@ -17,7 +17,11 @@ relevantTechniques:
 query: |
   //This query visualises total emails with Spam detections over time summarizing the data daily.
   EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where ThreatTypes has "Spam"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | make-series Count = count() default = 0 on Timestamp step 1d
   // | render timechart // Uncomment this line to render as a graph
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
@@ -16,60 +16,16 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total emails with Spam detections over time summarizing the data daily by various Spam Detection technologies/controls in Microsoft Defender for Office 365.
-  let minTime = startofday(ago(30d)); // last 30 days by default, replace 30d with the desired period
+  //(v4) Single mv-expand over DetectionMethods.Spam replaces the previous 8-way union: less scan, and new spam techniques appear automatically.
+  let minTime = startofday(ago(30d));
   let maxTime = startofday(now());
-  let baseQuery = EmailEvents
+  EmailEvents
+  | where Timestamp >= minTime
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where DetectionMethods has "Spam"
-  | where Timestamp >= minTime;
-  let ml=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Advanced filter'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Advanced filter";
-  let gf=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'General filter'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "General filter";
-  let bl=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'BulkFilter'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "BulkFilter";
-  let mx=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Mixed analysis detection'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Mixed analysis detection";
-  let frp=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Fingerprint matching'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Fingerprint matching";
-  let umr=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'URL malicious reputation'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "URL malicious reputation";
-  let dr=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Domain reputation'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Domain reputation";
-  let ipr=baseQuery
-  | where Timestamp >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'IP reputation' 
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "IP reputation";
-  union ml,gf,bl,mx,frp,umr,dr,ipr
-  | project Count, Details, Timestamp
-  | render timechart 
-version: 1.0.0
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
+  | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
+  // | render timechart
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
@@ -26,6 +26,7 @@ query: |
   | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
   | summarize arg_max(Timestamp, *) by Key
   | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
+  | where Timestamp < maxTime
   | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
   // | render timechart
 version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detections by Sender Country.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Spam/Spam Detections by Sender Country.yaml
@@ -1,0 +1,29 @@
+id: bdd60985-c235-4c74-af19-a3d77360f527
+name: Spam Detections by Sender Country
+description: |
+  This query summarizes inbound spam detections by the geographic country of the sending IP address, using the EmailEvents table.
+description-detailed: |
+  Mapping spam detections to the country of the sending IP address helps identify the regions and sending infrastructure behind bulk and spam campaigns. This query resolves the sender IPv4 address to a country and counts inbound spam detections per country, with the number of distinct sending IPs. Country is derived from IP geolocation and is approximate.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Inbound spam detections by sender-IP country. Country is from IP geolocation and is approximate.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and isnotempty(SenderIPv4)
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | extend Country = tostring(geo_info_from_ip_address(SenderIPv4).country)
+  | where isnotempty(Country)
+  | summarize SpamEmails = count(), SenderIPs = dcount(SenderIPv4) by Country
+  | top 20 by SpamEmails
+  | project Country, SpamEmails, SenderIPs
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/Blocked URL Clicks by Workload.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/Blocked URL Clicks by Workload.yaml
@@ -1,0 +1,23 @@
+id: 41831d30-f03e-44a9-bd27-f713033393b7
+name: Blocked URL Clicks by Workload
+description: |
+  This query visualises blocked Safe Links URL clicks over time broken down by the workload the click came from (Email, Teams, Office, Microsoft 365 Copilot).
+description-detailed: |
+  This query visualises Safe Links URL clicks that were blocked (ActionType == "ClickBlocked") over time in Microsoft Defender for Office 365, broken down by the workload the click originated from (Email, Teams, Office, Microsoft 365 Copilot), to show where users most often attempt to reach malicious URLs.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp >= TimeStart
+  | where ActionType == "ClickBlocked"
+  | make-series Teams = countif(Workload == "Teams"), Office = countif(Workload == "Office"), Email = countif(Workload == "Email"), Copilot = countif(Workload == "Copilot") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/Top 20 Malicious URLs by Clicks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/Top 20 Malicious URLs by Clicks.yaml
@@ -1,0 +1,22 @@
+id: 188a0e9a-d775-4ad2-b7a0-64df26c0b931
+name: Top 20 Malicious URLs by Clicks
+description: |
+  This query lists the top 20 URLs carrying a detection ranked by the number of clicks registered, with the threat type, click action and workload for each.
+description-detailed: |
+  This query lists the top 20 URLs with an associated threat detection in Microsoft Defender for Office 365, ranked by the number of Safe Links clicks registered, and shows the threat type, click action (blocked, allowed, and so on) and the workload the clicks came from - a forensic view of the most-clicked malicious URLs.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  UrlClickEvents
+  | where Timestamp > ago(30d)
+  | where ThreatTypes != ""
+  | summarize ['Click Count'] = count() by Url, ThreatTypes, ActionType, Workload
+  | top 20 by ['Click Count']
+  | project ['URL'] = Url, ['Threat Types'] = ThreatTypes, ['Action Type'] = ActionType, Workload, ['Click Count']
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/Top Clicks on Malicious URLs.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/Top Clicks on Malicious URLs.yaml
@@ -1,0 +1,24 @@
+id: b47707bf-1155-4d75-864f-079343f7cf7f
+name: Top Clicks on Malicious URLs
+description: |
+  This query lists the malicious URLs that registered the most user clicks, with threat type, click action and workload, using the UrlClickEvents table.
+description-detailed: |
+  Ranking the specific URLs (not just the users) that attract the most clicks highlights the malicious links most effectively reaching users, and where the clicks happen (Outlook, Microsoft Teams, Microsoft 365 Copilot, Office apps). This query lists the top URLs associated with a detection by click count, with the threat type, click action and workload for context.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Top 20 malicious URLs by click count, with threat type, click action and workload for context.
+  UrlClickEvents
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | summarize ClickCount = count() by Url, ThreatTypes, ActionType, Workload
+  | top 20 by ClickCount
+  | project Url, ThreatTypes, ActionType, Workload, ClickCount
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/URL Click-Through by Workload.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/URL Click-Through by Workload.yaml
@@ -1,0 +1,23 @@
+id: f9cc3c34-3424-42c6-878b-9f67808b086f
+name: URL Click-Through by Workload
+description: |
+  This query shows malicious URL click-throughs (where the user proceeded past the Safe Links warning) broken down by the workload the click came from.
+description-detailed: |
+  This query shows Safe Links click-through activity in Microsoft Defender for Office 365 - clicks on URLs carrying a threat where the user chose to proceed past the warning page (IsClickedThrough) - broken down by the workload the click originated from (Email, Teams, Office, Microsoft 365 Copilot).
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  UrlClickEvents
+  | where Timestamp > ago(30d)
+  | where IsClickedThrough != "0"
+  | where isnotempty(ThreatTypes)
+  | summarize ['Click-Through Count'] = count() by Workload
+  | sort by ['Click-Through Count'] desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/URL Threat Protection Summary.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL Click/URL Threat Protection Summary.yaml
@@ -1,0 +1,25 @@
+id: 074959c6-2e9d-4f11-b9c8-971b7387aa99
+name: URL Threat Protection Summary
+description: |
+  This query summarises URL threat protection activity (Safe Links click outcomes and distinct URLs seen in email) as a set of headline metrics for the selected period.
+description-detailed: |
+  This query summarises URL threat protection activity in Microsoft Defender for Office 365 as headline metrics: malicious clicks blocked, clicks allowed through, distinct users clicking links (from UrlClickEvents), and distinct URLs seen in email (from EmailUrlInfo).
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+  - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let clicks = UrlClickEvents | where Timestamp > ago(30d);
+  union
+  (clicks | where ActionType in ("ClickBlocked","ClickBlockedByTenantPolicy") | summarize Count = count() | extend Details = "Malicious Clicks Blocked", Ord = 1),
+  (clicks | where ActionType == "ClickAllowed" | summarize Count = count() | extend Details = "Clicks Allowed Through", Ord = 2),
+  (clicks | summarize Count = dcount(AccountUpn) | extend Details = "Users Clicking Links", Ord = 3),
+  (EmailUrlInfo | where Timestamp > ago(30d) | summarize Count = dcount(Url) | extend Details = "Distinct URLs in Email", Ord = 4)
+  | sort by Ord asc
+  | project Count, Details
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Malware URL Detections Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Malware URL Detections Trend.yaml
@@ -1,0 +1,28 @@
+id: 7a25af1f-c757-490e-909d-f803b94ed8d2
+name: Malware URL Detections Trend
+description: |
+  This query visualises inbound email malware detections attributed to URL-based detection technologies over time.
+description-detailed: |
+  This query visualises inbound email malware detections in Microsoft Defender for Office 365 over time, limited to URL-based malware detection technologies (for example URL detonation). Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where MalwareMethod contains "URL"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by MalwareMethod
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Phishing URL Detections Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Phishing URL Detections Trend.yaml
@@ -1,0 +1,28 @@
+id: 53278c60-3354-4452-a032-d2e239bed34b
+name: Phishing URL Detections Trend
+description: |
+  This query visualises inbound email phishing detections attributed to URL-based detection technologies over time.
+description-detailed: |
+  This query visualises inbound email phishing detections in Microsoft Defender for Office 365 over time, limited to URL-based phishing detection technologies (for example URL detonation, URL malicious reputation). Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Phish"
+  | mv-expand PhishMethod = parse_json(DetectionMethods).Phish to typeof(string)
+  | where PhishMethod contains "URL"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by PhishMethod
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/QR Code URL Detections Trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/QR Code URL Detections Trend.yaml
@@ -1,0 +1,32 @@
+id: aa121105-95a2-4424-84d7-1c5c47e5d44b
+name: QR Code URL Detections Trend
+description: |
+  This query visualises inbound email detections involving URLs embedded in QR codes over time, split by the threat type of the detection (phishing, malware, spam).
+description-detailed: |
+  This query visualises inbound email detections in Microsoft Defender for Office 365 where the malicious URL was embedded in a QR code (EmailUrlInfo UrlLocation == "QRCode"), over time and split by whether the URL was flagged for phishing, malware or spam. Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let qrMessages = EmailUrlInfo
+  | where Timestamp >= TimeStart
+  | where UrlLocation == "QRCode"
+  | distinct NetworkMessageId;
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where EmailDirection == "Inbound" and DetectionMethods has "Url"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where NetworkMessageId in (qrMessages)
+  | make-series ['Phish QR Detection'] = countif(parse_json(DetectionMethods).Phish has "URL"), ['Malware QR Detection'] = countif(parse_json(DetectionMethods).Malware has "URL"), ['Spam QR Detection'] = countif(parse_json(DetectionMethods).Spam has "URL") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
@@ -17,6 +17,6 @@ query: |
   | summarize TotalClickCount = count(), MalwareClickCount = countif(ThreatTypes has "Malware") by AccountUpn
   | extend Bad_Click_Percentage = round(100.0 * MalwareClickCount / TotalClickCount, 2)
   | where MalwareClickCount != 0
-  | top 15 by MalwareClickCount
+  | top 10 by MalwareClickCount
   | project User = AccountUpn, MalwareClicks = MalwareClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
 version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
@@ -13,8 +13,10 @@ relevantTechniques:
   - T1566
 query: |
   UrlClickEvents
-  | where ThreatTypes == "Malware"
-  | summarize count() by AccountUpn
-  | top 10 by count_
-  | render piechart
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | summarize TotalClickCount = count(), MalwareClickCount = countif(ThreatTypes has "Malware") by AccountUpn
+  | extend Bad_Click_Percentage = round(100.0 * MalwareClickCount / TotalClickCount, 2)
+  | where MalwareClickCount != 0
+  | top 15 by MalwareClickCount
+  | project User = AccountUpn, MalwareClicks = MalwareClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
@@ -13,8 +13,10 @@ relevantTechniques:
   - T1566
 query: |
   UrlClickEvents
-  | where ThreatTypes == "Phish"
-  | summarize count() by AccountUpn
-  | top 10 by count_
-  | render piechart
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | summarize TotalClickCount = count(), PhishClickCount = countif(ThreatTypes has "Phish") by AccountUpn
+  | extend Bad_Click_Percentage = round(100.0 * PhishClickCount / TotalClickCount, 2)
+  | where PhishClickCount != 0
+  | top 15 by PhishClickCount
+  | project User = AccountUpn, PhishClicks = PhishClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
@@ -17,6 +17,6 @@ query: |
   | summarize TotalClickCount = count(), PhishClickCount = countif(ThreatTypes has "Phish") by AccountUpn
   | extend Bad_Click_Percentage = round(100.0 * PhishClickCount / TotalClickCount, 2)
   | where PhishClickCount != 0
-  | top 15 by PhishClickCount
+  | top 10 by PhishClickCount
   | project User = AccountUpn, PhishClicks = PhishClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
 version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
@@ -17,6 +17,6 @@ query: |
   | summarize TotalClickCount = count(), SpamClickCount = countif(ThreatTypes has "Spam") by AccountUpn
   | extend Bad_Click_Percentage = round(100.0 * SpamClickCount / TotalClickCount, 2)
   | where SpamClickCount != 0
-  | top 15 by SpamClickCount
+  | top 10 by SpamClickCount
   | project User = AccountUpn, SpamClicks = SpamClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
 version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
@@ -13,8 +13,10 @@ relevantTechniques:
   - T1566
 query: |
   UrlClickEvents
-  | where ThreatTypes == "Spam"
-  | summarize count() by AccountUpn
-  | top 10 by count_
-  | render piechart
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | summarize TotalClickCount = count(), SpamClickCount = countif(ThreatTypes has "Spam") by AccountUpn
+  | extend Bad_Click_Percentage = round(100.0 * SpamClickCount / TotalClickCount, 2)
+  | where SpamClickCount != 0
+  | top 15 by SpamClickCount
+  | project User = AccountUpn, SpamClicks = SpamClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/SecOps Mailbox Override Count.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/SecOps Mailbox Override Count.yaml
@@ -1,0 +1,22 @@
+id: 293d6bbe-97b6-458e-8670-929e9f1756d2
+name: SecOps Mailbox Override Count
+description: |
+  This query counts inbound emails delivered to the SecOps mailbox by an organisation-level allow override.
+description-detailed: |
+  This query counts inbound emails delivered to the SecOps mailbox in Microsoft Defender for Office 365 as a result of an organisation-level allow override (OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"), so the volume of deliberately-allowed SecOps deliveries can be isolated from other admin overrides. Messages are de-duplicated to the latest record per NetworkMessageId and recipient.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"
+  | summarize ['SecOps Mailbox Deliveries'] = count()
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/SecOps Mailbox Overrides by Threat Type.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/SecOps Mailbox Overrides by Threat Type.yaml
@@ -1,0 +1,25 @@
+id: b5ac7138-d807-450e-9f67-dbdac948f651
+name: SecOps Mailbox Overrides by Threat Type
+description: |
+  This query breaks down inbound emails delivered to the SecOps mailbox by an organisation-level allow override, grouped by threat type.
+description-detailed: |
+  This query breaks down inbound emails delivered to the SecOps mailbox in Microsoft Defender for Office 365 as a result of an organisation-level allow override (OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"), grouped by threat type (Malware, Phish, Spam). Messages are de-duplicated to the latest record per NetworkMessageId and recipient.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where OrgLevelPolicy == "SecOps Mailbox" and OrgLevelAction == "Allow"
+  | extend ThreatType = case(ThreatTypes has "Malware", "Malware", ThreatTypes has "Phish", "Phish", ThreatTypes has "Spam", "Spam", ThreatTypes)
+  | summarize TotalEmails = count() by OrgLevelAction, OrgLevelPolicy, ThreatType
+  | sort by TotalEmails desc
+  | project ['Override Action'] = OrgLevelAction, ['Override Policy'] = OrgLevelPolicy, ['Threat Type'] = ThreatType, ['Total Emails'] = TotalEmails
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Top Recipients Receiving Threats Delivered by Override.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Top Recipients Receiving Threats Delivered by Override.yaml
@@ -1,0 +1,36 @@
+id: 95f7ab0b-3025-487e-9523-1b68152f4b91
+name: Top Recipients Receiving Threats Delivered by Override
+description: |
+  This query lists the recipients who received the most threats that were delivered because of an admin or user override, with the share overridden and a breakdown of override types, using the EmailEvents table.
+description-detailed: |
+  Threats delivered because of an admin or user override (allow policies, safe-sender lists, Exchange transport rules, quarantine release) bypass Microsoft Defender for Office 365 protection and reach the user. This query ranks the recipients with the most overridden threats, showing the total threats they received, how many were delivered via an override, the override percentage, and which override types were responsible. A high override rate on a mailbox warrants a policy review.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Recipients with the most threats delivered via an admin or user override, with the override share and type breakdown.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | extend OverrideType = case(
+      OrgLevelAction == "Allow" and OrgLevelPolicy != "" and OrgLevelPolicy != "SecOps Mailbox", OrgLevelPolicy,
+      UserLevelAction == "Allow", strcat("User: ", UserLevelPolicy),
+      "(none)")
+  | summarize PerType = count() by RecipientEmailAddress, OverrideType
+  | summarize TotalThreats = sum(PerType),
+              OverriddenThreats = sumif(PerType, OverrideType != "(none)"),
+              OverrideTypes = strcat_array(make_set_if(strcat(OverrideType, " (", PerType, ")"), OverrideType != "(none)"), "; ")
+          by RecipientEmailAddress
+  | where OverriddenThreats > 0
+  | extend OverridePercent = round(OverriddenThreats * 100.0 / TotalThreats, 1)
+  | top 15 by OverriddenThreats
+  | project Recipient = RecipientEmailAddress, TotalThreats, OverriddenThreats, OverridePercent, OverrideTypes
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Top Sender Domains Delivering Threats via Override.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Top Sender Domains Delivering Threats via Override.yaml
@@ -1,0 +1,36 @@
+id: d3427b51-d7b9-4610-a871-5738e59cfa93
+name: Top Sender Domains Delivering Threats via Override
+description: |
+  This query lists the sender domains whose threats were most often delivered because of an admin or user override, with the share overridden and a breakdown of override types, using the EmailEvents table.
+description-detailed: |
+  A sender domain with a high share of its threats delivered because of an admin or user override (allow policies, safe-sender lists, Exchange transport rules, quarantine release) is bypassing Microsoft Defender for Office 365 protection. This query ranks sender domains by the number of threats delivered via an override, showing the total threats, the overridden count, the override percentage, and which override types were responsible. High override rates are strong candidates for policy review or a Tenant Allow/Block List (TABL) block.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Sender domains with the most threats delivered via an admin or user override, with the override share and type breakdown.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | extend OverrideType = case(
+      OrgLevelAction == "Allow" and OrgLevelPolicy != "" and OrgLevelPolicy != "SecOps Mailbox", OrgLevelPolicy,
+      UserLevelAction == "Allow", strcat("User: ", UserLevelPolicy),
+      "(none)")
+  | summarize PerType = count() by SenderFromDomain, OverrideType
+  | summarize TotalThreats = sum(PerType),
+              OverriddenThreats = sumif(PerType, OverrideType != "(none)"),
+              OverrideTypes = strcat_array(make_set_if(strcat(OverrideType, " (", PerType, ")"), OverrideType != "(none)"), "; ")
+          by SenderFromDomain
+  | where OverriddenThreats > 0
+  | extend OverridePercent = round(OverriddenThreats * 100.0 / TotalThreats, 1)
+  | top 10 by OverriddenThreats
+  | project SenderDomain = SenderFromDomain, TotalThreats, OverriddenThreats, OverridePercent, OverrideTypes
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Allow.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Allow.yaml
@@ -16,8 +16,11 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  EmailEvents 
-  | where OrgLevelPolicy != "" and OrgLevelAction == "Allow" // and OrgLevelPolicy != "SecOps Mailbox" // Remove to filter SecOps mailbox
-  | make-series Count= count() on Timestamp from TimeStart to TimeEnd step 1d by OrgLevelPolicy
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where OrgLevelPolicy != "" and OrgLevelAction == "Allow"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by OrgLevelPolicy
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Block.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with Admin Overrides - Block.yaml
@@ -14,11 +14,16 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
   EmailEvents
+  | where Timestamp >= TimeStart
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where OrgLevelPolicy != "" and OrgLevelAction == "Block"
-  | make-series TotalAdminOverrides = count() default = 0 on Timestamp step 1d
-  // | render columnchart // Uncomment this line to render as a graph
-version: 1.0.0
+  | make-series TotalAdminOverrides = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.1.0
 
 
 

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Allow.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Allow.yaml
@@ -15,8 +15,10 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where UserLevelPolicy != "" and UserLevelAction == "Allow"
-  | summarize Emails=count() by UserLevelAction,UserLevelPolicy,ThreatTypes
-  | sort by Emails
-  // | render columnchart // Uncomment this line to render as a graph
-version: 1.0.0
+  | summarize Emails = count() by UserLevelAction, UserLevelPolicy, ThreatTypes
+  | sort by Emails desc
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Block.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Overrides/Total Emails with User Overrides - Block.yaml
@@ -14,8 +14,13 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
   EmailEvents
+  | where Timestamp >= TimeStart
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | where UserLevelPolicy != "" and UserLevelAction == "Block"
-  | make-series TotalUserOverrides = count() default = 0 on Timestamp step 1d
-  // | render columnchart // Uncomment this line to render as a graph
-version: 1.0.0
+  | make-series TotalUserOverrides = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Bulk Detection Top10 Domains.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Bulk Detection Top10 Domains.yaml
@@ -17,10 +17,12 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails which has any Bulk complaint level. It is summarizing the data by the various Bulk Complaint levels and SenderFromDomain of the email sender. It provides insights how many messages are detected with each Bulk Complaint level for each sender domain.
   EmailEvents
-  | where EmailDirection == "Inbound" and BulkComplaintLevel !=""
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where EmailDirection == "Inbound" and isnotempty(BulkComplaintLevel)
   | summarize count() by BulkComplaintLevel, SenderFromDomain
-  | sort by count_ desc
-  | project SenderFromDomain,BulkComplaintLevel,Emails=count_
-  | take 10
-version: 1.0.0
+  | top 10 by count_
+  | project SenderFromDomain, BulkComplaintLevel, Emails = count_
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Delivery Location.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Delivery Location.yaml
@@ -16,8 +16,11 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where DetectionMethods has "Spam" and EmailDirection == "Inbound"
-  | make-series TotalSpamDetections=count(),Quarantine = countif(DeliveryLocation == "Quarantine"),Junkfolder=countif(DeliveryLocation == "Junk folder") ,Inbox=countif(DeliveryLocation == "Inbox/folder"),Failed=countif(DeliveryLocation == "Failed"),Dropped=countif(DeliveryLocation == "Dropped") default = 0 on Timestamp step 1d 
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | make-series TotalSpamDetections=count(),Quarantine = countif(DeliveryLocation == "Quarantine"),Junkfolder=countif(DeliveryLocation == "Junk folder"),Inbox=countif(DeliveryLocation == "Inbox/folder"),Failed=countif(DeliveryLocation == "Failed"),Dropped=countif(DeliveryLocation == "Dropped") default = 0 on Timestamp step 1d
   // | render timechart // Uncomment this line to render as a graph
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection IP and Geo Position.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection IP and Geo Position.yaml
@@ -18,22 +18,26 @@ relevantTechniques:
 query: |
   //This query visualises total emails with Spam detections summarizing the data by email sender IP address (SenderIPv4, SenderIPv6).
   let ipv4position = EmailEvents
-  | where ThreatTypes has "Spam" 
-  | where TimeGenerated > ago(90d) // last 30 days by default, replace 30d with the desired period
-  | where SenderIPv4 != ""
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and SenderIPv4 != ""
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderIPv4
   | extend GeoInfo = geo_info_from_ip_address(SenderIPv4)
-  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude)
-  | project SenderIPv4, Latitude, Longitude, count_;
+  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude), Country = tostring(GeoInfo.country)
+  | project SenderIPv4, Country, Latitude, Longitude, count_;
   let ipv6position = EmailEvents
-  | where ThreatTypes has "Spam" 
-  | where TimeGenerated > ago(90d) // last 30 days by default, replace 30d with the desired period
-  | where SenderIPv6 != ""
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and SenderIPv6 != ""
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderIPv6
   | extend GeoInfo = geo_info_from_ip_address(SenderIPv6)
-  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude)
-  | project SenderIPv6, Latitude, Longitude, count_;
+  | extend Latitude = tostring(GeoInfo.latitude), Longitude = tostring(GeoInfo.longitude), Country = tostring(GeoInfo.country)
+  | project SenderIPv6, Country, Latitude, Longitude, count_;
   ipv4position
   | union ipv6position
-  | project SenderIPv6, SenderIPv4, Latitude, Longitude, count_;
-version: 1.0.0
+  | project SenderIPv6, SenderIPv4, Country, Latitude, Longitude, count_
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Mails with BCL.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Mails with BCL.yaml
@@ -17,9 +17,12 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails which has any Bulk complaint level. It is summarizing the data by the various Bulk Complaint levels to understand how many messages are detected with each Bulk Complaint level.
   EmailEvents
-  | where EmailDirection == "Inbound" and BulkComplaintLevel !=""
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where EmailDirection == "Inbound" and isnotempty(BulkComplaintLevel)
   | summarize count() by BulkComplaintLevel
   | sort by BulkComplaintLevel desc
-  | project BulkComplaintLevel,Emails=count_
-version: 1.0.0
+  | project BulkComplaintLevel, Emails = count_
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Tech.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Tech.yaml
@@ -16,10 +16,13 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total emails with Spam detections summarizing the data by various Spam detection technologies/controls in Microsoft Defender for Office 365.
-  EmailEvents 
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where DetectionMethods has 'Spam'
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | project Timestamp, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) | summarize count() by Spam=tostring(column_ifexists('Spam', ''))
   | sort by count_
   // | render piechart  // Uncomment this line to render as a graph
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top10 Domains.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top10 Domains.yaml
@@ -16,11 +16,15 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 10 email sender P2 domain (SenderFromDomain).
-  EmailEvents 
-  | where ThreatTypes has "Spam" and EmailDirection =="Inbound"
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
-  | summarize count() by SenderFromDomain
-  | sort by count_ desc 
-  | take 10
-  // | render piechart // Uncomment this line to render as a graph
-version: 1.0.0
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where EmailDirection == "Inbound"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), SpamEmailCount = countif(ThreatTypes has "Spam") by SenderFromDomain
+  | extend Bad_Traffic_Percentage_Inbound = round(100.0 * SpamEmailCount / TotalEmailCount, 2)
+  | where SpamEmailCount != 0
+  | top 10 by SpamEmailCount
+  | project SenderFromDomain, SpamEmailCount, TotalEmailCount, Bad_Traffic_Percentage_Inbound
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top10 Users.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top10 Users.yaml
@@ -16,11 +16,12 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 10 recipient email address (RecipientEmailAddress).
-  EmailEvents 
-  | where ThreatTypes has "Spam" and EmailDirection =="Inbound" 
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
-  | summarize count() by RecipientEmailAddress 
-  | sort by count_ desc
-  | take 10
-  | render piechart // Uncomment this line to render as a graph
-version: 1.0.0
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and EmailDirection == "Inbound"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by RecipientEmailAddress
+  | top 10 by count_
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top15 Domains Details.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top15 Domains Details.yaml
@@ -17,13 +17,15 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 15 email sender P2 domain (SenderFromDomain). Adding additional insights for total inbound emails and bad traffic percentage for each sender domain.
   EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where EmailDirection == "Inbound"
-  | where TimeGenerated > ago(30d) // last 30 days by default, replace 30d with the desired period
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | summarize TotalEmailCount = count(),
-            SpamEmailCount = countif(ThreatTypes has "Spam") by SenderFromDomain
+              SpamEmailCount = countif(ThreatTypes has "Spam") by SenderFromDomain
   | extend Bad_Traffic_Percentage_Inbound = todouble(round(SpamEmailCount / todouble(TotalEmailCount) * 100, 2))
-  | where SpamEmailCount !=0
-  | sort by SpamEmailCount desc 
-  | project SenderFromDomain,SpamEmailCount,TotalEmailCount,Bad_Traffic_Percentage_Inbound
+  | where SpamEmailCount != 0
   | top 15 by SpamEmailCount
-version: 1.0.0
+  | project SenderFromDomain, SpamEmailCount, TotalEmailCount, Bad_Traffic_Percentage_Inbound
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top15 Users Details.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Top15 Users Details.yaml
@@ -17,10 +17,14 @@ relevantTechniques:
 query: |
   //This query visualises total inbound emails with Spam detections summarizing the data by the top 15 recipient email address (RecipientEmailAddress).
   EmailEvents
-  | where ThreatTypes has "Spam" and EmailDirection =="Inbound"
-  | where TimeGenerated > ago(90d) // last 30 days by default, replace 30d with the desired period
-  | summarize count() by RecipientEmailAddress
-  | sort by count_ desc
-  | take 15
-  | project RecipientEmailAddress,Emails=count_
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where EmailDirection == "Inbound"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize TotalEmailCount = count(), SpamEmailCount = countif(ThreatTypes has "Spam") by RecipientEmailAddress
+  | extend Bad_Traffic_Percentage_Inbound = round(100.0 * SpamEmailCount / TotalEmailCount, 2)
+  | where SpamEmailCount != 0
+  | top 15 by SpamEmailCount
+  | project RecipientEmailAddress, SpamEmailCount, TotalEmailCount, Bad_Traffic_Percentage_Inbound
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detection Trend.yaml
@@ -17,7 +17,11 @@ relevantTechniques:
 query: |
   //This query visualises total emails with Spam detections over time summarizing the data daily.
   EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where ThreatTypes has "Spam"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
   | make-series Count = count() default = 0 on Timestamp step 1d
   // | render timechart // Uncomment this line to render as a graph
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
@@ -26,6 +26,7 @@ query: |
   | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
   | summarize arg_max(Timestamp, *) by Key
   | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
+  | where Timestamp < maxTime
   | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
   // | render timechart
 version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detections by Detection technology.yaml
@@ -16,60 +16,16 @@ relevantTechniques:
   - T1566
 query: |
   //This query visualises total emails with Spam detections over time summarizing the data daily by various Spam Detection technologies/controls in Microsoft Defender for Office 365.
-  let minTime = startofday(ago(30d)); // last 30 days by default, replace 30d with the desired period
+  //(v4) Single mv-expand over DetectionMethods.Spam replaces the previous 8-way union: less scan, and new spam techniques appear automatically.
+  let minTime = startofday(ago(30d));
   let maxTime = startofday(now());
-  let baseQuery = EmailEvents
+  EmailEvents
+  | where Timestamp >= minTime
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
   | where DetectionMethods has "Spam"
-  | where TimeGenerated >= minTime;
-  let ml=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Advanced filter'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Advanced filter";
-  let gf=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'General filter'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "General filter";
-  let bl=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'BulkFilter'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "BulkFilter";
-  let mx=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Mixed analysis detection'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Mixed analysis detection";
-  let frp=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Fingerprint matching'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Fingerprint matching";
-  let umr=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'URL malicious reputation'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "URL malicious reputation";
-  let dr=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Domain reputation'
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "Domain reputation";
-  let ipr=baseQuery
-  | where TimeGenerated >= minTime
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'IP reputation' 
-  | make-series Count= count() default = 0 on Timestamp from minTime to maxTime step 1d 
-  | extend Details = "IP reputation";
-  union ml,gf,bl,mx,frp,umr,dr,ipr
-  | project Count, Details, Timestamp
-  | render timechart 
-version: 1.0.0
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
+  | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
+  // | render timechart
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detections by Sender Country.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Spam/Spam Detections by Sender Country.yaml
@@ -1,0 +1,29 @@
+id: fd9d2289-a2c3-4634-8a87-abe4a7db896f
+name: Spam Detections by Sender Country
+description: |
+  This query summarizes inbound spam detections by the geographic country of the sending IP address, using the EmailEvents table.
+description-detailed: |
+  Mapping spam detections to the country of the sending IP address helps identify the regions and sending infrastructure behind bulk and spam campaigns. This query resolves the sender IPv4 address to a country and counts inbound spam detections per country, with the number of distinct sending IPs. Country is derived from IP geolocation and is approximate.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Inbound spam detections by sender-IP country. Country is from IP geolocation and is approximate.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where ThreatTypes has "Spam" and isnotempty(SenderIPv4)
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | extend Country = tostring(geo_info_from_ip_address(SenderIPv4).country)
+  | where isnotempty(Country)
+  | summarize SpamEmails = count(), SenderIPs = dcount(SenderIPv4) by Country
+  | top 20 by SpamEmails
+  | project Country, SpamEmails, SenderIPs
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/Blocked URL Clicks by Workload.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/Blocked URL Clicks by Workload.yaml
@@ -1,0 +1,23 @@
+id: 22811654-25ac-43d6-ba63-699ec29dd6af
+name: Blocked URL Clicks by Workload
+description: |
+  This query visualises blocked Safe Links URL clicks over time broken down by the workload the click came from (Email, Teams, Office, Microsoft 365 Copilot).
+description-detailed: |
+  This query visualises Safe Links URL clicks that were blocked (ActionType == "ClickBlocked") over time in Microsoft Defender for Office 365, broken down by the workload the click originated from (Email, Teams, Office, Microsoft 365 Copilot), to show where users most often attempt to reach malicious URLs.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  UrlClickEvents
+  | where Timestamp >= TimeStart
+  | where ActionType == "ClickBlocked"
+  | make-series Teams = countif(Workload == "Teams"), Office = countif(Workload == "Office"), Email = countif(Workload == "Email"), Copilot = countif(Workload == "Copilot") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/Top 20 Malicious URLs by Clicks.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/Top 20 Malicious URLs by Clicks.yaml
@@ -1,0 +1,22 @@
+id: 13e20569-a96c-48c4-b0d7-3c2058d24245
+name: Top 20 Malicious URLs by Clicks
+description: |
+  This query lists the top 20 URLs carrying a detection ranked by the number of clicks registered, with the threat type, click action and workload for each.
+description-detailed: |
+  This query lists the top 20 URLs with an associated threat detection in Microsoft Defender for Office 365, ranked by the number of Safe Links clicks registered, and shows the threat type, click action (blocked, allowed, and so on) and the workload the clicks came from - a forensic view of the most-clicked malicious URLs.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  UrlClickEvents
+  | where Timestamp > ago(30d)
+  | where ThreatTypes != ""
+  | summarize ['Click Count'] = count() by Url, ThreatTypes, ActionType, Workload
+  | top 20 by ['Click Count']
+  | project ['URL'] = Url, ['Threat Types'] = ThreatTypes, ['Action Type'] = ActionType, Workload, ['Click Count']
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/Top Clicks on Malicious URLs.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/Top Clicks on Malicious URLs.yaml
@@ -1,0 +1,24 @@
+id: d31069b5-44a5-4a5d-96fa-68db27074023
+name: Top Clicks on Malicious URLs
+description: |
+  This query lists the malicious URLs that registered the most user clicks, with threat type, click action and workload, using the UrlClickEvents table.
+description-detailed: |
+  Ranking the specific URLs (not just the users) that attract the most clicks highlights the malicious links most effectively reaching users, and where the clicks happen (Outlook, Microsoft Teams, Microsoft 365 Copilot, Office apps). This query lists the top URLs associated with a detection by click count, with the threat type, click action and workload for context.
+  This query is part of the Microsoft Defender for Office 365 Detections and Insights workbook in Microsoft Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-3-build-custom-email-security-reports-with-power-bi-and-workbooks-in-micros/4490127
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  // Top 20 malicious URLs by click count, with threat type, click action and workload for context.
+  UrlClickEvents
+  | where Timestamp > ago(30d)
+  | where isnotempty(ThreatTypes)
+  | summarize ClickCount = count() by Url, ThreatTypes, ActionType, Workload
+  | top 20 by ClickCount
+  | project Url, ThreatTypes, ActionType, Workload, ClickCount
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/URL Click-Through by Workload.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/URL Click-Through by Workload.yaml
@@ -1,0 +1,23 @@
+id: 07e1f2f5-3662-4e8b-8f52-5273d220976b
+name: URL Click-Through by Workload
+description: |
+  This query shows malicious URL click-throughs (where the user proceeded past the Safe Links warning) broken down by the workload the click came from.
+description-detailed: |
+  This query shows Safe Links click-through activity in Microsoft Defender for Office 365 - clicks on URLs carrying a threat where the user chose to proceed past the warning page (IsClickedThrough) - broken down by the workload the click originated from (Email, Teams, Office, Microsoft 365 Copilot).
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  UrlClickEvents
+  | where Timestamp > ago(30d)
+  | where IsClickedThrough != "0"
+  | where isnotempty(ThreatTypes)
+  | summarize ['Click-Through Count'] = count() by Workload
+  | sort by ['Click-Through Count'] desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/URL Threat Protection Summary.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL Click/URL Threat Protection Summary.yaml
@@ -1,0 +1,25 @@
+id: a0d5391b-a44c-433c-8e08-7137f6e4a23c
+name: URL Threat Protection Summary
+description: |
+  This query summarises URL threat protection activity (Safe Links click outcomes and distinct URLs seen in email) as a set of headline metrics for the selected period.
+description-detailed: |
+  This query summarises URL threat protection activity in Microsoft Defender for Office 365 as headline metrics: malicious clicks blocked, clicks allowed through, distinct users clicking links (from UrlClickEvents), and distinct URLs seen in email (from EmailUrlInfo).
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - UrlClickEvents
+  - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let clicks = UrlClickEvents | where Timestamp > ago(30d);
+  union
+  (clicks | where ActionType in ("ClickBlocked","ClickBlockedByTenantPolicy") | summarize Count = count() | extend Details = "Malicious Clicks Blocked", Ord = 1),
+  (clicks | where ActionType == "ClickAllowed" | summarize Count = count() | extend Details = "Clicks Allowed Through", Ord = 2),
+  (clicks | summarize Count = dcount(AccountUpn) | extend Details = "Users Clicking Links", Ord = 3),
+  (EmailUrlInfo | where Timestamp > ago(30d) | summarize Count = dcount(Url) | extend Details = "Distinct URLs in Email", Ord = 4)
+  | sort by Ord asc
+  | project Count, Details
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Malware URL Detections Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Malware URL Detections Trend.yaml
@@ -1,0 +1,28 @@
+id: effba60e-0a4a-4558-bbf6-4e099607d82e
+name: Malware URL Detections Trend
+description: |
+  This query visualises inbound email malware detections attributed to URL-based detection technologies over time.
+description-detailed: |
+  This query visualises inbound email malware detections in Microsoft Defender for Office 365 over time, limited to URL-based malware detection technologies (for example URL detonation). Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Malware"
+  | mv-expand MalwareMethod = parse_json(DetectionMethods).Malware to typeof(string)
+  | where MalwareMethod contains "URL"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by MalwareMethod
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Phishing URL Detections Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Phishing URL Detections Trend.yaml
@@ -1,0 +1,28 @@
+id: 4bce2a7c-31fb-46e9-8487-ce611bd98004
+name: Phishing URL Detections Trend
+description: |
+  This query visualises inbound email phishing detections attributed to URL-based detection technologies over time.
+description-detailed: |
+  This query visualises inbound email phishing detections in Microsoft Defender for Office 365 over time, limited to URL-based phishing detection technologies (for example URL detonation, URL malicious reputation). Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where DetectionMethods has "Phish"
+  | mv-expand PhishMethod = parse_json(DetectionMethods).Phish to typeof(string)
+  | where PhishMethod contains "URL"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d by PhishMethod
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/QR Code URL Detections Trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/QR Code URL Detections Trend.yaml
@@ -1,0 +1,32 @@
+id: 88035c0e-0e2d-4805-a249-34d54a88c3fe
+name: QR Code URL Detections Trend
+description: |
+  This query visualises inbound email detections involving URLs embedded in QR codes over time, split by the threat type of the detection (phishing, malware, spam).
+description-detailed: |
+  This query visualises inbound email detections in Microsoft Defender for Office 365 where the malicious URL was embedded in a QR code (EmailUrlInfo UrlLocation == "QRCode"), over time and split by whether the URL was flagged for phishing, malware or spam. Messages are de-duplicated to the latest record per NetworkMessageId and recipient, and deliveries to the SecOps mailbox and by the phishing simulation system are excluded.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  let qrMessages = EmailUrlInfo
+  | where Timestamp >= TimeStart
+  | where UrlLocation == "QRCode"
+  | distinct NetworkMessageId;
+  EmailEvents
+  | where Timestamp >= TimeStart
+  | where OrgLevelPolicy != "Phishing simulation" and OrgLevelPolicy != "SecOps Mailbox"
+  | where EmailDirection == "Inbound" and DetectionMethods has "Url"
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where NetworkMessageId in (qrMessages)
+  | make-series ['Phish QR Detection'] = countif(parse_json(DetectionMethods).Phish has "URL"), ['Malware QR Detection'] = countif(parse_json(DetectionMethods).Malware has "URL"), ['Spam QR Detection'] = countif(parse_json(DetectionMethods).Spam has "URL") default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
@@ -17,6 +17,6 @@ query: |
   | summarize TotalClickCount = count(), MalwareClickCount = countif(ThreatTypes has "Malware") by AccountUpn
   | extend Bad_Click_Percentage = round(100.0 * MalwareClickCount / TotalClickCount, 2)
   | where MalwareClickCount != 0
-  | top 15 by MalwareClickCount
+  | top 10 by MalwareClickCount
   | project User = AccountUpn, MalwareClicks = MalwareClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
 version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Malware).yaml
@@ -13,8 +13,10 @@ relevantTechniques:
   - T1566
 query: |
   UrlClickEvents
-  | where ThreatTypes == "Malware"
-  | summarize count() by AccountUpn
-  | top 10 by count_
-  | render piechart
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | summarize TotalClickCount = count(), MalwareClickCount = countif(ThreatTypes has "Malware") by AccountUpn
+  | extend Bad_Click_Percentage = round(100.0 * MalwareClickCount / TotalClickCount, 2)
+  | where MalwareClickCount != 0
+  | top 15 by MalwareClickCount
+  | project User = AccountUpn, MalwareClicks = MalwareClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
@@ -13,8 +13,10 @@ relevantTechniques:
   - T1566
 query: |
   UrlClickEvents
-  | where ThreatTypes == "Phish"
-  | summarize count() by AccountUpn
-  | top 10 by count_
-  | render piechart
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | summarize TotalClickCount = count(), PhishClickCount = countif(ThreatTypes has "Phish") by AccountUpn
+  | extend Bad_Click_Percentage = round(100.0 * PhishClickCount / TotalClickCount, 2)
+  | where PhishClickCount != 0
+  | top 15 by PhishClickCount
+  | project User = AccountUpn, PhishClicks = PhishClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Phish).yaml
@@ -17,6 +17,6 @@ query: |
   | summarize TotalClickCount = count(), PhishClickCount = countif(ThreatTypes has "Phish") by AccountUpn
   | extend Bad_Click_Percentage = round(100.0 * PhishClickCount / TotalClickCount, 2)
   | where PhishClickCount != 0
-  | top 15 by PhishClickCount
+  | top 10 by PhishClickCount
   | project User = AccountUpn, PhishClicks = PhishClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
 version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
@@ -17,6 +17,6 @@ query: |
   | summarize TotalClickCount = count(), SpamClickCount = countif(ThreatTypes has "Spam") by AccountUpn
   | extend Bad_Click_Percentage = round(100.0 * SpamClickCount / TotalClickCount, 2)
   | where SpamClickCount != 0
-  | top 15 by SpamClickCount
+  | top 10 by SpamClickCount
   | project User = AccountUpn, SpamClicks = SpamClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
 version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/URL/Top 10 Users clicking on Malicious URLs (Spam).yaml
@@ -13,8 +13,10 @@ relevantTechniques:
   - T1566
 query: |
   UrlClickEvents
-  | where ThreatTypes == "Spam"
-  | summarize count() by AccountUpn
-  | top 10 by count_
-  | render piechart
-version: 1.0.0
+  | where Timestamp > ago(30d)
+  | summarize TotalClickCount = count(), SpamClickCount = countif(ThreatTypes has "Spam") by AccountUpn
+  | extend Bad_Click_Percentage = round(100.0 * SpamClickCount / TotalClickCount, 2)
+  | where SpamClickCount != 0
+  | top 15 by SpamClickCount
+  | project User = AccountUpn, SpamClicks = SpamClickCount, TotalClicks = TotalClickCount, Bad_Click_Percentage
+version: 1.1.0


### PR DESCRIPTION
### Change(s)
Adds 4 Advanced Hunting queries (Hunting Queries + Microsoft Defender XDR solution copies): Top Clicks on Malicious URLs; Spam Detections by Sender Country; Top Recipients Receiving Threats Delivered by Override; Top Sender Domains Delivering Threats via Override (with Tenant Allow/Block List guidance).
Improves 14 existing queries for accuracy and portability: URL top-clicker queries add Total Clicks + Bad-Click %; the spam detection-technology query replaces an eight-way union with a single mv-expand; spam IP/geo and related queries switch TimeGenerated to Timestamp (native advanced-hunting column, so they run in tenants without Sentinel) and add arg_max de-duplication + OrgLevelPolicy exclusions; top spam sender domains and recipients gain Total Inbound + Bad-Traffic % columns.

### Reason for Change(s)
Shares URL-click, spam and override hunting queries from the Microsoft Defender for Office 365 Detections and Insights workbook, and improves the accuracy and portability of the related existing queries.

### Solution Version: N/A
### Testing Completed: Yes
### Checked that the validations are passing: Yes