### PR TITLE
Add Microsoft Teams call and helpdesk impersonation hunting queries

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
@@ -1,0 +1,31 @@
+id: 6dcfd16d-d9f0-45d1-a9d3-cb08fbf8465b
+name: Microsoft Teams Call and Message Submissions Over Time
+description: |
+  This query trends Microsoft Teams call and message submissions over time, split by content type and by whether a user or an admin reported them.
+description-detailed: |
+  This query trends Microsoft Teams call and message submissions over the last 30 days, using Advanced hunting in Microsoft Defender XDR, split into four series: Teams calls and Teams messages, each reported by a user or submitted by an admin. A rise in Teams calls reported by users while message reporting stays flat is the shape worth investigating, because voice phishing is commonly layered onto Teams helpdesk impersonation so that malicious instructions are spoken rather than typed and never appear in the chat log.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query trends Microsoft Teams call and message submissions over the last 30 days, split by content type and reporter.
+  //A rise in reported Teams calls against flat message reporting is the shape to investigate, because voice phishing is often
+  //layered onto Teams helpdesk impersonation so that malicious instructions never enter the chat log.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | extend RD = parse_json(RawEventData)
+  | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
+  | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
+  | extend SubmissionType = iif(SubmissionContentType == "TeamsCall", "Teams Call", "Teams Message"),
+           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+  | summarize Submissions = count() by bin(Timestamp, 1d), ['Submission Type'] = strcat(SubmissionType, " (", Reporter, ")")
+  | render timechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
@@ -24,8 +24,10 @@ query: |
   | extend RD = parse_json(RawEventData)
   | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
   | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
+  //Exact match, because a graded submission also emits a UserSubmissionTriage record under the same SubmissionId.
+  | where ActionType in ("UserSubmission", "AdminSubmission")
   | extend SubmissionType = iif(SubmissionContentType == "TeamsCall", "Teams Call", "Teams Message"),
-           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+           Reporter = iif(ActionType == "AdminSubmission", "Admin", "User")
   | summarize Submissions = count() by bin(Timestamp, 1d), ['Submission Type'] = strcat(SubmissionType, " (", Reporter, ")")
   | render timechart
 version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
@@ -39,7 +39,7 @@ query: |
   let ByHour = CallStarts
       | extend IsImpersonationStyle = CallId in (ImpersonationCalls)
       | summarize TeamsCalls = count(), ImpersonationStyleCalls = countif(IsImpersonationStyle)
-          by HourUTC = hourofday(CallStart);
+          by HourUTC = tolong(hourofday(CallStart));
   range HourUTC from 0 to 23 step 1
   | join kind=leftouter (ByHour) on HourUTC
   | extend TeamsCalls = coalesce(TeamsCalls, 0), ImpersonationStyleCalls = coalesce(ImpersonationStyleCalls, 0)

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
@@ -1,0 +1,50 @@
+id: cdfc54c4-ea78-4008-9b50-da7e886bd8e2
+name: Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day
+description: |
+  This query compares all Microsoft Teams calls against impersonation-style calls across the 24 hours of the day in UTC.
+description-detailed: |
+  This query counts distinct Microsoft Teams calls by their starting hour of day in UTC over the last 30 days, using Advanced hunting in Microsoft Defender XDR, and plots two series side by side: every call, and only those where a participant's display name or address impersonates IT support, helpdesk, security or account maintenance, or where the participant is calling from a throwaway .onmicrosoft.com tenant. All 24 hours are returned in order so quiet hours stay visible. Comparing the two series is the point: normal calling follows the working day, whereas social-engineering calls cluster when the real helpdesk is unavailable and the user cannot verify the request through a colleague. An hour with few total calls but a high share of impersonation-style calls is far more interesting than the busiest hour of the day.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query compares all Microsoft Teams calls with impersonation-style calls by starting hour of day (UTC) over the
+  //last 30 days, returning all 24 hours so quiet hours stay visible. Normal calling tracks the working day; social
+  //engineering calls cluster when the real helpdesk is closed, so an hour with few calls but a high impersonation
+  //share matters more than the busiest hour.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  let suspRegex = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|sys ?admin|administrator|security|microsoft|google|apple|amazon|paypal|support|update|verif|account|password|mfa|maintenance";
+  let CallStarts = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "CallParticipantDetail"
+      | extend R = parse_json(RawEventData)
+      | extend CallId = tostring(R.CallId), JoinTime = todatetime(R.JoinTime), Attendees = R.Attendees
+      | where isnotempty(CallId) and isnotempty(JoinTime)
+      | summarize CallStart = min(JoinTime), Attendees = take_any(Attendees) by CallId;
+  let ImpersonationCalls = CallStarts
+      | mv-expand Attendee = Attendees
+      | extend CallerAddress = tolower(tostring(Attendee.UPN)), CallerName = tostring(Attendee.DisplayName)
+      | extend CallerDomain = tostring(split(CallerAddress, "@")[1])
+      | where CallerName matches regex suspRegex
+           or CallerAddress matches regex suspRegex
+           or CallerDomain endswith ".onmicrosoft.com"
+      | distinct CallId;
+  let ByHour = CallStarts
+      | extend IsImpersonationStyle = CallId in (ImpersonationCalls)
+      | summarize TeamsCalls = count(), ImpersonationStyleCalls = countif(IsImpersonationStyle)
+          by HourUTC = hourofday(CallStart);
+  range HourUTC from 0 to 23 step 1
+  | join kind=leftouter (ByHour) on HourUTC
+  | extend TeamsCalls = coalesce(TeamsCalls, 0), ImpersonationStyleCalls = coalesce(ImpersonationStyleCalls, 0)
+  | extend HourLabel = strcat(iif(HourUTC < 10, strcat("0", tostring(HourUTC)), tostring(HourUTC)), ":00")
+  | order by HourUTC asc
+  | project ['Hour of Day (UTC)']=HourLabel, ['Teams Calls']=TeamsCalls, ['Impersonation-Style Teams Calls']=ImpersonationStyleCalls
+  | render columnchart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
@@ -1,0 +1,41 @@
+id: 27cb923c-8d66-4caa-b52b-bce52e51d585
+name: Reported Microsoft Teams Calls
+description: |
+  This query lists Microsoft Teams calls that users reported to Microsoft, with the reporting user, to surface suspected voice phishing.
+description-detailed: |
+  This query lists Microsoft Teams calls that users reported to Microsoft over the last 30 days, using Advanced hunting in Microsoft Defender XDR. It returns who reported the call, the reported calling party and its domain, and the submission state. Teams helpdesk impersonation is frequently paired with a voice call so that malicious instructions and URLs are spoken rather than typed, which keeps them out of the chat log entirely. A user-reported call is therefore one of the earliest first-party signals available for that intrusion pattern, and it is invisible to message-based hunting. Repeat reports naming the same calling party are the rows to investigate first.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query lists Microsoft Teams calls that users reported to Microsoft over the last 30 days, with the reporting
+  //user, the reported calling party and the submission state.
+  //Reported calls matter because voice phishing is often layered onto Teams helpdesk impersonation so that malicious
+  //instructions never enter the chat log. Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat
+  //actors turn a remote session into enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | extend RD = parse_json(RawEventData)
+  | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
+  | where RecordType == "29" and SubmissionContentType == "TeamsCall"
+  | extend ReportedBy = tostring(RD.SubmitterDisplayName),
+           ReportedByEmail = tostring(RD.UserId),
+           ReportedCaller = tostring(RD.P2Sender),
+           ReportedCallerDomain = tostring(RD.P2SenderDomain),
+           SubmissionState = tostring(RD.SubmissionState),
+           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+  | project Timestamp,
+            ['Teams Call Reported By']=ReportedBy,
+            ['Reported By Email']=ReportedByEmail,
+            ['Reported Caller']=ReportedCaller,
+            ['Reported Caller Domain']=ReportedCallerDomain,
+            ['Reporter Type']=Reporter,
+            ['Teams Call Submission State']=SubmissionState
+  | sort by Timestamp desc
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
@@ -24,12 +24,14 @@ query: |
   | extend RD = parse_json(RawEventData)
   | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
   | where RecordType == "29" and SubmissionContentType == "TeamsCall"
+  //Exact match, because a graded submission also emits a UserSubmissionTriage record under the same SubmissionId.
+  | where ActionType in ("UserSubmission", "AdminSubmission")
   | extend ReportedBy = tostring(RD.SubmitterDisplayName),
            ReportedByEmail = tostring(RD.UserId),
            ReportedCaller = tostring(RD.P2Sender),
            ReportedCallerDomain = tostring(RD.P2SenderDomain),
            SubmissionState = tostring(RD.SubmissionState),
-           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+           Reporter = iif(ActionType == "AdminSubmission", "Admin", "User")
   | project Timestamp,
             ['Teams Call Reported By']=ReportedBy,
             ['Reported By Email']=ReportedByEmail,

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
@@ -1,0 +1,55 @@
+id: f905bb00-9c5f-4889-bc39-7d0765521228
+name: Suspicious Microsoft Teams Callers by Impersonation-Style Identity
+description: |
+  This query surfaces Microsoft Teams callers whose display name or address impersonates IT support, and calls placed from throwaway tenants.
+description-detailed: |
+  This query surfaces Microsoft Teams callers whose display name or address matches common IT support, helpdesk, security or account-maintenance impersonation themes over the last 30 days, using Advanced hunting in Microsoft Defender XDR. Each caller is classified by origin: a throwaway .onmicrosoft.com tenant, an external domain, or the organisation's own tenant. The organisation's accepted domains are derived from inbound mail recipients rather than a hard-coded tenant identifier, so the query is portable to any tenant without editing. Helpdesk impersonation over a Teams call is a common opening move because the malicious instructions are spoken and never appear in a chat log, making the caller identity itself one of the few durable artefacts available for hunting.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query surfaces Microsoft Teams callers whose display name or address impersonates IT support, helpdesk,
+  //security or account maintenance, over the last 30 days, and flags calls placed from throwaway tenants.
+  //Origin is derived from the organisation's own accepted domains (inbound mail recipients), not a tenant-id anchor,
+  //so no editing is needed to run it in any tenant.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  let suspRegex = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|sys ?admin|administrator|security|microsoft|google|apple|amazon|paypal|support|update|verif|account|password|mfa|maintenance";
+  let ownDomains = toscalar(EmailEvents
+      | where Timestamp > ago(30d)
+      | where EmailDirection == "Inbound"
+      | extend RecipientDomain = tolower(tostring(split(RecipientEmailAddress, "@")[1]))
+      | where isnotempty(RecipientDomain)
+      | summarize make_set(RecipientDomain, 200));
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | where ActionType == "CallParticipantDetail"
+  | extend R = parse_json(RawEventData)
+  | extend CallId = tostring(R.CallId), JoinTime = todatetime(R.JoinTime), Attendees = R.Attendees
+  | where isnotempty(CallId)
+  | summarize Attendees = take_any(Attendees), JoinTime = min(JoinTime) by CallId
+  | mv-expand Attendee = Attendees
+  | extend CallerAddress = tolower(tostring(Attendee.UPN)), CallerName = tostring(Attendee.DisplayName)
+  | where isnotempty(CallerAddress)
+  | extend CallerDomain = tostring(split(CallerAddress, "@")[1])
+  | extend SuspName = CallerName matches regex suspRegex or CallerAddress matches regex suspRegex
+  | where SuspName or CallerDomain endswith ".onmicrosoft.com"
+  | extend Origin = case(CallerDomain endswith ".onmicrosoft.com", "External (.onmicrosoft throwaway)",
+                         set_has_element(ownDomains, CallerDomain), "Own tenant",
+                         "External")
+  | summarize CallsPlaced = dcount(CallId), FirstSeen = min(JoinTime), LastSeen = max(JoinTime)
+      by CallerName, CallerAddress, CallerDomain, Origin
+  | extend OriginRank = case(Origin == "External (.onmicrosoft throwaway)", 0, Origin == "External", 1, 2)
+  | sort by OriginRank asc, CallsPlaced desc
+  | take 20
+  | project ['Teams Caller Display Name']=CallerName, ['Teams Caller Address']=CallerAddress,
+            ['Caller Domain']=CallerDomain, ['Origin']=Origin, ['Teams Calls Placed']=CallsPlaced,
+            ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
@@ -33,7 +33,7 @@ query: |
   | where ActionType == "CallParticipantDetail"
   | extend R = parse_json(RawEventData)
   | extend CallId = tostring(R.CallId), JoinTime = todatetime(R.JoinTime), Attendees = R.Attendees
-  | where isnotempty(CallId)
+  | where isnotempty(CallId) and isnotempty(JoinTime)
   | summarize Attendees = take_any(Attendees), JoinTime = min(JoinTime) by CallId
   | mv-expand Attendee = Attendees
   | extend CallerAddress = tolower(tostring(Attendee.UPN)), CallerName = tostring(Attendee.DisplayName)

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
@@ -21,6 +21,7 @@ query: |
   let SuspiciousDisplayNamePattern = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|it team|administrator|sys ?admin|security|microsoft|maintenance|support|update|verif|account|password|mfa";
   MessageEvents
   | where Timestamp > ago(30d)
+  | where isnotempty(TeamsMessageId)
   | summarize arg_max(Timestamp, *) by TeamsMessageId
   | where IsExternalThread == 1 and IsOwnedThread == 0
   | extend SenderDomain = tolower(tostring(split(SenderEmailAddress, "@")[1]))

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
@@ -3,8 +3,9 @@ name: Suspicious Teams Display Name
 description: |
   This query looks for Teams messages from an external user with a suspicious display name.
 description-detailed: |
-  This query looks for Teams messages from an external user with a suspicious display name.
+  This query looks for Teams messages from an external user with a suspicious display name, over the last 30 days.
   Threat actors may attempt to socially engineer a user by using display names such as IT Support or Help Desk to establish trust.
+  Senders operating from throwaway .onmicrosoft.com tenants are included because a newly created tenant is a common way to obtain a plausible-looking identity at no cost, and a reason column states why each sender was flagged. Results are aggregated per sender with the share of their messages that carried a threat, so a sender with few messages but a high threat rate is not buried beneath high-volume noise.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
@@ -14,8 +15,29 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let SuspiciousDisplayNames = pack_array("Microsoft  Security", "Help Desk", "Help Desk Team", "Help Desk IT", "Microsoft Security", "IT Support", "Helpdesk");
+  //This query surfaces external Microsoft Teams senders whose display name impersonates IT support or helpdesk, and
+  //senders operating from throwaway .onmicrosoft.com tenants, ranked by how many of their messages carried a threat.
+  //Messages are de-duplicated to the latest record per message.
+  let SuspiciousDisplayNamePattern = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|it team|administrator|sys ?admin|security|microsoft|maintenance|support|update|verif|account|password|mfa";
   MessageEvents
+  | where Timestamp > ago(30d)
+  | summarize arg_max(Timestamp, *) by TeamsMessageId
   | where IsExternalThread == 1 and IsOwnedThread == 0
-  | where SenderDisplayName has_any (SuspiciousDisplayNames)
-version: 1.0.0
+  | extend SenderDomain = tolower(tostring(split(SenderEmailAddress, "@")[1]))
+  | extend IsOnMicrosoft = SenderDomain endswith ".onmicrosoft.com"
+  | extend SuspName = SenderDisplayName matches regex SuspiciousDisplayNamePattern
+  | where IsOnMicrosoft or SuspName
+  | summarize TeamsMessages = count(), ThreatMessages = countif(isnotempty(ThreatTypes)),
+              FirstSeen = min(Timestamp), LastSeen = max(Timestamp)
+      by SenderDisplayName, SenderEmailAddress, SenderDomain, IsOnMicrosoft, SuspName
+  | extend WhyFlagged = case(IsOnMicrosoft and SuspName, "Throwaway .onmicrosoft tenant and helpdesk-style display name",
+                             IsOnMicrosoft, "Throwaway .onmicrosoft tenant",
+                             "Helpdesk or IT-style display name")
+  | extend ThreatPct = round(100.0 * ThreatMessages / TeamsMessages, 1)
+  | sort by ThreatMessages desc, TeamsMessages desc
+  | take 20
+  | project ['Sender Display Name']=SenderDisplayName, ['Sender Address']=SenderEmailAddress,
+            ['Sender Domain']=SenderDomain, ['Why Flagged']=WhyFlagged, ['Teams Messages']=TeamsMessages,
+            ['Threat Messages']=ThreatMessages, ['Threat %']=ThreatPct,
+            ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.1

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
@@ -1,0 +1,38 @@
+id: d9ca4ab6-de3f-4c24-aaef-00d41332caf4
+name: Top Reporters of Microsoft Teams Calls and Messages
+description: |
+  This query lists the users who reported the most Microsoft Teams calls and messages, split by content type, to surface actively targeted people.
+description-detailed: |
+  This query lists the top 20 users who reported Microsoft Teams calls and messages to Microsoft over the last 30 days, using Advanced hunting in Microsoft Defender XDR, with the count of Teams calls and Teams messages reported separately, and the first and last time each user reported. Splitting calls from messages per reporter is the point: a user reporting several Teams calls in a short window is a strong indicator of being actively targeted by helpdesk impersonation and voice phishing, which message-only reporting views do not reveal. The submitter email is included because display names alone do not disambiguate users.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query lists the top 20 users who reported Microsoft Teams calls and messages over the last 30 days, counting calls
+  //and messages separately per reporter, with the reporting window. A user reporting several Teams calls in a short window
+  //is a strong sign of being actively targeted, and voice phishing is often layered onto Teams helpdesk impersonation so
+  //that malicious instructions never enter the chat log.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | extend RD = parse_json(RawEventData)
+  | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
+  | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
+  | where ActionType startswith "UserSubmission"
+  | extend ReportedBy = tostring(RD.SubmitterDisplayName), ReportedByEmail = tostring(RD.UserId)
+  | where isnotempty(ReportedBy) and ReportedByEmail has "@"
+  | summarize ['Teams Calls Reported'] = countif(SubmissionContentType == "TeamsCall"),
+              ['Teams Messages Reported'] = countif(SubmissionContentType == "ChatMessage"),
+              ['Total Reported'] = count(),
+              ['First Reported'] = min(Timestamp),
+              ['Last Reported'] = max(Timestamp)
+      by ['Reported By'] = ReportedBy, ['Reported By Email'] = ReportedByEmail
+  | top 20 by ['Total Reported']
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
@@ -25,7 +25,8 @@ query: |
   | extend RD = parse_json(RawEventData)
   | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
   | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
-  | where ActionType startswith "UserSubmission"
+  //Exact match, because a graded submission also emits a UserSubmissionTriage record under the same SubmissionId.
+  | where ActionType == "UserSubmission"
   | extend ReportedBy = tostring(RD.SubmitterDisplayName), ReportedByEmail = tostring(RD.UserId)
   | where isnotempty(ReportedBy) and ReportedByEmail has "@"
   | summarize ['Teams Calls Reported'] = countif(SubmissionContentType == "TeamsCall"),

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
@@ -24,8 +24,10 @@ query: |
   | extend RD = parse_json(RawEventData)
   | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
   | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
+  //Exact match, because a graded submission also emits a UserSubmissionTriage record under the same SubmissionId.
+  | where ActionType in ("UserSubmission", "AdminSubmission")
   | extend SubmissionType = iif(SubmissionContentType == "TeamsCall", "Teams Call", "Teams Message"),
-           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+           Reporter = iif(ActionType == "AdminSubmission", "Admin", "User")
   | summarize Submissions = count() by bin(Timestamp, 1d), ['Submission Type'] = strcat(SubmissionType, " (", Reporter, ")")
   | render timechart
 version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Call and Message Submissions Over Time.yaml
@@ -1,0 +1,31 @@
+id: ef13dc37-6205-4cea-b969-2b6e0d8ab509
+name: Microsoft Teams Call and Message Submissions Over Time
+description: |
+  This query trends Microsoft Teams call and message submissions over time, split by content type and by whether a user or an admin reported them.
+description-detailed: |
+  This query trends Microsoft Teams call and message submissions over the last 30 days, using Advanced hunting in Microsoft Defender XDR, split into four series: Teams calls and Teams messages, each reported by a user or submitted by an admin. A rise in Teams calls reported by users while message reporting stays flat is the shape worth investigating, because voice phishing is commonly layered onto Teams helpdesk impersonation so that malicious instructions are spoken rather than typed and never appear in the chat log.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query trends Microsoft Teams call and message submissions over the last 30 days, split by content type and reporter.
+  //A rise in reported Teams calls against flat message reporting is the shape to investigate, because voice phishing is often
+  //layered onto Teams helpdesk impersonation so that malicious instructions never enter the chat log.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | extend RD = parse_json(RawEventData)
+  | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
+  | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
+  | extend SubmissionType = iif(SubmissionContentType == "TeamsCall", "Teams Call", "Teams Message"),
+           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+  | summarize Submissions = count() by bin(Timestamp, 1d), ['Submission Type'] = strcat(SubmissionType, " (", Reporter, ")")
+  | render timechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
@@ -39,7 +39,7 @@ query: |
   let ByHour = CallStarts
       | extend IsImpersonationStyle = CallId in (ImpersonationCalls)
       | summarize TeamsCalls = count(), ImpersonationStyleCalls = countif(IsImpersonationStyle)
-          by HourUTC = hourofday(CallStart);
+          by HourUTC = tolong(hourofday(CallStart));
   range HourUTC from 0 to 23 step 1
   | join kind=leftouter (ByHour) on HourUTC
   | extend TeamsCalls = coalesce(TeamsCalls, 0), ImpersonationStyleCalls = coalesce(ImpersonationStyleCalls, 0)

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day.yaml
@@ -1,0 +1,50 @@
+id: 55e28f8e-cc6d-4cc9-af24-398a6e2a721d
+name: Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day
+description: |
+  This query compares all Microsoft Teams calls against impersonation-style calls across the 24 hours of the day in UTC.
+description-detailed: |
+  This query counts distinct Microsoft Teams calls by their starting hour of day in UTC over the last 30 days, using Advanced hunting in Microsoft Defender XDR, and plots two series side by side: every call, and only those where a participant's display name or address impersonates IT support, helpdesk, security or account maintenance, or where the participant is calling from a throwaway .onmicrosoft.com tenant. All 24 hours are returned in order so quiet hours stay visible. Comparing the two series is the point: normal calling follows the working day, whereas social-engineering calls cluster when the real helpdesk is unavailable and the user cannot verify the request through a colleague. An hour with few total calls but a high share of impersonation-style calls is far more interesting than the busiest hour of the day.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query compares all Microsoft Teams calls with impersonation-style calls by starting hour of day (UTC) over the
+  //last 30 days, returning all 24 hours so quiet hours stay visible. Normal calling tracks the working day; social
+  //engineering calls cluster when the real helpdesk is closed, so an hour with few calls but a high impersonation
+  //share matters more than the busiest hour.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  let suspRegex = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|sys ?admin|administrator|security|microsoft|google|apple|amazon|paypal|support|update|verif|account|password|mfa|maintenance";
+  let CallStarts = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "CallParticipantDetail"
+      | extend R = parse_json(RawEventData)
+      | extend CallId = tostring(R.CallId), JoinTime = todatetime(R.JoinTime), Attendees = R.Attendees
+      | where isnotempty(CallId) and isnotempty(JoinTime)
+      | summarize CallStart = min(JoinTime), Attendees = take_any(Attendees) by CallId;
+  let ImpersonationCalls = CallStarts
+      | mv-expand Attendee = Attendees
+      | extend CallerAddress = tolower(tostring(Attendee.UPN)), CallerName = tostring(Attendee.DisplayName)
+      | extend CallerDomain = tostring(split(CallerAddress, "@")[1])
+      | where CallerName matches regex suspRegex
+           or CallerAddress matches regex suspRegex
+           or CallerDomain endswith ".onmicrosoft.com"
+      | distinct CallId;
+  let ByHour = CallStarts
+      | extend IsImpersonationStyle = CallId in (ImpersonationCalls)
+      | summarize TeamsCalls = count(), ImpersonationStyleCalls = countif(IsImpersonationStyle)
+          by HourUTC = hourofday(CallStart);
+  range HourUTC from 0 to 23 step 1
+  | join kind=leftouter (ByHour) on HourUTC
+  | extend TeamsCalls = coalesce(TeamsCalls, 0), ImpersonationStyleCalls = coalesce(ImpersonationStyleCalls, 0)
+  | extend HourLabel = strcat(iif(HourUTC < 10, strcat("0", tostring(HourUTC)), tostring(HourUTC)), ":00")
+  | order by HourUTC asc
+  | project ['Hour of Day (UTC)']=HourLabel, ['Teams Calls']=TeamsCalls, ['Impersonation-Style Teams Calls']=ImpersonationStyleCalls
+  | render columnchart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
@@ -1,0 +1,41 @@
+id: 225da6aa-6b34-448d-ab0b-72219d52bd44
+name: Reported Microsoft Teams Calls
+description: |
+  This query lists Microsoft Teams calls that users reported to Microsoft, with the reporting user, to surface suspected voice phishing.
+description-detailed: |
+  This query lists Microsoft Teams calls that users reported to Microsoft over the last 30 days, using Advanced hunting in Microsoft Defender XDR. It returns who reported the call, the reported calling party and its domain, and the submission state. Teams helpdesk impersonation is frequently paired with a voice call so that malicious instructions and URLs are spoken rather than typed, which keeps them out of the chat log entirely. A user-reported call is therefore one of the earliest first-party signals available for that intrusion pattern, and it is invisible to message-based hunting. Repeat reports naming the same calling party are the rows to investigate first.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query lists Microsoft Teams calls that users reported to Microsoft over the last 30 days, with the reporting
+  //user, the reported calling party and the submission state.
+  //Reported calls matter because voice phishing is often layered onto Teams helpdesk impersonation so that malicious
+  //instructions never enter the chat log. Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat
+  //actors turn a remote session into enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | extend RD = parse_json(RawEventData)
+  | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
+  | where RecordType == "29" and SubmissionContentType == "TeamsCall"
+  | extend ReportedBy = tostring(RD.SubmitterDisplayName),
+           ReportedByEmail = tostring(RD.UserId),
+           ReportedCaller = tostring(RD.P2Sender),
+           ReportedCallerDomain = tostring(RD.P2SenderDomain),
+           SubmissionState = tostring(RD.SubmissionState),
+           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+  | project Timestamp,
+            ['Teams Call Reported By']=ReportedBy,
+            ['Reported By Email']=ReportedByEmail,
+            ['Reported Caller']=ReportedCaller,
+            ['Reported Caller Domain']=ReportedCallerDomain,
+            ['Reporter Type']=Reporter,
+            ['Teams Call Submission State']=SubmissionState
+  | sort by Timestamp desc
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Reported Microsoft Teams Calls.yaml
@@ -24,12 +24,14 @@ query: |
   | extend RD = parse_json(RawEventData)
   | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
   | where RecordType == "29" and SubmissionContentType == "TeamsCall"
+  //Exact match, because a graded submission also emits a UserSubmissionTriage record under the same SubmissionId.
+  | where ActionType in ("UserSubmission", "AdminSubmission")
   | extend ReportedBy = tostring(RD.SubmitterDisplayName),
            ReportedByEmail = tostring(RD.UserId),
            ReportedCaller = tostring(RD.P2Sender),
            ReportedCallerDomain = tostring(RD.P2SenderDomain),
            SubmissionState = tostring(RD.SubmissionState),
-           Reporter = iif(ActionType startswith "AdminSubmission", "Admin", "User")
+           Reporter = iif(ActionType == "AdminSubmission", "Admin", "User")
   | project Timestamp,
             ['Teams Call Reported By']=ReportedBy,
             ['Reported By Email']=ReportedByEmail,

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
@@ -33,7 +33,7 @@ query: |
   | where ActionType == "CallParticipantDetail"
   | extend R = parse_json(RawEventData)
   | extend CallId = tostring(R.CallId), JoinTime = todatetime(R.JoinTime), Attendees = R.Attendees
-  | where isnotempty(CallId)
+  | where isnotempty(CallId) and isnotempty(JoinTime)
   | summarize Attendees = take_any(Attendees), JoinTime = min(JoinTime) by CallId
   | mv-expand Attendee = Attendees
   | extend CallerAddress = tolower(tostring(Attendee.UPN)), CallerName = tostring(Attendee.DisplayName)

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Microsoft Teams Callers by Impersonation-Style Identity.yaml
@@ -1,0 +1,55 @@
+id: 37f3d0f5-8ac3-46a3-9b27-a4fd082b6348
+name: Suspicious Microsoft Teams Callers by Impersonation-Style Identity
+description: |
+  This query surfaces Microsoft Teams callers whose display name or address impersonates IT support, and calls placed from throwaway tenants.
+description-detailed: |
+  This query surfaces Microsoft Teams callers whose display name or address matches common IT support, helpdesk, security or account-maintenance impersonation themes over the last 30 days, using Advanced hunting in Microsoft Defender XDR. Each caller is classified by origin: a throwaway .onmicrosoft.com tenant, an external domain, or the organisation's own tenant. The organisation's accepted domains are derived from inbound mail recipients rather than a hard-coded tenant identifier, so the query is portable to any tenant without editing. Helpdesk impersonation over a Teams call is a common opening move because the malicious instructions are spoken and never appear in a chat log, making the caller identity itself one of the few durable artefacts available for hunting.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query surfaces Microsoft Teams callers whose display name or address impersonates IT support, helpdesk,
+  //security or account maintenance, over the last 30 days, and flags calls placed from throwaway tenants.
+  //Origin is derived from the organisation's own accepted domains (inbound mail recipients), not a tenant-id anchor,
+  //so no editing is needed to run it in any tenant.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  let suspRegex = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|sys ?admin|administrator|security|microsoft|google|apple|amazon|paypal|support|update|verif|account|password|mfa|maintenance";
+  let ownDomains = toscalar(EmailEvents
+      | where Timestamp > ago(30d)
+      | where EmailDirection == "Inbound"
+      | extend RecipientDomain = tolower(tostring(split(RecipientEmailAddress, "@")[1]))
+      | where isnotempty(RecipientDomain)
+      | summarize make_set(RecipientDomain, 200));
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | where ActionType == "CallParticipantDetail"
+  | extend R = parse_json(RawEventData)
+  | extend CallId = tostring(R.CallId), JoinTime = todatetime(R.JoinTime), Attendees = R.Attendees
+  | where isnotempty(CallId)
+  | summarize Attendees = take_any(Attendees), JoinTime = min(JoinTime) by CallId
+  | mv-expand Attendee = Attendees
+  | extend CallerAddress = tolower(tostring(Attendee.UPN)), CallerName = tostring(Attendee.DisplayName)
+  | where isnotempty(CallerAddress)
+  | extend CallerDomain = tostring(split(CallerAddress, "@")[1])
+  | extend SuspName = CallerName matches regex suspRegex or CallerAddress matches regex suspRegex
+  | where SuspName or CallerDomain endswith ".onmicrosoft.com"
+  | extend Origin = case(CallerDomain endswith ".onmicrosoft.com", "External (.onmicrosoft throwaway)",
+                         set_has_element(ownDomains, CallerDomain), "Own tenant",
+                         "External")
+  | summarize CallsPlaced = dcount(CallId), FirstSeen = min(JoinTime), LastSeen = max(JoinTime)
+      by CallerName, CallerAddress, CallerDomain, Origin
+  | extend OriginRank = case(Origin == "External (.onmicrosoft throwaway)", 0, Origin == "External", 1, 2)
+  | sort by OriginRank asc, CallsPlaced desc
+  | take 20
+  | project ['Teams Caller Display Name']=CallerName, ['Teams Caller Address']=CallerAddress,
+            ['Caller Domain']=CallerDomain, ['Origin']=Origin, ['Teams Calls Placed']=CallsPlaced,
+            ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
@@ -21,6 +21,7 @@ query: |
   let SuspiciousDisplayNamePattern = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|it team|administrator|sys ?admin|security|microsoft|maintenance|support|update|verif|account|password|mfa";
   MessageEvents
   | where Timestamp > ago(30d)
+  | where isnotempty(TeamsMessageId)
   | summarize arg_max(Timestamp, *) by TeamsMessageId
   | where IsExternalThread == 1 and IsOwnedThread == 0
   | extend SenderDomain = tolower(tostring(split(SenderEmailAddress, "@")[1]))

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Suspicious Teams Display Name.yaml
@@ -3,8 +3,9 @@ name: Suspicious Teams Display Name
 description: |
   This query looks for Teams messages from an external user with a suspicious display name.
 description-detailed: |
-  This query looks for Teams messages from an external user with a suspicious display name.
+  This query looks for Teams messages from an external user with a suspicious display name, over the last 30 days.
   Threat actors may attempt to socially engineer a user by using display names such as IT Support or Help Desk to establish trust.
+  Senders operating from throwaway .onmicrosoft.com tenants are included because a newly created tenant is a common way to obtain a plausible-looking identity at no cost, and a reason column states why each sender was flagged. Results are aggregated per sender with the share of their messages that carried a threat, so a sender with few messages but a high threat rate is not buried beneath high-volume noise.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
@@ -14,8 +15,29 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let SuspiciousDisplayNames = pack_array("Microsoft  Security", "Help Desk", "Help Desk Team", "Help Desk IT", "Microsoft Security", "IT Support", "Helpdesk");
+  //This query surfaces external Microsoft Teams senders whose display name impersonates IT support or helpdesk, and
+  //senders operating from throwaway .onmicrosoft.com tenants, ranked by how many of their messages carried a threat.
+  //Messages are de-duplicated to the latest record per message.
+  let SuspiciousDisplayNamePattern = @"(?i)help ?desk|helpdesk|it ?support|service ?desk|it team|administrator|sys ?admin|security|microsoft|maintenance|support|update|verif|account|password|mfa";
   MessageEvents
+  | where Timestamp > ago(30d)
+  | summarize arg_max(Timestamp, *) by TeamsMessageId
   | where IsExternalThread == 1 and IsOwnedThread == 0
-  | where SenderDisplayName has_any (SuspiciousDisplayNames)
-version: 1.0.0
+  | extend SenderDomain = tolower(tostring(split(SenderEmailAddress, "@")[1]))
+  | extend IsOnMicrosoft = SenderDomain endswith ".onmicrosoft.com"
+  | extend SuspName = SenderDisplayName matches regex SuspiciousDisplayNamePattern
+  | where IsOnMicrosoft or SuspName
+  | summarize TeamsMessages = count(), ThreatMessages = countif(isnotempty(ThreatTypes)),
+              FirstSeen = min(Timestamp), LastSeen = max(Timestamp)
+      by SenderDisplayName, SenderEmailAddress, SenderDomain, IsOnMicrosoft, SuspName
+  | extend WhyFlagged = case(IsOnMicrosoft and SuspName, "Throwaway .onmicrosoft tenant and helpdesk-style display name",
+                             IsOnMicrosoft, "Throwaway .onmicrosoft tenant",
+                             "Helpdesk or IT-style display name")
+  | extend ThreatPct = round(100.0 * ThreatMessages / TeamsMessages, 1)
+  | sort by ThreatMessages desc, TeamsMessages desc
+  | take 20
+  | project ['Sender Display Name']=SenderDisplayName, ['Sender Address']=SenderEmailAddress,
+            ['Sender Domain']=SenderDomain, ['Why Flagged']=WhyFlagged, ['Teams Messages']=TeamsMessages,
+            ['Threat Messages']=ThreatMessages, ['Threat %']=ThreatPct,
+            ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.1

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
@@ -1,0 +1,38 @@
+id: 2324aae0-6628-4842-aa36-ae5bf13f3400
+name: Top Reporters of Microsoft Teams Calls and Messages
+description: |
+  This query lists the users who reported the most Microsoft Teams calls and messages, split by content type, to surface actively targeted people.
+description-detailed: |
+  This query lists the top 20 users who reported Microsoft Teams calls and messages to Microsoft over the last 30 days, using Advanced hunting in Microsoft Defender XDR, with the count of Teams calls and Teams messages reported separately, and the first and last time each user reported. Splitting calls from messages per reporter is the point: a user reporting several Teams calls in a short window is a strong indicator of being actively targeted by helpdesk impersonation and voice phishing, which message-only reporting views do not reveal. The submitter email is included because display names alone do not disambiguate users.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query lists the top 20 users who reported Microsoft Teams calls and messages over the last 30 days, counting calls
+  //and messages separately per reporter, with the reporting window. A user reporting several Teams calls in a short window
+  //is a strong sign of being actively targeted, and voice phishing is often layered onto Teams helpdesk impersonation so
+  //that malicious instructions never enter the chat log.
+  //Background: Microsoft Threat Intelligence, "Impersonating IT support: how threat actors turn a remote session into
+  //enterprise-wide access" (2 September 2026)
+  //https://www.microsoft.com/en-us/security/blog/2026/09/02/impersonating-it-support-threat-actors-turn-remote-session-into-enterprise-wide-access/
+  CloudAppEvents
+  | where Timestamp > ago(30d)
+  | extend RD = parse_json(RawEventData)
+  | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
+  | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
+  | where ActionType startswith "UserSubmission"
+  | extend ReportedBy = tostring(RD.SubmitterDisplayName), ReportedByEmail = tostring(RD.UserId)
+  | where isnotempty(ReportedBy) and ReportedByEmail has "@"
+  | summarize ['Teams Calls Reported'] = countif(SubmissionContentType == "TeamsCall"),
+              ['Teams Messages Reported'] = countif(SubmissionContentType == "ChatMessage"),
+              ['Total Reported'] = count(),
+              ['First Reported'] = min(Timestamp),
+              ['Last Reported'] = max(Timestamp)
+      by ['Reported By'] = ReportedBy, ['Reported By Email'] = ReportedByEmail
+  | top 20 by ['Total Reported']
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Microsoft Teams protection/Top Reporters of Microsoft Teams Calls and Messages.yaml
@@ -25,7 +25,8 @@ query: |
   | extend RD = parse_json(RawEventData)
   | extend RecordType = tostring(RD.RecordType), SubmissionContentType = tostring(RD.SubmissionContentType)
   | where RecordType == "29" and SubmissionContentType in ("ChatMessage", "TeamsCall")
-  | where ActionType startswith "UserSubmission"
+  //Exact match, because a graded submission also emits a UserSubmissionTriage record under the same SubmissionId.
+  | where ActionType == "UserSubmission"
   | extend ReportedBy = tostring(RD.SubmitterDisplayName), ReportedByEmail = tostring(RD.UserId)
   | where isnotempty(ReportedBy) and ReportedByEmail has "@"
   | summarize ['Teams Calls Reported'] = countif(SubmissionContentType == "TeamsCall"),


### PR DESCRIPTION
Five new hunting queries covering Microsoft Teams call activity, which the Email and Collaboration library did not previously reach, plus one improvement to an existing query.

New queries:

- **Suspicious Microsoft Teams Callers by Impersonation-Style Identity** — callers whose display name or address impersonates IT support, helpdesk, security or account maintenance, with calls from throwaway `.onmicrosoft.com` tenants called out separately. The organisation's own domains are derived from inbound mail recipients rather than a hard-coded tenant id, so it runs in any tenant without editing.
- **Microsoft Teams Calls and Impersonation-Style Calls by Hour of Day** — two series across all 24 hours in UTC, so an hour with few calls but a high impersonation share is visible rather than hidden by the busiest hour.
- **Reported Microsoft Teams Calls** — calls users reported to Microsoft, with the reported calling party and domain.
- **Microsoft Teams Call and Message Submissions Over Time** — submissions split by content type and by whether a user or an admin reported them.
- **Top Reporters of Microsoft Teams Calls and Messages** — reporters with calls and messages counted separately.

Voice contact is worth hunting separately because the malicious instructions are spoken rather than typed and never appear in the chat log, so message-based queries do not see them.

Update to an existing query:

**Suspicious Teams Display Name** matched seven literal display names and had no time bound, returning raw rows. It now uses a broader pattern, bounds the range, de-duplicates messages to the latest record, adds throwaway-tenant detection with a reason column, and reports a per-sender threat rate. Id, name and attribution preserved; version bumped to 1.0.1.

All queries are mirrored to both hunting locations with unique ids per copy, use `Timestamp` rather than `TimeGenerated`, carry an explicit time filter and a render where appropriate, and were validated against live data.
