### PR TITLE
Add campaign click ranking and quarantine malware reason, improve two existing queries

### DIFF
--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Malware reason.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine Malware reason.yaml
@@ -1,0 +1,24 @@
+id: 2d730733-6a56-470f-aa2c-f583611ffb50
+name: Quarantine Malware Reason
+description: |
+  This query visualises the total amount of malware emails that are quarantined, summarized by the detection method
+description-detailed: |
+  This query visualises the total amount of malware emails that are quarantined, summarized by the detection method that caught them, using Advanced hunting in Microsoft Defender XDR. It completes the set alongside the equivalent phish and spam quarantine reason queries. Knowing which detection technology is filling quarantine with malware shows where protection is actually working, and a sudden shift in the mix is worth investigating: it usually means either a change in the attacks arriving or a change in which layer is catching them.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and DetectionMethods has 'Malware' and DeliveryLocation == "Quarantine"
+  | mv-expand Malware = parse_json(DetectionMethods).Malware to typeof(string)
+  | where isnotempty(Malware)
+  | summarize count() by Malware
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine releases by Detection types.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Quarantine/Quarantine releases by Detection types.yaml
@@ -15,23 +15,27 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let totalQuery = EmailPostDeliveryEvents
-  | where Action == "Quarantine release"
-  | join kind=inner (EmailEvents | where DeliveryLocation == "Quarantine") on NetworkMessageId
-  | extend MDO_detection = parse_json(DetectionMethods1)
+  //Per detection technology: the share of its quarantined emails that were later released from quarantine.
+  //Release % = released / quarantined for that detection technology. A high rate flags a detector that may be
+  //over-flagging legitimate mail. Detectors with fewer than 10 quarantined emails are excluded so the rate is
+  //statistically meaningful rather than driven by one or two messages.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where DeliveryLocation == "Quarantine"
+  | extend MDO_detection = parse_json(DetectionMethods)
   | extend FirstDetection = iif(isempty(MDO_detection), "Clean", tostring(bag_keys(MDO_detection)[0]))
   | extend FirstSubcategory = iif(FirstDetection != "Clean" and array_length(MDO_detection[FirstDetection]) > 0, strcat(FirstDetection, ": ", tostring(MDO_detection[FirstDetection][0])), "No Detection (clean)")
   | where FirstSubcategory contains "Malware" or FirstSubcategory contains "Phish" or FirstSubcategory contains "Spam"
-  | count;
-  EmailPostDeliveryEvents
-  | where Action == "Quarantine release"
-  | join kind=inner (EmailEvents | where DeliveryLocation == "Quarantine") on NetworkMessageId
-  | extend MDO_detection = parse_json(DetectionMethods1)
-  | extend FirstDetection = iif(isempty(MDO_detection), "Clean", tostring(bag_keys(MDO_detection)[0]))
-  | extend FirstSubcategory = iif(FirstDetection != "Clean" and array_length(MDO_detection[FirstDetection]) > 0, strcat(FirstDetection, ": ", tostring(MDO_detection[FirstDetection][0])), "No Detection (clean)")
-  | where FirstSubcategory contains "Malware" or FirstSubcategory contains "Phish" or FirstSubcategory contains "Spam"
-  | summarize count_messages = count() by FirstSubcategory
-  | project FirstSubcategory, count_messages
-  | order by count_messages desc
-  | render piechart
-version: 1.0.0
+  | join kind=leftouter (
+      EmailPostDeliveryEvents
+      | where Timestamp > ago(30d)
+      | where Action == "Quarantine release"
+      | distinct NetworkMessageId
+      | extend ReleasedFlag = "yes"
+    ) on NetworkMessageId
+  | summarize Quarantined = dcount(NetworkMessageId), Released = dcountif(NetworkMessageId, ReleasedFlag == "yes") by FirstSubcategory
+  | where Quarantined >= 10
+  | extend ReleaseRate = round(Released * 100.0 / Quarantined, 2)
+  | project ['Detection Type']=FirstSubcategory, ['Quarantined Emails']=Quarantined, ['Released']=Released, ['Release %']=ReleaseRate
+  | order by ['Release %'] desc
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
@@ -14,11 +14,35 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "AdminSubmissionSubmitted"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType),P2SenderDomain=tostring((parse_json(RawEventData)).P2SenderDomain)
-  | where SubmissionContentType == "Mail" and SubmissionType in ("2","1","0")
-  | summarize count() by P2SenderDomain
-  | project P2SenderDomain, Emails = count_
-  | top 10 by Emails desc
-version: 1.0.0
+  //Top sender domains that admins reported as false negatives (missed threats), with each domain's Microsoft Defender
+  //for Office 365 detection profile for context: total inbound volume, how many of those already carried a threat
+  //verdict, and the threat-type split.
+  //The submission percentage is the point - 40 reports out of 12,000 inbound messages reads very differently from
+  //40 out of 60, and only the second is a filtering problem worth escalating.
+  let AdminSubmissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "AdminSubmissionSubmitted"
+      | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),
+               SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType),
+               P2SenderDomain = tostring((parse_json(RawEventData)).P2SenderDomain)
+      | where SubmissionContentType == "Mail" and SubmissionType in ("2","1","0")
+      | where isnotempty(P2SenderDomain)
+      | summarize AdminSubmissions = count() by P2SenderDomain;
+  let DomainProfile = EmailEvents
+      | where Timestamp > ago(30d)
+      | where EmailDirection == "Inbound"
+      | summarize TotalInbound = count(),
+                  EmailsWithThreats = countif(isnotempty(ThreatTypes)),
+                  Malware = countif(ThreatTypes has "Malware"),
+                  Phish = countif(ThreatTypes has "Phish"),
+                  Spam = countif(ThreatTypes has "Spam")
+          by SenderFromDomain;
+  AdminSubmissions
+  | join kind=leftouter (DomainProfile) on $left.P2SenderDomain == $right.SenderFromDomain
+  | extend AdminSubmissionPct = round(AdminSubmissions * 100.0 / todouble(coalesce(TotalInbound, AdminSubmissions)), 2)
+  | top 10 by AdminSubmissions desc
+  | project ['Sender Domain']=P2SenderDomain, ['Admin Submissions']=AdminSubmissions,
+            ['Total Inbound']=coalesce(TotalInbound, 0), ['Admin Submission %']=AdminSubmissionPct,
+            ['Emails With Threats']=coalesce(EmailsWithThreats, 0), ['Malware']=coalesce(Malware, 0),
+            ['Phish']=coalesce(Phish, 0), ['Spam']=coalesce(Spam, 0)
+version: 1.1.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
@@ -39,7 +39,8 @@ query: |
           by SenderFromDomain;
   AdminSubmissions
   | join kind=leftouter (DomainProfile) on $left.P2SenderDomain == $right.SenderFromDomain
-  | extend AdminSubmissionPct = round(AdminSubmissions * 100.0 / todouble(coalesce(TotalInbound, AdminSubmissions)), 2)
+  //Null rather than a misleading 100% when the domain has no matching inbound mail in the window.
+  | extend AdminSubmissionPct = iif(isnull(TotalInbound) or TotalInbound == 0, real(null), round(AdminSubmissions * 100.0 / todouble(TotalInbound), 2))
   | top 10 by AdminSubmissions desc
   | project ['Sender Domain']=P2SenderDomain, ['Admin Submissions']=AdminSubmissions,
             ['Total Inbound']=coalesce(TotalInbound, 0), ['Admin Submission %']=AdminSubmissionPct,

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
@@ -1,0 +1,58 @@
+id: 28ce9655-f35f-4733-af43-8266b39a87f1
+name: Malicious Email Campaigns by Recipient URL Clicks
+description: |
+  This query ranks malicious inbound email campaigns by how many recipients clicked a URL in them, rather than by campaign size.
+description-detailed: |
+  Microsoft Defender for Office 365 groups related malicious messages into campaigns through EmailClusterId. This query ranks those campaigns over the last 30 days by the number of recipient URL clicks they attracted, using Advanced hunting in Microsoft Defender XDR, and flags campaigns that carried QR codes. Ranking by clicks rather than by message volume answers a different question from campaign size: a small campaign that reached mailboxes and was clicked represents realised risk, whereas a large campaign that was blocked at delivery did not. For triage that inverts the priority order, because the campaigns worth investigating first are the ones users actually engaged with. Messages are de-duplicated to the latest record per message and recipient, and phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query ranks malicious inbound email campaigns from the last 30 days by recipient URL clicks, not by size.
+  //A small campaign that reached mailboxes and got clicked is realised risk; a large one blocked at delivery is not,
+  //so ranking by engagement inverts the triage order compared with ranking by message volume.
+  //Campaigns carrying QR codes are flagged, since the URL is not visible to the user or to link inspection.
+  //Phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
+  let ClicksByCluster = UrlClickEvents
+      | where Timestamp > ago(30d)
+      | join kind=inner (EmailEvents | where Timestamp > ago(30d) | where EmailClusterId > 0 | distinct NetworkMessageId, EmailClusterId) on NetworkMessageId
+      | summarize UrlClicks = count() by EmailClusterId;
+  let QrClusters = EmailUrlInfo
+      | where Timestamp > ago(30d)
+      | where UrlLocation == "QRCode"
+      | join kind=inner (EmailEvents | where Timestamp > ago(30d) | where EmailClusterId > 0 | distinct NetworkMessageId, EmailClusterId) on NetworkMessageId
+      | summarize QrMessages = dcount(NetworkMessageId) by EmailClusterId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and EmailClusterId > 0
+  | where OrgLevelPolicy !in ("Phishing simulation", "SecOps Mailbox")
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize Messages = count(),
+              Recipients = dcount(RecipientEmailAddress),
+              SenderDomains = dcount(SenderFromDomain),
+              SampleSenderDomains = make_set(SenderFromDomain, 5),
+              ThreatTypesRaw = make_set(ThreatTypes, 50),
+              SampleSubjects = make_set(Subject, 5),
+              FirstSeen = min(Timestamp),
+              LastSeen = max(Timestamp)
+          by EmailClusterId
+  | join kind=inner (ClicksByCluster) on EmailClusterId
+  | where UrlClicks > 0
+  | join kind=leftouter (QrClusters) on EmailClusterId
+  | extend CarriedQrCode = iif(coalesce(QrMessages, 0) > 0, "QR code", "")
+  | extend ThreatMix = array_sort_asc(set_union(split(strcat_array(ThreatTypesRaw, ", "), ", "), dynamic([])))
+  | top 20 by UrlClicks
+  | project ['Email Cluster ID']=EmailClusterId, ['URL Clicks']=UrlClicks, ['Messages']=Messages,
+            ['Recipients']=Recipients, ['Sender Domains']=SenderDomains,
+            ['Sample Sender Domains']=SampleSenderDomains, ['Threat Mix']=ThreatMix,
+            ['QR Code']=CarriedQrCode, ['Sample Subjects']=SampleSubjects,
+            ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.0

--- a/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
+++ b/Hunting Queries/Microsoft 365 Defender/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
@@ -1,9 +1,9 @@
 id: 28ce9655-f35f-4733-af43-8266b39a87f1
 name: Malicious Email Campaigns by Recipient URL Clicks
 description: |
-  This query ranks malicious inbound email campaigns by how many recipients clicked a URL in them, rather than by campaign size.
+  This query ranks malicious inbound email campaigns by the number of URL clicks they attracted and by how many distinct users clicked, rather than by campaign size.
 description-detailed: |
-  Microsoft Defender for Office 365 groups related malicious messages into campaigns through EmailClusterId. This query ranks those campaigns over the last 30 days by the number of recipient URL clicks they attracted, using Advanced hunting in Microsoft Defender XDR, and flags campaigns that carried QR codes. Ranking by clicks rather than by message volume answers a different question from campaign size: a small campaign that reached mailboxes and was clicked represents realised risk, whereas a large campaign that was blocked at delivery did not. For triage that inverts the priority order, because the campaigns worth investigating first are the ones users actually engaged with. Messages are de-duplicated to the latest record per message and recipient, and phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
+  Microsoft Defender for Office 365 groups related malicious messages into campaigns through EmailClusterId. This query ranks those campaigns over the last 30 days by the number of recipient URL clicks they attracted, using Advanced hunting in Microsoft Defender XDR, and flags campaigns that carried QR codes. Both the total number of clicks and the number of distinct users behind them are returned, so one repeat clicker is not mistaken for broad engagement. Ranking by clicks rather than by message volume answers a different question from campaign size: a small campaign that reached mailboxes and was clicked represents realised risk, whereas a large campaign that was blocked at delivery did not. For triage that inverts the priority order, because the campaigns worth investigating first are the ones users actually engaged with. Messages are de-duplicated to the latest record per message and recipient, and phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
@@ -23,7 +23,7 @@ query: |
   let ClicksByCluster = UrlClickEvents
       | where Timestamp > ago(30d)
       | join kind=inner (EmailEvents | where Timestamp > ago(30d) | where EmailClusterId > 0 | distinct NetworkMessageId, EmailClusterId) on NetworkMessageId
-      | summarize UrlClicks = count() by EmailClusterId;
+      | summarize UrlClicks = count(), ClickingUsers = dcount(AccountUpn) by EmailClusterId;
   let QrClusters = EmailUrlInfo
       | where Timestamp > ago(30d)
       | where UrlLocation == "QRCode"
@@ -50,7 +50,8 @@ query: |
   | extend CarriedQrCode = iif(coalesce(QrMessages, 0) > 0, "QR code", "")
   | extend ThreatMix = array_sort_asc(set_union(split(strcat_array(ThreatTypesRaw, ", "), ", "), dynamic([])))
   | top 20 by UrlClicks
-  | project ['Email Cluster ID']=EmailClusterId, ['URL Clicks']=UrlClicks, ['Messages']=Messages,
+  | project ['Email Cluster ID']=EmailClusterId, ['URL Clicks']=UrlClicks, ['Clicking Users']=ClickingUsers,
+            ['Messages']=Messages,
             ['Recipients']=Recipients, ['Sender Domains']=SenderDomains,
             ['Sample Sender Domains']=SampleSenderDomains, ['Threat Mix']=ThreatMix,
             ['QR Code']=CarriedQrCode, ['Sample Subjects']=SampleSubjects,

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Malware reason.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine Malware reason.yaml
@@ -1,0 +1,24 @@
+id: c38282e0-5748-467d-95fc-4202b904dbc7
+name: Quarantine Malware Reason
+description: |
+  This query visualises the total amount of malware emails that are quarantined, summarized by the detection method
+description-detailed: |
+  This query visualises the total amount of malware emails that are quarantined, summarized by the detection method that caught them, using Advanced hunting in Microsoft Defender XDR. It completes the set alongside the equivalent phish and spam quarantine reason queries. Knowing which detection technology is filling quarantine with malware shows where protection is actually working, and a sudden shift in the mix is worth investigating: it usually means either a change in the attacks arriving or a change in which layer is catching them.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and DetectionMethods has 'Malware' and DeliveryLocation == "Quarantine"
+  | mv-expand Malware = parse_json(DetectionMethods).Malware to typeof(string)
+  | where isnotempty(Malware)
+  | summarize count() by Malware
+  | sort by count_ desc
+  | render piechart
+version: 1.0.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine releases by Detection types.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Quarantine/Quarantine releases by Detection types.yaml
@@ -15,23 +15,27 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  let totalQuery = EmailPostDeliveryEvents
-  | where Action == "Quarantine release"
-  | join kind=inner (EmailEvents | where DeliveryLocation == "Quarantine") on NetworkMessageId
-  | extend MDO_detection = parse_json(DetectionMethods1)
+  //Per detection technology: the share of its quarantined emails that were later released from quarantine.
+  //Release % = released / quarantined for that detection technology. A high rate flags a detector that may be
+  //over-flagging legitimate mail. Detectors with fewer than 10 quarantined emails are excluded so the rate is
+  //statistically meaningful rather than driven by one or two messages.
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where DeliveryLocation == "Quarantine"
+  | extend MDO_detection = parse_json(DetectionMethods)
   | extend FirstDetection = iif(isempty(MDO_detection), "Clean", tostring(bag_keys(MDO_detection)[0]))
   | extend FirstSubcategory = iif(FirstDetection != "Clean" and array_length(MDO_detection[FirstDetection]) > 0, strcat(FirstDetection, ": ", tostring(MDO_detection[FirstDetection][0])), "No Detection (clean)")
   | where FirstSubcategory contains "Malware" or FirstSubcategory contains "Phish" or FirstSubcategory contains "Spam"
-  | count;
-  EmailPostDeliveryEvents
-  | where Action == "Quarantine release"
-  | join kind=inner (EmailEvents | where DeliveryLocation == "Quarantine") on NetworkMessageId
-  | extend MDO_detection = parse_json(DetectionMethods1)
-  | extend FirstDetection = iif(isempty(MDO_detection), "Clean", tostring(bag_keys(MDO_detection)[0]))
-  | extend FirstSubcategory = iif(FirstDetection != "Clean" and array_length(MDO_detection[FirstDetection]) > 0, strcat(FirstDetection, ": ", tostring(MDO_detection[FirstDetection][0])), "No Detection (clean)")
-  | where FirstSubcategory contains "Malware" or FirstSubcategory contains "Phish" or FirstSubcategory contains "Spam"
-  | summarize count_messages = count() by FirstSubcategory
-  | project FirstSubcategory, count_messages
-  | order by count_messages desc
-  | render piechart
-version: 1.0.0
+  | join kind=leftouter (
+      EmailPostDeliveryEvents
+      | where Timestamp > ago(30d)
+      | where Action == "Quarantine release"
+      | distinct NetworkMessageId
+      | extend ReleasedFlag = "yes"
+    ) on NetworkMessageId
+  | summarize Quarantined = dcount(NetworkMessageId), Released = dcountif(NetworkMessageId, ReleasedFlag == "yes") by FirstSubcategory
+  | where Quarantined >= 10
+  | extend ReleaseRate = round(Released * 100.0 / Quarantined, 2)
+  | project ['Detection Type']=FirstSubcategory, ['Quarantined Emails']=Quarantined, ['Released']=Released, ['Release %']=ReleaseRate
+  | order by ['Release %'] desc
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
@@ -14,11 +14,35 @@ tactics:
 relevantTechniques:
   - T1566
 query: |
-  CloudAppEvents
-  | where ActionType == "AdminSubmissionSubmitted"
-  | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),SubmissionContentType=tostring((parse_json(RawEventData)).SubmissionContentType),P2SenderDomain=tostring((parse_json(RawEventData)).P2SenderDomain)
-  | where SubmissionContentType == "Mail" and SubmissionType in ("2","1","0")
-  | summarize count() by P2SenderDomain
-  | project P2SenderDomain, Emails = count_
-  | top 10 by Emails desc
-version: 1.0.0
+  //Top sender domains that admins reported as false negatives (missed threats), with each domain's Microsoft Defender
+  //for Office 365 detection profile for context: total inbound volume, how many of those already carried a threat
+  //verdict, and the threat-type split.
+  //The submission percentage is the point - 40 reports out of 12,000 inbound messages reads very differently from
+  //40 out of 60, and only the second is a filtering problem worth escalating.
+  let AdminSubmissions = CloudAppEvents
+      | where Timestamp > ago(30d)
+      | where ActionType == "AdminSubmissionSubmitted"
+      | extend SubmissionType = tostring((parse_json(RawEventData)).SubmissionType),
+               SubmissionContentType = tostring((parse_json(RawEventData)).SubmissionContentType),
+               P2SenderDomain = tostring((parse_json(RawEventData)).P2SenderDomain)
+      | where SubmissionContentType == "Mail" and SubmissionType in ("2","1","0")
+      | where isnotempty(P2SenderDomain)
+      | summarize AdminSubmissions = count() by P2SenderDomain;
+  let DomainProfile = EmailEvents
+      | where Timestamp > ago(30d)
+      | where EmailDirection == "Inbound"
+      | summarize TotalInbound = count(),
+                  EmailsWithThreats = countif(isnotempty(ThreatTypes)),
+                  Malware = countif(ThreatTypes has "Malware"),
+                  Phish = countif(ThreatTypes has "Phish"),
+                  Spam = countif(ThreatTypes has "Spam")
+          by SenderFromDomain;
+  AdminSubmissions
+  | join kind=leftouter (DomainProfile) on $left.P2SenderDomain == $right.SenderFromDomain
+  | extend AdminSubmissionPct = round(AdminSubmissions * 100.0 / todouble(coalesce(TotalInbound, AdminSubmissions)), 2)
+  | top 10 by AdminSubmissions desc
+  | project ['Sender Domain']=P2SenderDomain, ['Admin Submissions']=AdminSubmissions,
+            ['Total Inbound']=coalesce(TotalInbound, 0), ['Admin Submission %']=AdminSubmissionPct,
+            ['Emails With Threats']=coalesce(EmailsWithThreats, 0), ['Malware']=coalesce(Malware, 0),
+            ['Phish']=coalesce(Phish, 0), ['Spam']=coalesce(Spam, 0)
+version: 1.1.0

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Submissions/Top Sender Domains - Admin Submissions FN.yaml
@@ -39,7 +39,8 @@ query: |
           by SenderFromDomain;
   AdminSubmissions
   | join kind=leftouter (DomainProfile) on $left.P2SenderDomain == $right.SenderFromDomain
-  | extend AdminSubmissionPct = round(AdminSubmissions * 100.0 / todouble(coalesce(TotalInbound, AdminSubmissions)), 2)
+  //Null rather than a misleading 100% when the domain has no matching inbound mail in the window.
+  | extend AdminSubmissionPct = iif(isnull(TotalInbound) or TotalInbound == 0, real(null), round(AdminSubmissions * 100.0 / todouble(TotalInbound), 2))
   | top 10 by AdminSubmissions desc
   | project ['Sender Domain']=P2SenderDomain, ['Admin Submissions']=AdminSubmissions,
             ['Total Inbound']=coalesce(TotalInbound, 0), ['Admin Submission %']=AdminSubmissionPct,

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
@@ -1,9 +1,9 @@
 id: af3477a3-22f8-45a3-aa01-069d40ba4bd3
 name: Malicious Email Campaigns by Recipient URL Clicks
 description: |
-  This query ranks malicious inbound email campaigns by how many recipients clicked a URL in them, rather than by campaign size.
+  This query ranks malicious inbound email campaigns by the number of URL clicks they attracted and by how many distinct users clicked, rather than by campaign size.
 description-detailed: |
-  Microsoft Defender for Office 365 groups related malicious messages into campaigns through EmailClusterId. This query ranks those campaigns over the last 30 days by the number of recipient URL clicks they attracted, using Advanced hunting in Microsoft Defender XDR, and flags campaigns that carried QR codes. Ranking by clicks rather than by message volume answers a different question from campaign size: a small campaign that reached mailboxes and was clicked represents realised risk, whereas a large campaign that was blocked at delivery did not. For triage that inverts the priority order, because the campaigns worth investigating first are the ones users actually engaged with. Messages are de-duplicated to the latest record per message and recipient, and phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
+  Microsoft Defender for Office 365 groups related malicious messages into campaigns through EmailClusterId. This query ranks those campaigns over the last 30 days by the number of recipient URL clicks they attracted, using Advanced hunting in Microsoft Defender XDR, and flags campaigns that carried QR codes. Both the total number of clicks and the number of distinct users behind them are returned, so one repeat clicker is not mistaken for broad engagement. Ranking by clicks rather than by message volume answers a different question from campaign size: a small campaign that reached mailboxes and was clicked represents realised risk, whereas a large campaign that was blocked at delivery did not. For triage that inverts the priority order, because the campaigns worth investigating first are the ones users actually engaged with. Messages are de-duplicated to the latest record per message and recipient, and phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
 requiredDataConnectors:
 - connectorId: MicrosoftThreatProtection
   dataTypes:
@@ -23,7 +23,7 @@ query: |
   let ClicksByCluster = UrlClickEvents
       | where Timestamp > ago(30d)
       | join kind=inner (EmailEvents | where Timestamp > ago(30d) | where EmailClusterId > 0 | distinct NetworkMessageId, EmailClusterId) on NetworkMessageId
-      | summarize UrlClicks = count() by EmailClusterId;
+      | summarize UrlClicks = count(), ClickingUsers = dcount(AccountUpn) by EmailClusterId;
   let QrClusters = EmailUrlInfo
       | where Timestamp > ago(30d)
       | where UrlLocation == "QRCode"
@@ -50,7 +50,8 @@ query: |
   | extend CarriedQrCode = iif(coalesce(QrMessages, 0) > 0, "QR code", "")
   | extend ThreatMix = array_sort_asc(set_union(split(strcat_array(ThreatTypesRaw, ", "), ", "), dynamic([])))
   | top 20 by UrlClicks
-  | project ['Email Cluster ID']=EmailClusterId, ['URL Clicks']=UrlClicks, ['Messages']=Messages,
+  | project ['Email Cluster ID']=EmailClusterId, ['URL Clicks']=UrlClicks, ['Clicking Users']=ClickingUsers,
+            ['Messages']=Messages,
             ['Recipients']=Recipients, ['Sender Domains']=SenderDomains,
             ['Sample Sender Domains']=SampleSenderDomains, ['Threat Mix']=ThreatMix,
             ['QR Code']=CarriedQrCode, ['Sample Subjects']=SampleSubjects,

--- a/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
+++ b/Solutions/Microsoft Defender XDR/Hunting Queries/Email and Collaboration Queries/Top Attacks/Malicious Email Campaigns by Recipient URL Clicks.yaml
@@ -1,0 +1,58 @@
+id: af3477a3-22f8-45a3-aa01-069d40ba4bd3
+name: Malicious Email Campaigns by Recipient URL Clicks
+description: |
+  This query ranks malicious inbound email campaigns by how many recipients clicked a URL in them, rather than by campaign size.
+description-detailed: |
+  Microsoft Defender for Office 365 groups related malicious messages into campaigns through EmailClusterId. This query ranks those campaigns over the last 30 days by the number of recipient URL clicks they attracted, using Advanced hunting in Microsoft Defender XDR, and flags campaigns that carried QR codes. Ranking by clicks rather than by message volume answers a different question from campaign size: a small campaign that reached mailboxes and was clicked represents realised risk, whereas a large campaign that was blocked at delivery did not. For triage that inverts the priority order, because the campaigns worth investigating first are the ones users actually engaged with. Messages are de-duplicated to the latest record per message and recipient, and phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - EmailEvents
+  - EmailUrlInfo
+  - UrlClickEvents
+tactics:
+  - InitialAccess
+relevantTechniques:
+  - T1566
+query: |
+  //This query ranks malicious inbound email campaigns from the last 30 days by recipient URL clicks, not by size.
+  //A small campaign that reached mailboxes and got clicked is realised risk; a large one blocked at delivery is not,
+  //so ranking by engagement inverts the triage order compared with ranking by message volume.
+  //Campaigns carrying QR codes are flagged, since the URL is not visible to the user or to link inspection.
+  //Phishing simulation and SecOps mailbox traffic are excluded so internal exercises do not inflate the ranking.
+  let ClicksByCluster = UrlClickEvents
+      | where Timestamp > ago(30d)
+      | join kind=inner (EmailEvents | where Timestamp > ago(30d) | where EmailClusterId > 0 | distinct NetworkMessageId, EmailClusterId) on NetworkMessageId
+      | summarize UrlClicks = count() by EmailClusterId;
+  let QrClusters = EmailUrlInfo
+      | where Timestamp > ago(30d)
+      | where UrlLocation == "QRCode"
+      | join kind=inner (EmailEvents | where Timestamp > ago(30d) | where EmailClusterId > 0 | distinct NetworkMessageId, EmailClusterId) on NetworkMessageId
+      | summarize QrMessages = dcount(NetworkMessageId) by EmailClusterId;
+  EmailEvents
+  | where Timestamp > ago(30d)
+  | where EmailDirection == "Inbound" and isnotempty(ThreatTypes) and EmailClusterId > 0
+  | where OrgLevelPolicy !in ("Phishing simulation", "SecOps Mailbox")
+  | extend Key = strcat(NetworkMessageId, "-", RecipientEmailAddress)
+  | summarize arg_max(Timestamp, *) by Key
+  | summarize Messages = count(),
+              Recipients = dcount(RecipientEmailAddress),
+              SenderDomains = dcount(SenderFromDomain),
+              SampleSenderDomains = make_set(SenderFromDomain, 5),
+              ThreatTypesRaw = make_set(ThreatTypes, 50),
+              SampleSubjects = make_set(Subject, 5),
+              FirstSeen = min(Timestamp),
+              LastSeen = max(Timestamp)
+          by EmailClusterId
+  | join kind=inner (ClicksByCluster) on EmailClusterId
+  | where UrlClicks > 0
+  | join kind=leftouter (QrClusters) on EmailClusterId
+  | extend CarriedQrCode = iif(coalesce(QrMessages, 0) > 0, "QR code", "")
+  | extend ThreatMix = array_sort_asc(set_union(split(strcat_array(ThreatTypesRaw, ", "), ", "), dynamic([])))
+  | top 20 by UrlClicks
+  | project ['Email Cluster ID']=EmailClusterId, ['URL Clicks']=UrlClicks, ['Messages']=Messages,
+            ['Recipients']=Recipients, ['Sender Domains']=SenderDomains,
+            ['Sample Sender Domains']=SampleSenderDomains, ['Threat Mix']=ThreatMix,
+            ['QR Code']=CarriedQrCode, ['Sample Subjects']=SampleSubjects,
+            ['First Seen']=FirstSeen, ['Last Seen']=LastSeen
+version: 1.0.0


### PR DESCRIPTION
New:

- **Malicious Email Campaigns by Recipient URL Clicks** — ranks campaigns by the recipient clicks they drew rather than by message volume. A small campaign that reached mailboxes and was clicked is realised risk; a large one blocked at delivery is not, so this inverts the triage order compared with ranking by size. Campaigns carrying QR codes are flagged, since the URL is not visible to the user or to link inspection.
- **Quarantine Malware Reason** — completes the set alongside the existing `Quarantine Phish Reason` and `Quarantine Spam Reason` queries, which had no malware equivalent. Same structure and shape as its siblings.

Improved:

- **Quarantine releases by Detection types** now reports a release **percentage** per detection technology rather than a raw count, which is what indicates a detector may be over-flagging legitimate mail. Detectors with fewer than ten quarantined emails are excluded so the rate is not driven by one or two messages. Also removes a duplicated block whose result was computed and never used, and reads `DetectionMethods` from `EmailEvents` directly rather than the join-suffixed `DetectionMethods1`.
- **Top Sender Domains - Admin Submissions FN** now includes the domain's total inbound volume, the share of it reported, and the threat-type split. A domain reported forty times out of twelve thousand messages reads very differently from one reported forty times out of sixty, and only the second is a filtering problem worth escalating.

Both improved queries keep their existing id, name and attribution, with the version bumped to 1.1.0.

All queries are mirrored to both hunting locations with unique ids per copy, use `Timestamp` rather than `TimeGenerated`, carry an explicit time filter, and were validated against live data.