### PR TITLE
Fix Thinkst Canary publisherId as per manual review request

### DIFF
--- a/Solutions/ThinkstCanary/SolutionMetadata.json
+++ b/Solutions/ThinkstCanary/SolutionMetadata.json
@@ -1,0 +1,36 @@
+{
+  "version": "3.0.0",
+  "kind": "Solution",
+  "contentSchemaVersion": "3.0.0",
+  "contentId": "thinkst-canary",
+  "parentId": "thinkst-canary",
+  "source": {
+    "kind": "Solution",
+    "name": "Thinkst Canary",
+    "sourceId": "thinkst-canary"
+  },
+  "author": {
+    "name": "Thinkst Applied Research",
+    "email": "support@canary.tools"
+  },
+  "support": {
+    "name": "Thinkst Applied Research",
+    "email": "support@canary.tools",
+    "tier": "Partner",
+    "link": "https://help.canary.tools/"
+  },
+  "dependencies": {},
+  "firstPublishDate": "2026-08-18",
+  "lastPublishDate": "2026-08-18",
+  "providers": [
+    "Thinkst Applied Research"
+  ],
+  "categories": {
+    "domains": [
+      "Security - Threat Protection"
+    ],
+    "verticals": []
+  },
+  "offerId": "thinkst-canary-solution-for-azure-sentinel",
+  "publisherId": "thinkst"
+}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Updated `SolutionsMetaData.json` with expected `publisherId` and `offerId`

   Reason for Change(s):
   - Requested by manual verification process when publishing.

   Version Updated:
   - No

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes