### PR TITLE
Refine Teams first-contact sender query to externally initiated threads

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/First-Contact External Teams Senders.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/First-Contact External Teams Senders.yaml
@@ -17,8 +17,8 @@ query: |
   MessageEvents
   | where Timestamp > ago(30d)
   | summarize FirstTimestamp = min(Timestamp), arg_max(Timestamp, *) by TeamsMessageId
-  | where IsExternalThread == true
+  | where IsOwnedThread == 0 and IsExternalThread == 1
   | summarize FirstSeen = min(FirstTimestamp), Messages = count(), ThreatMessages = countif(isnotempty(ThreatTypes)) by SenderEmailAddress
   | top 20 by FirstSeen desc
   | project ['Sender']=SenderEmailAddress, ['First Seen']=FirstSeen, ['Messages']=Messages, ['Threat Messages']=ThreatMessages
-version: 1.0.0
+version: 1.0.1

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/First-Contact External Teams Senders.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/First-Contact External Teams Senders.yaml
@@ -17,8 +17,8 @@ query: |
   MessageEvents
   | where Timestamp > ago(30d)
   | summarize FirstTimestamp = min(Timestamp), arg_max(Timestamp, *) by TeamsMessageId
-  | where IsExternalThread == true
+  | where IsOwnedThread == 0 and IsExternalThread == 1
   | summarize FirstSeen = min(FirstTimestamp), Messages = count(), ThreatMessages = countif(isnotempty(ThreatTypes)) by SenderEmailAddress
   | top 20 by FirstSeen desc
   | project ['Sender']=SenderEmailAddress, ['First Seen']=FirstSeen, ['Messages']=Messages, ['Threat Messages']=ThreatMessages
-version: 1.0.0
+version: 1.0.1


### PR DESCRIPTION
Refine Teams first-contact sender query to externally initiated threads

Small follow-up improvement to one of the Microsoft Teams protection hunting queries.

`First-Contact External Teams Senders` filtered on `IsExternalThread` alone. That flag is also true for tenant-owned threads that simply include an external participant, so the resulting sender list could surface internal senders alongside genuine external first contacts.

This aligns the query with the inbound filter convention already used across the other queries in the same folder:

```kusto
| where IsOwnedThread == 0 and IsExternalThread == 1