### PR TITLE
Add SOC and remediation hunting queries; improve quarantine and post-delivery queries

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
@@ -18,7 +18,7 @@ query: |
   let maxTime = startofday(now());
   EmailEvents
   | where Timestamp >= minTime
-  | where DetectionMethods has "Phish" and DeliveryLocation == "Quarantine"
+  | where EmailDirection == "Inbound" and DetectionMethods has "Phish" and DeliveryLocation == "Quarantine"
   | mv-expand Details = parse_json(DetectionMethods).Phish to typeof(string)
   | where isnotempty(Details)
   | where Timestamp < maxTime

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
@@ -14,92 +14,15 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let TimeStart = startofday(ago(30d));
-  let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
-  | where Timestamp >= TimeStart
-  | where DetectionMethods has "Phish" and DeliveryLocation == "Quarantine";
-  let ml=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Advanced filter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Advanced filter";
-  let camp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Campaign'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Campaign";
-  let fd=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'File detonation' and Phish !has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation";
-  let fdr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation reputation";
-  let frp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Fingerprint matching' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Fingerprint matching";
-  let gf=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'General filter' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "General filter";
-  let bimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Impersonation brand' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Impersonation brand";
-  let dimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Impersonation domain' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Impersonation domain";
-  let uimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Impersonation user' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Impersonation user";
-  let mimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Mailbox intelligence impersonation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Mailbox intelligence impersonation";
-  let sdmarc=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Spoof DMARC' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Spoof DMARC";
-  let spoofe=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Spoof external domain' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Spoof external domain";
-  let spoofi=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Spoof intra-org' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Spoof intra-org";
-  let ud=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'URL detonation' and Phish !has 'URL detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation";
-  let udr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'URL detonation reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation reputation";
-  let umr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'URL malicious reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL malicious reputation";
-  union ml,camp,fd,fdr,frp,gf,bimp,dimp,uimp,mimp,sdmarc,spoofe,spoofi,ud,udr,umr
+  let minTime = startofday(ago(30d));
+  let maxTime = startofday(now());
+  EmailEvents
+  | where Timestamp >= minTime
+  | where DetectionMethods has "Phish" and DeliveryLocation == "Quarantine"
+  | mv-expand Details = parse_json(DetectionMethods).Phish to typeof(string)
+  | where isnotempty(Details)
+  | where Timestamp < maxTime
+  | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
   | project Count, Details, Timestamp
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Phish reason.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Phish reason.yaml
@@ -15,7 +15,11 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
+  | where Timestamp > ago(30d)
   | where EmailDirection == "Inbound" and DetectionMethods has 'Phish' and DeliveryLocation == "Quarantine"
-  | project DT=parse_json(DetectionMethods)| evaluate bag_unpack(DT)| summarize count() by Phish=tostring(column_ifexists('Phish', ''))
+  | mv-expand Phish = parse_json(DetectionMethods).Phish to typeof(string)
+  | where isnotempty(Phish)
+  | summarize count() by Phish
+  | sort by count_ desc
   | render piechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
@@ -17,12 +17,13 @@ query: |
   let Quarantine_Releases = toscalar(EmailPostDeliveryEvents
   | where Timestamp > ago(30d)
   | where Action == "Quarantine release"
-  | join kind=leftouter (EmailEvents | where Timestamp > ago(30d) | where DeliveryLocation == "Quarantine") on NetworkMessageId
-  | summarize count());
+  | distinct NetworkMessageId, RecipientEmailAddress
+  | count);
   let Quarantined_Mailflow = toscalar(EmailEvents
   | where Timestamp > ago(30d)
   | where DeliveryLocation == "Quarantine"
-  | summarize count());
+  | distinct NetworkMessageId, RecipientEmailAddress
+  | count);
   print
   Quarantine_Releases = toreal(Quarantine_Releases),
   Quarantined_Mailflow = toreal(Quarantined_Mailflow),

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
@@ -1,0 +1,30 @@
+id: 5fb333a4-39bb-474b-ab37-9efdca8e9182
+name: Quarantine Release Percentage
+description: |
+  This query calculates the percentage of quarantined emails that were subsequently released, out of the total quarantined.
+description-detailed: |
+  This query calculates the percentage of quarantined emails in Microsoft Defender for Office 365 that were subsequently released (EmailPostDeliveryEvents Action == "Quarantine release") out of the total quarantined (EmailEvents DeliveryLocation == "Quarantine"). The percentage is guarded against a zero denominator.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let Quarantine_Releases = toscalar(EmailPostDeliveryEvents
+  | where Timestamp > ago(30d)
+  | where Action == "Quarantine release"
+  | join kind=leftouter (EmailEvents | where Timestamp > ago(30d) | where DeliveryLocation == "Quarantine") on NetworkMessageId
+  | summarize count());
+  let Quarantined_Mailflow = toscalar(EmailEvents
+  | where Timestamp > ago(30d)
+  | where DeliveryLocation == "Quarantine"
+  | summarize count());
+  print
+  Quarantine_Releases = toreal(Quarantine_Releases),
+  Quarantined_Mailflow = toreal(Quarantined_Mailflow),
+  Release_Percentage = iff(Quarantined_Mailflow == 0, 0.0, round((toreal(Quarantine_Releases) / toreal(Quarantined_Mailflow)) * 100, 2))
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
@@ -14,55 +14,15 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let TimeStart = startofday(ago(30d));
-  let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
-  | where Timestamp >= TimeStart
-  | where DetectionMethods has "Spam" and DeliveryLocation == "Quarantine";
-  let timerange = 
-  baseQuery
-  | summarize minTime = min(Timestamp), maxTime = max(Timestamp);
-  let ml=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Advanced filter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Advanced filter";
-  let gf=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'General filter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "General filter";
-  let bl=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'BulkFilter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "BulkFilter";
-  let mx=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Mixed analysis detection'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Mixed analysis detection";
-  let frp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Fingerprint matching'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Fingerprint matching";
-  let umr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'URL malicious reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL malicious reputation";
-  let dr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Domain reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Domain reputation";
-  let ipr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'IP reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "IP reputation";
-  union ml,gf,bl,mx,frp,umr,dr,ipr
+  let minTime = startofday(ago(30d));
+  let maxTime = startofday(now());
+  EmailEvents
+  | where Timestamp >= minTime
+  | where DetectionMethods has "Spam" and DeliveryLocation == "Quarantine"
+  | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
+  | where isnotempty(Details)
+  | where Timestamp < maxTime
+  | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
   | project Count, Details, Timestamp
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
@@ -18,7 +18,7 @@ query: |
   let maxTime = startofday(now());
   EmailEvents
   | where Timestamp >= minTime
-  | where DetectionMethods has "Spam" and DeliveryLocation == "Quarantine"
+  | where EmailDirection == "Inbound" and DetectionMethods has "Spam" and DeliveryLocation == "Quarantine"
   | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
   | where isnotempty(Details)
   | where Timestamp < maxTime

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Spam reason.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Spam reason.yaml
@@ -15,7 +15,11 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
+  | where Timestamp > ago(30d)
   | where EmailDirection == "Inbound" and DetectionMethods has 'Spam' and DeliveryLocation == "Quarantine"
-  | project DT=parse_json(DetectionMethods)| evaluate bag_unpack(DT)| summarize count() by Spam=tostring(column_ifexists('Spam', ''))
+  | mv-expand Spam = parse_json(DetectionMethods).Spam to typeof(string)
+  | where isnotempty(Spam)
+  | summarize count() by Spam
+  | sort by count_ desc
   | render piechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
@@ -1,0 +1,52 @@
+id: e13d7b0c-1cfa-41dd-a5cf-45d598055cef
+name: Automated Investigation Outcomes by Day
+description: |
+  This query summarizes daily automated investigation outcomes (threat detected versus clean) by correlating automated remediation events with alert evidence, using the EmailPostDeliveryEvents and AlertEvidence tables.
+description-detailed: |
+  This query classifies each automated remediation as Threat Detected or Clean by deriving the verdict from AlertEvidence (last verdict, threat analysis summary, and threat intelligence), weighting mail clusters by their message count, and summarizes the daily volume of each outcome, so SOC teams can see how many post-delivery investigations actually caught a threat.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailPostDeliveryEvents
+  - AlertEvidence
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let AutoRemediations =
+      EmailPostDeliveryEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "Automated Remediation"
+      | summarize arg_max(Timestamp, ActionResult) by NetworkMessageId, RecipientEmailAddress
+      | project NetworkMessageId, RecipientEmailAddress, Timestamp;
+  let EvidenceVerdicts =
+      AlertEvidence
+      | where Timestamp > ago(30d)
+      | where EntityType in ("MailMessage", "MailCluster")
+      | extend extra = todynamic(AdditionalFields)
+      | extend networkIds = iff(
+          isnull(extra.NetworkMessageIds) or array_length(extra.NetworkMessageIds) == 0,
+          pack_array(NetworkMessageId),
+          extra.NetworkMessageIds)
+      | mv-expand nmID = networkIds
+      | extend lastVerdict = tolower(tostring(extra.LastVerdict)),
+               threatAIList = extra.ThreatAnalysisSummary,
+               threatInt = extra.ThreatIntelligence
+      | extend verdictFromAnalysis = iff(array_length(threatAIList) > 0, tolower(tostring(threatAIList[0].Verdict)), ""),
+               verdictTI = iff(array_length(threatInt) > 0, "malicious", "")
+      | extend ThreatDetectedFlag = case(
+          lastVerdict in ("malicious", "suspicious") or verdictFromAnalysis in ("malicious", "suspicious") or verdictTI == "malicious",
+          true, false)
+      | extend MailCountInt = toint(extra.MailCount)
+      | extend Weight = iff(EntityType == "MailCluster", coalesce(MailCountInt, 1), 1)
+      | summarize IsThreatDetected = any(ThreatDetectedFlag), WeightSum = sum(Weight) by nmID = tostring(nmID);
+  AutoRemediations
+  | join kind=leftouter EvidenceVerdicts on $left.NetworkMessageId == $right.nmID
+  | extend isThreat = coalesce(IsThreatDetected, false), effectiveWeight = coalesce(WeightSum, 1)
+  | extend InvestigationOutcome = iif(isThreat, "Threat Detected", "Clean")
+  | summarize PreventionCount = sum(effectiveWeight) by Day = bin(Timestamp, 1d), InvestigationOutcome
+  | order by Day asc, InvestigationOutcome asc
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
@@ -41,7 +41,7 @@ query: |
           true, false)
       | extend MailCountInt = toint(extra.MailCount)
       | extend Weight = iff(EntityType == "MailCluster", coalesce(MailCountInt, 1), 1)
-      | summarize IsThreatDetected = any(ThreatDetectedFlag), WeightSum = sum(Weight) by nmID = tostring(nmID);
+      | summarize IsThreatDetected = any(ThreatDetectedFlag), WeightSum = max(Weight) by nmID = tostring(nmID);
   AutoRemediations
   | join kind=leftouter EvidenceVerdicts on $left.NetworkMessageId == $right.nmID
   | extend isThreat = coalesce(IsThreatDetected, false), effectiveWeight = coalesce(WeightSum, 1)

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
@@ -22,7 +22,7 @@ query: |
     | summarize FirstDelivery = min(Timestamp) by MsgKey, Threat = tostring(ThreatTypes);
   let remediations = EmailPostDeliveryEvents
     | where Timestamp > ago(30d)
-    | where ActionType =~ "Automated Remediation"
+    | where ActionType == "Automated Remediation"
     | extend MsgKey = strcat(NetworkMessageId, "-", RecipientEmailAddress)
     | summarize FirstRemediation = min(Timestamp) by MsgKey;
   deliveries

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
@@ -1,0 +1,34 @@
+id: 094266b5-c2ef-4818-8558-cfacdb267d23
+name: Automated Remediation Delivery to Action Latency
+description: |
+  This query measures how long after delivery Microsoft Defender for Office 365 automated remediation acts on a message, reported as daily average and percentiles, using the EmailEvents and EmailPostDeliveryEvents tables.
+description-detailed: |
+  The delay between a threat email being delivered and automated remediation removing it is a key Security Operations metric. This query joins delivered emails to their automated remediation events and reports the daily average, P80, P90 and P99 delay in minutes, so SOC teams can track and improve time-to-remediation.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let deliveries = EmailEvents
+    | where Timestamp > ago(30d)
+    | where DeliveryAction == "Delivered"
+    | extend MsgKey = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+    | summarize FirstDelivery = min(Timestamp) by MsgKey, Threat = tostring(ThreatTypes);
+  let remediations = EmailPostDeliveryEvents
+    | where Timestamp > ago(30d)
+    | where ActionType =~ "Automated Remediation"
+    | extend MsgKey = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+    | summarize FirstRemediation = min(Timestamp) by MsgKey;
+  deliveries
+  | join kind=inner remediations on MsgKey
+  | extend DelayMinutes = datetime_diff("minute", FirstRemediation, FirstDelivery)
+  | where DelayMinutes >= 0
+  | summarize ['Avg (min)'] = avg(DelayMinutes), ['P80 (min)'] = percentile(DelayMinutes, 80), ['P90 (min)'] = percentile(DelayMinutes, 90), ['P99 (min)'] = percentile(DelayMinutes, 99), CountEmails = count() by bin(FirstRemediation, 1d)
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
@@ -16,7 +16,7 @@ relevantTechniques:
 query: |
   EmailPostDeliveryEvents
   | where Timestamp > ago(30d)
-  | where ActionType =~ "Automated Remediation"
+  | where ActionType == "Automated Remediation"
   | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
   | summarize arg_max(Timestamp, *) by Key
   | summarize Count = count() by bin(Timestamp, 1d), ActionResult

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
@@ -1,0 +1,24 @@
+id: e189343d-f3f1-4d2d-a82e-29b4619d9091
+name: Automated Remediation Efficiency Over Time
+description: |
+  This query trends the outcome (success versus failure) of Microsoft Defender for Office 365 automated remediation actions over time, using the EmailPostDeliveryEvents table.
+description-detailed: |
+  Automated Investigation and Response (AIR) can remediate malicious mail after delivery. This query counts automated remediation events by result over time, deduplicated to the latest event per message and recipient, so SOC teams can see whether automated remediation is succeeding and spot spikes in failures that warrant attention.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailPostDeliveryEvents
+  | where Timestamp > ago(30d)
+  | where ActionType =~ "Automated Remediation"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize Count = count() by bin(Timestamp, 1d), ActionResult
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Manual versus Automatic Approval.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Remediation/Automated Remediation Manual versus Automatic Approval.yaml
@@ -1,0 +1,24 @@
+id: 6782a329-feee-4dbc-bbca-d31cb12e1437
+name: Automated Remediation Manual versus Automatic Approval
+description: |
+  This query shows whether Microsoft Defender for Office 365 automated remediation actions were taken automatically or required manual admin approval, using the EmailPostDeliveryEvents table.
+description-detailed: |
+  Automated Investigation and Response actions can be fully automatic or held for manual approval. This query breaks down automated remediation events by their trigger (automatic versus manual approval), deduplicated to the latest event per message and recipient, so teams can understand how much of their remediation is hands-off versus analyst-gated.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailPostDeliveryEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ActionType == "Automated Remediation"
+  | summarize count() by ActionTrigger
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Top Attacks/Largest Malicious Email Campaigns by Cluster.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Top Attacks/Largest Malicious Email Campaigns by Cluster.yaml
@@ -1,0 +1,34 @@
+id: cb73a6da-421d-4596-92e5-0984e02ece9e
+name: Largest Malicious Email Campaigns by Cluster
+description: |
+  This query surfaces the largest malicious inbound email campaigns, clustered by EmailClusterId, with one row per attack wave, using the EmailEvents table.
+description-detailed: |
+  Microsoft Defender for Office 365 groups related malicious messages into campaigns via EmailClusterId. This query returns the top campaigns by message volume, deduplicated to the latest record per message and recipient, with the number of messages and recipients, distinct sender domains, the mix of threat types, and sample subjects, so analysts can quickly triage the biggest attack waves.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and EmailClusterId > 0
+  | where OrgLevelPolicy !in ("Phishing simulation", "SecOps Mailbox")
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize Messages = count(),
+              Recipients = dcount(RecipientEmailAddress),
+              SenderDomains = dcount(SenderFromDomain),
+              ThreatTypesRaw = make_set(ThreatTypes, 50),
+              SampleSubjects = make_set(Subject, 5),
+              FirstSeen = min(Timestamp),
+              LastSeen = max(Timestamp)
+          by EmailClusterId
+  | extend ThreatMix = array_sort_asc(set_union(split(strcat_array(ThreatTypesRaw, ", "), ", "), dynamic([])))
+  | top 20 by Messages
+  | project ['Email Cluster ID']=EmailClusterId, ['Messages']=Messages, ['Recipients']=Recipients, ['Sender Domains']=SenderDomains, ['Threat Mix']=ThreatMix, ['Sample Subjects']=SampleSubjects, ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/ZAP/Post Delivery Events by Admin.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/ZAP/Post Delivery Events by Admin.yaml
@@ -14,32 +14,16 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let TimeStart = startofday(ago(30d));
-  let TimeEnd = startofday(now());
-  let baseQuery = EmailPostDeliveryEvents
-  | where Timestamp >= TimeStart
-  | where ActionTrigger has "AdminAction";
-  let sdelete=baseQuery
-  | where Action has 'Soft Delete'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Soft Delete";
-  let hdelete=baseQuery
-  | where Action has 'Hard Delete'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Hard Delete";
-  let mtojunk=baseQuery
-  | where Action has 'Moved to junk folder'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Moved to junk folder";
-  let mtoinbox=baseQuery
-  | where Action has 'Moved to inbox'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Moved to inbox";
-  let qrel=baseQuery
-  | where Action has 'Quarantine release'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Quarantine release";
-  union sdelete,hdelete,mtojunk,mtoinbox,qrel
-  | project Count, Details, Timestamp
+  let gran = 1d;
+  let minTime = startofday(ago(30d));
+  let maxTime = startofday(now());
+  let agg = materialize(EmailPostDeliveryEvents
+      | where Timestamp >= minTime and Timestamp < maxTime
+      | where ActionTrigger has "AdminAction"
+      | summarize ["Soft Delete"] = countif(Action has 'Soft Delete'), ["Hard Delete"] = countif(Action has 'Hard Delete'), ["Moved to junk folder"] = countif(Action has 'Moved to junk folder'), ["Moved to inbox"] = countif(Action has 'Moved to inbox'), ["Quarantine release"] = countif(Action has 'Quarantine release') by Timestamp = bin(Timestamp, gran));
+  range Timestamp from minTime to maxTime - 1d step gran
+  | join kind=leftouter (agg) on Timestamp
+  | project Timestamp, ["Soft Delete"] = coalesce(["Soft Delete"], 0), ["Hard Delete"] = coalesce(["Hard Delete"], 0), ["Moved to junk folder"] = coalesce(["Moved to junk folder"], 0), ["Moved to inbox"] = coalesce(["Moved to inbox"], 0), ["Quarantine release"] = coalesce(["Quarantine release"], 0)
+  | sort by Timestamp asc
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
@@ -16,22 +16,9 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  let baseQuery = EmailPostDeliveryEvents
+  EmailPostDeliveryEvents
   | where Timestamp >= TimeStart
-  | where ActionType has "ZAP";
-  let szap=baseQuery
-  | where ActionType has 'Spam ZAP'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Spam ZAP";
-  let pzap=baseQuery
-  | where ActionType has 'Phish ZAP'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Phish ZAP";
-  let mzap=baseQuery
-  | where ActionType has 'Malware ZAP'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Malware ZAP";
-  union szap,pzap,mzap
-  | project Count, Details, Timestamp
+  | where ActionType has "ZAP"
+  | make-series ['Spam ZAP'] = countif(ActionType has 'Spam ZAP'), ['Phish ZAP'] = countif(ActionType has 'Phish ZAP'), ['Malware ZAP'] = countif(ActionType has 'Malware ZAP') default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
@@ -19,6 +19,7 @@ query: |
   EmailPostDeliveryEvents
   | where Timestamp >= TimeStart
   | where ActionType has "ZAP"
+  | where Timestamp < TimeEnd
   | make-series ['Spam ZAP'] = countif(ActionType has 'Spam ZAP'), ['Phish ZAP'] = countif(ActionType has 'Phish ZAP'), ['Malware ZAP'] = countif(ActionType has 'Malware ZAP') default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
 version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
@@ -18,7 +18,7 @@ query: |
   let maxTime = startofday(now());
   EmailEvents
   | where Timestamp >= minTime
-  | where DetectionMethods has "Phish" and DeliveryLocation == "Quarantine"
+  | where EmailDirection == "Inbound" and DetectionMethods has "Phish" and DeliveryLocation == "Quarantine"
   | mv-expand Details = parse_json(DetectionMethods).Phish to typeof(string)
   | where isnotempty(Details)
   | where Timestamp < maxTime

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Phish reason trend.yaml
@@ -14,92 +14,15 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let TimeStart = startofday(ago(30d));
-  let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
-  | where TimeGenerated >= TimeStart
-  | where DetectionMethods has "Phish" and DeliveryLocation == "Quarantine";
-  let ml=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Advanced filter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Advanced filter";
-  let camp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Campaign'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Campaign";
-  let fd=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'File detonation' and Phish !has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation";
-  let fdr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'File detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "File detonation reputation";
-  let frp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Fingerprint matching' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Fingerprint matching";
-  let gf=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'General filter' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "General filter";
-  let bimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Impersonation brand' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Impersonation brand";
-  let dimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Impersonation domain' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Impersonation domain";
-  let uimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Impersonation user' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Impersonation user";
-  let mimp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Mailbox intelligence impersonation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Mailbox intelligence impersonation";
-  let sdmarc=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Spoof DMARC' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Spoof DMARC";
-  let spoofe=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Spoof external domain' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Spoof external domain";
-  let spoofi=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'Spoof intra-org' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Spoof intra-org";
-  let ud=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'URL detonation' and Phish !has 'URL detonation reputation'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation";
-  let udr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'URL detonation reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL detonation reputation";
-  let umr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Phish has 'URL malicious reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL malicious reputation";
-  union ml,camp,fd,fdr,frp,gf,bimp,dimp,uimp,mimp,sdmarc,spoofe,spoofi,ud,udr,umr
+  let minTime = startofday(ago(30d));
+  let maxTime = startofday(now());
+  EmailEvents
+  | where Timestamp >= minTime
+  | where DetectionMethods has "Phish" and DeliveryLocation == "Quarantine"
+  | mv-expand Details = parse_json(DetectionMethods).Phish to typeof(string)
+  | where isnotempty(Details)
+  | where Timestamp < maxTime
+  | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
   | project Count, Details, Timestamp
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Phish reason.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Phish reason.yaml
@@ -15,7 +15,11 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
+  | where Timestamp > ago(30d)
   | where EmailDirection == "Inbound" and DetectionMethods has 'Phish' and DeliveryLocation == "Quarantine"
-  | project DT=parse_json(DetectionMethods)| evaluate bag_unpack(DT)| summarize count() by Phish=tostring(column_ifexists('Phish', ''))
+  | mv-expand Phish = parse_json(DetectionMethods).Phish to typeof(string)
+  | where isnotempty(Phish)
+  | summarize count() by Phish
+  | sort by count_ desc
   | render piechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
@@ -17,12 +17,13 @@ query: |
   let Quarantine_Releases = toscalar(EmailPostDeliveryEvents
   | where Timestamp > ago(30d)
   | where Action == "Quarantine release"
-  | join kind=leftouter (EmailEvents | where Timestamp > ago(30d) | where DeliveryLocation == "Quarantine") on NetworkMessageId
-  | summarize count());
+  | distinct NetworkMessageId, RecipientEmailAddress
+  | count);
   let Quarantined_Mailflow = toscalar(EmailEvents
   | where Timestamp > ago(30d)
   | where DeliveryLocation == "Quarantine"
-  | summarize count());
+  | distinct NetworkMessageId, RecipientEmailAddress
+  | count);
   print
   Quarantine_Releases = toreal(Quarantine_Releases),
   Quarantined_Mailflow = toreal(Quarantined_Mailflow),

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Release Percentage.yaml
@@ -1,0 +1,30 @@
+id: 60cf8dc6-b3f7-4bd9-b877-3ed9c9443750
+name: Quarantine Release Percentage
+description: |
+  This query calculates the percentage of quarantined emails that were subsequently released, out of the total quarantined.
+description-detailed: |
+  This query calculates the percentage of quarantined emails in Microsoft Defender for Office 365 that were subsequently released (EmailPostDeliveryEvents Action == "Quarantine release") out of the total quarantined (EmailEvents DeliveryLocation == "Quarantine"). The percentage is guarded against a zero denominator.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let Quarantine_Releases = toscalar(EmailPostDeliveryEvents
+  | where Timestamp > ago(30d)
+  | where Action == "Quarantine release"
+  | join kind=leftouter (EmailEvents | where Timestamp > ago(30d) | where DeliveryLocation == "Quarantine") on NetworkMessageId
+  | summarize count());
+  let Quarantined_Mailflow = toscalar(EmailEvents
+  | where Timestamp > ago(30d)
+  | where DeliveryLocation == "Quarantine"
+  | summarize count());
+  print
+  Quarantine_Releases = toreal(Quarantine_Releases),
+  Quarantined_Mailflow = toreal(Quarantined_Mailflow),
+  Release_Percentage = iff(Quarantined_Mailflow == 0, 0.0, round((toreal(Quarantine_Releases) / toreal(Quarantined_Mailflow)) * 100, 2))
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
@@ -18,7 +18,7 @@ query: |
   let maxTime = startofday(now());
   EmailEvents
   | where Timestamp >= minTime
-  | where DetectionMethods has "Spam" and DeliveryLocation == "Quarantine"
+  | where EmailDirection == "Inbound" and DetectionMethods has "Spam" and DeliveryLocation == "Quarantine"
   | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
   | where isnotempty(Details)
   | where Timestamp < maxTime

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Spam reason trend.yaml
@@ -14,55 +14,15 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let TimeStart = startofday(ago(30d));
-  let TimeEnd = startofday(now());
-  let baseQuery = EmailEvents
-  | where TimeGenerated >= TimeStart
-  | where DetectionMethods has "Spam" and DeliveryLocation == "Quarantine";
-  let timerange = 
-  baseQuery
-  | summarize minTime = min(Timestamp), maxTime = max(Timestamp);
-  let ml=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Advanced filter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Advanced filter";
-  let gf=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'General filter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "General filter";
-  let bl=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'BulkFilter'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "BulkFilter";
-  let mx=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Mixed analysis detection'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Mixed analysis detection";
-  let frp=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Fingerprint matching'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Fingerprint matching";
-  let umr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'URL malicious reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "URL malicious reputation";
-  let dr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'Domain reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "Domain reputation";
-  let ipr=baseQuery
-  | project Timestamp,RecipientEmailAddress,NetworkMessageId, DT=parse_json(DetectionMethods) | evaluate bag_unpack(DT) 
-  | where Spam has 'IP reputation' 
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d 
-  | extend Details = "IP reputation";
-  union ml,gf,bl,mx,frp,umr,dr,ipr
+  let minTime = startofday(ago(30d));
+  let maxTime = startofday(now());
+  EmailEvents
+  | where Timestamp >= minTime
+  | where DetectionMethods has "Spam" and DeliveryLocation == "Quarantine"
+  | mv-expand Details = parse_json(DetectionMethods).Spam to typeof(string)
+  | where isnotempty(Details)
+  | where Timestamp < maxTime
+  | make-series Count = count() default = 0 on Timestamp from minTime to maxTime step 1d by Details
   | project Count, Details, Timestamp
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Spam reason.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Spam reason.yaml
@@ -15,7 +15,11 @@ relevantTechniques:
   - T1566
 query: |
   EmailEvents
+  | where Timestamp > ago(30d)
   | where EmailDirection == "Inbound" and DetectionMethods has 'Spam' and DeliveryLocation == "Quarantine"
-  | project DT=parse_json(DetectionMethods)| evaluate bag_unpack(DT)| summarize count() by Spam=tostring(column_ifexists('Spam', ''))
+  | mv-expand Spam = parse_json(DetectionMethods).Spam to typeof(string)
+  | where isnotempty(Spam)
+  | summarize count() by Spam
+  | sort by count_ desc
   | render piechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
@@ -41,7 +41,7 @@ query: |
           true, false)
       | extend MailCountInt = toint(extra.MailCount)
       | extend Weight = iff(EntityType == "MailCluster", coalesce(MailCountInt, 1), 1)
-      | summarize IsThreatDetected = any(ThreatDetectedFlag), WeightSum = sum(Weight) by nmID = tostring(nmID);
+      | summarize IsThreatDetected = any(ThreatDetectedFlag), WeightSum = max(Weight) by nmID = tostring(nmID);
   AutoRemediations
   | join kind=leftouter EvidenceVerdicts on $left.NetworkMessageId == $right.nmID
   | extend isThreat = coalesce(IsThreatDetected, false), effectiveWeight = coalesce(WeightSum, 1)

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Investigation Outcomes by Day.yaml
@@ -1,0 +1,52 @@
+id: 8c86aaf1-46c1-4eee-8953-60f163e83253
+name: Automated Investigation Outcomes by Day
+description: |
+  This query summarizes daily automated investigation outcomes (threat detected versus clean) by correlating automated remediation events with alert evidence, using the EmailPostDeliveryEvents and AlertEvidence tables.
+description-detailed: |
+  This query classifies each automated remediation as Threat Detected or Clean by deriving the verdict from AlertEvidence (last verdict, threat analysis summary, and threat intelligence), weighting mail clusters by their message count, and summarizes the daily volume of each outcome, so SOC teams can see how many post-delivery investigations actually caught a threat.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailPostDeliveryEvents
+  - AlertEvidence
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let AutoRemediations =
+      EmailPostDeliveryEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "Automated Remediation"
+      | summarize arg_max(Timestamp, ActionResult) by NetworkMessageId, RecipientEmailAddress
+      | project NetworkMessageId, RecipientEmailAddress, Timestamp;
+  let EvidenceVerdicts =
+      AlertEvidence
+      | where Timestamp > ago(30d)
+      | where EntityType in ("MailMessage", "MailCluster")
+      | extend extra = todynamic(AdditionalFields)
+      | extend networkIds = iff(
+          isnull(extra.NetworkMessageIds) or array_length(extra.NetworkMessageIds) == 0,
+          pack_array(NetworkMessageId),
+          extra.NetworkMessageIds)
+      | mv-expand nmID = networkIds
+      | extend lastVerdict = tolower(tostring(extra.LastVerdict)),
+               threatAIList = extra.ThreatAnalysisSummary,
+               threatInt = extra.ThreatIntelligence
+      | extend verdictFromAnalysis = iff(array_length(threatAIList) > 0, tolower(tostring(threatAIList[0].Verdict)), ""),
+               verdictTI = iff(array_length(threatInt) > 0, "malicious", "")
+      | extend ThreatDetectedFlag = case(
+          lastVerdict in ("malicious", "suspicious") or verdictFromAnalysis in ("malicious", "suspicious") or verdictTI == "malicious",
+          true, false)
+      | extend MailCountInt = toint(extra.MailCount)
+      | extend Weight = iff(EntityType == "MailCluster", coalesce(MailCountInt, 1), 1)
+      | summarize IsThreatDetected = any(ThreatDetectedFlag), WeightSum = sum(Weight) by nmID = tostring(nmID);
+  AutoRemediations
+  | join kind=leftouter EvidenceVerdicts on $left.NetworkMessageId == $right.nmID
+  | extend isThreat = coalesce(IsThreatDetected, false), effectiveWeight = coalesce(WeightSum, 1)
+  | extend InvestigationOutcome = iif(isThreat, "Threat Detected", "Clean")
+  | summarize PreventionCount = sum(effectiveWeight) by Day = bin(Timestamp, 1d), InvestigationOutcome
+  | order by Day asc, InvestigationOutcome asc
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
@@ -1,0 +1,34 @@
+id: 3027abf0-a965-42bd-babe-79f34bbd9e7a
+name: Automated Remediation Delivery to Action Latency
+description: |
+  This query measures how long after delivery Microsoft Defender for Office 365 automated remediation acts on a message, reported as daily average and percentiles, using the EmailEvents and EmailPostDeliveryEvents tables.
+description-detailed: |
+  The delay between a threat email being delivered and automated remediation removing it is a key Security Operations metric. This query joins delivered emails to their automated remediation events and reports the daily average, P80, P90 and P99 delay in minutes, so SOC teams can track and improve time-to-remediation.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let deliveries = EmailEvents
+    | where Timestamp > ago(30d)
+    | where DeliveryAction == "Delivered"
+    | extend MsgKey = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+    | summarize FirstDelivery = min(Timestamp) by MsgKey, Threat = tostring(ThreatTypes);
+  let remediations = EmailPostDeliveryEvents
+    | where Timestamp > ago(30d)
+    | where ActionType =~ "Automated Remediation"
+    | extend MsgKey = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+    | summarize FirstRemediation = min(Timestamp) by MsgKey;
+  deliveries
+  | join kind=inner remediations on MsgKey
+  | extend DelayMinutes = datetime_diff("minute", FirstRemediation, FirstDelivery)
+  | where DelayMinutes >= 0
+  | summarize ['Avg (min)'] = avg(DelayMinutes), ['P80 (min)'] = percentile(DelayMinutes, 80), ['P90 (min)'] = percentile(DelayMinutes, 90), ['P99 (min)'] = percentile(DelayMinutes, 99), CountEmails = count() by bin(FirstRemediation, 1d)
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Delivery to Action Latency.yaml
@@ -22,7 +22,7 @@ query: |
     | summarize FirstDelivery = min(Timestamp) by MsgKey, Threat = tostring(ThreatTypes);
   let remediations = EmailPostDeliveryEvents
     | where Timestamp > ago(30d)
-    | where ActionType =~ "Automated Remediation"
+    | where ActionType == "Automated Remediation"
     | extend MsgKey = strcat(NetworkMessageId, "-", RecipientEmailAddress)
     | summarize FirstRemediation = min(Timestamp) by MsgKey;
   deliveries

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
@@ -16,7 +16,7 @@ relevantTechniques:
 query: |
   EmailPostDeliveryEvents
   | where Timestamp > ago(30d)
-  | where ActionType =~ "Automated Remediation"
+  | where ActionType == "Automated Remediation"
   | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
   | summarize arg_max(Timestamp, *) by Key
   | summarize Count = count() by bin(Timestamp, 1d), ActionResult

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Efficiency Over Time.yaml
@@ -1,0 +1,24 @@
+id: ca968fd4-2778-4bca-9da3-2dd1f1b38746
+name: Automated Remediation Efficiency Over Time
+description: |
+  This query trends the outcome (success versus failure) of Microsoft Defender for Office 365 automated remediation actions over time, using the EmailPostDeliveryEvents table.
+description-detailed: |
+  Automated Investigation and Response (AIR) can remediate malicious mail after delivery. This query counts automated remediation events by result over time, deduplicated to the latest event per message and recipient, so SOC teams can see whether automated remediation is succeeding and spot spikes in failures that warrant attention.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailPostDeliveryEvents
+  | where Timestamp > ago(30d)
+  | where ActionType =~ "Automated Remediation"
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize Count = count() by bin(Timestamp, 1d), ActionResult
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Manual versus Automatic Approval.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Remediation/Automated Remediation Manual versus Automatic Approval.yaml
@@ -1,0 +1,24 @@
+id: 2a3fe5b0-9a99-467a-b5f9-57825530b22b
+name: Automated Remediation Manual versus Automatic Approval
+description: |
+  This query shows whether Microsoft Defender for Office 365 automated remediation actions were taken automatically or required manual admin approval, using the EmailPostDeliveryEvents table.
+description-detailed: |
+  Automated Investigation and Response actions can be fully automatic or held for manual approval. This query breaks down automated remediation events by their trigger (automatic versus manual approval), deduplicated to the latest event per message and recipient, so teams can understand how much of their remediation is hands-off versus analyst-gated.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailPostDeliveryEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailPostDeliveryEvents
+  | where Timestamp > ago(30d)
+  | extend Key = strcat(NetworkMessageId, '-', RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | where ActionType == "Automated Remediation"
+  | summarize count() by ActionTrigger
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Top Attacks/Largest Malicious Email Campaigns by Cluster.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Top Attacks/Largest Malicious Email Campaigns by Cluster.yaml
@@ -1,0 +1,34 @@
+id: a92a3921-1a71-4a4d-8382-873b689ff7d8
+name: Largest Malicious Email Campaigns by Cluster
+description: |
+  This query surfaces the largest malicious inbound email campaigns, clustered by EmailClusterId, with one row per attack wave, using the EmailEvents table.
+description-detailed: |
+  Microsoft Defender for Office 365 groups related malicious messages into campaigns via EmailClusterId. This query returns the top campaigns by message volume, deduplicated to the latest record per message and recipient, with the number of messages and recipients, distinct sender domains, the mix of threat types, and sample subjects, so analysts can quickly triage the biggest attack waves.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and EmailClusterId > 0
+  | where OrgLevelPolicy !in ("Phishing simulation", "SecOps Mailbox")
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize Messages = count(),
+              Recipients = dcount(RecipientEmailAddress),
+              SenderDomains = dcount(SenderFromDomain),
+              ThreatTypesRaw = make_set(ThreatTypes, 50),
+              SampleSubjects = make_set(Subject, 5),
+              FirstSeen = min(Timestamp),
+              LastSeen = max(Timestamp)
+          by EmailClusterId
+  | extend ThreatMix = array_sort_asc(set_union(split(strcat_array(ThreatTypesRaw, ", "), ", "), dynamic([])))
+  | top 20 by Messages
+  | project ['Email Cluster ID']=EmailClusterId, ['Messages']=Messages, ['Recipients']=Recipients, ['Sender Domains']=SenderDomains, ['Threat Mix']=ThreatMix, ['Sample Subjects']=SampleSubjects, ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/ZAP/Post Delivery Events by Admin.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/ZAP/Post Delivery Events by Admin.yaml
@@ -14,32 +14,16 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let TimeStart = startofday(ago(30d));
-  let TimeEnd = startofday(now());
-  let baseQuery = EmailPostDeliveryEvents
-  | where TimeGenerated >= TimeStart
-  | where ActionTrigger has "AdminAction";
-  let sdelete=baseQuery
-  | where Action has 'Soft Delete'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Soft Delete";
-  let hdelete=baseQuery
-  | where Action has 'Hard Delete'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Hard Delete";
-  let mtojunk=baseQuery
-  | where Action has 'Moved to junk folder'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Moved to junk folder";
-  let mtoinbox=baseQuery
-  | where Action has 'Moved to inbox'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Moved to inbox";
-  let qrel=baseQuery
-  | where Action has 'Quarantine release'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Quarantine release";
-  union sdelete,hdelete,mtojunk,mtoinbox,qrel
-  | project Count, Details, Timestamp
+  let gran = 1d;
+  let minTime = startofday(ago(30d));
+  let maxTime = startofday(now());
+  let agg = materialize(EmailPostDeliveryEvents
+      | where Timestamp >= minTime and Timestamp < maxTime
+      | where ActionTrigger has "AdminAction"
+      | summarize ["Soft Delete"] = countif(Action has 'Soft Delete'), ["Hard Delete"] = countif(Action has 'Hard Delete'), ["Moved to junk folder"] = countif(Action has 'Moved to junk folder'), ["Moved to inbox"] = countif(Action has 'Moved to inbox'), ["Quarantine release"] = countif(Action has 'Quarantine release') by Timestamp = bin(Timestamp, gran));
+  range Timestamp from minTime to maxTime - 1d step gran
+  | join kind=leftouter (agg) on Timestamp
+  | project Timestamp, ["Soft Delete"] = coalesce(["Soft Delete"], 0), ["Hard Delete"] = coalesce(["Hard Delete"], 0), ["Moved to junk folder"] = coalesce(["Moved to junk folder"], 0), ["Moved to inbox"] = coalesce(["Moved to inbox"], 0), ["Quarantine release"] = coalesce(["Quarantine release"], 0)
+  | sort by Timestamp asc
   | render timechart
-version: 1.0.0
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
@@ -19,6 +19,7 @@ query: |
   EmailPostDeliveryEvents
   | where Timestamp >= TimeStart
   | where ActionType has "ZAP"
+  | where Timestamp < TimeEnd
   | make-series ['Spam ZAP'] = countif(ActionType has 'Spam ZAP'), ['Phish ZAP'] = countif(ActionType has 'Phish ZAP'), ['Malware ZAP'] = countif(ActionType has 'Malware ZAP') default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
 version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/ZAP/Post Delivery Events by ZAP type.yaml
@@ -16,22 +16,9 @@ relevantTechniques:
 query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
-  let baseQuery = EmailPostDeliveryEvents
-  | where TimeGenerated >= TimeStart
-  | where ActionType has "ZAP";
-  let szap=baseQuery
-  | where ActionType has 'Spam ZAP'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Spam ZAP";
-  let pzap=baseQuery
-  | where ActionType has 'Phish ZAP'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Phish ZAP";
-  let mzap=baseQuery
-  | where ActionType has 'Malware ZAP'
-  | make-series Count= count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
-  | extend Details = "Malware ZAP";
-  union szap,pzap,mzap
-  | project Count, Details, Timestamp
+  EmailPostDeliveryEvents
+  | where Timestamp >= TimeStart
+  | where ActionType has "ZAP"
+  | make-series ['Spam ZAP'] = countif(ActionType has 'Spam ZAP'), ['Phish ZAP'] = countif(ActionType has 'Phish ZAP'), ['Malware ZAP'] = countif(ActionType has 'Malware ZAP') default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | render timechart
-version: 1.0.0
+version: 1.1.0


### PR DESCRIPTION
Adds five hunting queries from the Microsoft Defender for Office 365 workbook's SOC Insights tab: automated remediation efficiency over time, delivery-to-action latency, manual versus automatic approval, automated investigation outcomes by day, and largest malicious email campaigns by cluster. Also updates three existing queries with V4 improvements: the quarantine phish and spam reason trends now use a single mv-expand instead of a per-technique union, and post-delivery events by admin uses a single-pass countif with zero-filled daily buckets. Each query is mirrored to both the Hunting and Solutions locations and renders a chart.