### PR TITLE
Add Email user false-positive submission hunting queries

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
@@ -1,0 +1,25 @@
+id: fa0ce1b0-59fa-4fea-87e8-6752951cec3f
+name: Top accounts performing user submissions (FP)
+description: |
+  This query visualises the top accounts performing user false positive submissions.
+description-detailed: |
+  This query visualises the top accounts performing user false positive submissions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend RawData = parse_json(RawEventData)
+  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), UserId = tostring(RawData.UserId)
+  | where RecordType == 29 and SubmissionType == "3"
+  | summarize count() by UserId
+  | top 15 by count_
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
@@ -17,7 +17,7 @@ query: |
   CloudAppEvents
   | where ActionType == "UserSubmission"
   | extend RawData = parse_json(RawEventData)
-  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), UserId = tostring(RawData.UserId)
+  | extend RecordType = toint(RawData.RecordType), SubmissionType = tostring(RawData.SubmissionType), UserId = tostring(RawData.UserId)
   | where RecordType == 29 and SubmissionType == "3"
   | summarize count() by UserId
   | top 15 by count_

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
@@ -1,0 +1,30 @@
+id: b2c772f0-f6b2-406f-9a80-756b596f0b57
+name: User Email Submissions (FP) - Top Inbound Subjects
+description: |
+  This query visualises the top 10 subjects of inbound emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 subjects of inbound emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by Subject
+  | top 10 by count_
+  | project ['Subject'] = Subject, ['Emails'] = count_
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
@@ -15,15 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient before counting
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound"
-  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by Subject
   | top 10 by count_
   | project ['Subject'] = Subject, ['Emails'] = count_

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
@@ -1,0 +1,30 @@
+id: 2e5e39ae-99f9-4ba0-b5c4-9e76919a0f53
+name: User Email Submissions (FP) - Top Intra-Org P2 Senders
+description: |
+  This query visualises the top 10 intra-org senders of emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 intra-org senders of emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Intra-org"
+  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by SenderMailFromAddress
+  | top 10 by count_
+  | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
@@ -15,15 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient before counting
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Intra-org"
-  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderMailFromAddress
   | top 10 by count_
   | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) sender domains FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) sender domains FP.yaml
@@ -1,0 +1,24 @@
+id: d090ed89-3c2b-4bd7-9b87-d8a5f552e174
+name: User Email Submissions (FP) - Top P2 Sender Domains
+description: |
+  This query visualises the top 10 sender domains of emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 sender domains of emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), P2SenderDomain = tostring((parse_json(RawEventData)).P2SenderDomain)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | summarize count() by P2SenderDomain
+  | top 10 by count_
+  | project ['Sender Domain'] = P2SenderDomain, ['Emails'] = count_
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
@@ -1,0 +1,30 @@
+id: e1973a95-fd22-4669-8758-dba8f9828c8f
+name: User Email Submissions (FP) - Top Inbound P2 Senders
+description: |
+  This query visualises the top 10 inbound senders of emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 inbound senders of emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by SenderMailFromAddress
+  | top 10 by count_
+  | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
@@ -15,15 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient before counting
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound"
-  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderMailFromAddress
   | top 10 by count_
   | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
@@ -1,0 +1,28 @@
+id: 98ed7471-ce5e-4d48-b9f9-dae4cf045b3e
+name: User Email Submission Trend (FP)
+description: |
+  This query visualises the daily amount of user false positive email submissions over time.
+description-detailed: |
+  This query visualises the daily amount of user false positive email submissions over time.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  CloudAppEvents
+  | where Timestamp >= TimeStart
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType)
+  | where SubmissionType == "3" and SubmissionContentType == "Mail"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | extend Details = "User_Email_FP"
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
@@ -17,10 +17,10 @@ query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
   CloudAppEvents
-  | where Timestamp >= TimeStart
+  | where Timestamp >= TimeStart and Timestamp < TimeEnd
   | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType)
-  | where SubmissionType == "3" and SubmissionContentType == "Mail"
+  | extend RawData = parse_json(RawEventData)
+  | where tostring(RawData.SubmissionType) == "3" and tostring(RawData.SubmissionContentType) == "Mail"
   | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | extend Details = "User_Email_FP"
   | project Count, Details, Timestamp

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
@@ -15,16 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient so the verdict is read once
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound" and DetectionMethods has 'Phish'
-  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
-  // Robustly expand the Phish detection sub-methods rather than brittle JSON substring matching
   | mv-expand Phish = parse_json(DetectionMethods).Phish to typeof(string)
   | where isnotempty(Phish)
   | summarize count() by Phish

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
@@ -1,0 +1,32 @@
+id: 5990abd3-7e11-4441-947b-17e60c69f28f
+name: User Submissions by Detection Method - Phish (FP)
+description: |
+  This query visualises user false positive submissions by the original phish filter verdict on the reported message.
+description-detailed: |
+  This query visualises user false positive submissions by the original phish filter verdict on the reported message.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound" and DetectionMethods has 'Phish'
+  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  // Robustly expand the Phish detection sub-methods rather than brittle JSON substring matching
+  | mv-expand Phish = parse_json(DetectionMethods).Phish to typeof(string)
+  | where isnotempty(Phish)
+  | summarize count() by Phish
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
@@ -15,16 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient so the verdict is read once
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound" and DetectionMethods has 'Spam'
-  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
-  // Robustly expand the Spam detection sub-methods rather than brittle JSON substring matching
   | mv-expand Spam = parse_json(DetectionMethods).Spam to typeof(string)
   | where isnotempty(Spam)
   | summarize count() by Spam

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
@@ -1,0 +1,32 @@
+id: 91a1a3f0-1386-4c70-9c66-215f59b2af28
+name: User Submissions by Detection Method - Spam (FP)
+description: |
+  This query visualises user false positive submissions by the original spam filter verdict on the reported message.
+description-detailed: |
+  This query visualises user false positive submissions by the original spam filter verdict on the reported message.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound" and DetectionMethods has 'Spam'
+  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  // Robustly expand the Spam detection sub-methods rather than brittle JSON substring matching
+  | mv-expand Spam = parse_json(DetectionMethods).Spam to typeof(string)
+  | where isnotempty(Spam)
+  | summarize count() by Spam
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
@@ -1,0 +1,24 @@
+id: f8637343-8fbc-48de-b31a-ed4bb68b60f2
+name: User Submissions by Submission State (FP)
+description: |
+  This query visualises user false positive submissions by submission state.
+description-detailed: |
+  This query visualises user false positive submissions by submission state.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend RawData = parse_json(RawEventData)
+  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), SubmissionState = tostring(RawData.SubmissionState)
+  | where RecordType == 29 and SubmissionType == "3"
+  | summarize count() by SubmissionState
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
@@ -17,7 +17,7 @@ query: |
   CloudAppEvents
   | where ActionType == "UserSubmission"
   | extend RawData = parse_json(RawEventData)
-  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), SubmissionState = tostring(RawData.SubmissionState)
+  | extend RecordType = toint(RawData.RecordType), SubmissionType = tostring(RawData.SubmissionType), SubmissionState = tostring(RawData.SubmissionState)
   | where RecordType == 29 and SubmissionType == "3"
   | summarize count() by SubmissionState
   | render piechart

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
@@ -17,7 +17,7 @@ query: |
   CloudAppEvents
   | where ActionType == "UserSubmission"
   | extend RawData = parse_json(RawEventData)
-  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), UserId = tostring(RawData.UserId)
+  | extend RecordType = toint(RawData.RecordType), SubmissionType = tostring(RawData.SubmissionType), UserId = tostring(RawData.UserId)
   | where RecordType == 29 and SubmissionType == "3"
   | summarize count() by UserId
   | top 15 by count_

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top accounts performing user submissions - FP.yaml
@@ -1,0 +1,25 @@
+id: 2bf1fded-7eb8-4cff-9e1d-efd204cac3f6
+name: Top accounts performing user submissions (FP)
+description: |
+  This query visualises the top accounts performing user false positive submissions.
+description-detailed: |
+  This query visualises the top accounts performing user false positive submissions.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend RawData = parse_json(RawEventData)
+  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), UserId = tostring(RawData.UserId)
+  | where RecordType == 29 and SubmissionType == "3"
+  | summarize count() by UserId
+  | top 15 by count_
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
@@ -1,0 +1,30 @@
+id: 3f252bcb-71a8-4c04-bed9-4dd53419ecb6
+name: User Email Submissions (FP) - Top Inbound Subjects
+description: |
+  This query visualises the top 10 subjects of inbound emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 subjects of inbound emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by Subject
+  | top 10 by count_
+  | project ['Subject'] = Subject, ['Emails'] = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Inbound Subjects FP.yaml
@@ -15,15 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient before counting
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound"
-  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by Subject
   | top 10 by count_
   | project ['Subject'] = Subject, ['Emails'] = count_

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
@@ -1,0 +1,30 @@
+id: 6b26701a-a1c7-4782-a662-f44cdca5bb5f
+name: User Email Submissions (FP) - Top Intra-Org P2 Senders
+description: |
+  This query visualises the top 10 intra-org senders of emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 intra-org senders of emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Intra-org"
+  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by SenderMailFromAddress
+  | top 10 by count_
+  | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top Intra-Org P2 senders FP.yaml
@@ -15,15 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient before counting
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Intra-org"
-  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderMailFromAddress
   | top 10 by count_
   | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) sender domains FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) sender domains FP.yaml
@@ -1,0 +1,24 @@
+id: 97f19cad-130a-47b3-a3bb-cbc2e66845f0
+name: User Email Submissions (FP) - Top P2 Sender Domains
+description: |
+  This query visualises the top 10 sender domains of emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 sender domains of emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), P2SenderDomain = tostring((parse_json(RawEventData)).P2SenderDomain)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | summarize count() by P2SenderDomain
+  | top 10 by count_
+  | project ['Sender Domain'] = P2SenderDomain, ['Emails'] = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
@@ -1,0 +1,30 @@
+id: 37511ce4-f88e-4e2d-b505-27411af1a226
+name: User Email Submissions (FP) - Top Inbound P2 Senders
+description: |
+  This query visualises the top 10 inbound senders of emails submitted as false positives by users.
+description-detailed: |
+  This query visualises the top 10 inbound senders of emails submitted as false positives by users.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound"
+  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize count() by SenderMailFromAddress
+  | top 10 by count_
+  | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions - Top email (P2) senders FP.yaml
@@ -15,15 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient before counting
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound"
-  // De-duplicate each delivery (NetworkMessageId + recipient) before counting so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
   | summarize count() by SenderMailFromAddress
   | top 10 by count_
   | project ['Sender Address'] = SenderMailFromAddress, ['Emails'] = count_

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
@@ -17,10 +17,10 @@ query: |
   let TimeStart = startofday(ago(30d));
   let TimeEnd = startofday(now());
   CloudAppEvents
-  | where Timestamp >= TimeStart
+  | where Timestamp >= TimeStart and Timestamp < TimeEnd
   | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType)
-  | where SubmissionType == "3" and SubmissionContentType == "Mail"
+  | extend RawData = parse_json(RawEventData)
+  | where tostring(RawData.SubmissionType) == "3" and tostring(RawData.SubmissionContentType) == "Mail"
   | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
   | extend Details = "User_Email_FP"
   | project Count, Details, Timestamp

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions Trend - FP.yaml
@@ -1,0 +1,28 @@
+id: 97f0d020-be70-4732-b5d7-abcfeecc459c
+name: User Email Submission Trend (FP)
+description: |
+  This query visualises the daily amount of user false positive email submissions over time.
+description-detailed: |
+  This query visualises the daily amount of user false positive email submissions over time.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  let TimeStart = startofday(ago(30d));
+  let TimeEnd = startofday(now());
+  CloudAppEvents
+  | where Timestamp >= TimeStart
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType)
+  | where SubmissionType == "3" and SubmissionContentType == "Mail"
+  | make-series Count = count() default = 0 on Timestamp from TimeStart to TimeEnd step 1d
+  | extend Details = "User_Email_FP"
+  | project Count, Details, Timestamp
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
@@ -15,16 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient so the verdict is read once
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound" and DetectionMethods has 'Phish'
-  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
-  // Robustly expand the Phish detection sub-methods rather than brittle JSON substring matching
   | mv-expand Phish = parse_json(DetectionMethods).Phish to typeof(string)
   | where isnotempty(Phish)
   | summarize count() by Phish

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Phish FP.yaml
@@ -1,0 +1,32 @@
+id: 4ae87c11-4030-42cb-b87d-993198ca40e0
+name: User Submissions by Detection Method - Phish (FP)
+description: |
+  This query visualises user false positive submissions by the original phish filter verdict on the reported message.
+description-detailed: |
+  This query visualises user false positive submissions by the original phish filter verdict on the reported message.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound" and DetectionMethods has 'Phish'
+  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  // Robustly expand the Phish detection sub-methods rather than brittle JSON substring matching
+  | mv-expand Phish = parse_json(DetectionMethods).Phish to typeof(string)
+  | where isnotempty(Phish)
+  | summarize count() by Phish
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
@@ -1,0 +1,32 @@
+id: 05d933db-f605-48d5-a177-af64be537cf4
+name: User Submissions by Detection Method - Spam (FP)
+description: |
+  This query visualises user false positive submissions by the original spam filter verdict on the reported message.
+description-detailed: |
+  This query visualises user false positive submissions by the original spam filter verdict on the reported message.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
+  | where SubmissionContentType == "Mail" and SubmissionType == "3"
+  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  | where EmailDirection == "Inbound" and DetectionMethods has 'Spam'
+  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
+  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
+  | summarize arg_max(Timestamp, *) by Key
+  // Robustly expand the Spam detection sub-methods rather than brittle JSON substring matching
+  | mv-expand Spam = parse_json(DetectionMethods).Spam to typeof(string)
+  | where isnotempty(Spam)
+  | summarize count() by Spam
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Detection Method - Spam FP.yaml
@@ -15,16 +15,19 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "UserSubmission"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType), SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType), RecipientObjectId = AccountObjectId, NetworkMessageId = tostring((parse_json(RawEventData)).ObjectId)
-  | where SubmissionContentType == "Mail" and SubmissionType == "3"
-  | join kind=inner EmailEvents on NetworkMessageId, RecipientObjectId
+  let Submissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "UserSubmission"
+      | extend RawData = parse_json(RawEventData)
+      | where tostring(RawData.SubmissionContentType) == "Mail" and tostring(RawData.SubmissionType) == "3"
+      | extend NetworkMessageId = tostring(RawData.ObjectId), RecipientObjectId = AccountObjectId
+      | distinct NetworkMessageId, RecipientObjectId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | join kind=inner Submissions on NetworkMessageId, RecipientObjectId
+  // De-duplicate to the latest EmailEvents record per message and recipient so the verdict is read once
+  | summarize arg_max(Timestamp, *) by NetworkMessageId, RecipientObjectId
   | where EmailDirection == "Inbound" and DetectionMethods has 'Spam'
-  // De-duplicate each delivery (NetworkMessageId + recipient) before reading the verdict so re-scanned messages are counted once
-  | extend Key = strcat(NetworkMessageId, '-', RecipientObjectId)
-  | summarize arg_max(Timestamp, *) by Key
-  // Robustly expand the Spam detection sub-methods rather than brittle JSON substring matching
   | mv-expand Spam = parse_json(DetectionMethods).Spam to typeof(string)
   | where isnotempty(Spam)
   | summarize count() by Spam

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
@@ -1,0 +1,24 @@
+id: 2f8a0226-b3f3-4a31-b32b-2dd15d644625
+name: User Submissions by Submission State (FP)
+description: |
+  This query visualises user false positive submissions by submission state.
+description-detailed: |
+  This query visualises user false positive submissions by submission state.
+  Query is also included as part of the Defender for Office 365 solution in Sentinel: https://techcommunity.microsoft.com/blog/microsoftdefenderforoffice365blog/part-2-build-custom-email-security-reports-and-dashboards-with-workbooks-in-micr/4411303
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  CloudAppEvents
+  | where ActionType == "UserSubmission"
+  | extend RawData = parse_json(RawEventData)
+  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), SubmissionState = tostring(RawData.SubmissionState)
+  | where RecordType == 29 and SubmissionType == "3"
+  | summarize count() by SubmissionState
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/User Submissions by Submission State - FP.yaml
@@ -17,7 +17,7 @@ query: |
   CloudAppEvents
   | where ActionType == "UserSubmission"
   | extend RawData = parse_json(RawEventData)
-  | extend RecordType = RawData.RecordType, SubmissionType = tostring(RawData.SubmissionType), SubmissionState = tostring(RawData.SubmissionState)
+  | extend RecordType = toint(RawData.RecordType), SubmissionType = tostring(RawData.SubmissionType), SubmissionState = tostring(RawData.SubmissionState)
   | where RecordType == 29 and SubmissionType == "3"
   | summarize count() by SubmissionState
   | render piechart


### PR DESCRIPTION
### Summary
Adds the user false-positive (FP) submission analytics for Defender for Office 365, completing
the submissions set: the folder already covers admin FN/FP and user false-negative (FN)
submissions, but had no user-FP equivalents. These 9 queries mirror the existing user-FN family
using the FP submission type.

### What's added (9 queries, each mirrored to Hunting Queries  and Solutions/Microsoft Defender XDR  = 18 files)
- User Email Submission Trend (FP) - daily FP submissions over time
- User Submissions by Submission State (FP)
- Top accounts performing user submissions (FP)
- User Submissions by Detection Method - Phish (FP) - original phish verdict on the reported mail
- User Submissions by Detection Method - Spam (FP) - original spam verdict on the reported mail
- User Email Submissions (FP) - Top P2 Sender Domains
- User Email Submissions (FP) - Top Inbound P2 Senders
- User Email Submissions (FP) - Top Inbound Subjects
- User Email Submissions (FP) - Top Intra-Org P2 Senders

### Details
- Data source: `CloudAppEvents` (UserSubmission), joined to `EmailEvents` where the original
  message verdict is needed. Connector: MicrosoftThreatProtection. Tactic: InitialAccess (T1566).
- The verdict breakdowns expand `DetectionMethods` with `mv-expand` rather than brittle JSON
  substring matching, and each `EmailEvents` join is de-duplicated per delivery
  (NetworkMessageId + recipient) before counting so re-scanned messages are not counted twice.
- Each query is mirrored in both hunting folder path  with unique template IDs.

### Validation
- Passes the repository KqlValidations offline tests.
- Each query was run in the advanced hunting portal against a test M365 tenant and returns the
  expected visualization (trend, pie, and table).